### PR TITLE
Replace Math.round patterns with roundAmount helper

### DIFF
--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -823,8 +823,7 @@ export class CopilotMoneyTools {
             total_spending: roundAmount(data.total),
             transaction_count: data.count,
             average_transaction: data.count > 0 ? roundAmount(data.total / data.count) : 0,
-            percentage:
-              totalSpending > 0 ? roundAmount((data.total / totalSpending) * 100) : 0,
+            percentage: totalSpending > 0 ? roundAmount((data.total / totalSpending) * 100) : 0,
           };
         });
 
@@ -7226,9 +7225,7 @@ export class CopilotMoneyTools {
       if (startPrice !== null && endPrice !== null) {
         priceChange = roundAmount(endPrice - startPrice);
         percentChange =
-          startPrice !== 0
-            ? roundAmount(((endPrice - startPrice) / startPrice) * 100)
-            : null;
+          startPrice !== 0 ? roundAmount(((endPrice - startPrice) / startPrice) * 100) : null;
 
         if (percentChange !== null) {
           if (percentChange > 0.5) trend = 'up';


### PR DESCRIPTION
Replace all instances of Math.round(x * 10000) / 100 and Math.round(x * 100) / 100 patterns with the roundAmount() helper function for consistent decimal rounding throughout the codebase.

Affected patterns:
- Percentage calculations (x * 10000 / 100 -> roundAmount(x * 100))
- Two-decimal rounding (x * 100 / 100 -> roundAmount(x))