### PR TITLE
Fix sign convention to match Copilot Money format

### DIFF
--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -9,9 +9,11 @@ import { z } from 'zod';
 /**
  * Transaction schema with validation.
  *
- * Amount sign convention (standard accounting):
- * - Positive amounts = income/credits (money coming IN)
- * - Negative amounts = expenses (money going OUT)
+ * Amount sign convention (Copilot Money format):
+ * - Positive amounts = expenses (money going OUT)
+ * - Negative amounts = income/credits (money coming IN)
+ *
+ * Note: This is the opposite of standard accounting convention.
  */
 export const TransactionSchema = z
   .object({

--- a/tests/core/database.test.ts
+++ b/tests/core/database.test.ts
@@ -7,11 +7,11 @@ import { CopilotDatabase } from '../../src/core/database.js';
 import type { Transaction, Account, Recurring } from '../../src/models/index.js';
 
 // Mock the decoder functions
-// Standard accounting: negative = expenses, positive = income
+// Copilot Money format: positive = expenses, negative = income
 const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn1',
-    amount: -50.0, // Expense
+    amount: 50.0, // Expense (positive in Copilot format)
     date: '2024-01-15',
     name: 'Coffee Shop',
     category_id: 'food_dining',
@@ -19,7 +19,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn2',
-    amount: -120.5, // Expense
+    amount: 120.5, // Expense (positive in Copilot format)
     date: '2024-01-20',
     name: 'Grocery Store',
     category_id: 'groceries',
@@ -27,7 +27,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn3',
-    amount: -25.0, // Expense
+    amount: 25.0, // Expense (positive in Copilot format)
     date: '2024-02-10',
     original_name: 'Fast Food',
     category_id: 'food_dining',

--- a/tests/core/decoder-coverage.test.ts
+++ b/tests/core/decoder-coverage.test.ts
@@ -584,7 +584,7 @@ describe('decoder coverage', () => {
           id: 'txn1',
           fields: {
             transaction_id: 'txn1',
-            amount: -50.0,
+            amount: 50.0,
             date: '2024-01-15',
             name: 'Coffee Shop',
           },
@@ -607,7 +607,7 @@ describe('decoder coverage', () => {
           fields: {
             recurring_id: 'rec1',
             name: 'Netflix',
-            amount: -15.99,
+            amount: 15.99,
             frequency: 'monthly',
           },
         },
@@ -723,7 +723,7 @@ describe('decoder coverage', () => {
           id: 'txn1',
           fields: {
             transaction_id: 'txn1',
-            amount: -50.0,
+            amount: 50.0,
             date: '2024-01-15',
             name: 'Coffee Shop',
           },
@@ -733,7 +733,7 @@ describe('decoder coverage', () => {
           id: 'txn2',
           fields: {
             transaction_id: 'txn2',
-            amount: -50.0,
+            amount: 50.0,
             date: '2024-01-15',
             name: 'Coffee Shop', // Same name/amount/date = duplicate
           },

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -11,11 +11,11 @@ import { CopilotDatabase } from '../../src/core/database.js';
 import type { Transaction, Account } from '../../src/models/index.js';
 
 // Mock data for E2E tests
-// Standard accounting: negative = expenses, positive = income
+// Copilot Money format: positive = expenses, negative = income
 const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn1',
-    amount: -50.0, // Expense (negative = money out)
+    amount: 50.0, // Expense (positive = money out in Copilot format)
     date: '2025-01-15',
     name: 'Coffee Shop',
     category_id: 'food_dining',
@@ -23,7 +23,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn2',
-    amount: -120.5, // Expense (negative = money out)
+    amount: 120.5, // Expense (positive = money out in Copilot format)
     date: '2025-01-20',
     name: 'Grocery Store',
     category_id: 'groceries',
@@ -31,7 +31,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn3',
-    amount: -10.0, // Expense (negative = money out)
+    amount: 10.0, // Expense (positive = money out in Copilot format)
     date: '2025-01-15',
     name: 'Parking',
     category_id: 'transportation',
@@ -39,7 +39,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn4',
-    amount: -25.0, // Expense (negative = money out)
+    amount: 25.0, // Expense (positive = money out in Copilot format)
     date: '2025-01-18',
     name: 'Fast Food',
     category_id: 'food_dining',

--- a/tests/integration/database.test.ts
+++ b/tests/integration/database.test.ts
@@ -12,11 +12,11 @@ import { CopilotDatabase } from '../../src/core/database.js';
 import type { Transaction, Account } from '../../src/models/index.js';
 
 // Mock transactions for testing
-// Standard accounting: negative = expenses, positive = income
+// Copilot Money format: positive = expenses, negative = income
 const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn1',
-    amount: -50.0, // Expense
+    amount: 50.0, // Expense (positive in Copilot format)
     date: '2025-01-15',
     name: 'Starbucks',
     category_id: 'food_dining',
@@ -24,7 +24,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn2',
-    amount: -15.5, // Expense
+    amount: 15.5, // Expense (positive in Copilot format)
     date: '2025-01-10',
     name: 'Starbucks Coffee',
     category_id: 'food_dining',
@@ -32,7 +32,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn3',
-    amount: -120.0, // Expense
+    amount: 120.0, // Expense (positive in Copilot format)
     date: '2025-01-08',
     name: 'Whole Foods',
     category_id: 'groceries',
@@ -40,7 +40,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn4',
-    amount: -8.0, // Expense
+    amount: 8.0, // Expense (positive in Copilot format)
     date: '2025-01-05',
     name: 'Starbucks',
     category_id: 'food_dining',
@@ -48,7 +48,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn5',
-    amount: -250.0, // Expense
+    amount: 250.0, // Expense (positive in Copilot format)
     date: '2024-12-20',
     name: 'Target',
     category_id: 'shopping',

--- a/tests/integration/tools.test.ts
+++ b/tests/integration/tools.test.ts
@@ -10,11 +10,11 @@ import { CopilotDatabase } from '../../src/core/database.js';
 import type { Transaction, Account } from '../../src/models/index.js';
 
 // Mock data
-// Standard accounting: negative = expenses, positive = income
+// Copilot Money format: positive = expenses, negative = income
 const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn1',
-    amount: -50.0, // Expense
+    amount: 50.0, // Expense (positive in Copilot format)
     date: '2025-01-15',
     name: 'Starbucks',
     category_id: 'food_dining',
@@ -22,7 +22,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn2',
-    amount: -15.5, // Expense
+    amount: 15.5, // Expense (positive in Copilot format)
     date: '2025-01-10',
     name: 'Starbucks Coffee',
     category_id: 'food_dining',
@@ -30,7 +30,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn3',
-    amount: -120.0, // Expense
+    amount: 120.0, // Expense (positive in Copilot format)
     date: '2025-01-08',
     name: 'Whole Foods',
     category_id: 'groceries',
@@ -38,7 +38,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn4',
-    amount: 1000.0, // Income (positive = money in)
+    amount: -1000.0, // Income (negative in Copilot format = money coming in)
     date: '2025-01-05',
     name: 'Paycheck',
     category_id: 'income',
@@ -46,7 +46,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn5',
-    amount: -250.0, // Expense
+    amount: 250.0, // Expense (positive in Copilot format)
     date: '2024-12-20',
     name: 'Target',
     category_id: 'shopping',

--- a/tests/tools/tools-coverage.test.ts
+++ b/tests/tools/tools-coverage.test.ts
@@ -10,12 +10,12 @@ import { CopilotDatabase } from '../../src/core/database.js';
 import type { Transaction, Account, Budget, Goal, GoalHistory } from '../../src/models/index.js';
 
 // Extended mock data for comprehensive testing
-// Standard accounting: negative = expenses, positive = income/credits
+// Copilot Money format: positive = expenses, negative = income/credits
 const mockTransactions: Transaction[] = [
   // Regular expenses (negative = money out)
   {
     transaction_id: 'txn1',
-    amount: -50.0,
+    amount: 50.0,
     date: '2024-01-15',
     name: 'Coffee Shop',
     category_id: 'food_dining',
@@ -23,7 +23,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn2',
-    amount: -120.5,
+    amount: 120.5,
     date: '2024-01-20',
     name: 'Grocery Store',
     category_id: 'groceries',
@@ -31,7 +31,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn3',
-    amount: -25.0,
+    amount: 25.0,
     date: '2024-01-22',
     original_name: 'Fast Food',
     category_id: 'food_dining',
@@ -49,7 +49,7 @@ const mockTransactions: Transaction[] = [
   // Foreign transaction (expense)
   {
     transaction_id: 'txn_foreign',
-    amount: -75.0,
+    amount: 75.0,
     date: '2024-01-18',
     name: 'Santiago Restaurant CL',
     category_id: 'food_dining',
@@ -78,7 +78,7 @@ const mockTransactions: Transaction[] = [
   // HSA eligible (expense)
   {
     transaction_id: 'txn_medical',
-    amount: -45.0,
+    amount: 45.0,
     date: '2024-01-21',
     name: 'CVS Pharmacy',
     category_id: 'medical',
@@ -87,7 +87,7 @@ const mockTransactions: Transaction[] = [
   // Tagged transaction (expense)
   {
     transaction_id: 'txn_tagged',
-    amount: -30.0,
+    amount: 30.0,
     date: '2024-01-22',
     name: 'Business Lunch #work #expense',
     category_id: 'food_dining',
@@ -96,7 +96,7 @@ const mockTransactions: Transaction[] = [
   // Duplicate pattern (expense)
   {
     transaction_id: 'txn_dup1',
-    amount: -99.99,
+    amount: 99.99,
     date: '2024-01-23',
     name: 'Subscription Service',
     category_id: 'subscriptions',
@@ -104,7 +104,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn_dup2',
-    amount: -99.99,
+    amount: 99.99,
     date: '2024-01-23',
     name: 'Subscription Service',
     category_id: 'subscriptions',
@@ -113,7 +113,7 @@ const mockTransactions: Transaction[] = [
   // Fee transaction (expense)
   {
     transaction_id: 'txn_fee',
-    amount: -5.0,
+    amount: 5.0,
     date: '2024-01-24',
     name: 'ATM Fee',
     category_id: 'bank_fees',
@@ -131,7 +131,7 @@ const mockTransactions: Transaction[] = [
   // More transactions for time-based analysis (expenses)
   {
     transaction_id: 'txn_week1',
-    amount: -40.0,
+    amount: 40.0,
     date: '2024-01-08',
     name: 'Week 1 Expense',
     category_id: 'food_dining',
@@ -139,7 +139,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn_week2',
-    amount: -60.0,
+    amount: 60.0,
     date: '2024-01-14',
     name: 'Week 2 Expense',
     category_id: 'food_dining',
@@ -1850,19 +1850,19 @@ describe('CopilotMoneyTools Extended Coverage', () => {
 
     describe('dividends analysis with dividend transactions', () => {
       test('returns dividend data with formatting', async () => {
-        // Set up dividend transactions (negative amounts in standard accounting)
+        // Set up dividend transactions (negative amounts = income in Copilot format)
         (db as any)._transactions = [
           {
             transaction_id: 'div1',
-            amount: -50.0, // Dividends are income (negative in this system)
+            amount: -50.0, // Dividends are income (negative in Copilot format)
             date: '2024-01-15',
             name: 'AAPL Dividend Payment',
-            category_id: 'investment_dividend',
+            category_id: 'dividend',
             account_id: 'acc_invest',
           },
           {
             transaction_id: 'div2',
-            amount: -75.0,
+            amount: -75.0, // Dividends are income (negative in Copilot format)
             date: '2024-01-20',
             name: 'MSFT Quarterly Dividend',
             category_id: 'dividend',
@@ -1870,10 +1870,10 @@ describe('CopilotMoneyTools Extended Coverage', () => {
           },
           {
             transaction_id: 'div3',
-            amount: -25.0,
+            amount: -25.0, // Dividends are income (negative in Copilot format)
             date: '2024-01-25',
             name: 'GOOG Dividend',
-            category_id: 'investment_dividend',
+            category_id: 'dividend',
             account_id: 'acc_invest',
           },
         ];
@@ -1913,7 +1913,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
           },
           {
             transaction_id: 'fee2',
-            amount: -25.0,
+            amount: 25.0,
             date: '2024-01-20',
             name: 'Account Fee',
             category_id: 'bank_fees',
@@ -1947,7 +1947,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         (db as any)._transactions = [
           {
             transaction_id: 'txn_unresolved1',
-            amount: -100.0,
+            amount: 100.0,
             date: '2024-01-15',
             name: 'Unknown Merchant',
             category_id: 'abcdefghij1234567890ab', // 22 char alphanumeric (Firebase-like ID)
@@ -1955,7 +1955,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
           },
           {
             transaction_id: 'txn_unresolved2',
-            amount: -200.0,
+            amount: 200.0,
             date: '2024-01-16',
             name: 'Another Unknown',
             category_id: 'abcdefghij1234567890ab', // Same unresolved ID
@@ -1963,7 +1963,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
           },
           {
             transaction_id: 'txn_unresolved3',
-            amount: -50.0,
+            amount: 50.0,
             date: '2024-01-17',
             name: 'Third Unknown',
             category_id: '12345678', // 8-digit numeric ID
@@ -1988,7 +1988,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         (db as any)._transactions = [
           {
             transaction_id: 'duplicate_txn_id',
-            amount: -50.0,
+            amount: 50.0,
             date: '2024-01-15',
             name: 'First Transaction',
             category_id: 'food_dining',
@@ -1996,7 +1996,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
           },
           {
             transaction_id: 'duplicate_txn_id', // Same ID
-            amount: -75.0,
+            amount: 75.0,
             date: '2024-01-16',
             name: 'Second Transaction',
             category_id: 'shopping',
@@ -2004,7 +2004,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
           },
           {
             transaction_id: 'duplicate_txn_id', // Same ID again
-            amount: -100.0,
+            amount: 100.0,
             date: '2024-01-17',
             name: 'Third Transaction',
             category_id: 'groceries',
@@ -2012,7 +2012,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
           },
           {
             transaction_id: 'unique_txn_id',
-            amount: -25.0,
+            amount: 25.0,
             date: '2024-01-18',
             name: 'Unique Transaction',
             category_id: 'food_dining',
@@ -2303,7 +2303,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         // Entertainment - 50% (approaching)
         {
           transaction_id: 'txn_ent',
-          amount: -500.0,
+          amount: 500.0,
           date: `${thisMonth}-15`,
           name: 'Entertainment',
           category_id: 'entertainment',
@@ -2312,7 +2312,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         // Food - 85% (warning)
         {
           transaction_id: 'txn_food',
-          amount: -85.0,
+          amount: 85.0,
           date: `${thisMonth}-15`,
           name: 'Restaurant',
           category_id: 'food_dining',
@@ -2321,7 +2321,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         // Groceries - 120% (exceeded)
         {
           transaction_id: 'txn_groc',
-          amount: -60.0,
+          amount: 60.0,
           date: `${thisMonth}-15`,
           name: 'Grocery Store',
           category_id: 'groceries',
@@ -2357,35 +2357,35 @@ describe('CopilotMoneyTools Extended Coverage', () => {
   // ============================================
   describe('Dividend Income Formatting Coverage', () => {
     test('formats dividends with monthly and source grouping', async () => {
-      // Set up dividend transactions
+      // Set up dividend transactions (negative amounts = income in Copilot format)
       (db as any)._transactions = [
         {
           transaction_id: 'div_aapl1',
-          amount: -50.0, // Dividend (negative = income)
+          amount: -50.0, // Dividend income (negative in Copilot format)
           date: '2024-01-15',
           name: 'AAPL Dividend',
-          category_id: 'investment_dividend',
+          category_id: 'dividend',
           account_id: 'acc_invest',
         },
         {
           transaction_id: 'div_aapl2',
-          amount: -50.0,
+          amount: -50.0, // Dividend income (negative in Copilot format)
           date: '2024-02-15',
           name: 'AAPL Dividend',
-          category_id: 'investment_dividend',
+          category_id: 'dividend',
           account_id: 'acc_invest',
         },
         {
           transaction_id: 'div_msft1',
-          amount: -75.0,
+          amount: -75.0, // Dividend income (negative in Copilot format)
           date: '2024-01-20',
           name: 'MSFT Quarterly Dividend',
-          category_id: 'investment_dividend',
+          category_id: 'dividend',
           account_id: 'acc_invest',
         },
         {
           transaction_id: 'div_goog1',
-          amount: -100.0,
+          amount: -100.0, // Dividend income (negative in Copilot format)
           date: '2024-01-25',
           original_name: 'GOOG Div Payment', // Use original_name
           category_id: 'dividend',
@@ -2665,7 +2665,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
       (db as any)._transactions = [
         {
           transaction_id: 'txn_search1',
-          amount: -100.0,
+          amount: 100.0,
           date: '2024-01-15',
           name: 'Business Dinner Quarterly Review',
           original_name: 'Restaurant XYZ',
@@ -2674,7 +2674,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         },
         {
           transaction_id: 'txn_search2',
-          amount: -250.0,
+          amount: 250.0,
           date: '2024-01-16',
           name: 'Office Supplies',
           original_name: 'Quarterly Supply Store',
@@ -2683,7 +2683,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         },
         {
           transaction_id: 'txn_no_match',
-          amount: -50.0,
+          amount: 50.0,
           date: '2024-01-17',
           name: 'Coffee Shop',
           category_id: 'food_dining',
@@ -2715,7 +2715,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
       (db as any)._transactions = [
         {
           transaction_id: 'txn_meeting1',
-          amount: -75.0,
+          amount: 75.0,
           date: '2024-01-10',
           name: 'Lunch Meeting Expenses',
           category_id: 'food_dining',
@@ -2723,7 +2723,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         },
         {
           transaction_id: 'txn_meeting2',
-          amount: -120.0,
+          amount: 120.0,
           date: '2024-01-15',
           name: 'Conference Room Rental',
           original_name: 'Meeting Space Inc',
@@ -2732,7 +2732,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         },
         {
           transaction_id: 'txn_meeting3',
-          amount: -200.0,
+          amount: 200.0,
           date: '2024-01-20',
           name: 'Team Meeting Dinner',
           category_id: 'food_dining',
@@ -2767,7 +2767,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
       (db as any)._transactions = [
         {
           transaction_id: 'txn_close1',
-          amount: -50.0,
+          amount: 50.0,
           date: '2024-01-15',
           name: 'Close Restaurant',
           category_id: 'food_dining',
@@ -2778,7 +2778,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         },
         {
           transaction_id: 'txn_far',
-          amount: -75.0,
+          amount: 75.0,
           date: '2024-01-16',
           name: 'Far Away Store',
           category_id: 'shopping',
@@ -2789,7 +2789,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         },
         {
           transaction_id: 'txn_close2',
-          amount: -25.0,
+          amount: 25.0,
           date: '2024-01-17',
           name: 'Close Coffee',
           category_id: 'food_dining',
@@ -2836,7 +2836,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
       (db as any)._transactions = [
         {
           transaction_id: 'txn_sf1',
-          amount: -100.0,
+          amount: 100.0,
           date: '2024-01-15',
           name: 'SF Restaurant 1',
           category_id: 'food_dining',
@@ -2847,7 +2847,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         },
         {
           transaction_id: 'txn_sf2',
-          amount: -150.0,
+          amount: 150.0,
           date: '2024-01-16',
           name: 'SF Restaurant 2',
           category_id: 'food_dining',
@@ -2858,7 +2858,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         },
         {
           transaction_id: 'txn_oak',
-          amount: -75.0,
+          amount: 75.0,
           date: '2024-01-17',
           name: 'Oakland Store',
           category_id: 'shopping',
@@ -2900,7 +2900,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
       (db as any)._transactions = [
         {
           transaction_id: 'txn_us',
-          amount: -100.0,
+          amount: 100.0,
           date: '2024-01-15',
           name: 'US Store',
           category_id: 'shopping',
@@ -2910,7 +2910,7 @@ describe('CopilotMoneyTools Extended Coverage', () => {
         },
         {
           transaction_id: 'txn_mx',
-          amount: -75.0,
+          amount: 75.0,
           date: '2024-01-16',
           name: 'Mexico Store',
           category_id: 'shopping',

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -8,11 +8,11 @@ import { CopilotDatabase } from '../../src/core/database.js';
 import type { Transaction, Account } from '../../src/models/index.js';
 
 // Mock data
-// Standard accounting: negative = expenses, positive = income
+// Copilot Money format: positive = expenses, negative = income
 const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn1',
-    amount: -50.0, // Expense (negative = money out)
+    amount: 50.0, // Expense (positive = money out in Copilot format)
     date: '2024-01-15',
     name: 'Coffee Shop',
     category_id: 'food_dining',
@@ -20,7 +20,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn2',
-    amount: -120.5, // Expense (negative = money out)
+    amount: 120.5, // Expense (positive = money out in Copilot format)
     date: '2024-01-20',
     name: 'Grocery Store',
     category_id: 'groceries',
@@ -28,7 +28,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn3',
-    amount: -25.0, // Expense (negative = money out)
+    amount: 25.0, // Expense (positive = money out in Copilot format)
     date: '2024-02-10',
     original_name: 'Fast Food',
     category_id: 'food_dining',
@@ -36,7 +36,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn4',
-    amount: 1000.0, // Income (positive = money in)
+    amount: -1000.0, // Income (negative = money in in Copilot format)
     date: '2024-01-31',
     name: 'Paycheck',
     category_id: 'income',
@@ -66,7 +66,7 @@ const mockAccounts: Account[] = [
 const mockTransactionsWithFilters: Transaction[] = [
   {
     transaction_id: 'txn_normal',
-    amount: -50.0,
+    amount: 50.0, // Expense
     date: '2024-03-01',
     name: 'Normal Transaction',
     category_id: 'shopping',
@@ -74,7 +74,7 @@ const mockTransactionsWithFilters: Transaction[] = [
   },
   {
     transaction_id: 'txn_transfer',
-    amount: -100.0,
+    amount: 100.0, // Transfer (expense)
     date: '2024-03-01',
     name: 'Transfer',
     category_id: 'transfer_credit_card',
@@ -83,7 +83,7 @@ const mockTransactionsWithFilters: Transaction[] = [
   },
   {
     transaction_id: 'txn_deleted',
-    amount: -30.0,
+    amount: 30.0, // Expense
     date: '2024-03-01',
     name: 'Deleted Transaction',
     category_id: 'shopping',
@@ -92,7 +92,7 @@ const mockTransactionsWithFilters: Transaction[] = [
   },
   {
     transaction_id: 'txn_excluded',
-    amount: -40.0,
+    amount: 40.0, // Expense
     date: '2024-03-01',
     name: 'Excluded Transaction',
     category_id: 'shopping',
@@ -638,7 +638,7 @@ describe('CopilotMoneyTools', () => {
         // Last year - food spending
         {
           transaction_id: 'ly1',
-          amount: -100.0, // Expense
+          amount: 100.0, // Expense (positive in Copilot format)
           date: `${lastYear}-06-10`,
           name: 'Restaurant',
           category_id: 'food_dining',
@@ -646,7 +646,7 @@ describe('CopilotMoneyTools', () => {
         },
         {
           transaction_id: 'ly2',
-          amount: -50.0, // Expense
+          amount: 50.0, // Expense (positive in Copilot format)
           date: `${lastYear}-06-15`,
           name: 'Grocery',
           category_id: 'groceries',
@@ -655,7 +655,7 @@ describe('CopilotMoneyTools', () => {
         // This year - food spending increased
         {
           transaction_id: 'ty1',
-          amount: -150.0, // Expense
+          amount: 150.0, // Expense (positive in Copilot format)
           date: `${currentYear}-01-10`,
           name: 'Restaurant',
           category_id: 'food_dining',
@@ -663,7 +663,7 @@ describe('CopilotMoneyTools', () => {
         },
         {
           transaction_id: 'ty2',
-          amount: -75.0, // Expense
+          amount: 75.0, // Expense (positive in Copilot format)
           date: `${currentYear}-01-15`,
           name: 'Grocery',
           category_id: 'groceries',
@@ -672,7 +672,7 @@ describe('CopilotMoneyTools', () => {
         // New category in this year only
         {
           transaction_id: 'ty3',
-          amount: -200.0, // Expense
+          amount: 200.0, // Expense (positive in Copilot format)
           date: `${currentYear}-01-08`,
           name: 'Electronics Store',
           category_id: 'shopping',
@@ -843,11 +843,11 @@ describe('New MCP Tools', () => {
   let tools: CopilotMoneyTools;
 
   // Extended mock data with foreign transactions and refunds
-  // Standard accounting: negative = expenses, positive = income/refunds
+  // Copilot Money format: positive = expenses, negative = income/refunds
   const extendedMockTransactions: Transaction[] = [
     {
       transaction_id: 'txn1',
-      amount: -50.0, // Expense
+      amount: 50.0, // Expense (positive in Copilot format)
       date: '2024-01-15',
       name: 'Coffee Shop',
       category_id: 'food_dining',
@@ -856,7 +856,7 @@ describe('New MCP Tools', () => {
     },
     {
       transaction_id: 'txn2',
-      amount: -120.5, // Expense
+      amount: 120.5, // Expense (positive in Copilot format)
       date: '2024-01-16',
       name: 'Grocery Store',
       category_id: 'groceries',
@@ -865,7 +865,7 @@ describe('New MCP Tools', () => {
     },
     {
       transaction_id: 'txn3',
-      amount: -200.0, // Expense
+      amount: 200.0, // Expense (positive in Copilot format)
       date: '2024-01-17',
       name: 'Foreign Restaurant',
       category_id: 'food_dining',
@@ -874,7 +874,7 @@ describe('New MCP Tools', () => {
     },
     {
       transaction_id: 'txn4',
-      amount: 50.0, // Refund (positive = money coming back)
+      amount: -50.0, // Refund (negative = money coming back in Copilot format)
       date: '2024-01-18',
       name: 'Amazon Refund',
       category_id: 'shopping',
@@ -882,7 +882,7 @@ describe('New MCP Tools', () => {
     },
     {
       transaction_id: 'txn5',
-      amount: 25.0, // Statement credit (positive = money coming back)
+      amount: -25.0, // Statement credit (negative = money coming back in Copilot format)
       date: '2024-01-19',
       name: 'Uber Credit',
       category_id: 'travel',
@@ -890,7 +890,7 @@ describe('New MCP Tools', () => {
     },
     {
       transaction_id: 'txn6',
-      amount: -15.0, // Expense
+      amount: 15.0, // Expense (positive in Copilot format)
       date: '2024-01-15', // Same date as txn1 - potential duplicate
       name: 'Coffee Shop',
       category_id: 'food_dining',
@@ -898,7 +898,7 @@ describe('New MCP Tools', () => {
     },
     {
       transaction_id: 'txn7',
-      amount: -45.0, // Expense
+      amount: 45.0, // Expense (positive in Copilot format)
       date: '2024-01-20',
       name: 'CVS Pharmacy',
       category_id: 'medical_pharmacies_and_supplements',
@@ -1278,7 +1278,7 @@ describe('New MCP Tools', () => {
         // Income - should be excluded (negative amount)
         {
           transaction_id: 'inc1',
-          amount: -3000.0,
+          amount: 3000.0,
           date: '2024-01-15',
           name: 'Employer Inc',
           category_id: 'income',
@@ -1799,7 +1799,7 @@ describe('New MCP Tools', () => {
         // Trip to France
         {
           transaction_id: 'trip1',
-          amount: -150.0, // Expense
+          amount: 150.0, // Expense (positive in Copilot format)
           date: '2024-03-01',
           name: 'Hotel Paris',
           category_id: 'travel',
@@ -1809,7 +1809,7 @@ describe('New MCP Tools', () => {
         },
         {
           transaction_id: 'trip2',
-          amount: -45.0, // Expense
+          amount: 45.0, // Expense (positive in Copilot format)
           date: '2024-03-02',
           name: 'Restaurant Paris',
           category_id: 'food_dining',
@@ -1819,7 +1819,7 @@ describe('New MCP Tools', () => {
         },
         {
           transaction_id: 'trip3',
-          amount: -80.0, // Expense
+          amount: 80.0, // Expense (positive in Copilot format)
           date: '2024-03-03',
           name: 'Museum',
           category_id: 'entertainment',
@@ -1830,7 +1830,7 @@ describe('New MCP Tools', () => {
         // Domestic transaction (should be excluded)
         {
           transaction_id: 'dom1',
-          amount: -50.0, // Expense
+          amount: 50.0, // Expense (positive in Copilot format)
           date: '2024-03-05',
           name: 'Local Store',
           category_id: 'shopping',
@@ -1840,7 +1840,7 @@ describe('New MCP Tools', () => {
         // Trip to Japan (separate trip)
         {
           transaction_id: 'trip4',
-          amount: -200.0, // Expense
+          amount: 200.0, // Expense (positive in Copilot format)
           date: '2024-05-10',
           name: 'Tokyo Hotel',
           category_id: 'travel',
@@ -1850,7 +1850,7 @@ describe('New MCP Tools', () => {
         },
         {
           transaction_id: 'trip5',
-          amount: -60.0, // Expense
+          amount: 60.0, // Expense (positive in Copilot format)
           date: '2024-05-11',
           name: 'Sushi Restaurant',
           category_id: 'food_dining',
@@ -1941,7 +1941,7 @@ describe('New MCP Tools', () => {
       const travelCategoryTransactions: Transaction[] = [
         {
           transaction_id: 'tc1',
-          amount: -500.0, // Expense
+          amount: 500.0, // Expense (positive in Copilot format)
           date: '2024-06-01',
           name: 'Airline',
           category_id: 'travel',
@@ -1949,7 +1949,7 @@ describe('New MCP Tools', () => {
         },
         {
           transaction_id: 'tc2',
-          amount: -200.0, // Expense
+          amount: 200.0, // Expense (positive in Copilot format)
           date: '2024-06-02',
           name: 'Hotel',
           category_id: 'travel',
@@ -1971,7 +1971,7 @@ describe('New MCP Tools', () => {
       const numericCategoryTransactions: Transaction[] = [
         {
           transaction_id: 'nc1',
-          amount: -300.0, // Expense
+          amount: 300.0, // Expense (positive in Copilot format)
           date: '2024-07-01',
           name: 'Travel Agency',
           category_id: '22001',
@@ -1979,7 +1979,7 @@ describe('New MCP Tools', () => {
         },
         {
           transaction_id: 'nc2',
-          amount: -150.0, // Expense
+          amount: 150.0, // Expense (positive in Copilot format)
           date: '2024-07-02',
           name: 'Car Rental',
           category_id: '22002',
@@ -2003,7 +2003,7 @@ describe('New MCP Tools', () => {
         // First trip
         {
           transaction_id: 'st1',
-          amount: -100.0, // Expense
+          amount: 100.0, // Expense (positive in Copilot format)
           date: '2024-04-01',
           name: 'Hotel Mexico',
           category_id: 'travel',
@@ -2013,7 +2013,7 @@ describe('New MCP Tools', () => {
         },
         {
           transaction_id: 'st2',
-          amount: -50.0, // Expense
+          amount: 50.0, // Expense (positive in Copilot format)
           date: '2024-04-02',
           name: 'Restaurant Mexico',
           category_id: 'food_dining',
@@ -2024,7 +2024,7 @@ describe('New MCP Tools', () => {
         // Second trip (>3 days later)
         {
           transaction_id: 'st3',
-          amount: -150.0, // Expense
+          amount: 150.0, // Expense (positive in Copilot format)
           date: '2024-04-10',
           name: 'Hotel Mexico City',
           category_id: 'travel',
@@ -2034,7 +2034,7 @@ describe('New MCP Tools', () => {
         },
         {
           transaction_id: 'st4',
-          amount: -75.0, // Expense
+          amount: 75.0, // Expense (positive in Copilot format)
           date: '2024-04-11',
           name: 'Restaurant Mexico City',
           category_id: 'food_dining',
@@ -2060,7 +2060,7 @@ describe('New MCP Tools', () => {
       const noCityTransactions: Transaction[] = [
         {
           transaction_id: 'ncty1',
-          amount: -100.0, // Expense
+          amount: 100.0, // Expense (positive in Copilot format)
           date: '2024-08-01',
           name: 'Hotel',
           category_id: 'travel',
@@ -2070,7 +2070,7 @@ describe('New MCP Tools', () => {
         },
         {
           transaction_id: 'ncty2',
-          amount: -50.0, // Expense
+          amount: 50.0, // Expense (positive in Copilot format)
           date: '2024-08-02',
           name: 'Restaurant',
           category_id: 'food_dining',
@@ -2097,7 +2097,7 @@ describe('New MCP Tools', () => {
       const transactionsWithRefund: Transaction[] = [
         {
           transaction_id: 'ref1',
-          amount: -200.0, // Expense
+          amount: 200.0, // Expense (positive in Copilot format)
           date: '2024-09-01',
           name: 'Hotel Italy',
           category_id: 'travel',
@@ -2107,7 +2107,7 @@ describe('New MCP Tools', () => {
         },
         {
           transaction_id: 'ref2',
-          amount: 50.0, // Refund (positive = money back)
+          amount: -50.0, // Refund (negative in Copilot format = money coming back)
           date: '2024-09-02',
           name: 'Refund',
           category_id: 'travel',
@@ -2117,7 +2117,7 @@ describe('New MCP Tools', () => {
         },
         {
           transaction_id: 'ref3',
-          amount: -100.0, // Expense
+          amount: 100.0, // Expense (positive in Copilot format)
           date: '2024-09-03',
           name: 'Restaurant',
           category_id: 'food_dining',
@@ -2158,7 +2158,7 @@ describe('New MCP Tools', () => {
       const usaTransactions: Transaction[] = [
         {
           transaction_id: 'usa1',
-          amount: -100.0, // Expense
+          amount: 100.0, // Expense (positive in Copilot format)
           date: '2024-10-01',
           name: 'Hotel',
           category_id: 'travel',
@@ -2218,7 +2218,7 @@ describe('New MCP Tools', () => {
       const singleDayTrip: Transaction[] = [
         {
           transaction_id: 'sd1',
-          amount: -50.0, // Expense
+          amount: 50.0, // Expense (positive in Copilot format)
           date: '2024-11-15',
           name: 'Day Trip',
           category_id: 'travel',
@@ -2248,7 +2248,7 @@ describe('New MCP Tools', () => {
       const gappyTrip: Transaction[] = [
         {
           transaction_id: 'gt1',
-          amount: -100.0, // Expense
+          amount: 100.0, // Expense (positive in Copilot format)
           date: '2024-12-01',
           name: 'Hotel Day 1',
           category_id: 'travel',
@@ -2259,7 +2259,7 @@ describe('New MCP Tools', () => {
         // 3 day gap - should still be same trip
         {
           transaction_id: 'gt2',
-          amount: -75.0, // Expense
+          amount: 75.0, // Expense (positive in Copilot format)
           date: '2024-12-04',
           name: 'Restaurant Day 4',
           category_id: 'food_dining',
@@ -2289,7 +2289,7 @@ describe('New MCP Tools', () => {
       const unknownCountryTransactions: Transaction[] = [
         {
           transaction_id: 'uc1',
-          amount: -100.0, // Expense
+          amount: 100.0, // Expense (positive in Copilot format)
           date: '2024-01-15',
           name: 'Mystery Place',
           category_id: 'travel',
@@ -2298,7 +2298,7 @@ describe('New MCP Tools', () => {
         },
         {
           transaction_id: 'uc2',
-          amount: -50.0, // Expense
+          amount: 50.0, // Expense (positive in Copilot format)
           date: '2024-01-16',
           name: 'Mystery Restaurant',
           category_id: 'travel',
@@ -3163,7 +3163,7 @@ describe('New MCP Tools', () => {
       expect(result.transaction).toBeDefined();
       if (result.transaction) {
         expect(result.transaction.transaction_id).toBe('txn1');
-        expect(result.transaction.amount).toBe(-50.0); // Expense (negative)
+        expect(result.transaction.amount).toBe(50.0); // Expense (positive in Copilot format)
         expect(result.transaction.name).toBe('Coffee Shop');
       }
     });
@@ -3358,7 +3358,7 @@ describe('New MCP Tools', () => {
         // Negative unrealistic transaction (large income)
         {
           transaction_id: 'unrealistic2',
-          amount: -1500000.0,
+          amount: 1500000.0,
           date: '2024-01-28',
           name: 'Suspicious Income',
           category_id: 'income',

--- a/tests/unit/server-protocol.test.ts
+++ b/tests/unit/server-protocol.test.ts
@@ -12,11 +12,11 @@ import { CopilotMoneyTools } from '../../src/tools/tools.js';
 import type { Transaction, Account } from '../../src/models/index.js';
 
 // Mock data for testing
-// Standard accounting: negative = expenses, positive = income/refunds
+// Copilot Money format: positive = expenses, negative = income/refunds
 const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn1',
-    amount: -50.0, // Expense
+    amount: 50.0, // Expense (positive in Copilot format)
     date: '2025-01-15',
     name: 'Coffee Shop',
     category_id: 'food_dining',
@@ -25,7 +25,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn2',
-    amount: -120.5, // Expense
+    amount: 120.5, // Expense (positive in Copilot format)
     date: '2025-01-20',
     name: 'Grocery Store',
     category_id: 'groceries',
@@ -34,7 +34,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn3',
-    amount: -10.0, // Expense
+    amount: 10.0, // Expense (positive in Copilot format)
     date: '2024-12-15',
     name: 'Parking',
     category_id: 'transportation',
@@ -50,7 +50,7 @@ const mockTransactions: Transaction[] = [
   },
   {
     transaction_id: 'txn5',
-    amount: -100.0, // Expense
+    amount: 100.0, // Expense (positive in Copilot format)
     date: '2025-01-10',
     name: 'Foreign Purchase',
     category_id: 'shopping',

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -9,11 +9,11 @@ import { CopilotMoneyTools } from '../../src/tools/tools.js';
 import type { Transaction, Account } from '../../src/models/index.js';
 
 // Mock data
-// Standard accounting: negative = expenses, positive = income
+// Copilot Money format: positive = expenses, negative = income
 const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn1',
-    amount: -50.0, // Expense
+    amount: 50.0, // Expense (positive in Copilot format)
     date: '2025-01-15',
     name: 'Test Transaction',
     category_id: 'food_dining',

--- a/tests/unit/signal-timer-coverage.test.ts
+++ b/tests/unit/signal-timer-coverage.test.ts
@@ -24,7 +24,7 @@ import fs from 'node:fs';
 const mockTransactions: Transaction[] = [
   {
     transaction_id: 'txn1',
-    amount: -50.0,
+    amount: 50.0,
     date: '2025-01-15',
     name: 'Coffee Shop',
     category_id: 'food_dining',


### PR DESCRIPTION
## Summary

- **Fixes critical bug** where `get_spending` and `getSpendingByCategory` were reporting ~93% of spending as "Uncategorized"
- **Root cause**: PR #71 incorrectly inverted sign checks to use "standard accounting" when Copilot Money uses the opposite convention
- **Copilot Money format**: Positive = expenses (money OUT), Negative = income (money IN)

### Before (broken)
```
get_spending(group_by="category"):
  Uncategorized: $5,320.33 (93%)
  Other categories: ~$400 (7%)
```

### After (fixed)
```
get_spending(group_by="category"):
  Rent: $2,995.66 (37%)
  Restaurants: $1,073.67 (13%)
  General Shopping: $743.81 (9%)
  Hotels: $510.09 (6%)
  Healthcare: $477.89 (6%)
  Groceries: $449.36 (6%)
  ... and 11 more categories
```

## Changes

- Fix ~50 sign checks in `src/tools/tools.ts`:
  - `amount > 0` for expense detection (was incorrectly `< 0`)
  - `amount < 0` for income detection (was incorrectly `> 0`)
- Fix `getHsaFsaEligible`, `getRefunds`, `getCredits` sign checks
- Update documentation in `src/models/transaction.ts`
- Update all test mock data to use correct sign convention (12 test files)

## Test plan

- [x] All 1028 tests pass
- [x] Verified `get_spending(group_by="category")` against real database
- [x] Verified `getSpendingByCategory` against real database
- [x] Real database integration tests pass (26 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)