### PR TITLE
fix(ci): enable Claude review for fork PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,7 +1,7 @@
 name: AI Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review]
 
 jobs:
@@ -16,8 +16,13 @@ jobs:
       id-token: write
 
     steps:
+      # SECURITY: Always checkout the BASE branch, never the PR head.
+      # This workflow uses `gh pr diff` to read changes — it never executes PR code.
+      # This is critical for fork PRs: pull_request_target has secret access,
+      # so checking out untrusted PR code would be a security vulnerability.
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
 
       - name: Load secrets from 1Password


### PR DESCRIPTION
## Summary

- Switches `claude-review.yml` from `pull_request` to `pull_request_target` so fork PRs (like #120) have access to secrets and can run the AI review
- Explicitly checks out the base branch (`ref: base.ref`) instead of the PR head to prevent untrusted code execution

## Context

PR #120 is the first external contribution and the Claude review job failed because `pull_request` from forks runs without secret access. `pull_request_target` runs in the base repo context with secrets available.

**Why this is safe:**
- Claude never executes PR code — it reads changes via `gh pr diff`
- We checkout the base branch only, never the fork's code
- `claude_args` already restricts Claude to read-only + comment tools (no approve/merge)
- Auto-merge still requires owner approval (`ignaciohermosillacornejo`)

## Test plan

- [ ] Merge this PR
- [ ] Re-trigger CI on #120 (push a comment or close/reopen)
- [ ] Verify Claude review runs successfully on the fork PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)