### PR TITLE
Add budgets extraction and get_budgets tool

### DIFF
--- a/src/models/budget.ts
+++ b/src/models/budget.ts
@@ -1,0 +1,60 @@
+/**
+ * Budget model for Copilot Money data.
+ *
+ * Represents budget rules and limits stored in Copilot's
+ * /budgets/ Firestore collection.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Known period values for budgets.
+ * Used for documentation and type hints.
+ */
+export const KNOWN_PERIODS = ['monthly', 'yearly', 'weekly', 'daily'] as const;
+
+export type KnownPeriod = (typeof KNOWN_PERIODS)[number];
+
+/**
+ * Date format regex for YYYY-MM-DD validation.
+ */
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Budget schema with validation.
+ *
+ * Represents user-defined spending limits and budget rules.
+ */
+export const BudgetSchema = z
+  .object({
+    // Required fields
+    budget_id: z.string(),
+
+    // Budget details
+    name: z.string().optional(),
+    amount: z.number().optional(),
+    period: z.enum(['monthly', 'yearly', 'weekly', 'daily']).optional(),
+
+    // Category association
+    category_id: z.string().optional(),
+
+    // Date range
+    start_date: z.string().regex(DATE_REGEX, 'Must be YYYY-MM-DD format').optional(),
+    end_date: z.string().regex(DATE_REGEX, 'Must be YYYY-MM-DD format').optional(),
+
+    // Status
+    is_active: z.boolean().optional(),
+
+    // Metadata
+    iso_currency_code: z.string().optional(),
+  })
+  .strict();
+
+export type Budget = z.infer<typeof BudgetSchema>;
+
+/**
+ * Get the best display name for a budget.
+ */
+export function getBudgetDisplayName(budget: Budget): string {
+  return budget.name ?? budget.category_id ?? 'Unknown Budget';
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -21,3 +21,5 @@ export {
 export { CategorySchema, type Category } from './category.js';
 
 export { RecurringSchema, type Recurring, getRecurringDisplayName } from './recurring.js';
+
+export { BudgetSchema, type Budget, getBudgetDisplayName } from './budget.js';

--- a/src/server.ts
+++ b/src/server.ts
@@ -139,6 +139,12 @@ export class CopilotMoneyServer {
           );
           break;
 
+        case 'get_budgets':
+          result = this.tools.getBudgets(
+            (typedArgs as Parameters<typeof this.tools.getBudgets>[0]) || {}
+          );
+          break;
+
         case 'get_income':
           result = this.tools.getIncome(
             (typedArgs as Parameters<typeof this.tools.getIncome>[0]) || {}

--- a/tests/integration/tools.test.ts
+++ b/tests/integration/tools.test.ts
@@ -300,7 +300,7 @@ describe('CopilotMoneyTools Integration', () => {
   describe('tool schemas', () => {
     test('returns correct number of tool schemas', () => {
       const schemas = createToolSchemas();
-      expect(schemas.length).toBe(23);
+      expect(schemas.length).toBe(24);
     });
 
     test('all tools have readOnlyHint annotation', () => {

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -567,7 +567,7 @@ describe('CopilotMoneyTools', () => {
 describe('createToolSchemas', () => {
   test('returns 23 tool schemas', () => {
     const schemas = createToolSchemas();
-    expect(schemas).toHaveLength(23);
+    expect(schemas).toHaveLength(24);
   });
 
   test('all tools have readOnlyHint: true', () => {

--- a/tests/unit/server-protocol.test.ts
+++ b/tests/unit/server-protocol.test.ts
@@ -173,7 +173,7 @@ describe('CopilotMoneyServer.handleListTools', () => {
     for (const expected of expectedTools) {
       expect(actualNames).toContain(expected);
     }
-    expect(response.tools.length).toBe(23);
+    expect(response.tools.length).toBe(24);
   });
 
   test('tool schemas have valid JSON schema format', () => {


### PR DESCRIPTION
## Summary
- Create Budget model with schema validation for budget rules
- Add `decodeBudgets()` function to extract from `/budgets/` Firestore collection
- Add `getBudgets()` method to CopilotDatabase with active_only filtering
- Add `get_budgets` MCP tool with monthly equivalent calculation
- Update test expectations to 24 tools

## Changes
### New Model (`src/models/budget.ts`)
- `BudgetSchema` with fields: budget_id, name, amount, period, category_id, start_date, end_date, is_active, iso_currency_code
- Period enum: monthly, yearly, weekly, daily
- Date validation with regex (YYYY-MM-DD format)
- Helper function `getBudgetDisplayName()` for display formatting

### Decoder (`src/core/decoder.ts`)
- `decodeBudgets()` extracts budgets from `/budgets/` collection
- Follows same proven pattern as recurring transactions
- Deduplicates by budget_id
- Graceful error handling with development logging

### Database Layer (`src/core/database.ts`)
- `getBudgets()` method with lazy loading
- `active_only` parameter to filter active budgets
- Treats undefined `is_active` as potentially active (better UX)

### MCP Tool (`src/tools/tools.ts`)
- `get_budgets` tool returns budgets with summary statistics
- **Automatically converts all budget periods to monthly equivalents**:
  - Yearly → amount / 12
  - Weekly → amount * 4.33
  - Daily → amount * 30
  - Monthly → amount (no conversion)
- Returns `total_budgeted` as sum of monthly equivalents
- Includes category names for better readability

### Server Integration (`src/server.ts`)
- Added handler for `get_budgets` tool calls

## Test Plan
- ✅ All 417 tests passing
- ✅ Build succeeds
- ✅ ESLint passes (only existing warnings)
- ✅ Prettier formatting applied
- ✅ Test expectations updated to 24 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)