### PR TITLE
Add pre-commit checks with husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+bun run check

--- a/package.json
+++ b/package.json
@@ -48,9 +48,12 @@
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "typecheck": "tsc --noEmit",
+    "check": "bun run typecheck && bun run lint && bun run format:check && bun run test",
+    "fix": "bun run lint:fix && bun run format",
     "clean": "rm -rf dist coverage .bun-build",
     "pack:mcpb": "bun run build:bundle && bun run build && bunx @anthropic-ai/mcpb pack",
-    "prepublishOnly": "bun run clean && bun run build && bun test"
+    "prepublishOnly": "bun run clean && bun run build && bun test",
+    "prepare": "husky"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.2.0",
@@ -66,6 +69,7 @@
     "@typescript-eslint/parser": "^6.20.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
+    "husky": "^9.1.7",
     "prettier": "^3.2.5",
     "typescript": "^5.3.3"
   }


### PR DESCRIPTION
## Summary
- Add `check` script that runs typecheck, lint, format check, and tests in sequence
- Add `fix` script to auto-fix lint and formatting issues
- Set up husky pre-commit hook to enforce checks on local commits

## Usage
```bash
bun run check   # validate before committing
bun run fix     # auto-fix lint/formatting issues
```

## Test plan
- [x] Verified `bun run check` passes
- [x] Verified pre-commit hook runs on commit
- [ ] Clone fresh repo and run `bun install` to verify husky sets up automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)