### PR TITLE
Add name filter and detail view to get_recurring_transactions

### DIFF
--- a/docs/firestore-collections.md
+++ b/docs/firestore-collections.md
@@ -155,17 +155,47 @@ Monthly budget configurations.
 
 **Path:** `users/{user_id}/recurring/{recurring_id}`
 
-Recurring transaction patterns detected or defined by user.
+Recurring transaction patterns (subscriptions, bills) detected or defined by user.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `recurring_id` | string | Unique identifier |
-| `name` | string | Recurring item name |
-| `amount` | number | Expected amount |
-| `frequency` | string | Frequency (`"monthly"`, `"weekly"`, etc.) |
-| `category_id` | string | Associated category |
-| `next_date` | string | Next expected date |
-| `is_income` | boolean | Whether this is income |
+| `id` | string | Unique identifier (stored as `id`, mapped to `recurring_id`) |
+| `name` | string | Display name (user-editable) |
+| `emoji` | string | Display emoji for UI |
+| `amount` | number | Expected amount (positive = expense) |
+| `min_amount` | number | Minimum amount for matching range |
+| `max_amount` | number | Maximum amount for matching range |
+| `frequency` | string | Frequency (see values below) |
+| `state` | string | Status: `"active"`, `"paused"`, `"archived"` |
+| `latest_date` | string | Last payment date (YYYY-MM-DD) |
+| `category_id` | string | Internal category ID |
+| `plaid_category_id` | string | Plaid category ID (e.g., `"18009000"`) |
+| `match_string` | string | Merchant name pattern for matching transactions |
+| `transaction_ids` | string[] | Array of associated transaction IDs |
+| `included_transaction_ids` | string[] | Manually included transaction IDs |
+| `excluded_transaction_ids` | string[] | Manually excluded transaction IDs |
+| `days_filter` | number | Day of month filter for matching |
+| `skip_filter_update` | boolean | Whether to skip automatic filter updates |
+| `identification_method` | string | How the recurring was detected (e.g., `"new_existing"`) |
+| `_origin` | string | Source of the record (e.g., `"firebase"`) |
+
+**Frequency Values:**
+- `daily`, `weekly`, `biweekly` (every 2 weeks)
+- `monthly`, `bimonthly` (every 2 months), `quarterly` (every 3 months)
+- `quadmonthly` (every 4 months), `semiannually` (every 6 months)
+- `annually` / `yearly`
+
+**Important Notes:**
+- `state` replaces the older `is_active` boolean field
+- `latest_date` is the actual field name (not `last_date`)
+- `next_date` is NOT stored - must be calculated from `latest_date` + `frequency`
+- `id` field contains the recurring_id (not `recurring_id`)
+- The UI groups items by state and payment status:
+  - **This Month**: Active items with `latest_date` in current month (paid) or calculated `next_date` in current month (upcoming)
+  - **Overdue**: Active items where calculated `next_date` is before today
+  - **In the Future**: Active items where calculated `next_date` is after current month
+  - **Paused**: Items with `state: "paused"`
+  - **Archived**: Items with `state: "archived"`
 
 ---
 
@@ -287,4 +317,5 @@ Transactions can be excluded via:
 
 | Date | Changes |
 |------|---------|
+| 2026-01-18 | Updated `recurring` collection with complete field list: `state`, `emoji`, `latest_date`, `match_string`, `min_amount`/`max_amount`, `transaction_ids`, `plaid_category_id`, etc. Added UI grouping logic notes. |
 | 2026-01-18 | Initial documentation. Added goal history parsing fixes. |

--- a/manifest.json
+++ b/manifest.json
@@ -42,7 +42,7 @@
     },
     {
       "name": "get_recurring_transactions",
-      "description": "Identify recurring/subscription charges with frequency, monthly cost, confidence score, and next expected charge date"
+      "description": "Identify recurring/subscription charges with frequency, monthly cost, confidence score, and next expected charge date. Filter by name or recurring_id for detailed view with transaction history and account info."
     },
     {
       "name": "get_budgets",

--- a/src/models/recurring.ts
+++ b/src/models/recurring.ts
@@ -9,19 +9,27 @@ import { z } from 'zod';
 
 /**
  * Known frequency values for recurring transactions.
- * Used for documentation and type hints; the schema accepts any string
- * to handle unexpected values from the database.
+ * Maps raw frequency strings to display-friendly names.
  */
 export const KNOWN_FREQUENCIES = [
   'daily',
   'weekly',
-  'biweekly',
+  'biweekly', // Every 2 weeks
   'monthly',
-  'quarterly',
+  'bimonthly', // Every 2 months
+  'quarterly', // Every 3 months
+  'quadmonthly', // Every 4 months
+  'semiannually', // Every 6 months
   'yearly',
 ] as const;
 
 export type KnownFrequency = (typeof KNOWN_FREQUENCIES)[number];
+
+/**
+ * State values for recurring items.
+ */
+export const RECURRING_STATES = ['active', 'paused', 'archived'] as const;
+export type RecurringState = (typeof RECURRING_STATES)[number];
 
 /**
  * Date format regex for YYYY-MM-DD validation.
@@ -43,18 +51,30 @@ export const RecurringSchema = z
     name: z.string().optional(),
     merchant_name: z.string().optional(),
     amount: z.number().optional(),
+    min_amount: z.number().optional(),
+    max_amount: z.number().optional(),
+    emoji: z.string().optional(),
 
     // Frequency and schedule
-    frequency: z.enum(['daily', 'weekly', 'biweekly', 'monthly', 'quarterly', 'yearly']).optional(),
+    frequency: z.string().optional(), // Accept any string since Copilot uses various values
     next_date: z.string().regex(DATE_REGEX, 'Must be YYYY-MM-DD format').optional(),
     last_date: z.string().regex(DATE_REGEX, 'Must be YYYY-MM-DD format').optional(),
+    days_filter: z.number().optional(), // Day of month filter
 
     // References
     category_id: z.string().optional(),
+    plaid_category_id: z.string().optional(),
     account_id: z.string().optional(),
 
-    // Status
+    // Status - state is the primary field, is_active derived for compatibility
+    state: z.enum(['active', 'paused', 'archived']).optional(),
     is_active: z.boolean().optional(),
+
+    // Matching rules
+    match_string: z.string().optional(),
+
+    // Associated transactions
+    transaction_ids: z.array(z.string()).optional(),
 
     // Metadata
     iso_currency_code: z.string().optional(),

--- a/tests/models/recurring-coverage.test.ts
+++ b/tests/models/recurring-coverage.test.ts
@@ -106,10 +106,29 @@ describe('recurring.ts', () => {
       }
     });
 
-    test('rejects invalid frequency values', () => {
+    test('accepts any frequency string value', () => {
+      // frequency is now a string type to accommodate various Copilot values
       const result = RecurringSchema.safeParse({
         recurring_id: 'rec-1',
-        frequency: 'semi-annually', // not a valid enum value
+        frequency: 'custom-frequency',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    test('validates state field with valid values', () => {
+      for (const state of ['active', 'paused', 'archived']) {
+        const result = RecurringSchema.safeParse({
+          recurring_id: 'rec-1',
+          state,
+        });
+        expect(result.success).toBe(true);
+      }
+    });
+
+    test('rejects invalid state values', () => {
+      const result = RecurringSchema.safeParse({
+        recurring_id: 'rec-1',
+        state: 'unknown-state',
       });
       expect(result.success).toBe(false);
     });
@@ -121,12 +140,15 @@ describe('recurring.ts', () => {
       expect(KNOWN_FREQUENCIES).toContain('weekly');
       expect(KNOWN_FREQUENCIES).toContain('biweekly');
       expect(KNOWN_FREQUENCIES).toContain('monthly');
+      expect(KNOWN_FREQUENCIES).toContain('bimonthly');
       expect(KNOWN_FREQUENCIES).toContain('quarterly');
+      expect(KNOWN_FREQUENCIES).toContain('quadmonthly');
+      expect(KNOWN_FREQUENCIES).toContain('semiannually');
       expect(KNOWN_FREQUENCIES).toContain('yearly');
     });
 
-    test('has exactly 6 frequency values', () => {
-      expect(KNOWN_FREQUENCIES.length).toBe(6);
+    test('has expected number of frequency values', () => {
+      expect(KNOWN_FREQUENCIES.length).toBe(9);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `name` (case-insensitive partial match) and `recurring_id` (exact match) filters to `get_recurring_transactions`
- When filtering, return detailed view with additional fields: min_amount, max_amount, match_string, account_id, account_name, transaction_history
- Fix items without `state` field defaulting to active (fixes Seattle Times missing from results)
- Enhanced decoder to extract new recurring fields: transaction_ids, match_string, emoji, min/max amounts

## Test plan
- [x] All 721 tests pass
- [x] TypeScript compiles without errors
- [x] Lint passes (warnings only for pre-existing non-null assertions)
- [ ] Test name filter: `get_recurring_transactions({ name: "Parking" })`
- [ ] Test ID filter: `get_recurring_transactions({ recurring_id: "..." })`
- [ ] Verify items without state (like Seattle Times) appear in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)