### PR TITLE
Add validation for large transaction amounts

### DIFF
--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -74,6 +74,34 @@ const DEFAULT_ISSUES_LIMIT = 20;
 const MAX_ISSUES_LIMIT = 100;
 
 // ============================================
+// Amount Validation Constants
+// ============================================
+
+/**
+ * Threshold for large transactions worth noting (but still normal).
+ * $10,000 is a common threshold for personal finance.
+ */
+export const LARGE_TRANSACTION_THRESHOLD = 10_000;
+
+/**
+ * Threshold for extremely large transactions that should be flagged for review.
+ * $100,000 is unusual for typical personal finance transactions.
+ */
+export const EXTREMELY_LARGE_THRESHOLD = 100_000;
+
+/**
+ * Threshold for unrealistic amounts that are likely data quality issues.
+ * $1,000,000 is almost certainly an error in personal finance data.
+ */
+export const UNREALISTIC_AMOUNT_THRESHOLD = 1_000_000;
+
+/**
+ * Maximum valid transaction amount (matches TransactionSchema validation).
+ * Amounts above this are rejected at the schema level.
+ */
+export const MAX_VALID_AMOUNT = 10_000_000;
+
+// ============================================
 // Validation Helpers
 // ============================================
 
@@ -4297,10 +4325,16 @@ export class CopilotMoneyTools {
         }
       }
 
-      // Flag very large transactions regardless
-      if (!isAnomaly && txn.amount > 1000) {
+      // Flag transactions based on amount thresholds (most severe first)
+      if (!isAnomaly && txn.amount >= UNREALISTIC_AMOUNT_THRESHOLD) {
         isAnomaly = true;
-        reason = 'Large transaction (>$1000)';
+        reason = `Unrealistic amount (>=$${UNREALISTIC_AMOUNT_THRESHOLD.toLocaleString()}) - likely data quality issue`;
+      } else if (!isAnomaly && txn.amount >= EXTREMELY_LARGE_THRESHOLD) {
+        isAnomaly = true;
+        reason = `Extremely large transaction (>=$${EXTREMELY_LARGE_THRESHOLD.toLocaleString()}) - review for accuracy`;
+      } else if (!isAnomaly && txn.amount >= LARGE_TRANSACTION_THRESHOLD) {
+        isAnomaly = true;
+        reason = `Large transaction (>=$${LARGE_TRANSACTION_THRESHOLD.toLocaleString()})`;
       }
 
       if (isAnomaly) {
@@ -4788,6 +4822,20 @@ export class CopilotMoneyTools {
         balances: number[];
       }>;
     };
+    amount_issues: {
+      count: number;
+      total: number;
+      has_more: boolean;
+      items: Array<{
+        transaction_id: string;
+        date: string;
+        merchant: string;
+        amount: number;
+        category_name: string;
+        severity: 'extremely_large' | 'unrealistic';
+        reason: string;
+      }>;
+    };
     suspicious_categorizations: {
       count: number;
       total: number;
@@ -5135,6 +5183,64 @@ export class CopilotMoneyTools {
     const hasMoreSuspiciousCategorizations =
       issuesOffset + issuesLimit < totalSuspiciousCategorizations;
 
+    // ===== AMOUNT ISSUES =====
+    const extremelyLargeTransactions: Array<{
+      transaction_id: string;
+      date: string;
+      merchant: string;
+      amount: number;
+      category_name: string;
+      severity: 'extremely_large' | 'unrealistic';
+      reason: string;
+    }> = [];
+
+    let extremelyLargeCount = 0;
+    let unrealisticCount = 0;
+
+    for (const txn of allTransactions) {
+      const absAmount = Math.abs(txn.amount);
+      const merchant = getTransactionDisplayName(txn);
+      const categoryName = txn.category_id ? getCategoryName(txn.category_id) : 'Unknown';
+
+      if (absAmount >= UNREALISTIC_AMOUNT_THRESHOLD) {
+        // Unrealistic amounts (>= $1,000,000) - almost certainly data errors
+        unrealisticCount++;
+        extremelyLargeTransactions.push({
+          transaction_id: txn.transaction_id,
+          date: txn.date,
+          merchant,
+          amount: txn.amount,
+          category_name: categoryName,
+          severity: 'unrealistic',
+          reason: `Amount $${absAmount.toLocaleString()} exceeds $${UNREALISTIC_AMOUNT_THRESHOLD.toLocaleString()} - likely a data quality issue or unconverted foreign currency`,
+        });
+      } else if (absAmount >= EXTREMELY_LARGE_THRESHOLD) {
+        // Extremely large amounts ($100,000 - $999,999) - unusual for personal finance
+        extremelyLargeCount++;
+        extremelyLargeTransactions.push({
+          transaction_id: txn.transaction_id,
+          date: txn.date,
+          merchant,
+          amount: txn.amount,
+          category_name: categoryName,
+          severity: 'extremely_large',
+          reason: `Amount $${absAmount.toLocaleString()} exceeds $${EXTREMELY_LARGE_THRESHOLD.toLocaleString()} - review for accuracy`,
+        });
+      }
+    }
+
+    // Sort by amount (largest first)
+    extremelyLargeTransactions.sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount));
+
+    const totalAmountIssues = extremelyLargeTransactions.length;
+    issuesFound += totalAmountIssues;
+
+    const paginatedAmountIssues = extremelyLargeTransactions.slice(
+      issuesOffset,
+      issuesOffset + issuesLimit
+    );
+    const hasMoreAmountIssues = issuesOffset + issuesLimit < totalAmountIssues;
+
     return {
       period: { start_date, end_date },
       analysis_metadata: {
@@ -5168,6 +5274,12 @@ export class CopilotMoneyTools {
           items: nonUniqueTransactionIds,
         },
         potential_duplicate_accounts: potentialDuplicateAccounts,
+      },
+      amount_issues: {
+        count: paginatedAmountIssues.length,
+        total: totalAmountIssues,
+        has_more: hasMoreAmountIssues,
+        items: paginatedAmountIssues,
       },
       suspicious_categorizations: {
         count: paginatedSuspiciousCategorizations.length,

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -5194,9 +5194,6 @@ export class CopilotMoneyTools {
       reason: string;
     }> = [];
 
-    let extremelyLargeCount = 0;
-    let unrealisticCount = 0;
-
     for (const txn of allTransactions) {
       const absAmount = Math.abs(txn.amount);
       const merchant = getTransactionDisplayName(txn);
@@ -5204,7 +5201,6 @@ export class CopilotMoneyTools {
 
       if (absAmount >= UNREALISTIC_AMOUNT_THRESHOLD) {
         // Unrealistic amounts (>= $1,000,000) - almost certainly data errors
-        unrealisticCount++;
         extremelyLargeTransactions.push({
           transaction_id: txn.transaction_id,
           date: txn.date,
@@ -5216,7 +5212,6 @@ export class CopilotMoneyTools {
         });
       } else if (absAmount >= EXTREMELY_LARGE_THRESHOLD) {
         // Extremely large amounts ($100,000 - $999,999) - unusual for personal finance
-        extremelyLargeCount++;
         extremelyLargeTransactions.push({
           transaction_id: txn.transaction_id,
           date: txn.date,

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -3011,196 +3011,296 @@ describe('New MCP Tools', () => {
     });
   });
 
-  describe('getDataQualityReport', () => {
-    test('returns analysis metadata', () => {
-      const result = tools.getDataQualityReport({});
+  describe('Amount Validation Constants', () => {
+    test('exports amount threshold constants', async () => {
+      const {
+        LARGE_TRANSACTION_THRESHOLD,
+        EXTREMELY_LARGE_THRESHOLD,
+        UNREALISTIC_AMOUNT_THRESHOLD,
+        MAX_VALID_AMOUNT,
+      } = await import('../../src/tools/tools.js');
 
-      expect(result.analysis_metadata).toBeDefined();
-      expect(result.analysis_metadata.transactions_analyzed).toBeGreaterThanOrEqual(0);
-      expect(typeof result.analysis_metadata.transaction_limit_reached).toBe('boolean');
-      expect(result.analysis_metadata.issues_limit).toBe(20); // default
-      expect(result.analysis_metadata.issues_offset).toBe(0); // default
+      expect(LARGE_TRANSACTION_THRESHOLD).toBe(10_000);
+      expect(EXTREMELY_LARGE_THRESHOLD).toBe(100_000);
+      expect(UNREALISTIC_AMOUNT_THRESHOLD).toBe(1_000_000);
+      expect(MAX_VALID_AMOUNT).toBe(10_000_000);
     });
 
-    test('respects custom transaction_limit', () => {
-      const result = tools.getDataQualityReport({ transaction_limit: 2 });
+    test('thresholds are in correct ascending order', async () => {
+      const {
+        LARGE_TRANSACTION_THRESHOLD,
+        EXTREMELY_LARGE_THRESHOLD,
+        UNREALISTIC_AMOUNT_THRESHOLD,
+        MAX_VALID_AMOUNT,
+      } = await import('../../src/tools/tools.js');
 
-      expect(result.analysis_metadata.transactions_analyzed).toBeLessThanOrEqual(2);
+      expect(LARGE_TRANSACTION_THRESHOLD).toBeLessThan(EXTREMELY_LARGE_THRESHOLD);
+      expect(EXTREMELY_LARGE_THRESHOLD).toBeLessThan(UNREALISTIC_AMOUNT_THRESHOLD);
+      expect(UNREALISTIC_AMOUNT_THRESHOLD).toBeLessThan(MAX_VALID_AMOUNT);
     });
+  });
 
-    test('respects custom issues_limit', () => {
-      const result = tools.getDataQualityReport({ issues_limit: 5 });
-
-      expect(result.analysis_metadata.issues_limit).toBe(5);
-    });
-
-    test('respects custom issues_offset', () => {
-      const result = tools.getDataQualityReport({ issues_offset: 10 });
-
-      expect(result.analysis_metadata.issues_offset).toBe(10);
-    });
-
-    test('clamps transaction_limit to max value', () => {
-      const result = tools.getDataQualityReport({ transaction_limit: 200000 });
-
-      // Should be clamped to MAX_DATA_QUALITY_TRANSACTION_LIMIT (100000)
-      expect(result.analysis_metadata.transactions_analyzed).toBeLessThanOrEqual(100000);
-    });
-
-    test('clamps issues_limit to max value', () => {
-      const result = tools.getDataQualityReport({ issues_limit: 500 });
-
-      // Should be clamped to MAX_ISSUES_LIMIT (100)
-      expect(result.analysis_metadata.issues_limit).toBeLessThanOrEqual(100);
-    });
-
-    test('returns summary with totals', () => {
-      const result = tools.getDataQualityReport({});
-
-      expect(result.summary).toBeDefined();
-      expect(typeof result.summary.total_transactions).toBe('number');
-      expect(typeof result.summary.total_accounts).toBe('number');
-      expect(typeof result.summary.issues_found).toBe('number');
-    });
-
-    test('returns category_issues with pagination metadata', () => {
-      const result = tools.getDataQualityReport({});
-
-      expect(result.category_issues).toBeDefined();
-      expect(typeof result.category_issues.count).toBe('number');
-      expect(typeof result.category_issues.total).toBe('number');
-      expect(typeof result.category_issues.has_more).toBe('boolean');
-      expect(Array.isArray(result.category_issues.unresolved_categories)).toBe(true);
-    });
-
-    test('returns currency_issues with pagination metadata', () => {
-      const result = tools.getDataQualityReport({});
-
-      expect(result.currency_issues).toBeDefined();
-      expect(typeof result.currency_issues.count).toBe('number');
-      expect(typeof result.currency_issues.total).toBe('number');
-      expect(typeof result.currency_issues.has_more).toBe('boolean');
-      expect(Array.isArray(result.currency_issues.suspicious_transactions)).toBe(true);
-    });
-
-    test('returns duplicate_issues with pagination metadata', () => {
-      const result = tools.getDataQualityReport({});
-
-      expect(result.duplicate_issues).toBeDefined();
-      expect(typeof result.duplicate_issues.non_unique_ids.count).toBe('number');
-      expect(typeof result.duplicate_issues.non_unique_ids.total).toBe('number');
-      expect(typeof result.duplicate_issues.non_unique_ids.has_more).toBe('boolean');
-      expect(Array.isArray(result.duplicate_issues.non_unique_ids.items)).toBe(true);
-      expect(Array.isArray(result.duplicate_issues.potential_duplicate_accounts)).toBe(true);
-    });
-
-    test('returns suspicious_categorizations with pagination metadata', () => {
-      const result = tools.getDataQualityReport({});
-
-      expect(result.suspicious_categorizations).toBeDefined();
-      expect(typeof result.suspicious_categorizations.count).toBe('number');
-      expect(typeof result.suspicious_categorizations.total).toBe('number');
-      expect(typeof result.suspicious_categorizations.has_more).toBe('boolean');
-      expect(Array.isArray(result.suspicious_categorizations.items)).toBe(true);
-    });
-
-    test('pagination works correctly with issues_offset', () => {
-      // Create mock data with unresolved categories
-      const txnsWithUnresolvedCategories: Transaction[] = [];
-      for (let i = 0; i < 30; i++) {
-        txnsWithUnresolvedCategories.push({
-          transaction_id: `unresolved_txn_${i}`,
-          amount: 100 + i,
+  describe('getUnusualTransactions - Amount Thresholds', () => {
+    beforeEach(() => {
+      const transactionsWithLargeAmounts: Transaction[] = [
+        // Normal transaction
+        {
+          transaction_id: 'normal1',
+          amount: 50.0,
           date: '2024-01-15',
-          name: `Merchant ${i}`,
-          category_id: `unresolved_category_${i % 25}`, // 25 unique unresolved categories
+          name: 'Coffee Shop',
+          category_id: 'food_dining',
           account_id: 'acc1',
-        });
-      }
-
-      (db as any)._transactions = txnsWithUnresolvedCategories;
-
-      // First page
-      const page1 = tools.getDataQualityReport({ issues_limit: 10, issues_offset: 0 });
-      // Second page
-      const page2 = tools.getDataQualityReport({ issues_limit: 10, issues_offset: 10 });
-
-      // Verify pagination metadata
-      expect(page1.category_issues.unresolved_categories.length).toBeLessThanOrEqual(10);
-      expect(page2.category_issues.unresolved_categories.length).toBeLessThanOrEqual(10);
-
-      // If there are more than 10 unresolved categories, has_more should be true for page1
-      if (page1.category_issues.total > 10) {
-        expect(page1.category_issues.has_more).toBe(true);
-      }
+        },
+        // Large transaction ($10,000+)
+        {
+          transaction_id: 'large1',
+          amount: 15000.0,
+          date: '2024-01-20',
+          name: 'Car Payment',
+          category_id: 'auto',
+          account_id: 'acc1',
+        },
+        // Extremely large transaction ($100,000+)
+        {
+          transaction_id: 'extreme1',
+          amount: 150000.0,
+          date: '2024-01-25',
+          name: 'House Down Payment',
+          category_id: 'real_estate',
+          account_id: 'acc1',
+        },
+        // Unrealistic transaction ($1,000,000+)
+        {
+          transaction_id: 'unrealistic1',
+          amount: 2500000.0,
+          date: '2024-01-30',
+          name: 'Suspicious Transaction',
+          category_id: 'other',
+          account_id: 'acc1',
+        },
+      ];
+      (db as any)._transactions = transactionsWithLargeAmounts;
     });
 
-    test('filters by date period', () => {
+    test('flags large transactions with appropriate threshold', () => {
+      const result = tools.getUnusualTransactions({
+        start_date: '2024-01-01',
+        end_date: '2024-01-31',
+      });
+
+      const largeTxn = result.transactions.find((t) => t.transaction_id === 'large1');
+      expect(largeTxn).toBeDefined();
+      expect(largeTxn?.anomaly_reason).toContain('Large transaction');
+      expect(largeTxn?.anomaly_reason).toContain('10,000');
+    });
+
+    test('flags extremely large transactions with higher severity', () => {
+      const result = tools.getUnusualTransactions({
+        start_date: '2024-01-01',
+        end_date: '2024-01-31',
+      });
+
+      const extremeTxn = result.transactions.find((t) => t.transaction_id === 'extreme1');
+      expect(extremeTxn).toBeDefined();
+      expect(extremeTxn?.anomaly_reason).toContain('Extremely large');
+      expect(extremeTxn?.anomaly_reason).toContain('100,000');
+    });
+
+    test('flags unrealistic amounts as data quality issues', () => {
+      const result = tools.getUnusualTransactions({
+        start_date: '2024-01-01',
+        end_date: '2024-01-31',
+      });
+
+      const unrealisticTxn = result.transactions.find((t) => t.transaction_id === 'unrealistic1');
+      expect(unrealisticTxn).toBeDefined();
+      expect(unrealisticTxn?.anomaly_reason).toContain('Unrealistic');
+      expect(unrealisticTxn?.anomaly_reason).toContain('data quality');
+    });
+
+    test('does not flag normal transactions based on amount alone', () => {
+      const result = tools.getUnusualTransactions({
+        start_date: '2024-01-01',
+        end_date: '2024-01-31',
+      });
+
+      const normalTxn = result.transactions.find((t) => t.transaction_id === 'normal1');
+      // Normal transaction should only be flagged if it's unusual compared to merchant/category average
+      // Not based on amount alone since $50 is below LARGE_TRANSACTION_THRESHOLD
+      if (normalTxn) {
+        expect(normalTxn.anomaly_reason).not.toContain('Large transaction');
+      }
+    });
+  });
+
+  describe('getDataQualityReport - Amount Issues', () => {
+    beforeEach(() => {
+      const transactionsWithAmountIssues: Transaction[] = [
+        // Normal transactions
+        {
+          transaction_id: 'normal1',
+          amount: 50.0,
+          date: '2024-01-15',
+          name: 'Coffee Shop',
+          category_id: 'food_dining',
+          account_id: 'acc1',
+        },
+        {
+          transaction_id: 'normal2',
+          amount: 200.0,
+          date: '2024-01-16',
+          name: 'Grocery Store',
+          category_id: 'groceries',
+          account_id: 'acc1',
+        },
+        // Extremely large transaction ($100,000+)
+        {
+          transaction_id: 'extreme1',
+          amount: 250000.0,
+          date: '2024-01-20',
+          name: 'Large Purchase',
+          category_id: 'real_estate',
+          account_id: 'acc1',
+        },
+        // Unrealistic transaction ($1,000,000+)
+        {
+          transaction_id: 'unrealistic1',
+          amount: 5000000.0,
+          date: '2024-01-25',
+          name: 'Suspicious Large Amount',
+          category_id: 'other',
+          account_id: 'acc1',
+        },
+        // Negative unrealistic transaction (large income)
+        {
+          transaction_id: 'unrealistic2',
+          amount: -1500000.0,
+          date: '2024-01-28',
+          name: 'Suspicious Income',
+          category_id: 'income',
+          account_id: 'acc1',
+        },
+      ];
+      (db as any)._transactions = transactionsWithAmountIssues;
+    });
+
+    test('includes amount_issues in report with pagination metadata', () => {
       const result = tools.getDataQualityReport({
         start_date: '2024-01-01',
         end_date: '2024-01-31',
       });
 
-      expect(result.period.start_date).toBe('2024-01-01');
-      expect(result.period.end_date).toBe('2024-01-31');
+      expect(result.amount_issues).toBeDefined();
+      expect(typeof result.amount_issues.count).toBe('number');
+      expect(typeof result.amount_issues.total).toBe('number');
+      expect(typeof result.amount_issues.has_more).toBe('boolean');
+      expect(Array.isArray(result.amount_issues.items)).toBe(true);
     });
 
-    test('parses period shorthand', () => {
-      const result = tools.getDataQualityReport({ period: 'last_30_days' });
+    test('detects extremely large transactions', () => {
+      const result = tools.getDataQualityReport({
+        start_date: '2024-01-01',
+        end_date: '2024-01-31',
+      });
 
-      expect(result.period.start_date).toBeDefined();
-      expect(result.period.end_date).toBeDefined();
+      expect(result.amount_issues.total).toBeGreaterThanOrEqual(1);
+      const extremeTxn = result.amount_issues.items.find(
+        (t) => t.transaction_id === 'extreme1'
+      );
+      expect(extremeTxn).toBeDefined();
+      expect(extremeTxn?.severity).toBe('extremely_large');
+      expect(extremeTxn?.reason).toContain('100,000');
     });
 
-    test('detects duplicate accounts', () => {
-      // Create mock accounts with duplicates
-      const accountsWithDuplicates: Account[] = [
-        {
-          account_id: 'acc1',
-          current_balance: 1500.0,
-          name: 'Checking Account',
-          account_type: 'checking',
-        },
-        {
-          account_id: 'acc2',
-          current_balance: 1600.0,
-          name: 'Checking Account', // Same name
-          account_type: 'checking', // Same type
-        },
-      ];
+    test('detects unrealistic amounts', () => {
+      const result = tools.getDataQualityReport({
+        start_date: '2024-01-01',
+        end_date: '2024-01-31',
+      });
 
-      (db as any)._accounts = accountsWithDuplicates;
-
-      const result = tools.getDataQualityReport({});
-
-      expect(result.duplicate_issues.potential_duplicate_accounts.length).toBeGreaterThan(0);
-      const duplicateGroup = result.duplicate_issues.potential_duplicate_accounts[0];
-      expect(duplicateGroup.count).toBe(2);
-      expect(duplicateGroup.account_ids).toContain('acc1');
-      expect(duplicateGroup.account_ids).toContain('acc2');
+      const unrealisticTxn = result.amount_issues.items.find(
+        (t) => t.transaction_id === 'unrealistic1'
+      );
+      expect(unrealisticTxn).toBeDefined();
+      expect(unrealisticTxn?.severity).toBe('unrealistic');
+      expect(unrealisticTxn?.reason).toContain('1,000,000');
     });
 
-    test('sets transaction_limit_reached when hitting limit', () => {
-      // Create many transactions to hit the limit
-      const manyTransactions: Transaction[] = [];
-      for (let i = 0; i < 10; i++) {
-        manyTransactions.push({
-          transaction_id: `txn_${i}`,
-          amount: 100,
+    test('detects unrealistic negative amounts (income)', () => {
+      const result = tools.getDataQualityReport({
+        start_date: '2024-01-01',
+        end_date: '2024-01-31',
+      });
+
+      const unrealisticIncome = result.amount_issues.items.find(
+        (t) => t.transaction_id === 'unrealistic2'
+      );
+      expect(unrealisticIncome).toBeDefined();
+      expect(unrealisticIncome?.severity).toBe('unrealistic');
+    });
+
+    test('sorts transactions by amount (largest first)', () => {
+      const result = tools.getDataQualityReport({
+        start_date: '2024-01-01',
+        end_date: '2024-01-31',
+      });
+
+      const transactions = result.amount_issues.items;
+      if (transactions.length >= 2) {
+        for (let i = 0; i < transactions.length - 1; i++) {
+          expect(Math.abs(transactions[i].amount)).toBeGreaterThanOrEqual(
+            Math.abs(transactions[i + 1].amount)
+          );
+        }
+      }
+    });
+
+    test('includes amount issues in total issues count', () => {
+      const result = tools.getDataQualityReport({
+        start_date: '2024-01-01',
+        end_date: '2024-01-31',
+      });
+
+      expect(result.summary.issues_found).toBeGreaterThanOrEqual(result.amount_issues.total);
+    });
+
+    test('does not flag normal transactions as amount issues', () => {
+      const result = tools.getDataQualityReport({
+        start_date: '2024-01-01',
+        end_date: '2024-01-31',
+      });
+
+      const normalTxn = result.amount_issues.items.find(
+        (t) => t.transaction_id === 'normal1' || t.transaction_id === 'normal2'
+      );
+      expect(normalTxn).toBeUndefined();
+    });
+
+    test('respects issues_limit for amount issues', () => {
+      // Add many large transactions
+      const manyLargeTransactions: Transaction[] = [];
+      for (let i = 0; i < 30; i++) {
+        manyLargeTransactions.push({
+          transaction_id: `large_${i}`,
+          amount: 150000 + i * 10000,
           date: '2024-01-15',
-          name: `Merchant ${i}`,
-          category_id: 'food_dining',
+          name: `Large Transaction ${i}`,
+          category_id: 'other',
           account_id: 'acc1',
         });
       }
+      (db as any)._transactions = manyLargeTransactions;
 
-      (db as any)._transactions = manyTransactions;
+      const result = tools.getDataQualityReport({
+        start_date: '2024-01-01',
+        end_date: '2024-01-31',
+        issues_limit: 10,
+      });
 
-      // With limit of 5, should hit limit
-      const result = tools.getDataQualityReport({ transaction_limit: 5 });
-
-      expect(result.analysis_metadata.transaction_limit_reached).toBe(true);
-      expect(result.analysis_metadata.transactions_analyzed).toBe(5);
+      expect(result.amount_issues.items.length).toBeLessThanOrEqual(10);
+      expect(result.amount_issues.total).toBe(30);
+      expect(result.amount_issues.has_more).toBe(true);
     });
   });
 });

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -2206,10 +2206,10 @@ describe('New MCP Tools', () => {
           category_id: 'groceries',
           account_id: 'acc1',
         },
-        // Large transaction (over $1000)
+        // Large transaction (over $10,000 threshold)
         {
           transaction_id: 'big1',
-          amount: 1500.0,
+          amount: 15000.0,
           date: '2024-01-25',
           name: 'Electronics Store',
           category_id: 'shopping',
@@ -2229,13 +2229,13 @@ describe('New MCP Tools', () => {
       expect(result.transactions).toBeDefined();
     });
 
-    test('flags large transactions over $1000', () => {
+    test('flags large transactions over $10,000', () => {
       const result = tools.getUnusualTransactions({
         start_date: '2024-01-01',
         end_date: '2024-01-31',
       });
 
-      const largeTransaction = result.transactions.find((t) => t.amount === 1500.0);
+      const largeTransaction = result.transactions.find((t) => t.amount === 15000.0);
       expect(largeTransaction).toBeDefined();
       if (largeTransaction) {
         expect(largeTransaction.anomaly_reason).toContain('Large transaction');
@@ -2483,10 +2483,10 @@ describe('New MCP Tools', () => {
           category_id: 'food_dining',
           account_id: 'acc1',
         },
-        // New merchant with unusually high amount for category (>$1000 triggers large transaction flag)
+        // New merchant with unusually high amount for category (>$10,000 triggers large transaction flag)
         {
           transaction_id: 'cat5',
-          amount: 1500.0, // Way above category average and > $1000
+          amount: 15000.0, // Way above category average and > $10,000
           date: '2024-01-15',
           name: 'Fancy New Restaurant',
           category_id: 'food_dining',
@@ -2713,7 +2713,7 @@ describe('New MCP Tools', () => {
       });
 
       // Large transaction should have category_name
-      const largeTransaction = result.transactions.find((t) => t.amount === 1500.0);
+      const largeTransaction = result.transactions.find((t) => t.amount === 15000.0);
       expect(largeTransaction).toBeDefined();
       if (largeTransaction) {
         expect(largeTransaction.category_name).toBeDefined();
@@ -2807,7 +2807,7 @@ describe('New MCP Tools', () => {
       for (let i = 0; i < 100; i++) {
         manyAnomalies.push({
           transaction_id: `many${i}`,
-          amount: 1500.0 + i, // All large transactions
+          amount: 15000.0 + i, // All large transactions (>= $10,000 threshold)
           date: `2024-01-${String((i % 28) + 1).padStart(2, '0')}`,
           name: `Merchant ${i}`,
           category_id: 'shopping',
@@ -2950,7 +2950,7 @@ describe('New MCP Tools', () => {
       const noCategoryTransactions: Transaction[] = [
         {
           transaction_id: 'nocat1',
-          amount: 1500.0, // Large transaction
+          amount: 15000.0, // Large transaction (>= $10,000 threshold)
           date: '2024-01-15',
           name: 'Uncategorized Purchase',
           // No category_id
@@ -3205,9 +3205,7 @@ describe('New MCP Tools', () => {
       });
 
       expect(result.amount_issues.total).toBeGreaterThanOrEqual(1);
-      const extremeTxn = result.amount_issues.items.find(
-        (t) => t.transaction_id === 'extreme1'
-      );
+      const extremeTxn = result.amount_issues.items.find((t) => t.transaction_id === 'extreme1');
       expect(extremeTxn).toBeDefined();
       expect(extremeTxn?.severity).toBe('extremely_large');
       expect(extremeTxn?.reason).toContain('100,000');


### PR DESCRIPTION
- Add validation constants for amount thresholds:
  - LARGE_TRANSACTION_THRESHOLD ($10,000)
  - EXTREMELY_LARGE_THRESHOLD ($100,000)
  - UNREALISTIC_AMOUNT_THRESHOLD ($1,000,000)
  - MAX_VALID_AMOUNT ($10,000,000)

- Add amount_issues section to getDataQualityReport:
  - Detects extremely large transactions (>=$100K)
  - Flags unrealistic amounts (>=$1M) as data quality issues
  - Includes severity levels and descriptive reasons
  - Sorts by amount and limits to top 20

- Update getUnusualTransactions with tiered thresholds:
  - Large transactions (>=$10K)
  - Extremely large (>=$100K) with review recommendation
  - Unrealistic amounts (>=$1M) flagged as likely data errors

- Add comprehensive tests for all new functionality

Addresses PR #19: Upper Bounds Validation