### PR TITLE
Fix native module compatibility with separate publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   "scripts": {
     "dev": "bun run src/server.ts",
     "dev:debug": "bun --inspect run src/server.ts",
-    "build": "bun build src/cli.ts --outdir dist --target node --format esm && chmod +x dist/cli.js",
-    "build:bundle": "bun build src/server.ts --outdir dist --target node --format esm",
+    "build": "bun build src/cli.ts --outdir dist --target node --format esm --external classic-level && chmod +x dist/cli.js",
+    "build:bundle": "bun build src/server.ts --outdir dist --target node --format esm --external classic-level",
     "test": "bun test",
     "test:watch": "bun test --watch",
     "test:coverage": "bun test --coverage",


### PR DESCRIPTION
## Summary

Implements dual distribution to support both Claude Desktop and Cursor/VS Code.

## Problem

Native module (`classic-level`) bundling conflicts between environments:
- **Claude Desktop (.mcpb)**: Needs self-contained bundle with native module included
- **Cursor/npm**: Needs external native module installed via npm

## Solution

Separate build commands for each distribution:

| Target | Command | Strategy |
|--------|---------|----------|
| Claude Desktop | `bun run pack:mcpb` | Bundles classic-level directly |
| npm/Cursor | `bun run build` | External classic-level (installed from npm) |

## Testing

- ✅ Claude Desktop: Works with bundled .mcpb
- ✅ Cursor: Works with local dev build
- ⏳ npm install: To be tested after publish

🤖 Generated with [Claude Code](https://claude.ai/code)