### PR TITLE
Add batch loading for 8x performance improvement and 3 new MCP tools

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -139,6 +139,18 @@
     {
       "name": "get_year_over_year",
       "description": "Compare spending and income year-over-year."
+    },
+    {
+      "name": "get_net_worth",
+      "description": "Calculate total net worth from all accounts (assets - liabilities)."
+    },
+    {
+      "name": "get_savings_rate",
+      "description": "Calculate savings rate (income - spending) / income for a period."
+    },
+    {
+      "name": "get_cash_flow",
+      "description": "Analyze cash flow showing money in vs money out for a period."
     }
   ],
   "tools_generated": false,

--- a/scripts/profile-database.ts
+++ b/scripts/profile-database.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env bun
+/**
+ * Profile database loading performance.
+ *
+ * Usage: RUN_REAL_DB_TESTS=1 bun run scripts/profile-database.ts
+ */
+
+import { existsSync, readdirSync, statSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { CopilotDatabase } from '../src/core/database.js';
+
+function findRealDatabase(): string | undefined {
+  const home = homedir();
+  const containerBase = join(
+    home,
+    'Library/Containers/com.copilot.production/Data/Library/Application Support'
+  );
+
+  if (!existsSync(containerBase)) return undefined;
+
+  const firestorePath = join(containerBase, 'firestore/__FIRAPP_DEFAULT');
+  if (!existsSync(firestorePath)) return undefined;
+
+  const entries = readdirSync(firestorePath, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.isDirectory() && entry.name.startsWith('copilot-')) {
+      const mainPath = join(firestorePath, entry.name, 'main');
+      if (existsSync(mainPath)) {
+        return mainPath;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function getDatabaseSize(dbPath: string): number {
+  let totalSize = 0;
+  const files = readdirSync(dbPath);
+  for (const file of files) {
+    const filePath = join(dbPath, file);
+    const stat = statSync(filePath);
+    if (stat.isFile()) {
+      totalSize += stat.size;
+    }
+  }
+  return totalSize;
+}
+
+async function profile() {
+  if (process.env.RUN_REAL_DB_TESTS !== '1') {
+    console.log('Set RUN_REAL_DB_TESTS=1 to run this script');
+    process.exit(1);
+  }
+
+  const dbPath = findRealDatabase();
+  if (!dbPath) {
+    console.log('No real database found');
+    process.exit(1);
+  }
+
+  const dbSize = getDatabaseSize(dbPath);
+  console.log(`\n📂 Database: ${dbPath}`);
+  console.log(`📊 Size: ${(dbSize / 1024 / 1024).toFixed(2)} MB\n`);
+
+  const timings: Record<string, number> = {};
+
+  // Initialize database
+  console.log('⏳ Initializing database...');
+  let start = performance.now();
+  const db = new CopilotDatabase(dbPath);
+  timings['init'] = performance.now() - start;
+  console.log(`   Init: ${timings['init'].toFixed(0)}ms`);
+
+  // Load each entity type and time it
+  const entityLoaders = [
+    { name: 'transactions', loader: () => db.getAllTransactions() },
+    { name: 'accounts', loader: () => db.getAccounts() },
+    { name: 'recurring', loader: () => db.getRecurring() },
+    { name: 'budgets', loader: () => db.getBudgets() },
+    { name: 'goals', loader: () => db.getGoals() },
+    { name: 'goalHistory', loader: () => db.getGoalHistory() },
+    { name: 'investmentPrices', loader: () => db.getInvestmentPrices() },
+    { name: 'investmentSplits', loader: () => db.getInvestmentSplits() },
+    { name: 'items', loader: () => db.getItems() },
+    { name: 'userCategories', loader: () => db.getUserCategories() },
+    { name: 'userAccounts', loader: () => db.getUserAccounts() },
+  ];
+
+  console.log('\n⏳ Loading entities...');
+  const counts: Record<string, number> = {};
+
+  for (const { name, loader } of entityLoaders) {
+    start = performance.now();
+    const result = await loader();
+    timings[name] = performance.now() - start;
+    counts[name] = Array.isArray(result) ? result.length : 0;
+    console.log(
+      `   ${name}: ${timings[name].toFixed(0)}ms (${counts[name].toLocaleString()} items)`
+    );
+  }
+
+  // Summary
+  const totalTime = Object.values(timings).reduce((a, b) => a + b, 0);
+  const totalItems = Object.values(counts).reduce((a, b) => a + b, 0);
+
+  console.log('\n📈 Summary:');
+  console.log(`   Total time: ${(totalTime / 1000).toFixed(2)}s`);
+  console.log(`   Total items: ${totalItems.toLocaleString()}`);
+  console.log(`   Throughput: ${((dbSize / 1024 / 1024) / (totalTime / 1000)).toFixed(2)} MB/s`);
+
+  // Find slowest operations
+  const sorted = Object.entries(timings).sort(([, a], [, b]) => b - a);
+  console.log('\n🐌 Slowest operations:');
+  for (const [name, time] of sorted.slice(0, 5)) {
+    const pct = ((time / totalTime) * 100).toFixed(1);
+    console.log(`   ${name}: ${time.toFixed(0)}ms (${pct}%)`);
+  }
+}
+
+profile().catch(console.error);

--- a/src/server.ts
+++ b/src/server.ts
@@ -302,6 +302,24 @@ export class CopilotMoneyServer {
           );
           break;
 
+        case 'get_net_worth':
+          result = await this.tools.getNetWorth(
+            (typedArgs as Parameters<typeof this.tools.getNetWorth>[0]) || {}
+          );
+          break;
+
+        case 'get_savings_rate':
+          result = await this.tools.getSavingsRate(
+            (typedArgs as Parameters<typeof this.tools.getSavingsRate>[0]) || {}
+          );
+          break;
+
+        case 'get_cash_flow':
+          result = await this.tools.getCashFlow(
+            (typedArgs as Parameters<typeof this.tools.getCashFlow>[0]) || {}
+          );
+          break;
+
         default:
           return {
             content: [

--- a/tests/core/decoder-coverage.test.ts
+++ b/tests/core/decoder-coverage.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Additional tests for decoder.ts to achieve 100% code coverage.
+ */
+
+import { describe, test, expect, afterEach, beforeEach } from 'bun:test';
+import {
+  extractValue,
+  decodeInvestmentPrices,
+  decodeUserAccounts,
+  decodeItems,
+  decodeInvestmentSplits,
+} from '../../src/core/decoder.js';
+import { createTestDatabase, cleanupAllTempDatabases } from '../../src/core/leveldb-reader.js';
+import type { FirestoreValue } from '../../src/core/protobuf-parser.js';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const FIXTURES_DIR = path.join(__dirname, '../fixtures/decoder-coverage-tests');
+
+afterEach(() => {
+  cleanupAllTempDatabases();
+  if (fs.existsSync(FIXTURES_DIR)) {
+    fs.rmSync(FIXTURES_DIR, { recursive: true, force: true });
+  }
+});
+
+beforeEach(() => {
+  fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+});
+
+describe('decoder coverage', () => {
+  describe('extractValue', () => {
+    test('extracts string value', () => {
+      const value: FirestoreValue = { type: 'string', value: 'hello' };
+      expect(extractValue(value)).toBe('hello');
+    });
+
+    test('extracts integer value', () => {
+      const value: FirestoreValue = { type: 'integer', value: 42 };
+      expect(extractValue(value)).toBe(42);
+    });
+
+    test('extracts double value', () => {
+      const value: FirestoreValue = { type: 'double', value: 3.14 };
+      expect(extractValue(value)).toBe(3.14);
+    });
+
+    test('extracts boolean value', () => {
+      const value: FirestoreValue = { type: 'boolean', value: true };
+      expect(extractValue(value)).toBe(true);
+    });
+
+    test('extracts reference value', () => {
+      const value: FirestoreValue = { type: 'reference', value: 'projects/test/doc' };
+      expect(extractValue(value)).toBe('projects/test/doc');
+    });
+
+    test('extracts null value', () => {
+      const value: FirestoreValue = { type: 'null', value: null };
+      expect(extractValue(value)).toBeNull();
+    });
+
+    test('extracts timestamp value as date string', () => {
+      // January 15, 2024
+      const value: FirestoreValue = { type: 'timestamp', value: { seconds: 1705276800, nanos: 0 } };
+      const result = extractValue(value);
+      expect(result).toBe('2024-01-15');
+    });
+
+    test('extracts geopoint value', () => {
+      const value: FirestoreValue = {
+        type: 'geopoint',
+        value: { latitude: 40.7128, longitude: -74.006 },
+      };
+      expect(extractValue(value)).toEqual({ lat: 40.7128, lon: -74.006 });
+    });
+
+    test('extracts map value', () => {
+      const innerMap = new Map<string, FirestoreValue>([
+        ['name', { type: 'string', value: 'Test' }],
+      ]);
+      const value: FirestoreValue = { type: 'map', value: innerMap };
+      expect(extractValue(value)).toEqual({ name: 'Test' });
+    });
+
+    test('extracts array value', () => {
+      const arr: FirestoreValue[] = [
+        { type: 'integer', value: 1 },
+        { type: 'string', value: 'two' },
+      ];
+      const value: FirestoreValue = { type: 'array', value: arr };
+      expect(extractValue(value)).toEqual([1, 'two']);
+    });
+
+    test('extracts bytes value', () => {
+      const buf = Buffer.from([1, 2, 3]);
+      const value: FirestoreValue = { type: 'bytes', value: buf };
+      expect(extractValue(value)).toEqual(buf);
+    });
+
+    test('returns undefined for undefined input', () => {
+      expect(extractValue(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('decodeInvestmentPrices', () => {
+    test('decodes investment prices from database', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'investment-prices-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'investment_prices',
+          id: 'price1',
+          fields: {
+            investment_id: 'inv1',
+            ticker_symbol: 'AAPL',
+            price: 150.5,
+            close_price: 149.0,
+            date: '2024-01-15',
+            currency: 'USD',
+            high: 152.0,
+            low: 148.0,
+            open: 149.5,
+            volume: 1000000,
+          },
+        },
+        {
+          collection: 'investment_prices',
+          id: 'price2',
+          fields: {
+            investment_id: 'inv2',
+            ticker_symbol: 'GOOGL',
+            current_price: 140.0,
+            month: '2024-01',
+          },
+        },
+      ]);
+
+      const prices = await decodeInvestmentPrices(dbPath);
+
+      expect(prices.length).toBeGreaterThan(0);
+    });
+
+    test('filters by ticker symbol', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'investment-prices-filter-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'investment_prices',
+          id: 'price1',
+          fields: {
+            investment_id: 'inv1',
+            ticker_symbol: 'AAPL',
+            price: 150.0,
+            date: '2024-01-15',
+          },
+        },
+        {
+          collection: 'investment_prices',
+          id: 'price2',
+          fields: {
+            investment_id: 'inv2',
+            ticker_symbol: 'GOOGL',
+            price: 140.0,
+            date: '2024-01-15',
+          },
+        },
+      ]);
+
+      const prices = await decodeInvestmentPrices(dbPath, { tickerSymbol: 'AAPL' });
+
+      expect(prices.every((p) => p.ticker_symbol === 'AAPL')).toBe(true);
+    });
+
+    test('filters by date range', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'investment-prices-date-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'investment_prices',
+          id: 'price1',
+          fields: {
+            investment_id: 'inv1',
+            price: 150.0,
+            date: '2024-01-10',
+          },
+        },
+        {
+          collection: 'investment_prices',
+          id: 'price2',
+          fields: {
+            investment_id: 'inv2',
+            price: 155.0,
+            date: '2024-01-20',
+          },
+        },
+        {
+          collection: 'investment_prices',
+          id: 'price3',
+          fields: {
+            investment_id: 'inv3',
+            price: 160.0,
+            date: '2024-01-30',
+          },
+        },
+      ]);
+
+      const prices = await decodeInvestmentPrices(dbPath, {
+        startDate: '2024-01-15',
+        endDate: '2024-01-25',
+      });
+
+      expect(prices.every((p) => p.date! >= '2024-01-15' && p.date! <= '2024-01-25')).toBe(true);
+    });
+
+    test('returns empty array for empty database', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'empty-prices-db');
+      await createTestDatabase(dbPath, []);
+
+      const prices = await decodeInvestmentPrices(dbPath);
+
+      expect(prices).toEqual([]);
+    });
+  });
+
+  describe('decodeUserAccounts', () => {
+    test('decodes user account customizations', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'user-accounts-db');
+      // User accounts are in subcollection: users/{user_id}/accounts
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'users/user123/accounts',
+          id: 'acc1',
+          fields: {
+            account_id: 'acc1',
+            name: 'My Checking',
+            hidden: false,
+            order: 1,
+          },
+        },
+        {
+          collection: 'users/user123/accounts',
+          id: 'acc2',
+          fields: {
+            account_id: 'acc2',
+            name: 'My Savings',
+            hidden: true,
+            order: 2,
+          },
+        },
+      ]);
+
+      const userAccounts = await decodeUserAccounts(dbPath);
+
+      expect(userAccounts.length).toBe(2);
+      expect(userAccounts[0]?.name).toBe('My Checking');
+      expect(userAccounts[0]?.user_id).toBe('user123');
+    });
+
+    test('skips user accounts without name', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'user-accounts-no-name-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'users/user123/accounts',
+          id: 'acc1',
+          fields: {
+            account_id: 'acc1',
+            // No name - should be skipped
+            hidden: false,
+          },
+        },
+        {
+          collection: 'users/user123/accounts',
+          id: 'acc2',
+          fields: {
+            account_id: 'acc2',
+            name: 'Valid Account',
+          },
+        },
+      ]);
+
+      const userAccounts = await decodeUserAccounts(dbPath);
+
+      expect(userAccounts.length).toBe(1);
+      expect(userAccounts[0]?.name).toBe('Valid Account');
+    });
+
+    test('skips non-user-account collections', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'mixed-collections-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'accounts', // Not a user subcollection
+          id: 'acc1',
+          fields: {
+            account_id: 'acc1',
+            name: 'Regular Account',
+          },
+        },
+        {
+          collection: 'users/user123/accounts',
+          id: 'acc2',
+          fields: {
+            account_id: 'acc2',
+            name: 'User Account',
+          },
+        },
+      ]);
+
+      const userAccounts = await decodeUserAccounts(dbPath);
+
+      expect(userAccounts.length).toBe(1);
+      expect(userAccounts[0]?.name).toBe('User Account');
+    });
+
+    test('deduplicates user accounts by account_id', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'duplicate-user-accounts-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'users/user1/accounts',
+          id: 'acc1',
+          fields: {
+            account_id: 'acc1',
+            name: 'First Name',
+          },
+        },
+        {
+          collection: 'users/user2/accounts',
+          id: 'acc1',
+          fields: {
+            account_id: 'acc1',
+            name: 'Second Name',
+          },
+        },
+      ]);
+
+      const userAccounts = await decodeUserAccounts(dbPath);
+
+      // Should deduplicate by account_id
+      expect(userAccounts.length).toBe(1);
+    });
+  });
+
+  describe('decodeItems', () => {
+    test('decodes items with all fields', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'items-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'items',
+          id: 'item1',
+          fields: {
+            item_id: 'item1',
+            institution_name: 'Test Bank',
+            institution_id: 'ins_123',
+            connection_status: 'connected',
+            needs_update: false,
+            error_code: null,
+            error_message: null,
+            last_successful_update: '2024-01-15T10:00:00Z',
+            consent_expiration_time: '2025-01-15T10:00:00Z',
+          },
+        },
+      ]);
+
+      const items = await decodeItems(dbPath);
+
+      expect(items.length).toBe(1);
+      expect(items[0]?.item_id).toBe('item1');
+      expect(items[0]?.institution_name).toBe('Test Bank');
+    });
+
+    test('handles items with error state', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'items-error-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'items',
+          id: 'item1',
+          fields: {
+            item_id: 'item1',
+            institution_name: 'Test Bank',
+            connection_status: 'disconnected',
+            needs_update: true,
+            error_code: 'ITEM_LOGIN_REQUIRED',
+            error_message: 'Please re-authenticate',
+          },
+        },
+      ]);
+
+      const items = await decodeItems(dbPath);
+
+      expect(items.length).toBe(1);
+      expect(items[0]?.error_code).toBe('ITEM_LOGIN_REQUIRED');
+    });
+  });
+
+  describe('decodeInvestmentSplits', () => {
+    test('decodes investment splits', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'splits-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'investment_splits',
+          id: 'split1',
+          fields: {
+            split_id: 'split1',
+            ticker_symbol: 'AAPL',
+            split_date: '2024-01-15',
+            split_ratio: '4:1',
+            from_factor: 1,
+            to_factor: 4,
+            announcement_date: '2024-01-01',
+            record_date: '2024-01-14',
+            ex_date: '2024-01-15',
+            description: '4-for-1 stock split',
+          },
+        },
+      ]);
+
+      const splits = await decodeInvestmentSplits(dbPath);
+
+      expect(splits.length).toBe(1);
+      expect(splits[0]?.ticker_symbol).toBe('AAPL');
+      expect(splits[0]?.split_ratio).toBe('4:1');
+    });
+
+    test('filters splits by ticker symbol', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'splits-filter-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'investment_splits',
+          id: 'split1',
+          fields: {
+            split_id: 'split1',
+            ticker_symbol: 'AAPL',
+            split_date: '2024-01-15',
+          },
+        },
+        {
+          collection: 'investment_splits',
+          id: 'split2',
+          fields: {
+            split_id: 'split2',
+            ticker_symbol: 'GOOGL',
+            split_date: '2024-01-15',
+          },
+        },
+      ]);
+
+      const splits = await decodeInvestmentSplits(dbPath, { tickerSymbol: 'AAPL' });
+
+      expect(splits.length).toBe(1);
+      expect(splits[0]?.ticker_symbol).toBe('AAPL');
+    });
+
+    test('filters splits by date range', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'splits-date-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'investment_splits',
+          id: 'split1',
+          fields: {
+            split_id: 'split1',
+            ticker_symbol: 'AAPL',
+            split_date: '2024-01-10',
+          },
+        },
+        {
+          collection: 'investment_splits',
+          id: 'split2',
+          fields: {
+            split_id: 'split2',
+            ticker_symbol: 'AAPL',
+            split_date: '2024-01-20',
+          },
+        },
+      ]);
+
+      const splits = await decodeInvestmentSplits(dbPath, {
+        startDate: '2024-01-15',
+        endDate: '2024-01-25',
+      });
+
+      expect(splits.length).toBe(1);
+      expect(splits[0]?.split_date).toBe('2024-01-20');
+    });
+  });
+});

--- a/tests/core/leveldb-reader.test.ts
+++ b/tests/core/leveldb-reader.test.ts
@@ -1,0 +1,501 @@
+/**
+ * Tests for leveldb-reader.ts to achieve 100% code coverage.
+ */
+
+import { describe, test, expect, afterEach, beforeEach } from 'bun:test';
+import {
+  parseDocumentKey,
+  iterateDocuments,
+  getCollection,
+  getAllCollections,
+  documentToObject,
+  LevelDBReader,
+  createTestDatabase,
+  cleanupAllTempDatabases,
+} from '../../src/core/leveldb-reader.js';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const FIXTURES_DIR = path.join(__dirname, '../fixtures/leveldb-reader-tests');
+
+// Cleanup all test databases after each test
+afterEach(() => {
+  cleanupAllTempDatabases();
+  if (fs.existsSync(FIXTURES_DIR)) {
+    fs.rmSync(FIXTURES_DIR, { recursive: true, force: true });
+  }
+});
+
+// Ensure fixtures directory exists
+beforeEach(() => {
+  fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+});
+
+describe('leveldb-reader', () => {
+  describe('parseDocumentKey', () => {
+    test('parses simple string path format', () => {
+      const key = 'remote_document/projects/test/databases/(default)/documents/transactions/txn123';
+      const result = parseDocumentKey(key);
+
+      expect(result).toEqual({ collection: 'transactions', documentId: 'txn123' });
+    });
+
+    test('parses subcollection path format', () => {
+      const key =
+        'remote_document/projects/test/databases/(default)/documents/users/user1/orders/order123';
+      const result = parseDocumentKey(key);
+
+      expect(result).toEqual({ collection: 'users/user1/orders', documentId: 'order123' });
+    });
+
+    test('returns null for non-document keys', () => {
+      const key = 'some_other_key/without/documents';
+      const result = parseDocumentKey(key);
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null for keys without documents pattern', () => {
+      // Key without the /documents/collection/id pattern
+      const key = 'some_random_key_without_pattern';
+      const result = parseDocumentKey(key);
+
+      expect(result).toBeNull();
+    });
+
+    test('parses string key even without remote_document marker', () => {
+      // The string parser uses regex and doesn't require remote_document
+      const key = 'local_document/projects/test/databases/(default)/documents/test/123';
+      const result = parseDocumentKey(key);
+
+      // String parser matches based on documents/collection/id pattern
+      expect(result).toEqual({ collection: 'test', documentId: '123' });
+    });
+
+    test('parses binary format key', () => {
+      // Create a binary key with the Firestore SDK format using actual byte values
+      // Format: 0x85 + "remote_document" + segments with 0x00 0x01 0xBE markers
+      const marker = Buffer.from([0x85]);
+      const remoteDoc = Buffer.from('remote_document', 'utf8');
+      const sep = Buffer.from([0x00, 0x01, 0xbe]); // separator + string marker
+      const accounts = Buffer.from('accounts', 'utf8');
+      const acc123 = Buffer.from('acc123', 'utf8');
+      const end = Buffer.from([0x00, 0x01, 0x80]); // end marker
+
+      const keyBuffer = Buffer.concat([marker, remoteDoc, sep, accounts, sep, acc123, end]);
+      const result = parseDocumentKey(keyBuffer);
+
+      expect(result).not.toBeNull();
+      expect(result?.collection).toBe('accounts');
+      expect(result?.documentId).toBe('acc123');
+    });
+
+    test('returns null for binary key with less than 2 segments', () => {
+      // Create a binary key with only one segment
+      const marker = Buffer.from([0x85]);
+      const remoteDoc = Buffer.from('remote_document', 'utf8');
+      const sep = Buffer.from([0x00, 0x01, 0xbe]);
+      const onlyone = Buffer.from('onlyone', 'utf8');
+      const end = Buffer.from([0x00, 0x01, 0x80]);
+
+      const keyBuffer = Buffer.concat([marker, remoteDoc, sep, onlyone, end]);
+      const result = parseDocumentKey(keyBuffer);
+
+      expect(result).toBeNull();
+    });
+
+    test('returns null for binary key with skip collections', () => {
+      // Create a binary key where the second-to-last segment is a skip collection
+      const marker = Buffer.from([0x85]);
+      const remoteDoc = Buffer.from('remote_document', 'utf8');
+      const sep = Buffer.from([0x00, 0x01, 0xbe]);
+      const items = Buffer.from('items', 'utf8');
+      const collectionParent = Buffer.from('collection_parent', 'utf8');
+      const doc1 = Buffer.from('doc1', 'utf8');
+      const end = Buffer.from([0x00, 0x01, 0x80]);
+
+      // Key: items -> collection_parent -> doc1
+      // Last two are: collection_parent, doc1 - should skip
+      const keyBuffer = Buffer.concat([
+        marker,
+        remoteDoc,
+        sep,
+        items,
+        sep,
+        collectionParent,
+        sep,
+        doc1,
+        end,
+      ]);
+      const result = parseDocumentKey(keyBuffer);
+
+      // Should return null because collection_parent is in skip list
+      expect(result).toBeNull();
+    });
+
+    test('handles string containing remote_document but no valid path', () => {
+      const key = 'remote_document/invalid';
+      const result = parseDocumentKey(key);
+
+      expect(result).toBeNull();
+    });
+
+    test('string path parser does not filter skip collections', () => {
+      // Note: Skip collection filtering only applies to binary keys
+      // String key parser returns the match as-is
+      const key =
+        'remote_document/projects/test/databases/(default)/documents/collection_parent/doc1';
+      const result = parseDocumentKey(key);
+
+      // String parser returns the match without filtering
+      expect(result).toEqual({ collection: 'collection_parent', documentId: 'doc1' });
+    });
+  });
+
+  describe('iterateDocuments', () => {
+    test('throws error for non-existent path', async () => {
+      const gen = iterateDocuments('/nonexistent/path');
+      await expect(gen.next()).rejects.toThrow('Database path not found');
+    });
+
+    test('throws error for file instead of directory', async () => {
+      const tempFile = path.join(FIXTURES_DIR, 'test-file.txt');
+      fs.writeFileSync(tempFile, 'test');
+
+      const gen = iterateDocuments(tempFile);
+      await expect(gen.next()).rejects.toThrow('Path is not a directory');
+    });
+
+    test('iterates documents with limit', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'limit-test-db');
+      await createTestDatabase(dbPath, [
+        { collection: 'transactions', id: 'txn1', fields: { amount: 100 } },
+        { collection: 'transactions', id: 'txn2', fields: { amount: 200 } },
+        { collection: 'transactions', id: 'txn3', fields: { amount: 300 } },
+      ]);
+
+      const docs = [];
+      for await (const doc of iterateDocuments(dbPath, { limit: 2 })) {
+        docs.push(doc);
+      }
+
+      expect(docs.length).toBe(2);
+    });
+
+    test('filters by collection', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'filter-test-db');
+      await createTestDatabase(dbPath, [
+        { collection: 'transactions', id: 'txn1', fields: { amount: 100 } },
+        { collection: 'accounts', id: 'acc1', fields: { name: 'Test' } },
+        { collection: 'transactions', id: 'txn2', fields: { amount: 200 } },
+      ]);
+
+      const docs = [];
+      for await (const doc of iterateDocuments(dbPath, { collection: 'accounts' })) {
+        docs.push(doc);
+      }
+
+      expect(docs.length).toBe(1);
+      expect(docs[0]?.collection).toBe('accounts');
+    });
+
+    test('filters by keyPrefix', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'prefix-test-db');
+      await createTestDatabase(dbPath, [
+        { collection: 'transactions', id: 'txn1', fields: { amount: 100 } },
+      ]);
+
+      const docs = [];
+      for await (const doc of iterateDocuments(dbPath, { keyPrefix: 'remote_document' })) {
+        docs.push(doc);
+      }
+
+      expect(docs.length).toBe(1);
+    });
+  });
+
+  describe('getCollection', () => {
+    test('returns all documents from a collection', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'get-collection-db');
+      await createTestDatabase(dbPath, [
+        { collection: 'accounts', id: 'acc1', fields: { name: 'Checking' } },
+        { collection: 'accounts', id: 'acc2', fields: { name: 'Savings' } },
+        { collection: 'transactions', id: 'txn1', fields: { amount: 100 } },
+      ]);
+
+      const docs = await getCollection(dbPath, 'accounts');
+
+      expect(docs.length).toBe(2);
+      expect(docs.every((d) => d.collection === 'accounts')).toBe(true);
+    });
+  });
+
+  describe('getAllCollections', () => {
+    test('groups documents by collection', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'all-collections-db');
+      await createTestDatabase(dbPath, [
+        { collection: 'accounts', id: 'acc1', fields: { name: 'Checking' } },
+        { collection: 'transactions', id: 'txn1', fields: { amount: 100 } },
+        { collection: 'transactions', id: 'txn2', fields: { amount: 200 } },
+        { collection: 'budgets', id: 'bud1', fields: { amount: 500 } },
+      ]);
+
+      const collections = await getAllCollections(dbPath);
+
+      expect(collections.size).toBe(3);
+      expect(collections.get('accounts')?.length).toBe(1);
+      expect(collections.get('transactions')?.length).toBe(2);
+      expect(collections.get('budgets')?.length).toBe(1);
+    });
+  });
+
+  describe('documentToObject', () => {
+    test('converts LevelDBDocument to plain object', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'doc-to-object-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'accounts',
+          id: 'acc1',
+          fields: { name: 'Test Account', balance: 1000.5, active: true },
+        },
+      ]);
+
+      const docs = await getCollection(dbPath, 'accounts');
+      const obj = documentToObject(docs[0]!);
+
+      expect(obj._id).toBe('acc1');
+      expect(obj._collection).toBe('accounts');
+      expect(obj.name).toBe('Test Account');
+      expect(obj.balance).toBe(1000.5);
+      expect(obj.active).toBe(true);
+    });
+  });
+
+  describe('LevelDBReader class', () => {
+    test('opens and closes database', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'reader-open-close-db');
+      await createTestDatabase(dbPath, []);
+
+      const reader = new LevelDBReader(dbPath);
+      expect(reader.isOpen()).toBe(false);
+
+      await reader.open();
+      expect(reader.isOpen()).toBe(true);
+
+      await reader.close();
+      expect(reader.isOpen()).toBe(false);
+    });
+
+    test('throws when iterating without opening', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'reader-not-open-db');
+      const reader = new LevelDBReader(dbPath);
+
+      const gen = reader.iterate();
+      await expect(gen.next()).rejects.toThrow('Database not open');
+    });
+
+    test('throws when putting document without opening', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'reader-put-not-open-db');
+      const reader = new LevelDBReader(dbPath);
+
+      await expect(reader.putDocument('test', 'doc1', { foo: 'bar' })).rejects.toThrow(
+        'Database not open'
+      );
+    });
+
+    test('throws when deleting document without opening', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'reader-delete-not-open-db');
+      const reader = new LevelDBReader(dbPath);
+
+      await expect(reader.deleteDocument('test', 'doc1')).rejects.toThrow('Database not open');
+    });
+
+    test('iterates with collection filter', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'reader-iterate-filter-db');
+      await createTestDatabase(dbPath, [
+        { collection: 'accounts', id: 'acc1', fields: { name: 'Test' } },
+        { collection: 'transactions', id: 'txn1', fields: { amount: 100 } },
+      ]);
+
+      const reader = new LevelDBReader(dbPath);
+      await reader.open();
+
+      const docs = [];
+      for await (const doc of reader.iterate({ collection: 'accounts' })) {
+        docs.push(doc);
+      }
+
+      await reader.close();
+
+      expect(docs.length).toBe(1);
+      expect(docs[0]?.collection).toBe('accounts');
+    });
+
+    test('iterates with limit', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'reader-iterate-limit-db');
+      await createTestDatabase(dbPath, [
+        { collection: 'test', id: 'doc1', fields: { x: 1 } },
+        { collection: 'test', id: 'doc2', fields: { x: 2 } },
+        { collection: 'test', id: 'doc3', fields: { x: 3 } },
+      ]);
+
+      const reader = new LevelDBReader(dbPath);
+      await reader.open();
+
+      const docs = [];
+      for await (const doc of reader.iterate({ limit: 2 })) {
+        docs.push(doc);
+      }
+
+      await reader.close();
+
+      expect(docs.length).toBe(2);
+    });
+
+    test('iterates with keyPrefix filter', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'reader-iterate-prefix-db');
+      await createTestDatabase(dbPath, [{ collection: 'test', id: 'doc1', fields: { x: 1 } }]);
+
+      const reader = new LevelDBReader(dbPath);
+      await reader.open();
+
+      const docs = [];
+      for await (const doc of reader.iterate({ keyPrefix: 'remote_document' })) {
+        docs.push(doc);
+      }
+
+      await reader.close();
+
+      expect(docs.length).toBe(1);
+    });
+
+    test('getCollection returns documents from collection', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'reader-get-collection-db');
+      await createTestDatabase(dbPath, [
+        { collection: 'accounts', id: 'acc1', fields: { name: 'A' } },
+        { collection: 'accounts', id: 'acc2', fields: { name: 'B' } },
+      ]);
+
+      const reader = new LevelDBReader(dbPath);
+      await reader.open();
+
+      const docs = await reader.getCollection('accounts');
+
+      await reader.close();
+
+      expect(docs.length).toBe(2);
+    });
+
+    test('getDocument returns specific document', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'reader-get-document-db');
+      await createTestDatabase(dbPath, [
+        { collection: 'accounts', id: 'acc1', fields: { name: 'Account 1' } },
+        { collection: 'accounts', id: 'acc2', fields: { name: 'Account 2' } },
+      ]);
+
+      const reader = new LevelDBReader(dbPath);
+      await reader.open();
+
+      const doc = await reader.getDocument('accounts', 'acc2');
+
+      await reader.close();
+
+      expect(doc).not.toBeNull();
+      expect(doc?.documentId).toBe('acc2');
+    });
+
+    test('getDocument returns null for non-existent document', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'reader-get-nonexistent-db');
+      await createTestDatabase(dbPath, [
+        { collection: 'accounts', id: 'acc1', fields: { name: 'Account 1' } },
+      ]);
+
+      const reader = new LevelDBReader(dbPath);
+      await reader.open();
+
+      const doc = await reader.getDocument('accounts', 'nonexistent');
+
+      await reader.close();
+
+      expect(doc).toBeNull();
+    });
+
+    test('putDocument and deleteDocument work correctly', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'reader-put-delete-db');
+      await createTestDatabase(dbPath, []);
+
+      const reader = new LevelDBReader(dbPath);
+      await reader.open({ createIfMissing: true });
+
+      // Put a document
+      await reader.putDocument('test', 'doc1', { value: 'hello' });
+
+      // Verify it exists
+      let doc = await reader.getDocument('test', 'doc1');
+      expect(doc).not.toBeNull();
+
+      // Delete the document
+      await reader.deleteDocument('test', 'doc1');
+
+      // Verify it's gone
+      doc = await reader.getDocument('test', 'doc1');
+      expect(doc).toBeNull();
+
+      await reader.close();
+    });
+
+    test('close on already closed database is no-op', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'reader-double-close-db');
+      await createTestDatabase(dbPath, []);
+
+      const reader = new LevelDBReader(dbPath);
+      await reader.open();
+      await reader.close();
+
+      // Second close should not throw
+      await reader.close();
+      expect(reader.isOpen()).toBe(false);
+    });
+  });
+
+  describe('cleanupAllTempDatabases', () => {
+    test('cleans up all cached temp databases', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'cleanup-test-db');
+      await createTestDatabase(dbPath, [{ collection: 'test', id: 'doc1', fields: { x: 1 } }]);
+
+      // Iterate to create a temp copy
+      const docs = [];
+      for await (const doc of iterateDocuments(dbPath)) {
+        docs.push(doc);
+      }
+
+      // Clean up all temp databases
+      cleanupAllTempDatabases();
+
+      // Should not throw, just cleanup
+      expect(true).toBe(true);
+    });
+  });
+
+  describe('temp database cache', () => {
+    test('reuses cached temp database', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'cache-reuse-db');
+      await createTestDatabase(dbPath, [{ collection: 'test', id: 'doc1', fields: { x: 1 } }]);
+
+      // First iteration
+      let count1 = 0;
+      for await (const _doc of iterateDocuments(dbPath)) {
+        count1++;
+      }
+
+      // Second iteration should reuse cache
+      let count2 = 0;
+      for await (const _doc of iterateDocuments(dbPath)) {
+        count2++;
+      }
+
+      expect(count1).toBe(1);
+      expect(count2).toBe(1);
+    });
+  });
+});

--- a/tests/core/protobuf-parser.test.ts
+++ b/tests/core/protobuf-parser.test.ts
@@ -1,0 +1,791 @@
+/**
+ * Tests for protobuf-parser.ts to achieve 100% code coverage.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import {
+  decodeVarint,
+  decodeSignedVarint,
+  encodeVarint,
+  parseTag,
+  createTag,
+  skipField,
+  WireType,
+  parseFirestoreValue,
+  parseFirestoreDocument,
+  toPlainObject,
+  encodeFirestoreValue,
+  encodeFirestoreDocument,
+  type FirestoreValue,
+} from '../../src/core/protobuf-parser.js';
+
+describe('protobuf-parser', () => {
+  describe('decodeVarint', () => {
+    test('decodes single byte varint', () => {
+      const buf = Buffer.from([0x05]);
+      const { value, bytesRead } = decodeVarint(buf, 0);
+      expect(value).toBe(5);
+      expect(bytesRead).toBe(1);
+    });
+
+    test('decodes multi-byte varint', () => {
+      // 300 = 0x012C = 10101100 00000010 in varint
+      const buf = Buffer.from([0xac, 0x02]);
+      const { value, bytesRead } = decodeVarint(buf, 0);
+      expect(value).toBe(300);
+      expect(bytesRead).toBe(2);
+    });
+
+    test('decodes varint at offset', () => {
+      const buf = Buffer.from([0x00, 0x00, 0x0a]);
+      const { value, bytesRead } = decodeVarint(buf, 2);
+      expect(value).toBe(10);
+      expect(bytesRead).toBe(1);
+    });
+
+    test('throws for truncated varint', () => {
+      // MSB is set but no more bytes
+      const buf = Buffer.from([0x80]);
+      expect(() => decodeVarint(buf, 0)).toThrow('Truncated varint');
+    });
+
+    test('throws for empty buffer', () => {
+      const buf = Buffer.from([]);
+      expect(() => decodeVarint(buf, 0)).toThrow('Truncated varint');
+    });
+
+    test('throws for varint that is too long', () => {
+      // Create a varint with 10+ continuation bytes
+      const buf = Buffer.from([0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x01]);
+      expect(() => decodeVarint(buf, 0)).toThrow('Varint too long');
+    });
+  });
+
+  describe('decodeSignedVarint', () => {
+    test('decodes positive zigzag encoded value', () => {
+      // 1 is encoded as 2 in zigzag
+      const buf = Buffer.from([0x02]);
+      const { value, bytesRead } = decodeSignedVarint(buf, 0);
+      expect(value).toBe(1);
+      expect(bytesRead).toBe(1);
+    });
+
+    test('decodes negative zigzag encoded value', () => {
+      // -1 is encoded as 1 in zigzag
+      const buf = Buffer.from([0x01]);
+      const { value, bytesRead } = decodeSignedVarint(buf, 0);
+      expect(value).toBe(-1);
+      expect(bytesRead).toBe(1);
+    });
+
+    test('decodes zero', () => {
+      const buf = Buffer.from([0x00]);
+      const { value, bytesRead } = decodeSignedVarint(buf, 0);
+      expect(value).toBe(0);
+      expect(bytesRead).toBe(1);
+    });
+  });
+
+  describe('encodeVarint', () => {
+    test('encodes single byte value', () => {
+      const buf = encodeVarint(5);
+      expect(buf).toEqual(Buffer.from([0x05]));
+    });
+
+    test('encodes multi-byte value', () => {
+      const buf = encodeVarint(300);
+      expect(buf).toEqual(Buffer.from([0xac, 0x02]));
+    });
+
+    test('encodes zero', () => {
+      const buf = encodeVarint(0);
+      expect(buf).toEqual(Buffer.from([0x00]));
+    });
+  });
+
+  describe('parseTag / createTag', () => {
+    test('parses tag correctly', () => {
+      // Field 1, wire type 0 (Varint)
+      const { fieldNumber, wireType } = parseTag(0x08);
+      expect(fieldNumber).toBe(1);
+      expect(wireType).toBe(WireType.Varint);
+    });
+
+    test('parses tag with field 17', () => {
+      // Field 17, wire type 2 (LengthDelimited)
+      const { fieldNumber, wireType } = parseTag(0x8a);
+      expect(fieldNumber).toBe(17);
+      expect(wireType).toBe(WireType.LengthDelimited);
+    });
+
+    test('creates tag correctly', () => {
+      const tag = createTag(1, WireType.Varint);
+      expect(tag).toBe(0x08);
+    });
+
+    test('creates tag for higher field number', () => {
+      const tag = createTag(17, WireType.LengthDelimited);
+      expect(tag).toBe(0x8a);
+    });
+  });
+
+  describe('skipField', () => {
+    test('skips varint field', () => {
+      const buf = Buffer.from([0x96, 0x01]); // varint 150
+      const bytesSkipped = skipField(buf, 0, WireType.Varint);
+      expect(bytesSkipped).toBe(2);
+    });
+
+    test('skips fixed64 field', () => {
+      const buf = Buffer.alloc(10);
+      const bytesSkipped = skipField(buf, 0, WireType.Fixed64);
+      expect(bytesSkipped).toBe(8);
+    });
+
+    test('skips fixed32 field', () => {
+      const buf = Buffer.alloc(6);
+      const bytesSkipped = skipField(buf, 0, WireType.Fixed32);
+      expect(bytesSkipped).toBe(4);
+    });
+
+    test('skips length-delimited field', () => {
+      // Length of 5, followed by 5 bytes
+      const buf = Buffer.from([0x05, 0x01, 0x02, 0x03, 0x04, 0x05]);
+      const bytesSkipped = skipField(buf, 0, WireType.LengthDelimited);
+      expect(bytesSkipped).toBe(6); // 1 for length + 5 for data
+    });
+
+    test('throws for StartGroup wire type', () => {
+      const buf = Buffer.alloc(10);
+      expect(() => skipField(buf, 0, WireType.StartGroup)).toThrow(
+        'Deprecated wire type 3 not supported'
+      );
+    });
+
+    test('throws for EndGroup wire type', () => {
+      const buf = Buffer.alloc(10);
+      expect(() => skipField(buf, 0, WireType.EndGroup)).toThrow(
+        'Deprecated wire type 4 not supported'
+      );
+    });
+
+    test('throws for unknown wire type', () => {
+      const buf = Buffer.alloc(10);
+      expect(() => skipField(buf, 0, 7 as WireType)).toThrow('Unknown wire type 7');
+    });
+  });
+
+  describe('parseFirestoreValue', () => {
+    test('parses boolean true', () => {
+      // Field 1 (BooleanValue), varint 1
+      const buf = Buffer.from([0x08, 0x01]);
+      const result = parseFirestoreValue(buf);
+      expect(result).toEqual({ type: 'boolean', value: true });
+    });
+
+    test('parses boolean false', () => {
+      const buf = Buffer.from([0x08, 0x00]);
+      const result = parseFirestoreValue(buf);
+      expect(result).toEqual({ type: 'boolean', value: false });
+    });
+
+    test('parses integer', () => {
+      // Field 2 (IntegerValue), varint 42
+      const buf = Buffer.from([0x10, 0x2a]);
+      const result = parseFirestoreValue(buf);
+      expect(result).toEqual({ type: 'integer', value: 42 });
+    });
+
+    test('parses double', () => {
+      // Field 3 (DoubleValue), fixed64
+      const buf = Buffer.alloc(9);
+      buf[0] = 0x19; // Field 3, wire type 1
+      buf.writeDoubleLE(3.14, 1);
+      const result = parseFirestoreValue(buf);
+      expect(result.type).toBe('double');
+      expect((result.value as number).toFixed(2)).toBe('3.14');
+    });
+
+    test('parses string', () => {
+      // Field 17 (StringValue), length-delimited
+      const buf = Buffer.from([0x8a, 0x01, 0x05, 0x68, 0x65, 0x6c, 0x6c, 0x6f]); // "hello"
+      const result = parseFirestoreValue(buf);
+      expect(result).toEqual({ type: 'string', value: 'hello' });
+    });
+
+    test('parses null', () => {
+      // Field 11 (NullValue), varint 0
+      const buf = Buffer.from([0x58, 0x00]);
+      const result = parseFirestoreValue(buf);
+      expect(result).toEqual({ type: 'null', value: null });
+    });
+
+    test('parses bytes', () => {
+      // Field 18 (BytesValue), length-delimited
+      const buf = Buffer.from([0x92, 0x01, 0x03, 0x01, 0x02, 0x03]);
+      const result = parseFirestoreValue(buf);
+      expect(result.type).toBe('bytes');
+      expect(result.value).toEqual(Buffer.from([0x01, 0x02, 0x03]));
+    });
+
+    test('parses reference', () => {
+      // Field 5 (ReferenceValue), length-delimited
+      const refPath = 'projects/test/databases/(default)/documents/col/doc';
+      const refBuf = Buffer.from(refPath, 'utf-8');
+      const buf = Buffer.concat([
+        Buffer.from([0x2a]), // Field 5, wire type 2
+        encodeVarint(refBuf.length),
+        refBuf,
+      ]);
+      const result = parseFirestoreValue(buf);
+      expect(result).toEqual({ type: 'reference', value: refPath });
+    });
+
+    test('parses timestamp', () => {
+      // Field 10 (TimestampValue), length-delimited
+      // Inner: field 1 = seconds (varint), field 2 = nanos (varint)
+      const inner = Buffer.from([0x08, 0x64, 0x10, 0xc8, 0x01]); // seconds=100, nanos=200
+      const buf = Buffer.concat([
+        Buffer.from([0x52]), // Field 10, wire type 2
+        encodeVarint(inner.length),
+        inner,
+      ]);
+      const result = parseFirestoreValue(buf);
+      expect(result.type).toBe('timestamp');
+      expect((result.value as { seconds: number; nanos: number }).seconds).toBe(100);
+      expect((result.value as { seconds: number; nanos: number }).nanos).toBe(200);
+    });
+
+    test('parses geopoint', () => {
+      // Field 8 (GeoPointValue), length-delimited
+      // Inner: field 1 = latitude (double), field 2 = longitude (double)
+      const inner = Buffer.alloc(18);
+      let pos = 0;
+      inner[pos++] = 0x09; // Field 1, wire type 1 (fixed64)
+      inner.writeDoubleLE(37.7749, pos);
+      pos += 8;
+      inner[pos++] = 0x11; // Field 2, wire type 1 (fixed64)
+      inner.writeDoubleLE(-122.4194, pos);
+
+      const buf = Buffer.concat([
+        Buffer.from([0x42]), // Field 8, wire type 2
+        encodeVarint(inner.length),
+        inner,
+      ]);
+      const result = parseFirestoreValue(buf);
+      expect(result.type).toBe('geopoint');
+      const geo = result.value as { latitude: number; longitude: number };
+      expect(geo.latitude.toFixed(4)).toBe('37.7749');
+      expect(geo.longitude.toFixed(4)).toBe('-122.4194');
+    });
+
+    test('parses empty map', () => {
+      // Field 6 (MapValue), empty
+      const buf = Buffer.from([0x32, 0x00]);
+      const result = parseFirestoreValue(buf);
+      expect(result.type).toBe('map');
+      expect((result.value as Map<string, FirestoreValue>).size).toBe(0);
+    });
+
+    test('parses array', () => {
+      // Field 9 (ArrayValue)
+      // Inner: field 1 (values), each containing a Value
+      // Let's create an array with two integers
+      const val1 = Buffer.from([0x10, 0x01]); // integer 1
+      const val2 = Buffer.from([0x10, 0x02]); // integer 2
+      const arrayInner = Buffer.concat([
+        Buffer.from([0x0a]), // Field 1, wire type 2
+        encodeVarint(val1.length),
+        val1,
+        Buffer.from([0x0a]),
+        encodeVarint(val2.length),
+        val2,
+      ]);
+
+      const buf = Buffer.concat([
+        Buffer.from([0x4a]), // Field 9, wire type 2
+        encodeVarint(arrayInner.length),
+        arrayInner,
+      ]);
+
+      const result = parseFirestoreValue(buf);
+      expect(result.type).toBe('array');
+      const arr = result.value as FirestoreValue[];
+      expect(arr.length).toBe(2);
+      expect(arr[0]).toEqual({ type: 'integer', value: 1 });
+      expect(arr[1]).toEqual({ type: 'integer', value: 2 });
+    });
+
+    test('returns null for empty buffer', () => {
+      const buf = Buffer.from([]);
+      const result = parseFirestoreValue(buf);
+      expect(result).toEqual({ type: 'null', value: null });
+    });
+
+    test('skips unknown fields', () => {
+      // Field 99 (unknown), then field 2 (integer)
+      const buf = Buffer.from([
+        0xf8,
+        0x06,
+        0x00, // Field 99, varint 0
+        0x10,
+        0x2a, // Field 2, integer 42
+      ]);
+      const result = parseFirestoreValue(buf);
+      expect(result).toEqual({ type: 'integer', value: 42 });
+    });
+
+    test('throws for wrong wire type on boolean', () => {
+      // Field 1 but with wire type 2 instead of 0
+      const buf = Buffer.from([0x0a, 0x01, 0x00]);
+      expect(() => parseFirestoreValue(buf)).toThrow('Expected varint for boolean');
+    });
+
+    test('throws for wrong wire type on integer', () => {
+      const buf = Buffer.from([0x12, 0x01, 0x00]); // Field 2, wire type 2
+      expect(() => parseFirestoreValue(buf)).toThrow('Expected varint for integer');
+    });
+
+    test('throws for wrong wire type on double', () => {
+      const buf = Buffer.from([0x18, 0x00]); // Field 3, wire type 0
+      expect(() => parseFirestoreValue(buf)).toThrow('Expected fixed64 for double');
+    });
+
+    test('throws for wrong wire type on string', () => {
+      const buf = Buffer.from([0x88, 0x01, 0x00]); // Field 17, wire type 0
+      expect(() => parseFirestoreValue(buf)).toThrow('Expected length-delimited for string');
+    });
+
+    test('throws for wrong wire type on bytes', () => {
+      const buf = Buffer.from([0x90, 0x01, 0x00]); // Field 18, wire type 0
+      expect(() => parseFirestoreValue(buf)).toThrow('Expected length-delimited for bytes');
+    });
+
+    test('throws for wrong wire type on null', () => {
+      const buf = Buffer.from([0x5a, 0x00]); // Field 11, wire type 2
+      expect(() => parseFirestoreValue(buf)).toThrow('Expected varint for null');
+    });
+
+    test('throws for wrong wire type on reference', () => {
+      const buf = Buffer.from([0x28, 0x00]); // Field 5, wire type 0
+      expect(() => parseFirestoreValue(buf)).toThrow('Expected length-delimited for reference');
+    });
+
+    test('throws for wrong wire type on timestamp', () => {
+      const buf = Buffer.from([0x50, 0x00]); // Field 10, wire type 0
+      expect(() => parseFirestoreValue(buf)).toThrow('Expected length-delimited for timestamp');
+    });
+
+    test('throws for wrong wire type on geopoint', () => {
+      const buf = Buffer.from([0x40, 0x00]); // Field 8, wire type 0
+      expect(() => parseFirestoreValue(buf)).toThrow('Expected length-delimited for geopoint');
+    });
+
+    test('throws for wrong wire type on map', () => {
+      const buf = Buffer.from([0x30, 0x00]); // Field 6, wire type 0
+      expect(() => parseFirestoreValue(buf)).toThrow('Expected length-delimited for map');
+    });
+
+    test('throws for wrong wire type on array', () => {
+      const buf = Buffer.from([0x48, 0x00]); // Field 9, wire type 0
+      expect(() => parseFirestoreValue(buf)).toThrow('Expected length-delimited for array');
+    });
+  });
+
+  describe('parseFirestoreDocument', () => {
+    test('parses MaybeDocument wrapper', () => {
+      const doc = encodeFirestoreDocument({ name: 'Test', count: 42 });
+      const fields = parseFirestoreDocument(doc);
+
+      expect(fields.get('name')).toEqual({ type: 'string', value: 'Test' });
+      expect(fields.get('count')).toEqual({ type: 'integer', value: 42 });
+    });
+
+    test('returns empty map for empty buffer', () => {
+      const buf = Buffer.from([]);
+      const fields = parseFirestoreDocument(buf);
+      expect(fields.size).toBe(0);
+    });
+
+    test('returns empty map for NoDocument', () => {
+      // Field 1 (NoDocument) instead of field 2 (Document)
+      const buf = Buffer.from([0x0a, 0x02, 0x00, 0x00]);
+      const fields = parseFirestoreDocument(buf);
+      expect(fields.size).toBe(0);
+    });
+  });
+
+  describe('toPlainObject', () => {
+    test('converts string value', () => {
+      const fields = new Map<string, FirestoreValue>([['name', { type: 'string', value: 'Test' }]]);
+      const obj = toPlainObject(fields);
+      expect(obj.name).toBe('Test');
+    });
+
+    test('converts integer value', () => {
+      const fields = new Map<string, FirestoreValue>([['count', { type: 'integer', value: 42 }]]);
+      const obj = toPlainObject(fields);
+      expect(obj.count).toBe(42);
+    });
+
+    test('converts double value', () => {
+      const fields = new Map<string, FirestoreValue>([['price', { type: 'double', value: 19.99 }]]);
+      const obj = toPlainObject(fields);
+      expect(obj.price).toBe(19.99);
+    });
+
+    test('converts boolean value', () => {
+      const fields = new Map<string, FirestoreValue>([
+        ['active', { type: 'boolean', value: true }],
+      ]);
+      const obj = toPlainObject(fields);
+      expect(obj.active).toBe(true);
+    });
+
+    test('converts null value', () => {
+      const fields = new Map<string, FirestoreValue>([['data', { type: 'null', value: null }]]);
+      const obj = toPlainObject(fields);
+      expect(obj.data).toBeNull();
+    });
+
+    test('converts reference value', () => {
+      const fields = new Map<string, FirestoreValue>([
+        ['ref', { type: 'reference', value: 'projects/test/doc' }],
+      ]);
+      const obj = toPlainObject(fields);
+      expect(obj.ref).toBe('projects/test/doc');
+    });
+
+    test('converts bytes value', () => {
+      const buf = Buffer.from([1, 2, 3]);
+      const fields = new Map<string, FirestoreValue>([['data', { type: 'bytes', value: buf }]]);
+      const obj = toPlainObject(fields);
+      expect(obj.data).toEqual(buf);
+    });
+
+    test('converts timestamp to ISO string', () => {
+      const fields = new Map<string, FirestoreValue>([
+        ['created', { type: 'timestamp', value: { seconds: 1704067200, nanos: 0 } }],
+      ]);
+      const obj = toPlainObject(fields);
+      expect(obj.created).toBe('2024-01-01T00:00:00.000Z');
+    });
+
+    test('converts geopoint to lat/lon object', () => {
+      const fields = new Map<string, FirestoreValue>([
+        ['location', { type: 'geopoint', value: { latitude: 37.77, longitude: -122.42 } }],
+      ]);
+      const obj = toPlainObject(fields);
+      expect(obj.location).toEqual({ lat: 37.77, lon: -122.42 });
+    });
+
+    test('converts nested map', () => {
+      const innerMap = new Map<string, FirestoreValue>([
+        ['city', { type: 'string', value: 'NYC' }],
+      ]);
+      const fields = new Map<string, FirestoreValue>([
+        ['address', { type: 'map', value: innerMap }],
+      ]);
+      const obj = toPlainObject(fields);
+      expect(obj.address).toEqual({ city: 'NYC' });
+    });
+
+    test('converts array', () => {
+      const arr: FirestoreValue[] = [
+        { type: 'integer', value: 1 },
+        { type: 'integer', value: 2 },
+        { type: 'string', value: 'three' },
+      ];
+      const fields = new Map<string, FirestoreValue>([['items', { type: 'array', value: arr }]]);
+      const obj = toPlainObject(fields);
+      expect(obj.items).toEqual([1, 2, 'three']);
+    });
+  });
+
+  describe('encodeFirestoreValue', () => {
+    test('encodes null', () => {
+      const buf = encodeFirestoreValue(null);
+      expect(buf).toEqual(Buffer.from([0x58, 0x00]));
+    });
+
+    test('encodes undefined as null', () => {
+      const buf = encodeFirestoreValue(undefined);
+      expect(buf).toEqual(Buffer.from([0x58, 0x00]));
+    });
+
+    test('encodes boolean true', () => {
+      const buf = encodeFirestoreValue(true);
+      expect(buf).toEqual(Buffer.from([0x08, 0x01]));
+    });
+
+    test('encodes boolean false', () => {
+      const buf = encodeFirestoreValue(false);
+      expect(buf).toEqual(Buffer.from([0x08, 0x00]));
+    });
+
+    test('encodes integer', () => {
+      const buf = encodeFirestoreValue(42);
+      const decoded = parseFirestoreValue(buf);
+      expect(decoded).toEqual({ type: 'integer', value: 42 });
+    });
+
+    test('encodes double', () => {
+      const buf = encodeFirestoreValue(3.14);
+      const decoded = parseFirestoreValue(buf);
+      expect(decoded.type).toBe('double');
+      expect((decoded.value as number).toFixed(2)).toBe('3.14');
+    });
+
+    test('encodes string', () => {
+      const buf = encodeFirestoreValue('hello world');
+      const decoded = parseFirestoreValue(buf);
+      expect(decoded).toEqual({ type: 'string', value: 'hello world' });
+    });
+
+    test('encodes empty string', () => {
+      const buf = encodeFirestoreValue('');
+      const decoded = parseFirestoreValue(buf);
+      expect(decoded).toEqual({ type: 'string', value: '' });
+    });
+
+    test('encodes array', () => {
+      const buf = encodeFirestoreValue([1, 2, 'three']);
+      const decoded = parseFirestoreValue(buf);
+      expect(decoded.type).toBe('array');
+      const arr = decoded.value as FirestoreValue[];
+      expect(arr.length).toBe(3);
+    });
+
+    test('encodes empty array', () => {
+      const buf = encodeFirestoreValue([]);
+      const decoded = parseFirestoreValue(buf);
+      expect(decoded.type).toBe('array');
+      expect((decoded.value as FirestoreValue[]).length).toBe(0);
+    });
+
+    test('encodes object', () => {
+      const buf = encodeFirestoreValue({ name: 'Test', value: 42 });
+      const decoded = parseFirestoreValue(buf);
+      expect(decoded.type).toBe('map');
+      const map = decoded.value as Map<string, FirestoreValue>;
+      expect(map.get('name')).toEqual({ type: 'string', value: 'Test' });
+      expect(map.get('value')).toEqual({ type: 'integer', value: 42 });
+    });
+
+    test('encodes empty object', () => {
+      const buf = encodeFirestoreValue({});
+      const decoded = parseFirestoreValue(buf);
+      expect(decoded.type).toBe('map');
+      expect((decoded.value as Map<string, FirestoreValue>).size).toBe(0);
+    });
+
+    test('encodes nested object', () => {
+      const buf = encodeFirestoreValue({ outer: { inner: 'value' } });
+      const decoded = parseFirestoreValue(buf);
+      expect(decoded.type).toBe('map');
+    });
+  });
+
+  describe('parseFirestoreDocument additional coverage', () => {
+    test('skips field 1 (name) in Document proto', () => {
+      // Create a MaybeDocument with field 2 (Document) that has:
+      // - field 1 (name string) - should be skipped
+      // - field 2 (map entries)
+
+      // Document inner content:
+      // Field 1 (name): length-delimited string
+      const nameField = Buffer.concat([
+        Buffer.from([0x0a]), // Field 1, wire type 2
+        encodeVarint(10),
+        Buffer.from('test/path/', 'utf8'),
+      ]);
+
+      // Field 2 (map entry): key="foo", value=integer 42
+      const keyPart = Buffer.concat([
+        Buffer.from([0x0a, 0x03]), // Field 1 (key), length 3
+        Buffer.from('foo', 'utf8'),
+      ]);
+      const valuePart = Buffer.concat([
+        Buffer.from([0x12, 0x02]), // Field 2 (value), length 2
+        Buffer.from([0x10, 0x2a]), // integer 42
+      ]);
+      const mapEntry = Buffer.concat([keyPart, valuePart]);
+      const mapField = Buffer.concat([
+        Buffer.from([0x12]), // Field 2, wire type 2
+        encodeVarint(mapEntry.length),
+        mapEntry,
+      ]);
+
+      const documentContent = Buffer.concat([nameField, mapField]);
+
+      // Wrap in MaybeDocument: field 2 is Document
+      const maybeDoc = Buffer.concat([
+        Buffer.from([0x12]), // Field 2, wire type 2
+        encodeVarint(documentContent.length),
+        documentContent,
+      ]);
+
+      const fields = parseFirestoreDocument(maybeDoc);
+
+      // Should have parsed the map entry while skipping the name field
+      expect(fields.size).toBe(1);
+      expect(fields.get('foo')).toEqual({ type: 'integer', value: 42 });
+    });
+  });
+
+  describe('encodeFirestoreDocument', () => {
+    test('encodes and decodes document roundtrip', () => {
+      const original = {
+        name: 'Test Document',
+        count: 100,
+        active: true,
+        tags: ['a', 'b'],
+      };
+
+      const encoded = encodeFirestoreDocument(original);
+      const decoded = parseFirestoreDocument(encoded);
+      const obj = toPlainObject(decoded);
+
+      expect(obj.name).toBe('Test Document');
+      expect(obj.count).toBe(100);
+      expect(obj.active).toBe(true);
+      expect(obj.tags).toEqual(['a', 'b']);
+    });
+
+    test('handles empty document', () => {
+      const encoded = encodeFirestoreDocument({});
+      const decoded = parseFirestoreDocument(encoded);
+      expect(decoded.size).toBe(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('handles map with unknown fields', () => {
+      // Create a map value with an unknown field before the valid entries
+      // MapValue: field 1 = entries (repeated)
+      // Let's add field 99 (unknown) + field 1 (entry)
+      const keyBuf = Buffer.from([0x0a, 0x04, 0x74, 0x65, 0x73, 0x74]); // key: "test"
+      const valueBuf = Buffer.from([0x12, 0x02, 0x10, 0x2a]); // value: integer 42
+      const entry = Buffer.concat([keyBuf, valueBuf]);
+
+      const mapInner = Buffer.concat([
+        Buffer.from([0xf8, 0x06, 0x00]), // Field 99, varint 0 (unknown)
+        Buffer.from([0x0a]), // Field 1
+        encodeVarint(entry.length),
+        entry,
+      ]);
+
+      const buf = Buffer.concat([
+        Buffer.from([0x32]), // Field 6 (MapValue)
+        encodeVarint(mapInner.length),
+        mapInner,
+      ]);
+
+      const result = parseFirestoreValue(buf);
+      expect(result.type).toBe('map');
+      const map = result.value as Map<string, FirestoreValue>;
+      expect(map.get('test')).toEqual({ type: 'integer', value: 42 });
+    });
+
+    test('handles array with unknown fields', () => {
+      // ArrayValue: field 1 = values (repeated)
+      const val = Buffer.from([0x10, 0x05]); // integer 5
+
+      const arrayInner = Buffer.concat([
+        Buffer.from([0xf8, 0x06, 0x00]), // Field 99, varint 0 (unknown)
+        Buffer.from([0x0a]), // Field 1
+        encodeVarint(val.length),
+        val,
+      ]);
+
+      const buf = Buffer.concat([
+        Buffer.from([0x4a]), // Field 9 (ArrayValue)
+        encodeVarint(arrayInner.length),
+        arrayInner,
+      ]);
+
+      const result = parseFirestoreValue(buf);
+      expect(result.type).toBe('array');
+      const arr = result.value as FirestoreValue[];
+      expect(arr).toEqual([{ type: 'integer', value: 5 }]);
+    });
+
+    test('handles timestamp with unknown fields', () => {
+      // Timestamp with field 99 (unknown) + seconds + nanos
+      const inner = Buffer.from([
+        0xf8,
+        0x06,
+        0x00, // Field 99, varint 0 (unknown)
+        0x08,
+        0x64, // Field 1 (seconds), varint 100
+        0x10,
+        0xc8,
+        0x01, // Field 2 (nanos), varint 200
+      ]);
+
+      const buf = Buffer.concat([
+        Buffer.from([0x52]), // Field 10 (TimestampValue)
+        encodeVarint(inner.length),
+        inner,
+      ]);
+
+      const result = parseFirestoreValue(buf);
+      expect(result.type).toBe('timestamp');
+      const ts = result.value as { seconds: number; nanos: number };
+      expect(ts.seconds).toBe(100);
+      expect(ts.nanos).toBe(200);
+    });
+
+    test('handles geopoint with unknown fields', () => {
+      // GeoPoint with field 99 (unknown) + lat + lon
+      const inner = Buffer.alloc(21);
+      let pos = 0;
+      inner[pos++] = 0xf8;
+      inner[pos++] = 0x06;
+      inner[pos++] = 0x00; // Field 99, varint 0
+      inner[pos++] = 0x09; // Field 1, wire type 1
+      inner.writeDoubleLE(40.0, pos);
+      pos += 8;
+      inner[pos++] = 0x11; // Field 2, wire type 1
+      inner.writeDoubleLE(-74.0, pos);
+
+      const buf = Buffer.concat([
+        Buffer.from([0x42]), // Field 8 (GeoPointValue)
+        encodeVarint(inner.length),
+        inner,
+      ]);
+
+      const result = parseFirestoreValue(buf);
+      expect(result.type).toBe('geopoint');
+      const geo = result.value as { latitude: number; longitude: number };
+      expect(geo.latitude).toBe(40.0);
+      expect(geo.longitude).toBe(-74.0);
+    });
+
+    test('handles map entry with unknown fields', () => {
+      // Map entry with field 99 + key + value
+      const entry = Buffer.concat([
+        Buffer.from([0xf8, 0x06, 0x00]), // Field 99, varint 0
+        Buffer.from([0x0a, 0x03, 0x66, 0x6f, 0x6f]), // Field 1 (key): "foo"
+        Buffer.from([0x12, 0x02, 0x10, 0x01]), // Field 2 (value): integer 1
+      ]);
+
+      const mapInner = Buffer.concat([
+        Buffer.from([0x0a]), // Field 1 (entry)
+        encodeVarint(entry.length),
+        entry,
+      ]);
+
+      const buf = Buffer.concat([
+        Buffer.from([0x32]), // Field 6 (MapValue)
+        encodeVarint(mapInner.length),
+        mapInner,
+      ]);
+
+      const result = parseFirestoreValue(buf);
+      expect(result.type).toBe('map');
+      const map = result.value as Map<string, FirestoreValue>;
+      expect(map.get('foo')).toEqual({ type: 'integer', value: 1 });
+    });
+  });
+});

--- a/tests/integration/tools.test.ts
+++ b/tests/integration/tools.test.ts
@@ -314,7 +314,7 @@ describe('CopilotMoneyTools Integration', () => {
   describe('tool schemas', () => {
     test('returns correct number of tool schemas', async () => {
       const schemas = createToolSchemas();
-      expect(schemas.length).toBe(28);
+      expect(schemas.length).toBe(31);
     });
 
     test('all tools have readOnlyHint annotation', async () => {

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -590,9 +590,9 @@ describe('CopilotMoneyTools', () => {
 });
 
 describe('createToolSchemas', () => {
-  test('returns 28 tool schemas', async () => {
+  test('returns 31 tool schemas', async () => {
     const schemas = createToolSchemas();
-    expect(schemas).toHaveLength(28);
+    expect(schemas).toHaveLength(31);
   });
 
   test('all tools have readOnlyHint: true', async () => {

--- a/tests/unit/server-protocol.test.ts
+++ b/tests/unit/server-protocol.test.ts
@@ -148,7 +148,7 @@ describe('CopilotMoneyServer.handleListTools', () => {
     }
   });
 
-  test('returns all 28 tools', () => {
+  test('returns all 31 tools', () => {
     const response = server.handleListTools();
 
     const expectedTools = [
@@ -180,13 +180,16 @@ describe('CopilotMoneyServer.handleListTools', () => {
       'get_category_trends',
       'get_portfolio_allocation',
       'get_year_over_year',
+      'get_net_worth',
+      'get_savings_rate',
+      'get_cash_flow',
     ];
 
     const actualNames = response.tools.map((t) => t.name);
     for (const expected of expectedTools) {
       expect(actualNames).toContain(expected);
     }
-    expect(response.tools.length).toBe(28);
+    expect(response.tools.length).toBe(31);
   });
 
   test('tool schemas have valid JSON schema format', () => {


### PR DESCRIPTION
## Summary
- **8x performance improvement** via batch loading - reduces database load time from ~88s to ~11s
- **3 new MCP tools**: `get_net_worth`, `get_savings_rate`, `get_cash_flow`
- **Real-database tests now opt-in** via `RUN_REAL_DB_TESTS=1` env var to prevent CI timeouts

## Performance Optimization
The new `decodeAllCollections()` function performs a single pass through the database instead of 11 separate passes (one per entity type):

| Metric | Before | After |
|--------|--------|-------|
| Total time | ~88s | ~11s |
| Throughput | 3.5 MB/s | 27.9 MB/s |
| Speedup | - | **8x** |

First entity load triggers batch load, subsequent loads are instant from cache.

## New Tools (28 → 31 total)

| Tool | Description |
|------|-------------|
| `get_net_worth` | Calculate net worth (assets - liabilities) from all accounts |
| `get_savings_rate` | Calculate savings rate with interpretation (income - spending / income) |
| `get_cash_flow` | Analyze cash flow showing inflows vs outflows with breakdown |

## Test improvements
- Real-database tests are now opt-in via `RUN_REAL_DB_TESTS=1`
- Increased timeout from 120s to 5 minutes for large databases
- Added profiling script at `scripts/profile-database.ts`

## Test plan
- [x] All 927 tests pass
- [x] Profiling script confirms 8x performance improvement
- [x] New tools have proper schemas and dispatch handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)