### PR TITLE
Fix test fixtures using future dates

### DIFF
--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -15,7 +15,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn1',
     amount: 50.0,
-    date: '2026-01-15',
+    date: '2025-01-15',
     name: 'Coffee Shop',
     category_id: 'food_dining',
     account_id: 'acc1',
@@ -23,7 +23,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn2',
     amount: 120.5,
-    date: '2026-01-20',
+    date: '2025-01-20',
     name: 'Grocery Store',
     category_id: 'groceries',
     account_id: 'acc1',
@@ -31,7 +31,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn3',
     amount: 10.0,
-    date: '2026-01-15',
+    date: '2025-01-15',
     name: 'Parking',
     category_id: 'transportation',
     account_id: 'acc2',
@@ -39,7 +39,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn4',
     amount: 25.0,
-    date: '2026-01-18',
+    date: '2025-01-18',
     name: 'Fast Food',
     category_id: 'food_dining',
     account_id: 'acc1',
@@ -103,15 +103,15 @@ describe('CopilotMoneyServer E2E', () => {
 
     test('get_transactions with all filters', () => {
       const result = tools.getTransactions({
-        start_date: '2026-01-01',
-        end_date: '2026-01-31',
+        start_date: '2025-01-01',
+        end_date: '2025-01-31',
         min_amount: 5.0,
         max_amount: 100.0,
         limit: 20,
       });
 
       for (const txn of result.transactions) {
-        expect(txn.date >= '2026-01-01' && txn.date <= '2026-01-31').toBe(true);
+        expect(txn.date >= '2025-01-01' && txn.date <= '2025-01-31').toBe(true);
         expect(txn.amount >= 5.0 && txn.amount <= 100.0).toBe(true);
       }
     });
@@ -134,8 +134,8 @@ describe('CopilotMoneyServer E2E', () => {
 
     test('get_spending_by_category tool works', () => {
       const result = tools.getSpendingByCategory({
-        start_date: '2026-01-01',
-        end_date: '2026-01-31',
+        start_date: '2025-01-01',
+        end_date: '2025-01-31',
       });
 
       expect(result.period).toBeDefined();
@@ -170,8 +170,8 @@ describe('CopilotMoneyServer E2E', () => {
         {
           func: () =>
             tools.getSpendingByCategory({
-              start_date: '2026-01-01',
-              end_date: '2026-01-31',
+              start_date: '2025-01-01',
+              end_date: '2025-01-31',
             }),
         },
         { func: () => tools.getAccountBalance('acc1') },
@@ -189,8 +189,8 @@ describe('CopilotMoneyServer E2E', () => {
   describe('data accuracy', () => {
     test('spending aggregation is mathematically correct', () => {
       const result = tools.getSpendingByCategory({
-        start_date: '2026-01-01',
-        end_date: '2026-01-31',
+        start_date: '2025-01-01',
+        end_date: '2025-01-31',
       });
 
       const categoryTotal = result.categories.reduce((sum, cat) => sum + cat.total_spending, 0);
@@ -208,8 +208,8 @@ describe('CopilotMoneyServer E2E', () => {
 
     test('category transaction counts are accurate', () => {
       const result = tools.getSpendingByCategory({
-        start_date: '2026-01-01',
-        end_date: '2026-01-31',
+        start_date: '2025-01-01',
+        end_date: '2025-01-31',
       });
 
       for (const cat of result.categories) {
@@ -248,13 +248,13 @@ describe('CopilotMoneyServer E2E', () => {
   describe('boundary conditions', () => {
     test('single day date range works', () => {
       const result = tools.getTransactions({
-        start_date: '2026-01-15',
-        end_date: '2026-01-15',
+        start_date: '2025-01-15',
+        end_date: '2025-01-15',
         limit: 100,
       });
 
       for (const txn of result.transactions) {
-        expect(txn.date).toBe('2026-01-15');
+        expect(txn.date).toBe('2025-01-15');
       }
     });
 

--- a/tests/integration/database.test.ts
+++ b/tests/integration/database.test.ts
@@ -16,7 +16,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn1',
     amount: 50.0,
-    date: '2026-01-15',
+    date: '2025-01-15',
     name: 'Starbucks',
     category_id: 'food_dining',
     account_id: 'acc1',
@@ -24,7 +24,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn2',
     amount: 15.5,
-    date: '2026-01-10',
+    date: '2025-01-10',
     name: 'Starbucks Coffee',
     category_id: 'food_dining',
     account_id: 'acc1',
@@ -32,7 +32,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn3',
     amount: 120.0,
-    date: '2026-01-08',
+    date: '2025-01-08',
     name: 'Whole Foods',
     category_id: 'groceries',
     account_id: 'acc2',
@@ -40,7 +40,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn4',
     amount: 8.0,
-    date: '2026-01-05',
+    date: '2025-01-05',
     name: 'Starbucks',
     category_id: 'food_dining',
     account_id: 'acc1',
@@ -48,7 +48,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn5',
     amount: 250.0,
-    date: '2025-12-20',
+    date: '2024-12-20',
     name: 'Target',
     category_id: 'shopping',
     account_id: 'acc1',
@@ -107,12 +107,12 @@ describe('CopilotDatabase Integration', () => {
 
     test('filters transactions by date range', () => {
       const txns = db.getTransactions({
-        startDate: '2026-01-01',
-        endDate: '2026-01-10',
+        startDate: '2025-01-01',
+        endDate: '2025-01-10',
         limit: 1000,
       });
 
-      expect(txns.every((txn) => txn.date >= '2026-01-01' && txn.date <= '2026-01-10')).toBe(true);
+      expect(txns.every((txn) => txn.date >= '2025-01-01' && txn.date <= '2025-01-10')).toBe(true);
     });
 
     test('filters transactions by merchant name', () => {
@@ -161,15 +161,15 @@ describe('CopilotDatabase Integration', () => {
 
     test('combines multiple filters', () => {
       const txns = db.getTransactions({
-        startDate: '2026-01-01',
-        endDate: '2026-12-31',
+        startDate: '2025-01-01',
+        endDate: '2025-12-31',
         minAmount: 5.0,
         category: 'food',
         limit: 100,
       });
 
       for (const txn of txns) {
-        expect(txn.date >= '2026-01-01' && txn.date <= '2026-12-31').toBe(true);
+        expect(txn.date >= '2025-01-01' && txn.date <= '2025-12-31').toBe(true);
         expect(txn.amount >= 5.0).toBe(true);
         expect(txn.category_id && txn.category_id.toLowerCase().includes('food')).toBe(true);
       }

--- a/tests/integration/tools.test.ts
+++ b/tests/integration/tools.test.ts
@@ -14,7 +14,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn1',
     amount: 50.0,
-    date: '2026-01-15',
+    date: '2025-01-15',
     name: 'Starbucks',
     category_id: 'food_dining',
     account_id: 'acc1',
@@ -22,7 +22,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn2',
     amount: 15.5,
-    date: '2026-01-10',
+    date: '2025-01-10',
     name: 'Starbucks Coffee',
     category_id: 'food_dining',
     account_id: 'acc1',
@@ -30,7 +30,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn3',
     amount: 120.0,
-    date: '2026-01-08',
+    date: '2025-01-08',
     name: 'Whole Foods',
     category_id: 'groceries',
     account_id: 'acc2',
@@ -38,7 +38,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn4',
     amount: -1000.0, // Income
-    date: '2026-01-05',
+    date: '2025-01-05',
     name: 'Paycheck',
     category_id: 'income',
     account_id: 'acc1',
@@ -46,7 +46,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn5',
     amount: 250.0,
-    date: '2025-12-20',
+    date: '2024-12-20',
     name: 'Target',
     category_id: 'shopping',
     account_id: 'acc1',
@@ -100,13 +100,13 @@ describe('CopilotMoneyTools Integration', () => {
 
     test('filters by date range', () => {
       const result = tools.getTransactions({
-        start_date: '2026-01-01',
-        end_date: '2026-01-31',
+        start_date: '2025-01-01',
+        end_date: '2025-01-31',
         limit: 50,
       });
 
       for (const txn of result.transactions) {
-        expect(txn.date >= '2026-01-01' && txn.date <= '2026-01-31').toBe(true);
+        expect(txn.date >= '2025-01-01' && txn.date <= '2025-01-31').toBe(true);
       }
     });
 
@@ -206,8 +206,8 @@ describe('CopilotMoneyTools Integration', () => {
   describe('getSpendingByCategory', () => {
     test('aggregates spending by category', () => {
       const result = tools.getSpendingByCategory({
-        start_date: '2026-01-01',
-        end_date: '2026-01-31',
+        start_date: '2025-01-01',
+        end_date: '2025-01-31',
       });
 
       expect(result.period).toBeDefined();
@@ -215,14 +215,14 @@ describe('CopilotMoneyTools Integration', () => {
       expect(result.category_count).toBeDefined();
       expect(result.categories).toBeDefined();
 
-      expect(result.period.start_date).toBe('2026-01-01');
-      expect(result.period.end_date).toBe('2026-01-31');
+      expect(result.period.start_date).toBe('2025-01-01');
+      expect(result.period.end_date).toBe('2025-01-31');
     });
 
     test('categories are sorted by spending descending', () => {
       const result = tools.getSpendingByCategory({
-        start_date: '2026-01-01',
-        end_date: '2026-01-31',
+        start_date: '2025-01-01',
+        end_date: '2025-01-31',
       });
 
       const categories = result.categories;
@@ -233,8 +233,8 @@ describe('CopilotMoneyTools Integration', () => {
 
     test('excludes income (negative amounts)', () => {
       const result = tools.getSpendingByCategory({
-        start_date: '2026-01-01',
-        end_date: '2026-01-31',
+        start_date: '2025-01-01',
+        end_date: '2025-01-31',
       });
 
       // Should not include income category
@@ -244,8 +244,8 @@ describe('CopilotMoneyTools Integration', () => {
 
     test('total spending matches sum of categories', () => {
       const result = tools.getSpendingByCategory({
-        start_date: '2026-01-01',
-        end_date: '2026-01-31',
+        start_date: '2025-01-01',
+        end_date: '2025-01-31',
       });
 
       const calculatedTotal = result.categories.reduce((sum, cat) => sum + cat.total_spending, 0);
@@ -255,8 +255,8 @@ describe('CopilotMoneyTools Integration', () => {
 
     test('category structure is correct', () => {
       const result = tools.getSpendingByCategory({
-        start_date: '2026-01-01',
-        end_date: '2026-01-31',
+        start_date: '2025-01-01',
+        end_date: '2025-01-31',
       });
 
       if (result.categories.length > 0) {
@@ -377,8 +377,8 @@ describe('CopilotMoneyTools Integration', () => {
 
     test('spending responses are JSON serializable', () => {
       const result = tools.getSpendingByCategory({
-        start_date: '2026-01-01',
-        end_date: '2026-01-31',
+        start_date: '2025-01-01',
+        end_date: '2025-01-31',
       });
       const json = JSON.stringify(result);
       const parsed = JSON.parse(json);

--- a/tests/models/models.test.ts
+++ b/tests/models/models.test.ts
@@ -116,7 +116,7 @@ describe('Transaction model helpers', () => {
       const transaction: Transaction = {
         transaction_id: 'txn1',
         amount: 50,
-        date: '2026-01-15',
+        date: '2025-01-15',
         name: 'Starbucks',
         original_name: 'STARBUCKS #12345',
       };
@@ -128,7 +128,7 @@ describe('Transaction model helpers', () => {
       const transaction: Transaction = {
         transaction_id: 'txn1',
         amount: 50,
-        date: '2026-01-15',
+        date: '2025-01-15',
         original_name: 'STARBUCKS #12345',
       };
 
@@ -139,7 +139,7 @@ describe('Transaction model helpers', () => {
       const transaction: Transaction = {
         transaction_id: 'txn1',
         amount: 50,
-        date: '2026-01-15',
+        date: '2025-01-15',
       };
 
       expect(getTransactionDisplayName(transaction)).toBe('Unknown');
@@ -151,7 +151,7 @@ describe('Transaction model helpers', () => {
       const transaction: Transaction = {
         transaction_id: 'txn1',
         amount: 50,
-        date: '2026-01-15',
+        date: '2025-01-15',
         name: 'Starbucks',
       };
 
@@ -160,7 +160,7 @@ describe('Transaction model helpers', () => {
       expect(result.display_name).toBe('Starbucks');
       expect(result.transaction_id).toBe('txn1');
       expect(result.amount).toBe(50);
-      expect(result.date).toBe('2026-01-15');
+      expect(result.date).toBe('2025-01-15');
       expect(result.name).toBe('Starbucks');
     });
 
@@ -168,7 +168,7 @@ describe('Transaction model helpers', () => {
       const transaction: Transaction = {
         transaction_id: 'txn1',
         amount: 50,
-        date: '2026-01-15',
+        date: '2025-01-15',
         original_name: 'STARBUCKS #12345',
       };
 
@@ -182,7 +182,7 @@ describe('Transaction model helpers', () => {
       const transaction: Transaction = {
         transaction_id: 'txn1',
         amount: 50,
-        date: '2026-01-15',
+        date: '2025-01-15',
       };
 
       const result = withTransactionDisplayName(transaction);
@@ -194,7 +194,7 @@ describe('Transaction model helpers', () => {
       const transaction: Transaction = {
         transaction_id: 'txn1',
         amount: 50,
-        date: '2026-01-15',
+        date: '2025-01-15',
         name: 'Starbucks',
         category_id: 'food_dining',
         account_id: 'acc1',
@@ -206,7 +206,7 @@ describe('Transaction model helpers', () => {
 
       expect(result.transaction_id).toBe('txn1');
       expect(result.amount).toBe(50);
-      expect(result.date).toBe('2026-01-15');
+      expect(result.date).toBe('2025-01-15');
       expect(result.name).toBe('Starbucks');
       expect(result.category_id).toBe('food_dining');
       expect(result.account_id).toBe('acc1');

--- a/tests/unit/server-protocol.test.ts
+++ b/tests/unit/server-protocol.test.ts
@@ -16,7 +16,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn1',
     amount: 50.0,
-    date: '2026-01-15',
+    date: '2025-01-15',
     name: 'Coffee Shop',
     category_id: 'food_dining',
     account_id: 'acc1',
@@ -25,7 +25,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn2',
     amount: 120.5,
-    date: '2026-01-20',
+    date: '2025-01-20',
     name: 'Grocery Store',
     category_id: 'groceries',
     account_id: 'acc1',
@@ -34,7 +34,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn3',
     amount: 10.0,
-    date: '2025-12-15',
+    date: '2024-12-15',
     name: 'Parking',
     category_id: 'transportation',
     account_id: 'acc2',
@@ -42,7 +42,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn4',
     amount: -25.0, // Refund/Credit
-    date: '2026-01-18',
+    date: '2025-01-18',
     name: 'Refund - Fast Food',
     category_id: 'food_dining',
     account_id: 'acc1',
@@ -50,7 +50,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn5',
     amount: 100.0,
-    date: '2026-01-10',
+    date: '2025-01-10',
     name: 'Foreign Purchase',
     category_id: 'shopping',
     account_id: 'acc1',

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -13,7 +13,7 @@ const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn1',
     amount: 50.0,
-    date: '2026-01-15',
+    date: '2025-01-15',
     name: 'Test Transaction',
     category_id: 'food_dining',
     account_id: 'acc1',

--- a/tests/utils/date.test.ts
+++ b/tests/utils/date.test.ts
@@ -43,60 +43,60 @@ afterEach(() => {
 
 describe('parsePeriod', () => {
   test("parses 'this_month' period", () => {
-    setMockDate('2026-01-15T12:00:00Z');
+    setMockDate('2025-01-15T12:00:00Z');
     const [start, end] = parsePeriod('this_month');
-    expect(start).toBe('2026-01-01');
-    expect(end).toBe('2026-01-31');
+    expect(start).toBe('2025-01-01');
+    expect(end).toBe('2025-01-31');
   });
 
   test("parses 'last_month' period", () => {
-    setMockDate('2026-01-15T12:00:00Z');
+    setMockDate('2025-01-15T12:00:00Z');
     const [start, end] = parsePeriod('last_month');
-    expect(start).toBe('2025-12-01');
-    expect(end).toBe('2025-12-31');
+    expect(start).toBe('2024-12-01');
+    expect(end).toBe('2024-12-31');
   });
 
   test("parses 'this_year' period", () => {
-    setMockDate('2026-01-15T12:00:00Z');
+    setMockDate('2025-01-15T12:00:00Z');
     const [start, end] = parsePeriod('this_year');
-    expect(start).toBe('2026-01-01');
-    expect(end).toBe('2026-12-31');
-  });
-
-  test("parses 'last_year' period", () => {
-    setMockDate('2026-01-15T12:00:00Z');
-    const [start, end] = parsePeriod('last_year');
     expect(start).toBe('2025-01-01');
     expect(end).toBe('2025-12-31');
   });
 
+  test("parses 'last_year' period", () => {
+    setMockDate('2025-01-15T12:00:00Z');
+    const [start, end] = parsePeriod('last_year');
+    expect(start).toBe('2024-01-01');
+    expect(end).toBe('2024-12-31');
+  });
+
   test("parses 'last_7_days' period", () => {
-    setMockDate('2026-01-15T12:00:00Z');
+    setMockDate('2025-01-15T12:00:00Z');
     const [start, end] = parsePeriod('last_7_days');
     // Should be 7 days ago to today
-    expect(start).toBe('2026-01-08');
-    expect(end).toBe('2026-01-15');
+    expect(start).toBe('2025-01-08');
+    expect(end).toBe('2025-01-15');
   });
 
   test("parses 'last_30_days' period", () => {
-    setMockDate('2026-01-15T12:00:00Z');
+    setMockDate('2025-01-15T12:00:00Z');
     const [start, end] = parsePeriod('last_30_days');
-    expect(start).toBe('2025-12-16');
-    expect(end).toBe('2026-01-15');
+    expect(start).toBe('2024-12-16');
+    expect(end).toBe('2025-01-15');
   });
 
   test("parses 'last_90_days' period", () => {
-    setMockDate('2026-01-15T12:00:00Z');
+    setMockDate('2025-01-15T12:00:00Z');
     const [start, end] = parsePeriod('last_90_days');
-    expect(start).toBe('2025-10-17');
-    expect(end).toBe('2026-01-15');
+    expect(start).toBe('2024-10-17');
+    expect(end).toBe('2025-01-15');
   });
 
   test("parses 'ytd' (year to date) period", () => {
-    setMockDate('2026-01-15T12:00:00Z');
+    setMockDate('2025-01-15T12:00:00Z');
     const [start, end] = parsePeriod('ytd');
-    expect(start).toBe('2026-01-01');
-    expect(end).toBe('2026-01-15');
+    expect(start).toBe('2025-01-01');
+    expect(end).toBe('2025-01-15');
   });
 
   test('throws error for invalid period', () => {
@@ -104,32 +104,32 @@ describe('parsePeriod', () => {
   });
 
   test('parses last_month when current month is February', () => {
-    setMockDate('2026-02-15T12:00:00Z');
+    setMockDate('2025-02-15T12:00:00Z');
     const [start, end] = parsePeriod('last_month');
-    expect(start).toBe('2026-01-01');
-    expect(end).toBe('2026-01-31');
+    expect(start).toBe('2025-01-01');
+    expect(end).toBe('2025-01-31');
   });
 
   test('parses last_month when current month is March', () => {
-    setMockDate('2026-03-15T12:00:00Z');
+    setMockDate('2025-03-15T12:00:00Z');
     const [start, end] = parsePeriod('last_month');
-    // February 2026 (not a leap year)
-    expect(start).toBe('2026-02-01');
-    expect(end).toBe('2026-02-28');
+    // February 2025 (not a leap year)
+    expect(start).toBe('2025-02-01');
+    expect(end).toBe('2025-02-28');
   });
 });
 
 describe('getMonthRange', () => {
   test('gets range for January', () => {
-    const [start, end] = getMonthRange(2026, 1);
-    expect(start).toBe('2026-01-01');
-    expect(end).toBe('2026-01-31');
+    const [start, end] = getMonthRange(2025, 1);
+    expect(start).toBe('2025-01-01');
+    expect(end).toBe('2025-01-31');
   });
 
   test('gets range for February in non-leap year', () => {
-    const [start, end] = getMonthRange(2026, 2);
-    expect(start).toBe('2026-02-01');
-    expect(end).toBe('2026-02-28');
+    const [start, end] = getMonthRange(2025, 2);
+    expect(start).toBe('2025-02-01');
+    expect(end).toBe('2025-02-28');
   });
 
   test('gets range for February in leap year', () => {
@@ -139,22 +139,22 @@ describe('getMonthRange', () => {
   });
 
   test('gets range for December', () => {
-    const [start, end] = getMonthRange(2026, 12);
-    expect(start).toBe('2026-12-01');
-    expect(end).toBe('2026-12-31');
+    const [start, end] = getMonthRange(2025, 12);
+    expect(start).toBe('2025-12-01');
+    expect(end).toBe('2025-12-31');
   });
 
   test('gets range for April (30 days)', () => {
-    const [start, end] = getMonthRange(2026, 4);
-    expect(start).toBe('2026-04-01');
-    expect(end).toBe('2026-04-30');
+    const [start, end] = getMonthRange(2025, 4);
+    expect(start).toBe('2025-04-01');
+    expect(end).toBe('2025-04-30');
   });
 
   test('throws error for invalid month (13)', () => {
-    expect(() => getMonthRange(2026, 13)).toThrow();
+    expect(() => getMonthRange(2025, 13)).toThrow();
   });
 
   test('throws error for invalid month (0)', () => {
-    expect(() => getMonthRange(2026, 0)).toThrow();
+    expect(() => getMonthRange(2025, 0)).toThrow();
   });
 });


### PR DESCRIPTION
Changed all test mock data and assertions from 2026 dates to 2025 dates to ensure test data uses historical/past dates rather than future dates.

Files updated:
- tests/utils/date.test.ts: Mock dates and expected values
- tests/integration/tools.test.ts: Transaction dates and date ranges
- tests/integration/database.test.ts: Transaction dates and date ranges
- tests/unit/server-protocol.test.ts: Transaction dates
- tests/e2e/server.test.ts: Transaction dates and date ranges
- tests/models/models.test.ts: Transaction dates
- tests/unit/server.test.ts: Transaction dates