### PR TITLE
Fix category name resolution to use user-defined categories

### DIFF
--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -117,6 +117,7 @@ export class CopilotDatabase {
   private _budgets: Budget[] | null = null;
   private _goals: Goal[] | null = null;
   private _userCategories: Category[] | null = null;
+  private _categoryNameMap: Map<string, string> | null = null;
 
   /**
    * Initialize database connection.
@@ -450,10 +451,16 @@ export class CopilotDatabase {
    * Build a map of category ID to category name from user-defined categories.
    *
    * This map can be used for efficient category name lookups.
+   * The map is cached after the first call.
    *
    * @returns Map from category_id to category name
    */
   getCategoryNameMap(): Map<string, string> {
+    // Return cached map if available
+    if (this._categoryNameMap !== null) {
+      return this._categoryNameMap;
+    }
+
     const userCategories = this.getUserCategories();
     const nameMap = new Map<string, string>();
 
@@ -463,6 +470,7 @@ export class CopilotDatabase {
       }
     }
 
+    this._categoryNameMap = nameMap;
     return nameMap;
   }
 

--- a/src/models/category.ts
+++ b/src/models/category.ts
@@ -1,25 +1,59 @@
 /**
  * Category model for Copilot Money data.
  *
- * Categories can be hierarchical with parent-child relationships.
+ * Represents user-defined categories stored in Copilot's
+ * /users/{user_id}/categories/ Firestore collection.
+ *
+ * These are custom categories created by users in the Copilot Money app,
+ * distinct from the standard Plaid category taxonomy.
  */
 
 import { z } from 'zod';
 
 /**
  * Category schema with validation.
+ *
+ * Categories have a hierarchical structure with parent_category_id
+ * for nested organization.
  */
 export const CategorySchema = z
   .object({
     // Required fields
     category_id: z.string(),
-    name: z.string(),
 
-    // Optional fields
-    parent_category_id: z.string().optional(),
-    icon: z.string().optional(),
+    // Display information
+    name: z.string().optional(),
+    emoji: z.string().optional(),
     color: z.string().optional(),
+    bg_color: z.string().optional(),
+
+    // Hierarchy
+    parent_category_id: z.string().optional(),
+    children_category_ids: z.array(z.string()).optional(),
+    order: z.number().optional(),
+
+    // Behavior flags
+    excluded: z.boolean().optional(),
+    is_other: z.boolean().optional(),
+    auto_budget_lock: z.boolean().optional(),
+    auto_delete_lock: z.boolean().optional(),
+
+    // Plaid mapping - links custom categories to standard Plaid categories
+    plaid_category_ids: z.array(z.string()).optional(),
+
+    // Rules for auto-categorization
+    partial_name_rules: z.array(z.string()).optional(),
+
+    // Metadata
+    user_id: z.string().optional(),
   })
   .strict();
 
 export type Category = z.infer<typeof CategorySchema>;
+
+/**
+ * Get the best display name for a category.
+ */
+export function getCategoryDisplayName(category: Category): string {
+  return category.name ?? category.category_id;
+}

--- a/src/utils/categories.ts
+++ b/src/utils/categories.ts
@@ -910,11 +910,22 @@ export const INCOME_CATEGORIES = new Set([
 /**
  * Get the human-readable name for a category ID.
  *
- * @param categoryId - The category ID (e.g., "13005000", "food_dining")
+ * @param categoryId - The category ID (e.g., "13005000", "food_dining", or user-defined IDs)
+ * @param userCategoryMap - Optional map of user-defined category IDs to names.
+ *                          Pass this to resolve custom Copilot Money categories.
  * @returns Human-readable category name, or the original ID if not found
  */
-export function getCategoryName(categoryId: string): string {
-  // Check exact match first
+export function getCategoryName(categoryId: string, userCategoryMap?: Map<string, string>): string {
+  // First, check user-defined categories (highest priority)
+  // These are custom categories created by the user in Copilot Money
+  if (userCategoryMap) {
+    const userName = userCategoryMap.get(categoryId);
+    if (userName) {
+      return userName;
+    }
+  }
+
+  // Check exact match in static Plaid categories
   if (CATEGORY_NAMES[categoryId]) {
     return CATEGORY_NAMES[categoryId];
   }


### PR DESCRIPTION
## Summary
- Adds `decodeCategories()` function to read custom categories from Firestore (`/users/{user_id}/categories/{category_id}`)
- Updates all MCP tools to resolve category names from user-defined categories first, then fall back to static Plaid mapping
- Fixes issue where category IDs like `PXcWCjDFOqP6K0wJazhZ` displayed instead of names like "Restaurants" or "Hotels"

## Problem
The MCP server was only using a static mapping of ~800 Plaid categories to resolve category names. When users create custom categories in Copilot Money (which are stored in Firestore with auto-generated IDs), those categories would display as raw IDs instead of their human-readable names.

Example before:
```json
{
  "category_id": "5Qqr8qs3GHNCj8H6fIKd",
  "category_name": "5Qqr8qs3GHNCj8H6fIKd"
}
```

Example after:
```json
{
  "category_id": "5Qqr8qs3GHNCj8H6fIKd", 
  "category_name": "Restaurants"
}
```

## Changes
1. **`src/models/category.ts`** - Extended schema to include all Firestore fields (emoji, colors, hierarchy, flags)
2. **`src/core/decoder.ts`** - Added `decodeCategories()` to decode categories from LevelDB
3. **`src/core/database.ts`** - Added `getUserCategories()` and `getCategoryNameMap()` methods
4. **`src/utils/categories.ts`** - Updated `getCategoryName()` to accept optional user category map
5. **`src/tools/tools.ts`** - Added `resolveCategoryName()` method that uses user categories first
6. **`tests/core/decoder.test.ts`** - Added 10 tests for category decoding

## Test plan
- [x] All 984 tests pass
- [x] Typecheck passes
- [x] Lint passes (only pre-existing warnings)
- [ ] Manual testing with real Copilot Money data to verify category names display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)