### PR TITLE
Security: Lock down repository for public release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,37 @@
+# CODEOWNERS - Defines code ownership for PR review requirements
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# IMPORTANT: For this file to work, you must enable "Require review from Code Owners"
+# in GitHub branch protection rules for the main branch.
+
+# Default: owner reviews all changes
+* @ignaciohermosillacornejo
+
+# Critical security paths - ONLY owner can approve
+# These paths require explicit owner approval and cannot be auto-merged by Claude
+
+# GitHub Actions and workflows - highest risk for supply chain attacks
+.github/ @ignaciohermosillacornejo
+
+# Package configuration - controls dependencies and publishing
+package.json @ignaciohermosillacornejo
+package-lock.json @ignaciohermosillacornejo
+bun.lockb @ignaciohermosillacornejo
+
+# Build and bundle configuration
+manifest.json @ignaciohermosillacornejo
+tsconfig.json @ignaciohermosillacornejo
+eslint.config.js @ignaciohermosillacornejo
+.prettierrc.json @ignaciohermosillacornejo
+
+# Scripts that run during build/publish
+scripts/ @ignaciohermosillacornejo
+
+# Security and contribution policies
+SECURITY.md @ignaciohermosillacornejo
+CONTRIBUTING.md @ignaciohermosillacornejo
+PRIVACY.md @ignaciohermosillacornejo
+LICENSE @ignaciohermosillacornejo
+
+# Claude instructions - affects AI behavior
+CLAUDE.md @ignaciohermosillacornejo

--- a/.github/SECURITY_SETUP.md
+++ b/.github/SECURITY_SETUP.md
@@ -1,0 +1,137 @@
+# GitHub Security Configuration
+
+This document describes the GitHub settings that must be configured **manually** via the GitHub UI to complete the repository security lockdown.
+
+## Required: Branch Protection Rules
+
+Go to **Settings > Branches > Add branch ruleset** (or classic branch protection for older GitHub plans)
+
+### Main Branch Protection
+
+**Branch name pattern:** `main`
+
+Enable these settings:
+
+- [x] **Require a pull request before merging**
+  - [x] Require approvals: `1`
+  - [x] Dismiss stale pull request approvals when new commits are pushed
+  - [x] Require review from Code Owners (CRITICAL - makes CODEOWNERS file work)
+  - [x] Require approval of the most recent reviewable push
+
+- [x] **Require status checks to pass before merging**
+  - [x] Require branches to be up to date before merging
+  - Required checks:
+    - `test` (from test.yml workflow)
+    - `check-author` (from claude-review.yml)
+    - `review` (from claude-review.yml)
+
+- [x] **Require conversation resolution before merging**
+
+- [x] **Require signed commits** (Optional but recommended)
+
+- [x] **Do not allow bypassing the above settings**
+  - This applies to admins too - ensures even you can't bypass
+
+- [x] **Restrict who can push to matching branches**
+  - Only allow: `ignaciohermosillacornejo`
+
+- [x] **Block force pushes**
+
+- [x] **Block deletions**
+
+## Required: Repository Settings
+
+### Actions Permissions
+
+Go to **Settings > Actions > General**
+
+- [x] **Fork pull request workflows from outside collaborators**
+  - Select: "Require approval for first-time contributors"
+  - This prevents fork PRs from running workflows that could exfiltrate secrets
+
+- [x] **Workflow permissions**
+  - Select: "Read repository contents and packages permissions"
+  - Uncheck: "Allow GitHub Actions to create and approve pull requests"
+  - Individual workflows specify their own elevated permissions as needed
+
+### Collaborators & Teams
+
+Go to **Settings > Collaborators and teams**
+
+- Review all collaborators
+- Consider using a team for any future trusted contributors
+- Remove any collaborators who shouldn't have write access
+
+### Security & Analysis
+
+Go to **Settings > Code security and analysis**
+
+Enable:
+- [x] **Dependency graph**
+- [x] **Dependabot alerts**
+- [x] **Dependabot security updates**
+- [x] **Secret scanning**
+- [x] **Push protection** (prevents committing secrets)
+
+## Optional: Additional Hardening
+
+### Private vulnerability reporting
+
+Go to **Settings > Security > Advisories**
+
+- [x] Enable private vulnerability reporting
+
+### Tag protection (for releases)
+
+Go to **Settings > Tags > Add rule**
+
+- Pattern: `v*`
+- This protects release tags from being moved or deleted
+
+### Environment protection (for publishing)
+
+If you want additional control over npm publishing:
+
+1. Go to **Settings > Environments > New environment**
+2. Create environment: `npm-publish`
+3. Add protection rules:
+   - Required reviewers: `ignaciohermosillacornejo`
+   - Wait timer: 0 (or add delay for review)
+4. Update npm-publish.yml to use `environment: npm-publish`
+
+## Verification Checklist
+
+After configuring, verify:
+
+- [ ] Cannot push directly to main (should require PR)
+- [ ] PRs require approval from owner
+- [ ] CODEOWNERS paths require owner approval
+- [ ] Workflows cannot be modified without owner review
+- [ ] Dependabot alerts are visible in Security tab
+- [ ] Secret scanning is active
+
+## Emergency: If Compromised
+
+If you suspect the repository has been compromised:
+
+1. **Revoke all tokens immediately**
+   - GitHub PATs
+   - npm tokens (even though we use OIDC, check for any manual ones)
+   - 1Password service account token (regenerate in 1Password)
+
+2. **Review recent activity**
+   - Check Actions history for unexpected runs
+   - Review recent commits and force pushes
+   - Check for new collaborators or changed permissions
+
+3. **Unpublish compromised packages**
+   - `npm unpublish @copilot-money/mcp@<version>` (within 72 hours)
+   - Or deprecate: `npm deprecate @copilot-money/mcp@<version> "Security issue"`
+
+4. **Rotate secrets**
+   - Generate new 1Password service account token
+   - Update GitHub secret `OP_SERVICE_ACCOUNT_TOKEN`
+
+5. **Notify users**
+   - Create GitHub security advisory
+   - Post on relevant channels

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+# Dependabot configuration for automated security updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Group all minor/patch updates together
+    groups:
+      production-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@types/*"
+          - "eslint*"
+          - "prettier*"
+          - "typescript"
+        update-types:
+          - "minor"
+          - "patch"
+      dev-dependencies:
+        patterns:
+          - "@types/*"
+          - "eslint*"
+          - "prettier*"
+          - "typescript"
+        update-types:
+          - "minor"
+          - "patch"
+    # Open PRs for security updates immediately
+    open-pull-requests-limit: 10
+    # Assignees for dependency PRs
+    assignees:
+      - "ignaciohermosillacornejo"
+    # Labels for dependency PRs
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Assignees for workflow PRs
+    assignees:
+      - "ignaciohermosillacornejo"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,14 +6,26 @@ on:
 
 jobs:
   auto-merge:
-    # Only run when the review is an approval
-    if: github.event.review.state == 'approved'
+    # Only run when the owner approves
+    if: |
+      github.event.review.state == 'approved' &&
+      github.event.review.user.login == 'ignaciohermosillacornejo'
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
 
     steps:
+      - name: Verify approver is owner
+        run: |
+          APPROVER="${{ github.event.review.user.login }}"
+          echo "Approval from: $APPROVER"
+          if [[ "$APPROVER" != "ignaciohermosillacornejo" ]]; then
+            echo "::error::Only the repository owner can trigger auto-merge"
+            exit 1
+          fi
+          echo "✅ Owner approval verified"
+
       - name: Enable auto-merge
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -64,16 +64,11 @@ jobs:
             ```
             **Reasoning:** <why this improves the code>
 
-            Use `gh pr diff` to see changes, then use `gh pr comment` for feedback.
+            Use `gh pr diff` to see changes, then use `gh pr comment` for inline feedback.
             Be constructive. Praise good patterns too.
 
-            After completing your review, you MUST submit an official PR review:
+            After reviewing, post a summary comment with your overall assessment.
+            Use `gh pr comment` to post your summary.
 
-            - If NO blocking issues found (or only minor suggestions):
-              gh pr review ${{ github.event.pull_request.number }} --approve -b "✅ LGTM - No blocking issues found"
-              (Auto-merge will be enabled automatically by the auto-merge workflow)
-
-            - If blocking issues found (security, bugs, or major quality issues):
-              gh pr review ${{ github.event.pull_request.number }} --request-changes -b "⚠️ Please address the review comments before merging"
-
-          claude_args: '--model claude-sonnet-4-20250514 --allowedTools "Bash(gh:*),Read,Grep,Glob"'
+          # SECURITY: Only allow read and comment commands - NO approve/review commands
+          claude_args: '--model claude-sonnet-4-20250514 --allowedTools "Bash(gh pr comment*),Bash(gh pr diff*),Bash(gh pr view*),Read,Grep,Glob"'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -13,6 +13,8 @@ on:
 
 env:
   BUN_VERSION: 'latest'
+  # Only these users can publish packages
+  TRUSTED_PUBLISHERS: 'ignaciohermosillacornejo'
 
 permissions:
   contents: read
@@ -22,8 +24,26 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    # Only run for releases created by trusted publishers, or manual dispatch by owner
+    if: |
+      (github.event_name == 'release' && github.event.release.author.login == 'ignaciohermosillacornejo') ||
+      (github.event_name == 'workflow_dispatch' && github.actor == 'ignaciohermosillacornejo')
 
     steps:
+      - name: Verify publisher is trusted
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            PUBLISHER="${{ github.event.release.author.login }}"
+          else
+            PUBLISHER="${{ github.actor }}"
+          fi
+          echo "Publisher: $PUBLISHER"
+          if [[ "$PUBLISHER" != "ignaciohermosillacornejo" ]]; then
+            echo "::error::Publisher '$PUBLISHER' is not authorized to publish packages"
+            exit 1
+          fi
+          echo "Publisher '$PUBLISHER' is authorized"
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,77 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x.x   | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+We take security seriously. If you discover a security vulnerability, please report it responsibly.
+
+### How to Report
+
+**DO NOT** create a public GitHub issue for security vulnerabilities.
+
+Instead, please report security issues via one of these methods:
+
+1. **GitHub Security Advisories** (Preferred)
+   - Go to the [Security tab](../../security/advisories) of this repository
+   - Click "Report a vulnerability"
+   - Provide details about the vulnerability
+
+2. **Email**
+   - Send details to the repository owner via GitHub profile contact
+
+### What to Include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+### What to Expect
+
+- **Acknowledgment**: Within 48 hours
+- **Initial Assessment**: Within 7 days
+- **Resolution Timeline**: Depends on severity, typically within 30 days
+
+### Security Measures
+
+This project implements several security measures:
+
+1. **Local Processing Only**: All data processing happens locally. No network requests are made.
+2. **Read-Only Access**: The MCP server cannot modify the Copilot Money database.
+3. **No Data Exfiltration**: No telemetry, analytics, or data transmission.
+4. **OIDC Publishing**: npm packages are published using OIDC trusted publishing with provenance.
+5. **Code Review**: All PRs require owner approval for security-critical paths.
+6. **Dependency Auditing**: Regular security audits of dependencies.
+
+### Scope
+
+Security reports should relate to:
+
+- Vulnerabilities in the MCP server code
+- Data privacy issues
+- Supply chain security concerns
+- Authentication/authorization bypasses
+
+Out of scope:
+
+- Vulnerabilities in Copilot Money itself (report to Copilot)
+- Vulnerabilities in Claude Desktop (report to Anthropic)
+- Issues with third-party dependencies (report upstream, but let us know)
+
+## Security Hardening
+
+For contributors and security researchers, here are the key security controls:
+
+| Control | Implementation |
+|---------|---------------|
+| Package Publishing | OIDC trusted publishing, owner-only releases |
+| PR Approval | Owner and Claude-bot only, CODEOWNERS enforcement |
+| Security Paths | .github/, package.json, scripts/ require owner review |
+| Dependency Management | Regular audits, lockfile verification |
+| Code Review | Automated AI review + manual owner review for sensitive changes |


### PR DESCRIPTION
## Summary

- Restrict auto-merge to owner approval only (removes Claude from approvers)
- Claude Code now only comments on PRs (cannot approve) - immune to prompt injection
- Restrict npm publish to releases created by owner only
- Add CODEOWNERS for sensitive paths requiring owner review
- Add SECURITY.md vulnerability reporting policy
- Add dependabot.yml for automated security updates
- Add SECURITY_SETUP.md documenting required GitHub UI settings

## Security Model

| Action | Who |
|--------|-----|
| Review & comment on PRs | Claude (comments only) |
| Approve PRs | Owner only |
| Trigger auto-merge | Owner approval only |
| Publish to npm | Owner-created releases only |

## Files Changed

- `.github/workflows/auto-merge.yml` - Only owner approval triggers merge
- `.github/workflows/claude-review.yml` - Claude restricted to comment-only tools
- `.github/workflows/npm-publish.yml` - Gated on release author check
- `.github/CODEOWNERS` - Protects .github/, package.json, scripts/, etc.
- `.github/dependabot.yml` - Weekly security updates
- `.github/SECURITY_SETUP.md` - Manual GitHub settings checklist
- `SECURITY.md` - Vulnerability reporting policy

## Test plan

- [x] All tests pass (771 pass, 26 skip)
- [ ] Verify branch protection rules are configured per SECURITY_SETUP.md
- [ ] Test that non-owner PRs don't trigger auto-merge
- [ ] Verify Claude review only posts comments (no approval capability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)