### PR TITLE
fix: transaction dedup drops real txns + category totals double-count pending

### DIFF
--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -211,8 +211,6 @@ function deduplicateTransactions(transactions: Transaction[]): Transaction[] {
  *
  * This function drops the pending version when a matching posted version exists,
  * preventing double-counting in aggregations like category totals.
- *
- * Returns transactions sorted by date descending.
  */
 function reconcilePendingTransactions(transactions: Transaction[]): Transaction[] {
   // Collect transaction IDs that have been superseded by a posted version
@@ -224,14 +222,9 @@ function reconcilePendingTransactions(transactions: Transaction[]): Transaction[
   }
 
   // Filter out superseded pending transactions
-  const reconciled = transactions.filter(
+  return transactions.filter(
     (txn) => !(txn.pending && supersededPendingIds.has(txn.transaction_id))
   );
-
-  // Sort by date descending
-  reconciled.sort((a, b) => (a.date > b.date ? -1 : a.date < b.date ? 1 : 0));
-
-  return reconciled;
 }
 
 /**
@@ -250,8 +243,12 @@ export async function decodeTransactions(dbPath: string): Promise<Transaction[]>
   // without dropping distinct transactions that happen to share display_name/amount/date
   const deduped = deduplicateTransactions(transactions);
 
-  // Reconcile pending/posted pairs and sort by date descending
-  return reconcilePendingTransactions(deduped);
+  // Reconcile pending/posted pairs
+  const reconciled = reconcilePendingTransactions(deduped);
+
+  // Sort by date descending
+  reconciled.sort((a, b) => (a.date > b.date ? -1 : a.date < b.date ? 1 : 0));
+  return reconciled;
 }
 
 /**
@@ -1344,6 +1341,7 @@ export async function decodeAllCollections(dbPath: string): Promise<AllCollectio
 
   // Transactions: dedupe by transaction_id, reconcile pending/posted pairs, sort by date desc
   const transactions = reconcilePendingTransactions(deduplicateTransactions(rawTransactions));
+  transactions.sort((a, b) => (a.date > b.date ? -1 : a.date < b.date ? 1 : 0));
 
   // Accounts: dedupe by (name, mask)
   const accSeen = new Set<string>();

--- a/tests/core/decoder-coverage.test.ts
+++ b/tests/core/decoder-coverage.test.ts
@@ -11,6 +11,7 @@ import {
   decodeInvestmentSplits,
   decodeAllCollections,
   decodeGoalHistory,
+  decodeTransactions,
 } from '../../src/core/decoder.js';
 import { createTestDatabase, cleanupAllTempDatabases } from '../../src/core/leveldb-reader.js';
 import type { FirestoreValue } from '../../src/core/protobuf-parser.js';
@@ -751,7 +752,7 @@ describe('decoder coverage', () => {
       await createTestDatabase(dbPath, [
         {
           collection: 'transactions',
-          id: 'txn1',
+          id: 'doc-key-a',
           fields: {
             transaction_id: 'txn1',
             amount: 50.0,
@@ -761,7 +762,7 @@ describe('decoder coverage', () => {
         },
         {
           collection: 'transactions',
-          id: 'txn1',
+          id: 'doc-key-b',
           fields: {
             transaction_id: 'txn1',
             amount: 50.0,
@@ -836,6 +837,39 @@ describe('decoder coverage', () => {
       // Pending transaction with no posted counterpart should be kept
       expect(result.transactions.length).toBe(1);
       expect(result.transactions[0]?.pending).toBe(true);
+    });
+
+    test('decodeTransactions: reconciles pending/posted pairs', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'decode-txns-pending-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'transactions',
+          id: 'pending-1',
+          fields: {
+            transaction_id: 'pending-1',
+            amount: 50.0,
+            date: '2024-01-15',
+            name: 'BRIGHT HORIZONS PAYMENT',
+            pending: true,
+          },
+        },
+        {
+          collection: 'transactions',
+          id: 'posted-1',
+          fields: {
+            transaction_id: 'posted-1',
+            amount: 50.0,
+            date: '2024-01-15',
+            name: 'BRIGHT HORIZONS',
+            pending: false,
+            pending_transaction_id: 'pending-1',
+          },
+        },
+      ]);
+
+      const txns = await decodeTransactions(dbPath);
+      expect(txns.length).toBe(1);
+      expect(txns[0]?.transaction_id).toBe('posted-1');
     });
 
     test('handles empty database', async () => {


### PR DESCRIPTION
## Summary

Fixes #119. Two data quality bugs in `decodeTransactions()`:

- **Bug 1 — Real transactions silently dropped**: Dedup key was `displayName|amount|date`, which collapsed distinct transactions sharing those fields (e.g. two Airbnb charges on the same day). Now deduplicates by `transaction_id` (Firestore document ID), only collapsing true LevelDB-level duplicates.

- **Bug 2 — Category totals doubled for pending charges**: When a charge posts, pending and posted versions coexist in LevelDB with different display names, so both survived dedup. Category aggregation then double-counted them. Now reconciles pending/posted pairs via `pending_transaction_id` — drops the pending version when a matching posted version exists.

## Changes

- `src/core/decoder.ts`: Extracted `deduplicateTransactions()` (dedup by `transaction_id`) and `reconcilePendingTransactions()` (drop superseded pending txns) helper functions, applied in both `decodeTransactions()` and `decodeAllCollections()`
- `tests/core/decoder-coverage.test.ts`: Updated existing dedup test + added 4 new tests covering: distinct txns with same name/amount/date, true LevelDB duplicates, pending/posted reconciliation, and pending-only preservation

## Test plan

- [x] All 774 tests pass (`bun test`)
- [x] Typecheck, lint, format all clean (`bun run check`)
- [ ] Manual verification with real database (`RUN_REAL_DB_TESTS=1 bun test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)