### PR TITLE
fix(ci): use workflow_run trigger for Claude review on fork PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,7 +21,6 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
 
     steps:
       # SECURITY: Always checkout the BASE branch, never the PR head.
@@ -43,6 +42,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Provide GitHub token explicitly to bypass OIDC token exchange,
+          # which fails for non-pull_request events (anthropics/claude-code-action#713)
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # track_progress not supported with workflow_run events
           prompt: |
             You are a code reviewer for the copilot-money-mcp project.


### PR DESCRIPTION
## Summary

- Replaces `pull_request_target` with `workflow_run` trigger that fires after the Tests workflow completes
- Keeps 1Password + OAuth token authentication (no API key billing)

## Problem

Anthropic's OIDC token exchange endpoint rejects `pull_request_target` events ([anthropics/claude-code-action#713](https://github.com/anthropics/claude-code-action/issues/713)). This means Claude review can't run on fork PRs using `claude_code_oauth_token`.

## Solution

Use `workflow_run` as the trigger instead. When the Tests workflow completes on a PR:
1. This workflow fires with event type `workflow_run` (accepted by Anthropic's OIDC)
2. It runs in the base repo context (has access to secrets)
3. It only reviews if tests completed and the trigger was a PR (not a push to main)

This works for both same-repo and fork PRs without needing an API key.

## Test plan

- [ ] Merge this PR
- [ ] Have the contributor push to PR #120 (or close/reopen it)
- [ ] Tests workflow runs → triggers this workflow → Claude review posts comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)