### PR TITLE
Fix GitHub Action skipping release builds

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -1,11 +1,20 @@
-name: Build MCPB
+name: build release
 
 on:
   push:
-    branches: [main]
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Create a release'
+        required: true
+        type: boolean
+        default: true
+      version:
+        description: 'Version tag for the release (e.g., v1.0.0)'
+        required: true
+        type: string
 
 env:
   BUN_VERSION: '1.1.38'
@@ -59,7 +68,7 @@ jobs:
   release:
     name: Create Release
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.create_release)
     runs-on: ubuntu-latest
 
     permissions:
@@ -82,7 +91,11 @@ jobs:
       - name: Determine if prerelease
         id: prerelease
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            TAG="${{ inputs.version }}"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
           if [[ "$TAG" =~ (alpha|beta|rc|preview|dev) ]]; then
             echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           else
@@ -92,6 +105,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
           files: copilot-money-mcp.mcpb
           generate_release_notes: true
           draft: false


### PR DESCRIPTION
- Rename action to "build release"
- Add create_release and version inputs for manual workflow runs
- Update release job condition to run on workflow_dispatch
- Remove push on main branch trigger (releases only on tags or manual)