### PR TITLE
Fix AI code review auto-merge on approval

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -75,4 +75,4 @@ jobs:
             - If blocking issues found (security, bugs, or major quality issues):
               gh pr review ${{ github.event.pull_request.number }} --request-changes -b "⚠️ Please address the review comments before merging"
 
-          claude_args: '--model claude-sonnet-4-20250514 --allowed-tools "Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr review:*),Read,Grep,Glob"'
+          claude_args: '--model claude-sonnet-4-20250514 --allowed-tools "Bash(gh pr diff *),Bash(gh pr view *),Bash(gh pr comment *),Bash(gh pr review *),Read,Grep,Glob"'


### PR DESCRIPTION
Change colon separators to spaces in Bash() patterns to match actual gh CLI command format. The pattern `Bash(gh pr review:*)` was expecting commands like `gh pr review:46`, but actual commands use spaces like `gh pr review 46 --approve`. This fix allows the Claude review agent to successfully approve PRs, which triggers the auto-merge workflow.