### PR TITLE
Add investment holdings extraction and get_holdings tool

### DIFF
--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -13,6 +13,7 @@ import {
   decodeTransactions,
   decodeRecurring,
   decodeBalanceHistory,
+  decodeHoldings,
 } from './decoder.js';
 import {
   Account,
@@ -20,6 +21,7 @@ import {
   Category,
   Recurring,
   BalanceHistory,
+  Holding,
   getTransactionDisplayName,
 } from '../models/index.js';
 import { getCategoryName } from '../utils/categories.js';
@@ -104,6 +106,7 @@ export class CopilotDatabase {
   private _accounts: Account[] | null = null;
   private _recurring: Recurring[] | null = null;
   private _balanceHistory: BalanceHistory[] | null = null;
+  private _holdings: Holding[] | null = null;
 
   /**
    * Initialize database connection.
@@ -355,6 +358,29 @@ export class CopilotDatabase {
     if (options.endDate) {
       const endDate = options.endDate;
       result = result.filter((entry) => entry.date <= endDate);
+    }
+
+    return result;
+  }
+
+  /**
+   * Get investment holdings (positions) from accounts.
+   *
+   * @param options - Filter options
+   * @param options.accountId - Filter by specific account
+   * @returns List of investment holdings
+   */
+  getHoldings(options: { accountId?: string } = {}): Holding[] {
+    // Lazy load holdings
+    if (this._holdings === null) {
+      this._holdings = decodeHoldings(this.requireDbPath());
+    }
+
+    let result = [...this._holdings];
+
+    // Apply account ID filter
+    if (options.accountId) {
+      result = result.filter((holding) => holding.account_id === options.accountId);
     }
 
     return result;

--- a/src/models/holding.ts
+++ b/src/models/holding.ts
@@ -1,0 +1,49 @@
+/**
+ * Investment holding model for Copilot Money data.
+ *
+ * Represents investment positions stored in Copilot's
+ * /holdings_history/ Firestore collection.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Investment holding schema with validation.
+ *
+ * Each entry represents a security position in an investment account.
+ */
+export const HoldingSchema = z
+  .object({
+    // Required fields
+    holding_id: z.string(),
+
+    // Account reference
+    account_id: z.string().optional(),
+
+    // Security details
+    security_name: z.string().optional(),
+    ticker: z.string().optional(),
+
+    // Position data
+    quantity: z.number().optional(),
+    price: z.number().optional(),
+    value: z.number().optional(),
+    cost_basis: z.number().optional(),
+
+    // Metadata
+    iso_currency_code: z.string().optional(),
+    date: z.string().optional(), // YYYY-MM-DD - snapshot date
+  })
+  .strict();
+
+export type Holding = z.infer<typeof HoldingSchema>;
+
+/**
+ * Get the best display name for a holding.
+ */
+export function getHoldingDisplayName(holding: Holding): string {
+  if (holding.ticker && holding.security_name) {
+    return `${holding.ticker} - ${holding.security_name}`;
+  }
+  return holding.ticker ?? holding.security_name ?? 'Unknown';
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -23,3 +23,5 @@ export { CategorySchema, type Category } from './category.js';
 export { RecurringSchema, type Recurring, getRecurringDisplayName } from './recurring.js';
 
 export { BalanceHistorySchema, type BalanceHistory } from './balance_history.js';
+
+export { HoldingSchema, type Holding, getHoldingDisplayName } from './holding.js';

--- a/src/server.ts
+++ b/src/server.ts
@@ -145,6 +145,12 @@ export class CopilotMoneyServer {
           );
           break;
 
+        case 'get_holdings':
+          result = this.tools.getHoldings(
+            (typedArgs as Parameters<typeof this.tools.getHoldings>[0]) || {}
+          );
+          break;
+
         case 'get_income':
           result = this.tools.getIncome(
             (typedArgs as Parameters<typeof this.tools.getIncome>[0]) || {}

--- a/tests/integration/tools.test.ts
+++ b/tests/integration/tools.test.ts
@@ -300,7 +300,7 @@ describe('CopilotMoneyTools Integration', () => {
   describe('tool schemas', () => {
     test('returns correct number of tool schemas', () => {
       const schemas = createToolSchemas();
-      expect(schemas.length).toBe(24);
+      expect(schemas.length).toBe(25);
     });
 
     test('all tools have readOnlyHint annotation', () => {

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -567,7 +567,7 @@ describe('CopilotMoneyTools', () => {
 describe('createToolSchemas', () => {
   test('returns 24 tool schemas', () => {
     const schemas = createToolSchemas();
-    expect(schemas).toHaveLength(24);
+    expect(schemas).toHaveLength(25);
   });
 
   test('all tools have readOnlyHint: true', () => {

--- a/tests/unit/server-protocol.test.ts
+++ b/tests/unit/server-protocol.test.ts
@@ -173,7 +173,7 @@ describe('CopilotMoneyServer.handleListTools', () => {
     for (const expected of expectedTools) {
       expect(actualNames).toContain(expected);
     }
-    expect(response.tools.length).toBe(24);
+    expect(response.tools.length).toBe(25);
   });
 
   test('tool schemas have valid JSON schema format', () => {


### PR DESCRIPTION
## Summary
- Create Holding model with schema validation for investment positions
- Add `decodeHoldings()` function to extract from `/holdings_history/` Firestore collection
- Add `getHoldings()` method to CopilotDatabase with account filtering
- Add `get_holdings` MCP tool with automatic gain/loss calculation
- Update test expectations to 25 tools

## Changes
### New Model (`src/models/holding.ts`)
- `HoldingSchema` with fields: holding_id, account_id, security_name, ticker, quantity, price, value, cost_basis, iso_currency_code, date
- Helper function `getHoldingDisplayName()` for display formatting

### Decoder (`src/core/decoder.ts`)
- `decodeHoldings()` extracts holdings from `/holdings_history/` collection
- Follows same pattern as balance history extraction
- Deduplicates by holding_id

### Database Layer (`src/core/database.ts`)
- `getHoldings()` method with lazy loading
- Filter by account_id to see holdings for specific investment accounts

### MCP Tool (`src/tools/tools.ts`)
- `get_holdings` tool returns holdings with summary statistics
- Automatically calculates gain/loss and gain/loss percentage when cost_basis is available
- Returns total_value across all holdings

### Server Integration (`src/server.ts`)
- Added handler for `get_holdings` tool calls

## Test Plan
- ✅ All 425 tests passing
- ✅ Build succeeds
- ✅ ESLint passes (only existing warnings)
- ✅ Test expectations updated to 25 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)