### PR TITLE
Add coverage tests for model edge cases

### DIFF
--- a/tests/unit/category-full.test.ts
+++ b/tests/unit/category-full.test.ts
@@ -172,6 +172,21 @@ describe('isCategoryType', () => {
     // Unknown categories default to expense check
     expect(isCategoryType('unknown_expense', 'expense')).toBe(true);
   });
+
+  test('handles unknown income category with fallback', () => {
+    // Unknown category starting with 'income' should be considered income
+    expect(isCategoryType('income_unknown_source', 'income')).toBe(true);
+    // The fallback logic only checks prefix when matching that specific type
+    // For expense check on unknown categories, it defaults to true
+    expect(isCategoryType('non_income_unknown', 'income')).toBe(false);
+  });
+
+  test('handles unknown transfer category with fallback', () => {
+    // Unknown category starting with 'transfer' should be considered transfer
+    expect(isCategoryType('transfer_unknown_type', 'transfer')).toBe(true);
+    // Unknown categories default to expense if not income/transfer prefix match
+    expect(isCategoryType('some_random_category', 'expense')).toBe(true);
+  });
 });
 
 describe('getAllCategories', () => {

--- a/tests/unit/goal-history.test.ts
+++ b/tests/unit/goal-history.test.ts
@@ -198,6 +198,16 @@ describe('getLatestDailySnapshot', () => {
 
     expect(getLatestDailySnapshot(history)).toBeUndefined();
   });
+
+  test('returns undefined when daily_data is empty object', () => {
+    const history: GoalHistory = {
+      month: '2024-01',
+      goal_id: 'goal_123',
+      daily_data: {},
+    };
+
+    expect(getLatestDailySnapshot(history)).toBeUndefined();
+  });
 });
 
 describe('getMonthStartEnd', () => {
@@ -246,6 +256,42 @@ describe('getMonthStartEnd', () => {
     expect(result.end_amount).toBe(500.0);
     expect(result.change_amount).toBe(500.0);
     expect(result.change_percent).toBeUndefined(); // Can't calculate percent from 0
+  });
+
+  test('returns partial data when start amount is undefined', () => {
+    const history: GoalHistory = {
+      month: '2024-01',
+      goal_id: 'goal_123',
+      daily_data: {
+        '2024-01-01': {}, // No amount
+        '2024-01-31': { amount: 500.0 },
+      },
+    };
+
+    const result = getMonthStartEnd(history);
+
+    expect(result.start_amount).toBeUndefined();
+    expect(result.end_amount).toBe(500.0);
+    expect(result.change_amount).toBeUndefined();
+    expect(result.change_percent).toBeUndefined();
+  });
+
+  test('returns partial data when end amount is undefined', () => {
+    const history: GoalHistory = {
+      month: '2024-01',
+      goal_id: 'goal_123',
+      daily_data: {
+        '2024-01-01': { amount: 100.0 },
+        '2024-01-31': {}, // No amount
+      },
+    };
+
+    const result = getMonthStartEnd(history);
+
+    expect(result.start_amount).toBe(100.0);
+    expect(result.end_amount).toBeUndefined();
+    expect(result.change_amount).toBeUndefined();
+    expect(result.change_percent).toBeUndefined();
   });
 });
 

--- a/tests/unit/item.test.ts
+++ b/tests/unit/item.test.ts
@@ -315,6 +315,26 @@ describe('getItemStatusDescription', () => {
 
     expect(getItemStatusDescription(item)).toBe('Update required');
   });
+
+  test('returns Institution not responding for INSTITUTION_NOT_RESPONDING error', () => {
+    const item: Item = {
+      item_id: 'item_1',
+      error_code: 'INSTITUTION_NOT_RESPONDING',
+    };
+
+    expect(getItemStatusDescription(item)).toBe('Institution not responding');
+  });
+
+  test('returns Update required for needs_update without error codes', () => {
+    const item: Item = {
+      item_id: 'item_1',
+      connection_status: 'active',
+      needs_update: true,
+      error_code: 'ITEM_NO_ERROR', // No actionable error
+    };
+
+    expect(getItemStatusDescription(item)).toBe('Update required');
+  });
 });
 
 describe('getItemAccountCount', () => {


### PR DESCRIPTION
## Summary
- Add tests for `goal-history.ts`: empty daily_data and partial amounts in getMonthStartEnd
- Add tests for `item.ts`: INSTITUTION_NOT_RESPONDING error code  
- Add tests for `category-full.ts`: unknown income/transfer category fallbacks

Coverage improved from 99.04% to 99.35% lines.

## Test plan
- [x] All 981 tests pass
- [x] Typecheck passes
- [x] Lint passes
- [x] Format check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)