### PR TITLE
Fix repository URL format for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ignaciohermosillacornejo/copilot-money-mcp.git"
+    "url": "git+https://github.com/ignaciohermosillacornejo/copilot-money-mcp.git"
   },
   "bugs": {
     "url": "https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues"


### PR DESCRIPTION
## Summary
- Add `git+` prefix to repository URL as required by npm package standards
- Generated by `npm pkg fix`

## Test plan
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)