### PR TITLE
fix(ci): remove deprecated inputs from claude-review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,8 +37,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
-          mode: agent
-          track_progress: true
           prompt: |
             You are a code reviewer for the copilot-money-mcp project.
 


### PR DESCRIPTION
## Summary

- Removes deprecated `mode: agent` input (no longer valid in claude-code-action@v1)
- Removes `track_progress: true` which now forces tag mode (OIDC auth), bypassing our `claude_code_oauth_token` from 1Password

The action auto-detects agent mode from the `prompt` input and uses the provided OAuth token as intended.

## Test plan

- [ ] Merge this PR and verify the claude-review workflow runs successfully on #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)