### PR TITLE
fix(ci): use direct GitHub secret for Claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,7 @@ name: AI Code Review
 
 on:
   pull_request_target:
-    types: [opened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   review:


### PR DESCRIPTION
## Summary

- Replaces 1Password secret fetching with a direct `CLAUDE_CODE_OAUTH_TOKEN` GitHub Actions secret, fixing authentication failures on fork PRs
- Adds `reopened` to trigger types so close/reopen properly retriggers the review

## Context

After merging #121 (`pull_request_target`), the Claude review still failed because the 1Password service account token wasn't available. Using a direct GitHub secret is simpler and works reliably with `pull_request_target`.

## Required setup

Add `CLAUDE_CODE_OAUTH_TOKEN` as a repository secret (Settings > Secrets and variables > Actions) with the value from 1Password `Dev/CLAUDE_CODE_OAUTH_TOKEN`.

## Test plan

- [ ] Add the `CLAUDE_CODE_OAUTH_TOKEN` repo secret
- [ ] Merge this PR
- [ ] Close and reopen #120 to trigger Claude review
- [ ] Verify the review runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)