### PR TITLE
Enhance decoder to extract all fields and fix data accuracy

### DIFF
--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -73,7 +73,30 @@ function extractDoubleValue(data: Buffer, startPos: number, maxSearch: number = 
 }
 
 /**
+ * Extract a double value for a named field.
+ */
+function extractDoubleField(data: Buffer, fieldName: Buffer): number | null {
+  const idx = data.indexOf(fieldName);
+  if (idx === -1) {
+    return null;
+  }
+  return extractDoubleValue(data, idx + fieldName.length);
+}
+
+/**
+ * Create a length-prefixed field pattern for Firestore field names.
+ * Format: \x0a{length}{fieldname}
+ */
+function fieldPattern(name: string): Buffer {
+  return Buffer.from([0x0a, name.length, ...Buffer.from(name)]);
+}
+
+/**
  * Extract a boolean value for a field.
+ * Supports two formats:
+ * 1. Firestore format: \x0a{len}fieldname\x12\x02\x08{value}
+ * 2. Simple format: fieldname\x08{value}
+ * where value is 0x00 (false) or 0x01 (true)
  */
 function extractBooleanValue(data: Buffer, fieldName: Buffer): boolean | null {
   const idx = data.indexOf(fieldName);
@@ -85,9 +108,16 @@ function extractBooleanValue(data: Buffer, fieldName: Buffer): boolean | null {
   const searchEnd = Math.min(data.length, searchStart + 20);
   const after = data.subarray(searchStart, searchEnd);
 
-  for (let i = 0; i < after.length - 2; i++) {
+  // Try Firestore format first: \x12\x02\x08{value}
+  for (let i = 0; i < after.length - 3; i++) {
+    if (after[i] === 0x12 && after[i + 1] === 0x02 && after[i + 2] === 0x08) {
+      return Boolean(after[i + 3]);
+    }
+  }
+
+  // Fall back to simple format: \x08{value}
+  for (let i = 0; i < after.length - 1; i++) {
     if (after[i] === 0x08) {
-      // Boolean tag
       return Boolean(after[i + 1]);
     }
   }
@@ -142,53 +172,115 @@ export function decodeTransactions(dbPath: string): Transaction[] {
       const recordEnd = Math.min(data.length, idx + 1500);
       const record = data.subarray(recordStart, recordEnd);
 
-      // Extract fields
-      const name = extractStringValue(record, Buffer.from([0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65])); // "\x0a\x04name"
-      const originalName = extractStringValue(record, Buffer.from('original_name'));
-      const date = extractStringValue(record, Buffer.from('original_date'));
-      const categoryId = extractStringValue(record, Buffer.from('category_id'));
-      const accountId = extractStringValue(record, Buffer.from('account_id'));
-      const transactionId = extractStringValue(record, Buffer.from('transaction_id'));
-      const isoCurrencyCode = extractStringValue(record, Buffer.from('iso_currency_code'));
-      const pending = extractBooleanValue(record, Buffer.from('pending'));
-      const city = extractStringValue(record, Buffer.from([0x0a, 0x04, 0x63, 0x69, 0x74, 0x79])); // "\x0a\x04city"
-      const region = extractStringValue(
+      // Extract all string fields
+      const name = extractStringValue(record, fieldPattern('name'));
+      const originalName = extractStringValue(record, fieldPattern('original_name'));
+      const originalCleanName = extractStringValue(record, fieldPattern('original_clean_name'));
+      const date = extractStringValue(record, fieldPattern('original_date'));
+      const originalDate = extractStringValue(record, fieldPattern('original_date'));
+      const categoryId = extractStringValue(record, fieldPattern('category_id'));
+      const plaidCategoryId = extractStringValue(record, fieldPattern('plaid_category_id'));
+      const categoryIdSource = extractStringValue(record, fieldPattern('category_id_source'));
+      const accountId = extractStringValue(record, fieldPattern('account_id'));
+      const itemId = extractStringValue(record, fieldPattern('item_id'));
+      const userId = extractStringValue(record, fieldPattern('user_id'));
+      const transactionId = extractStringValue(record, fieldPattern('transaction_id'));
+      const pendingTransactionId = extractStringValue(
         record,
-        Buffer.from([0x0a, 0x06, 0x72, 0x65, 0x67, 0x69, 0x6f, 0x6e])
-      ); // "\x0a\x06region"
+        fieldPattern('pending_transaction_id')
+      );
+      const isoCurrencyCode = extractStringValue(record, fieldPattern('iso_currency_code'));
+      const transactionType = extractStringValue(record, fieldPattern('transaction_type'));
+      const plaidTransactionType = extractStringValue(
+        record,
+        fieldPattern('plaid_transaction_type')
+      );
+      const paymentMethod = extractStringValue(record, fieldPattern('payment_method'));
+      const paymentProcessor = extractStringValue(record, fieldPattern('payment_processor'));
+      const city = extractStringValue(record, fieldPattern('city'));
+      const region = extractStringValue(record, fieldPattern('region'));
+      const address = extractStringValue(record, fieldPattern('address'));
+      const postalCode = extractStringValue(record, fieldPattern('postal_code'));
+      const country = extractStringValue(record, fieldPattern('country'));
+      const referenceNumber = extractStringValue(record, fieldPattern('reference_number'));
+      const ppdId = extractStringValue(record, fieldPattern('ppd_id'));
+      const byOrderOf = extractStringValue(record, fieldPattern('by_order_of'));
+      const fromInvestment = extractStringValue(record, fieldPattern('from_investment'));
+      // Copilot type field: "internal_transfer", "income", "regular", etc.
+      const copilotType = extractStringValue(record, fieldPattern('type'));
+
+      // Extract boolean fields
+      const pending = extractBooleanValue(record, fieldPattern('pending'));
+      const excluded = extractBooleanValue(record, fieldPattern('excluded'));
+      const userReviewed = extractBooleanValue(record, fieldPattern('user_reviewed'));
+      const plaidDeleted = extractBooleanValue(record, fieldPattern('plaid_deleted'));
+      const isAmazon = extractBooleanValue(record, fieldPattern('is_amazon'));
+      const accountDashboardActive = extractBooleanValue(
+        record,
+        fieldPattern('account_dashboard_active')
+      );
+
+      // Extract numeric fields
+      const originalAmount = extractDoubleField(record, fieldPattern('original_amount'));
+      const lat = extractDoubleField(record, fieldPattern('lat'));
+      const lon = extractDoubleField(record, fieldPattern('lon'));
+
+      // Derive internal_transfer from copilot type
+      const isInternalTransfer = copilotType === 'internal_transfer';
 
       // Use name or original_name as display name
       const displayName = name || originalName;
 
       if (displayName && transactionId && date) {
         try {
-          // Build transaction object with optional fields
-          const txnData: {
-            transaction_id: string;
-            amount: number;
-            date: string;
-            name?: string;
-            original_name?: string;
-            account_id?: string;
-            category_id?: string;
-            iso_currency_code?: string;
-            pending?: boolean;
-            city?: string;
-            region?: string;
-          } = {
+          // Build transaction object with all extracted fields
+          const txnData: Record<string, string | number | boolean> = {
             transaction_id: transactionId,
             amount,
             date,
           };
 
+          // String fields
           if (name) txnData.name = name;
           if (originalName) txnData.original_name = originalName;
+          if (originalCleanName) txnData.original_clean_name = originalCleanName;
           if (accountId) txnData.account_id = accountId;
+          if (itemId) txnData.item_id = itemId;
+          if (userId) txnData.user_id = userId;
           if (categoryId) txnData.category_id = categoryId;
+          if (plaidCategoryId) txnData.plaid_category_id = plaidCategoryId;
+          if (categoryIdSource) txnData.category_id_source = categoryIdSource;
+          if (originalDate) txnData.original_date = originalDate;
+          if (pendingTransactionId) txnData.pending_transaction_id = pendingTransactionId;
           if (isoCurrencyCode) txnData.iso_currency_code = isoCurrencyCode;
-          if (pending !== null) txnData.pending = pending;
+          if (transactionType) txnData.transaction_type = transactionType;
+          if (plaidTransactionType) txnData.plaid_transaction_type = plaidTransactionType;
+          if (paymentMethod) txnData.payment_method = paymentMethod;
+          if (paymentProcessor) txnData.payment_processor = paymentProcessor;
           if (city) txnData.city = city;
           if (region) txnData.region = region;
+          if (address) txnData.address = address;
+          if (postalCode) txnData.postal_code = postalCode;
+          if (country) txnData.country = country;
+          if (referenceNumber) txnData.reference_number = referenceNumber;
+          if (ppdId) txnData.ppd_id = ppdId;
+          if (byOrderOf) txnData.by_order_of = byOrderOf;
+          if (fromInvestment) txnData.from_investment = fromInvestment;
+
+          // Boolean fields
+          if (pending !== null) txnData.pending = pending;
+          if (excluded !== null) txnData.excluded = excluded;
+          if (isInternalTransfer) txnData.internal_transfer = isInternalTransfer;
+          if (userReviewed !== null) txnData.user_reviewed = userReviewed;
+          if (plaidDeleted !== null) txnData.plaid_deleted = plaidDeleted;
+          if (isAmazon !== null) txnData.is_amazon = isAmazon;
+          if (accountDashboardActive !== null)
+            txnData.account_dashboard_active = accountDashboardActive;
+
+          // Numeric fields
+          if (originalAmount !== null) txnData.original_amount = originalAmount;
+          if (lat !== null) txnData.lat = lat;
+          if (lon !== null) txnData.lon = lon;
 
           // Validate with Zod
           const txn = TransactionSchema.parse(txnData);
@@ -255,24 +347,47 @@ export function decodeAccounts(dbPath: string): Account[] {
     while (idx !== -1) {
       searchPos = idx + 1;
 
-      const recordStart = Math.max(0, idx - 1000);
-      const recordEnd = Math.min(data.length, idx + 1000);
+      // Use wider window to capture all account fields
+      const recordStart = Math.max(0, idx - 2500);
+      const recordEnd = Math.min(data.length, idx + 2500);
       const record = data.subarray(recordStart, recordEnd);
 
-      const balanceIdx = record.indexOf(balancePattern);
+      // Calculate balance position within window based on original position
+      const balanceIdx = idx - recordStart;
       const balance = extractDoubleValue(record, balanceIdx + 15);
 
       if (balance !== null) {
-        const name = extractStringValue(record, Buffer.from([0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65])); // "\x0a\x04name"
-        const officialName = extractStringValue(record, Buffer.from('official_name'));
-        const accountType = extractStringValue(
-          record,
-          Buffer.from([0x0a, 0x04, 0x74, 0x79, 0x70, 0x65])
-        ); // "\x0a\x04type"
-        const subtype = extractStringValue(record, Buffer.from('subtype'));
-        const mask = extractStringValue(record, Buffer.from([0x0a, 0x04, 0x6d, 0x61, 0x73, 0x6b])); // "\x0a\x04mask"
-        const institutionName = extractStringValue(record, Buffer.from('institution_name'));
-        const accountId = extractStringValue(record, Buffer.from('account_id'));
+        // Search for fields after the balance position to avoid finding data from previous records
+        const afterBalance = record.subarray(balanceIdx);
+
+        const name = extractStringValue(afterBalance, fieldPattern('name'));
+        const officialName = extractStringValue(afterBalance, fieldPattern('official_name'));
+        const accountType = extractStringValue(afterBalance, fieldPattern('type'));
+        const subtype = extractStringValue(afterBalance, fieldPattern('subtype'));
+        const mask = extractStringValue(afterBalance, fieldPattern('mask'));
+        const institutionName = extractStringValue(afterBalance, fieldPattern('institution_name'));
+
+        // Try account_id first, then fall back to 'id' field
+        let accountId = extractStringValue(afterBalance, fieldPattern('account_id'));
+        if (!accountId) {
+          accountId = extractStringValue(afterBalance, fieldPattern('id'));
+        }
+
+        // If still no account ID, try extracting from /accounts/ path (search before balance)
+        if (!accountId) {
+          const beforeBalance = record.subarray(0, balanceIdx);
+          const accountsPathIdx = beforeBalance.lastIndexOf(Buffer.from('/accounts/'));
+          if (accountsPathIdx !== -1) {
+            // Extract ID after /accounts/
+            const afterPath = beforeBalance.subarray(accountsPathIdx + 10, accountsPathIdx + 60);
+            const match = afterPath.toString('utf-8').match(/^([a-zA-Z0-9_-]+)/);
+            // Only use as ID if it looks like a valid ID (not a field name)
+            // Valid IDs are usually 20+ chars with mixed case/numbers
+            if (match?.[1] && match[1].length >= 15 && /[A-Z]/.test(match[1])) {
+              accountId = match[1];
+            }
+          }
+        }
 
         if (accountId && (name || officialName)) {
           try {

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -45,6 +45,11 @@ export const TransactionSchema = z
     pending_transaction_id: z.string().optional(),
     user_reviewed: z.boolean().optional(),
     plaid_deleted: z.boolean().optional(),
+    excluded: z.boolean().optional(), // True if excluded from spending calculations
+    internal_transfer: z.boolean().optional(), // True if this is an internal transfer between accounts
+
+    // Transaction type
+    transaction_type: z.string().optional(), // "place", "special", "digital", etc.
 
     // Payment info
     payment_method: z.string().optional(),

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -400,18 +400,20 @@ export class CopilotMoneyTools {
       limit: 50000, // High limit for aggregation
     });
 
-    // Filter out transfers if requested
+    // Filter out transfers if requested (check both category and internal_transfer flag)
     if (exclude_transfers) {
-      transactions = transactions.filter((txn) => !isTransferCategory(txn.category_id));
+      transactions = transactions.filter(
+        (txn) => !isTransferCategory(txn.category_id) && !txn.internal_transfer
+      );
     }
 
-    // Aggregate by category
+    // Aggregate by category (always exclude internal transfers from spending)
     const categorySpending: Map<string, number> = new Map();
     const categoryCounts: Map<string, number> = new Map();
 
     for (const txn of transactions) {
-      // Only count positive amounts (expenses)
-      if (txn.amount > 0) {
+      // Only count positive amounts (expenses), skip internal transfers
+      if (txn.amount > 0 && !txn.internal_transfer) {
         const cat = txn.category_id || 'Uncategorized';
         categorySpending.set(cat, (categorySpending.get(cat) || 0) + txn.amount);
         categoryCounts.set(cat, (categoryCounts.get(cat) || 0) + 1);
@@ -917,20 +919,22 @@ export class CopilotMoneyTools {
       limit: 50000,
     });
 
-    // Filter out transfers if requested
+    // Filter out transfers if requested (check both category and internal_transfer flag)
     if (exclude_transfers) {
-      transactions = transactions.filter((txn) => !isTransferCategory(txn.category_id));
+      transactions = transactions.filter(
+        (txn) => !isTransferCategory(txn.category_id) && !txn.internal_transfer
+      );
     }
 
-    // Aggregate by merchant
+    // Aggregate by merchant (always exclude internal transfers from spending)
     const merchantSpending = new Map<
       string,
       { total: number; count: number; categoryId?: string }
     >();
 
     for (const txn of transactions) {
-      // Only count positive amounts (expenses)
-      if (txn.amount <= 0) continue;
+      // Only count positive amounts (expenses), skip internal transfers
+      if (txn.amount <= 0 || txn.internal_transfer) continue;
 
       const merchantName = getTransactionDisplayName(txn);
       const existing = merchantSpending.get(merchantName) || {
@@ -1506,8 +1510,11 @@ export class CopilotMoneyTools {
       limit: 50000,
     });
 
+    // Filter out transfers if requested (check both category and internal_transfer flag)
     if (exclude_transfers) {
-      transactions = transactions.filter((txn) => !isTransferCategory(txn.category_id));
+      transactions = transactions.filter(
+        (txn) => !isTransferCategory(txn.category_id) && !txn.internal_transfer
+      );
     }
 
     const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
@@ -1518,7 +1525,8 @@ export class CopilotMoneyTools {
     }
 
     for (const txn of transactions) {
-      if (txn.amount <= 0) continue; // Only count expenses
+      // Only count expenses, skip internal transfers
+      if (txn.amount <= 0 || txn.internal_transfer) continue;
       const dayOfWeek = new Date(txn.date + 'T12:00:00').getDay();
       const stats = dayStats.get(dayOfWeek)!;
       stats.total += txn.amount;
@@ -1842,8 +1850,11 @@ export class CopilotMoneyTools {
       limit: 50000,
     });
 
+    // Filter out transfers if requested (check both category and internal_transfer flag)
     if (exclude_transfers) {
-      transactions = transactions.filter((txn) => !isTransferCategory(txn.category_id));
+      transactions = transactions.filter(
+        (txn) => !isTransferCategory(txn.category_id) && !txn.internal_transfer
+      );
     }
 
     const merchantStats = new Map<
@@ -1858,7 +1869,8 @@ export class CopilotMoneyTools {
     >();
 
     for (const txn of transactions) {
-      if (txn.amount <= 0) continue;
+      // Only count expenses, skip internal transfers
+      if (txn.amount <= 0 || txn.internal_transfer) continue;
       const merchant = getTransactionDisplayName(txn);
       const existing = merchantStats.get(merchant) || {
         total: 0,
@@ -2322,8 +2334,11 @@ export class CopilotMoneyTools {
       limit: 50000,
     });
 
+    // Filter out transfers if requested (check both category and internal_transfer flag)
     if (exclude_transfers) {
-      transactions = transactions.filter((txn) => !isTransferCategory(txn.category_id));
+      transactions = transactions.filter(
+        (txn) => !isTransferCategory(txn.category_id) && !txn.internal_transfer
+      );
     }
 
     // Calculate period stats
@@ -2338,21 +2353,22 @@ export class CopilotMoneyTools {
       daysInPeriod
     );
 
+    // Always exclude internal transfers from spending calculations
     const totalSpending = transactions
-      .filter((txn) => txn.amount > 0)
+      .filter((txn) => txn.amount > 0 && !txn.internal_transfer)
       .reduce((sum, txn) => sum + txn.amount, 0);
 
     const dailyAverage = daysElapsed > 0 ? totalSpending / daysElapsed : 0;
     const weeklyAverage = dailyAverage * 7;
     const projectedMonthlyTotal = dailyAverage * 30;
 
-    // Weekly breakdown
+    // Weekly breakdown (exclude internal transfers)
     const weeklyTotals = new Map<
       string,
       { start: string; end: string; total: number; days: number }
     >();
     for (const txn of transactions) {
-      if (txn.amount <= 0) continue;
+      if (txn.amount <= 0 || txn.internal_transfer) continue;
       const txnDate = new Date(txn.date + 'T12:00:00');
       const weekStart = new Date(txnDate);
       weekStart.setDate(txnDate.getDate() - txnDate.getDay());
@@ -2864,8 +2880,11 @@ export class CopilotMoneyTools {
         limit: 50000,
       });
 
+      // Filter out transfers if requested (check both category and internal_transfer flag)
       if (exclude_transfers) {
-        transactions = transactions.filter((txn) => !isTransferCategory(txn.category_id));
+        transactions = transactions.filter(
+          (txn) => !isTransferCategory(txn.category_id) && !txn.internal_transfer
+        );
       }
 
       let spending = 0;
@@ -2873,11 +2892,12 @@ export class CopilotMoneyTools {
       const byCategory = new Map<string, number>();
 
       for (const txn of transactions) {
-        if (txn.amount > 0) {
+        // Always exclude internal transfers from spending calculations
+        if (txn.amount > 0 && !txn.internal_transfer) {
           spending += txn.amount;
           const cat = txn.category_id || 'Uncategorized';
           byCategory.set(cat, (byCategory.get(cat) || 0) + txn.amount);
-        } else {
+        } else if (txn.amount < 0) {
           income += Math.abs(txn.amount);
         }
       }


### PR DESCRIPTION
## Summary

- **Extract all transaction fields**: Added comprehensive field extraction (30+ fields) including location, payment, and metadata fields with proper `fieldPattern()` helper
- **Fix internal transfer detection**: Derive `internal_transfer` from `type` field value comparison; exclude from all spending calculations
- **Fix missing accounts**: Widened search window to 2500 bytes and added fallback for account_id extraction from `id` field and Firestore path

## Changes

### Decoder (`src/core/decoder.ts`)
- Add `fieldPattern()` helper for consistent length-prefixed field creation
- Add `extractDoubleField()` and update `extractBooleanValue()` to support both Firestore and simple formats
- Extract all available transaction fields (name variants, location, payment info, metadata, booleans)
- Widen account search window from 1000 to 2500 bytes
- Fix cross-record contamination by searching fields AFTER balance position

### Spending Tools (`src/tools/tools.ts`)
- Exclude `internal_transfer=true` transactions from all spending calculations
- Updated: `getSpendingByCategory`, `getSpendingByMerchant`, `getSpendingByDayOfWeek`, `getTopMerchants`, `getSpendingRate`, `comparePeriods`

### Tests (`tests/core/decoder.test.ts`)
- Update test helpers to use `fieldPattern()` for proper field encoding
- Add `createBooleanField()` helper supporting both encoding formats

## Test plan
- [x] All 400 tests pass
- [x] TypeScript, ESLint, and Prettier checks pass
- [x] Verified internal transfers are excluded from spending totals
- [x] Verified account detection captures all accounts

🤖 Generated with [Claude Code](https://claude.ai/code)