### PR TITLE
Filter out user_deleted accounts and improve transaction filtering

### DIFF
--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -700,6 +700,12 @@ function processAccount(fields: Map<string, FirestoreValue>, docId: string): Acc
     accData.available_balance = Math.round(availableBalance * 100) / 100;
   }
 
+  // Extract user_deleted flag - accounts that were deleted or merged
+  const userDeleted = getBoolean(fields, 'user_deleted');
+  if (userDeleted !== undefined) {
+    accData.user_deleted = userDeleted;
+  }
+
   if (!accData.name && !accData.official_name) {
     return null;
   }

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -34,6 +34,9 @@ export const AccountSchema = z
 
     // Metadata
     iso_currency_code: z.string().optional(),
+
+    // Visibility - accounts marked as deleted by user or merged into other accounts
+    user_deleted: z.boolean().optional(),
   })
   .strict();
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -102,7 +102,9 @@ export class CopilotMoneyServer {
           break;
 
         case 'get_accounts':
-          result = await this.tools.getAccounts(typedArgs?.account_type as string | undefined);
+          result = await this.tools.getAccounts(
+            typedArgs as Parameters<typeof this.tools.getAccounts>[0]
+          );
           break;
 
         case 'get_spending': {

--- a/tests/integration/tools.test.ts
+++ b/tests/integration/tools.test.ts
@@ -209,10 +209,14 @@ describe('CopilotMoneyTools Integration', () => {
     });
 
     test('filters by account type', async () => {
-      const result = await tools.getAccounts('checking');
+      const result = await tools.getAccounts({ account_type: 'checking' });
 
       for (const acc of result.accounts) {
-        expect(acc.account_type && acc.account_type.toLowerCase().includes('checking')).toBe(true);
+        // Account may have account_type='depository' with subtype='checking', or account_type='checking'
+        const matchesAccountType =
+          acc.account_type?.toLowerCase().includes('checking') ||
+          acc.subtype?.toLowerCase().includes('checking');
+        expect(matchesAccountType).toBe(true);
       }
     });
   });


### PR DESCRIPTION
## Summary
- Fixes phantom account issue where merged/deleted accounts were still appearing
- Add `user_deleted` field to Account schema and decoder  
- Filter accounts with `user_deleted=true` by default in `getAccounts()` and `getNetWorth()`
- Improve transaction filtering: exclude transfers, deleted, and excluded transactions by default
- Add `include_hidden` option to show hidden/deleted accounts when needed

## Root Cause
The phantom Meta 401k account (mask: 1355, institution: `ins_118395`) was appearing because Copilot uses `user_deleted: true` (not `hidden: true`) to mark accounts that were merged into newer connections. The UserAccountCustomization collection was empty, so the existing `hidden` filtering had nothing to filter.

The account was auto-merged on 2023-10-01 when switching from Plaid (`ins_118395`) to Akoya direct connection (`akoya_fidelity`).

## Test plan
- [x] All 1028 tests pass
- [x] Verified phantom account is filtered out by default
- [x] Verified phantom account appears when `include_hidden: true`
- [x] Rebuilt and tested MCP bundle

🤖 Generated with [Claude Code](https://claude.ai/code)