### PR TITLE
Create GitHub Action for .mcpb builds

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -7,6 +7,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+env:
+  BUN_VERSION: '1.1.38'
+
 jobs:
   build:
     name: Build .mcpb Bundle
@@ -18,7 +21,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install dependencies
         run: bun install
@@ -38,6 +41,14 @@ jobs:
       - name: Build .mcpb bundle
         run: bun run pack:mcpb
 
+      - name: Verify .mcpb file exists
+        run: |
+          if [ ! -f copilot-money-mcp.mcpb ]; then
+            echo "Error: .mcpb file not found"
+            exit 1
+          fi
+          ls -la copilot-money-mcp.mcpb
+
       - name: Upload .mcpb artifact
         uses: actions/upload-artifact@v4
         with:
@@ -55,18 +66,28 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Download .mcpb artifact
+        uses: actions/download-artifact@v4
         with:
-          bun-version: latest
+          name: copilot-money-mcp-bundle
 
-      - name: Install dependencies
-        run: bun install
+      - name: Verify .mcpb file exists
+        run: |
+          if [ ! -f copilot-money-mcp.mcpb ]; then
+            echo "Error: .mcpb file not found"
+            exit 1
+          fi
+          ls -la copilot-money-mcp.mcpb
 
-      - name: Build .mcpb bundle
-        run: bun run pack:mcpb
+      - name: Determine if prerelease
+        id: prerelease
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [[ "$TAG" =~ (alpha|beta|rc|preview|dev) ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -74,4 +95,4 @@ jobs:
           files: copilot-money-mcp.mcpb
           generate_release_notes: true
           draft: false
-          prerelease: ${{ contains(github.ref, '-') }}
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}


### PR DESCRIPTION
Add workflow that:
- Builds .mcpb bundle on every push to main
- Runs quality checks (typecheck, lint, format, tests) before building
- Uploads .mcpb as artifact for every build
- Creates GitHub releases with .mcpb attached when version tags are pushed
- Supports manual triggering via workflow_dispatch