### PR TITLE
Improve test coverage from 95.48% to 95.98%

### DIFF
--- a/tests/core/database.test.ts
+++ b/tests/core/database.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for CopilotDatabase abstraction layer.
  */
 
-import { describe, test, expect, beforeEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { CopilotDatabase } from '../../src/core/database.js';
 import type { Transaction, Account, Recurring } from '../../src/models/index.js';
 
@@ -260,6 +260,80 @@ describe('CopilotDatabase', () => {
       const result = await db.getRecurring(true);
       const inactive = result.find((r) => r.is_active === false);
       expect(inactive).toBeUndefined();
+    });
+  });
+
+  describe('Cache TTL configuration', () => {
+    const originalEnv = process.env.COPILOT_CACHE_TTL_MINUTES;
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.COPILOT_CACHE_TTL_MINUTES;
+      } else {
+        process.env.COPILOT_CACHE_TTL_MINUTES = originalEnv;
+      }
+    });
+
+    test('uses custom TTL from environment variable', async () => {
+      process.env.COPILOT_CACHE_TTL_MINUTES = '10';
+
+      // Create a new database to pick up the env var
+      const testDb = new CopilotDatabase('/fake/path');
+      (testDb as any)._transactions = [...mockTransactions];
+      (testDb as any)._accounts = [...mockAccounts];
+      (testDb as any)._recurring = [...mockRecurring];
+      (testDb as any)._budgets = [];
+      (testDb as any)._goals = [];
+      (testDb as any)._goalHistory = [];
+      (testDb as any)._investmentPrices = [];
+      (testDb as any)._investmentSplits = [];
+      (testDb as any)._items = [];
+      (testDb as any)._userCategories = [];
+      (testDb as any)._userAccounts = [];
+      (testDb as any)._cacheLoadedAt = Date.now();
+
+      // The cache should not be stale since we just set cacheLoadedAt
+      const cacheInfo = await testDb.getCacheInfo();
+      expect(cacheInfo).toBeDefined();
+      expect(cacheInfo?.transaction_count).toBe(3);
+    });
+
+    test('disables caching when TTL is 0', async () => {
+      process.env.COPILOT_CACHE_TTL_MINUTES = '0';
+
+      // Create a new database to pick up the env var
+      const testDb = new CopilotDatabase('/fake/path');
+      (testDb as any)._transactions = [...mockTransactions];
+      (testDb as any)._accounts = [...mockAccounts];
+      (testDb as any)._recurring = [...mockRecurring];
+      (testDb as any)._budgets = [];
+      (testDb as any)._goals = [];
+      (testDb as any)._goalHistory = [];
+      (testDb as any)._investmentPrices = [];
+      (testDb as any)._investmentSplits = [];
+      (testDb as any)._items = [];
+      (testDb as any)._userCategories = [];
+      (testDb as any)._userAccounts = [];
+      (testDb as any)._cacheLoadedAt = Date.now();
+
+      // With TTL=0, isCacheStale should always return true
+      // Which means getCacheInfo should trigger a reload attempt
+      // But since we have fake path, it will fail gracefully
+      const cacheInfo = await testDb.getCacheInfo();
+      expect(cacheInfo).toBeDefined();
+    });
+
+    test('handles invalid TTL value gracefully', async () => {
+      process.env.COPILOT_CACHE_TTL_MINUTES = 'not-a-number';
+
+      // Should fall back to default TTL
+      const testDb = new CopilotDatabase('/fake/path');
+      (testDb as any)._transactions = [...mockTransactions];
+      (testDb as any)._accounts = [...mockAccounts];
+      (testDb as any)._cacheLoadedAt = Date.now();
+
+      const cacheInfo = await testDb.getCacheInfo();
+      expect(cacheInfo).toBeDefined();
     });
   });
 });

--- a/tests/core/decoder-coverage.test.ts
+++ b/tests/core/decoder-coverage.test.ts
@@ -786,5 +786,425 @@ describe('decoder coverage', () => {
       expect(result.userAccounts[0]?.name).toBe('My Custom Account Name');
       expect(result.userAccounts[0]?.user_id).toBe('user123');
     });
+
+    test('handles internal_transfer transactions', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'internal-transfer-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'transactions',
+          id: 'txn1',
+          fields: {
+            transaction_id: 'txn1',
+            amount: 500.0,
+            date: '2024-01-15',
+            name: 'Transfer to Savings',
+            type: 'internal_transfer',
+          },
+        },
+      ]);
+
+      const result = await decodeAllCollections(dbPath);
+
+      expect(result.transactions.length).toBe(1);
+      expect(result.transactions[0]?.internal_transfer).toBe(true);
+    });
+
+    test('handles accounts with available_balance', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'available-balance-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'accounts',
+          id: 'acc1',
+          fields: {
+            account_id: 'acc1',
+            name: 'Checking',
+            current_balance: 1000.0,
+            available_balance: 950.0,
+            account_type: 'depository',
+          },
+        },
+      ]);
+
+      const result = await decodeAllCollections(dbPath);
+
+      expect(result.accounts.length).toBe(1);
+      expect(result.accounts[0]?.available_balance).toBe(950);
+    });
+
+    test('handles accounts with user_deleted flag', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'user-deleted-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'accounts',
+          id: 'acc1',
+          fields: {
+            account_id: 'acc1',
+            name: 'Old Account',
+            current_balance: 0,
+            user_deleted: true,
+          },
+        },
+      ]);
+
+      const result = await decodeAllCollections(dbPath);
+
+      expect(result.accounts.length).toBe(1);
+      expect(result.accounts[0]?.user_deleted).toBe(true);
+    });
+
+    test('skips accounts without balance', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'no-balance-account-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'accounts',
+          id: 'acc1',
+          fields: {
+            account_id: 'acc1',
+            name: 'Bad Account',
+            // No current_balance - should be skipped
+          },
+        },
+        {
+          collection: 'accounts',
+          id: 'acc2',
+          fields: {
+            account_id: 'acc2',
+            name: 'Good Account',
+            current_balance: 100,
+          },
+        },
+      ]);
+
+      const result = await decodeAllCollections(dbPath);
+
+      expect(result.accounts.length).toBe(1);
+      expect(result.accounts[0]?.account_id).toBe('acc2');
+    });
+
+    test('skips accounts without name or official_name', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'no-name-account-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'accounts',
+          id: 'acc1',
+          fields: {
+            account_id: 'acc1',
+            current_balance: 100,
+            // No name or official_name - should be skipped
+          },
+        },
+        {
+          collection: 'accounts',
+          id: 'acc2',
+          fields: {
+            account_id: 'acc2',
+            official_name: 'My Official Account',
+            current_balance: 200,
+          },
+        },
+      ]);
+
+      const result = await decodeAllCollections(dbPath);
+
+      expect(result.accounts.length).toBe(1);
+      expect(result.accounts[0]?.official_name).toBe('My Official Account');
+    });
+
+    test('handles recurring with transaction_ids array', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'recurring-txn-ids-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'recurring',
+          id: 'rec1',
+          fields: {
+            recurring_id: 'rec1',
+            name: 'Netflix',
+            amount: 15.99,
+            frequency: 'monthly',
+            transaction_ids: ['txn1', 'txn2', 'txn3'],
+          },
+        },
+      ]);
+
+      const result = await decodeAllCollections(dbPath);
+
+      expect(result.recurring.length).toBe(1);
+      expect(result.recurring[0]?.transaction_ids).toEqual(['txn1', 'txn2', 'txn3']);
+    });
+
+    test('handles recurring with emoji field', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'recurring-emoji-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'recurring',
+          id: 'rec1',
+          fields: {
+            recurring_id: 'rec1',
+            name: 'Spotify',
+            amount: 9.99,
+            frequency: 'monthly',
+            emoji: '🎵',
+          },
+        },
+      ]);
+
+      const result = await decodeAllCollections(dbPath);
+
+      expect(result.recurring.length).toBe(1);
+      expect(result.recurring[0]?.emoji).toBe('🎵');
+    });
+
+    test('handles recurring with state field', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'recurring-state-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'recurring',
+          id: 'rec1',
+          fields: {
+            recurring_id: 'rec1',
+            name: 'Old Subscription',
+            amount: 20.0,
+            frequency: 'monthly',
+            state: 'paused',
+          },
+        },
+      ]);
+
+      const result = await decodeAllCollections(dbPath);
+
+      expect(result.recurring.length).toBe(1);
+      expect(result.recurring[0]?.state).toBe('paused');
+    });
+
+    test('calculates next_date from latest_date and frequency', async () => {
+      // Note: Copilot uses 'latest_date' field, and next_date is calculated from it
+      const dbPath = path.join(FIXTURES_DIR, 'recurring-next-date-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'recurring',
+          id: 'rec1',
+          fields: {
+            recurring_id: 'rec1',
+            name: 'Weekly Sub',
+            amount: 10.0,
+            frequency: 'weekly',
+            latest_date: '2024-01-15', // Use latest_date (Copilot's field name)
+          },
+        },
+        {
+          collection: 'recurring',
+          id: 'rec2',
+          fields: {
+            recurring_id: 'rec2',
+            name: 'Biweekly Sub',
+            amount: 20.0,
+            frequency: 'biweekly',
+            latest_date: '2024-01-15',
+          },
+        },
+        {
+          collection: 'recurring',
+          id: 'rec3',
+          fields: {
+            recurring_id: 'rec3',
+            name: 'Quarterly Sub',
+            amount: 30.0,
+            frequency: 'quarterly',
+            latest_date: '2024-01-15',
+          },
+        },
+        {
+          collection: 'recurring',
+          id: 'rec4',
+          fields: {
+            recurring_id: 'rec4',
+            name: 'Yearly Sub',
+            amount: 100.0,
+            frequency: 'yearly',
+            latest_date: '2024-01-15',
+          },
+        },
+        {
+          collection: 'recurring',
+          id: 'rec5',
+          fields: {
+            recurring_id: 'rec5',
+            name: 'Semiannual Sub',
+            amount: 50.0,
+            frequency: 'semiannually',
+            latest_date: '2024-01-15',
+          },
+        },
+        {
+          collection: 'recurring',
+          id: 'rec6',
+          fields: {
+            recurring_id: 'rec6',
+            name: 'Daily Sub',
+            amount: 1.0,
+            frequency: 'daily',
+            latest_date: '2024-01-15',
+          },
+        },
+        {
+          collection: 'recurring',
+          id: 'rec7',
+          fields: {
+            recurring_id: 'rec7',
+            name: 'Bimonthly Sub',
+            amount: 25.0,
+            frequency: 'bimonthly',
+            latest_date: '2024-01-15',
+          },
+        },
+        {
+          collection: 'recurring',
+          id: 'rec8',
+          fields: {
+            recurring_id: 'rec8',
+            name: 'Quadmonthly Sub',
+            amount: 40.0,
+            frequency: 'quadmonthly',
+            latest_date: '2024-01-15',
+          },
+        },
+        {
+          collection: 'recurring',
+          id: 'rec9',
+          fields: {
+            recurring_id: 'rec9',
+            name: 'Unknown Freq Sub',
+            amount: 5.0,
+            frequency: 'unknown_frequency',
+            latest_date: '2024-01-15',
+          },
+        },
+      ]);
+
+      const result = await decodeAllCollections(dbPath);
+
+      expect(result.recurring.length).toBe(9);
+
+      // Find each recurring by name and verify next_date calculation
+      const weekly = result.recurring.find((r) => r.name === 'Weekly Sub');
+      expect(weekly?.next_date).toBe('2024-01-22'); // +7 days
+
+      const biweekly = result.recurring.find((r) => r.name === 'Biweekly Sub');
+      expect(biweekly?.next_date).toBe('2024-01-29'); // +14 days
+
+      const quarterly = result.recurring.find((r) => r.name === 'Quarterly Sub');
+      expect(quarterly?.next_date).toBe('2024-04-15'); // +3 months
+
+      const yearly = result.recurring.find((r) => r.name === 'Yearly Sub');
+      expect(yearly?.next_date).toBe('2025-01-15'); // +1 year
+
+      const semiannual = result.recurring.find((r) => r.name === 'Semiannual Sub');
+      expect(semiannual?.next_date).toBe('2024-07-15'); // +6 months
+
+      const daily = result.recurring.find((r) => r.name === 'Daily Sub');
+      expect(daily?.next_date).toBe('2024-01-16'); // +1 day
+
+      const bimonthly = result.recurring.find((r) => r.name === 'Bimonthly Sub');
+      expect(bimonthly?.next_date).toBe('2024-03-15'); // +2 months
+
+      const quadmonthly = result.recurring.find((r) => r.name === 'Quadmonthly Sub');
+      expect(quadmonthly?.next_date).toBe('2024-05-15'); // +4 months
+
+      const unknown = result.recurring.find((r) => r.name === 'Unknown Freq Sub');
+      expect(unknown?.next_date).toBe('2024-02-15'); // default monthly
+    });
+
+    test('handles investment prices with sorting', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'investment-prices-sort-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'investment_prices',
+          id: 'price1',
+          fields: {
+            investment_id: 'inv1',
+            ticker_symbol: 'AAPL',
+            price: 150.0,
+            date: '2024-01-10',
+          },
+        },
+        {
+          collection: 'investment_prices',
+          id: 'price2',
+          fields: {
+            investment_id: 'inv1',
+            ticker_symbol: 'AAPL',
+            price: 155.0,
+            date: '2024-01-20',
+          },
+        },
+        {
+          collection: 'investment_prices',
+          id: 'price3',
+          fields: {
+            investment_id: 'inv2',
+            ticker_symbol: 'GOOGL',
+            price: 140.0,
+            date: '2024-01-15',
+          },
+        },
+      ]);
+
+      const result = await decodeAllCollections(dbPath);
+
+      // Should be sorted by investment_id, then by date (newest first)
+      expect(result.investmentPrices.length).toBe(3);
+      // First investment sorted by date desc
+      expect(result.investmentPrices[0]?.investment_id).toBe('inv1');
+      expect(result.investmentPrices[0]?.date).toBe('2024-01-20');
+      expect(result.investmentPrices[1]?.investment_id).toBe('inv1');
+      expect(result.investmentPrices[1]?.date).toBe('2024-01-10');
+      // Then second investment
+      expect(result.investmentPrices[2]?.investment_id).toBe('inv2');
+    });
+
+    test('handles investment splits with sorting', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'investment-splits-sort-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'investment_splits',
+          id: 'split1',
+          fields: {
+            split_id: 'split1',
+            ticker_symbol: 'AAPL',
+            split_date: '2024-01-10',
+          },
+        },
+        {
+          collection: 'investment_splits',
+          id: 'split2',
+          fields: {
+            split_id: 'split2',
+            ticker_symbol: 'AAPL',
+            split_date: '2024-01-20',
+          },
+        },
+        {
+          collection: 'investment_splits',
+          id: 'split3',
+          fields: {
+            split_id: 'split3',
+            ticker_symbol: 'GOOGL',
+            split_date: '2024-01-15',
+          },
+        },
+      ]);
+
+      const result = await decodeAllCollections(dbPath);
+
+      // Should be sorted by ticker_symbol, then by split_date (newest first)
+      expect(result.investmentSplits.length).toBe(3);
+      // AAPL first (alphabetically), newest date first
+      expect(result.investmentSplits[0]?.ticker_symbol).toBe('AAPL');
+      expect(result.investmentSplits[0]?.split_date).toBe('2024-01-20');
+      expect(result.investmentSplits[1]?.ticker_symbol).toBe('AAPL');
+      expect(result.investmentSplits[1]?.split_date).toBe('2024-01-10');
+      // Then GOOGL
+      expect(result.investmentSplits[2]?.ticker_symbol).toBe('GOOGL');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Improve overall test coverage from 95.48% to 95.98%
- **tools.ts**: 96.01% → 100% line coverage
- **decoder.ts**: 83.20% → 90.24% line coverage
- **Fix native module compatibility** with Cursor and other Electron apps

## Changes

### Test Coverage
- Add tests for query, tag, hsa_eligible, tagged transaction filters
- Add tests for tree/search/subcategories category views
- Add tests for pattern-based recurring detection
- Add tests for copilot_subscriptions grouping by state
- Add tests for all calculateNextDate frequency variants
- Add tests for internal_transfer transactions
- Add tests for account edge cases (user_deleted, available_balance)
- Add tests for recurring fields (emoji, state, transaction_ids)
- Add tests for investment prices/splits sorting
- Add tests for TTL configuration

### Bug Fix
- Mark `classic-level` as external in build to fix "No native build was found" error in Cursor/Electron environments

## Test Stats
- 771 tests (up from 757)
- 2044 assertions (up from 1996)

🤖 Generated with [Claude Code](https://claude.ai/code)