### PR TITLE
fix(ci): broaden Claude review tool permissions for posting comments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -76,7 +76,8 @@ jobs:
             After reviewing, post a summary comment with your overall assessment.
             Use `gh pr comment` to post your summary.
 
-          # SECURITY: Only allow read and comment commands - NO approve/review commands
+          # SECURITY: Allow read-only gh commands and commenting — block approve/merge
           claude_args: |
             --model claude-sonnet-4-6
-            --allowedTools "Bash(gh pr comment*),Bash(gh pr diff*),Bash(gh pr view*),Read,Grep,Glob"
+            --allowedTools "Bash(gh pr comment*),Bash(gh pr diff*),Bash(gh pr view*),Bash(gh pr review --comment*),Bash(gh api */pulls/*/comments*),Bash(gh api */pulls/*/reviews*),Bash(gh api */issues/*/comments*),Read,Grep,Glob"
+            --disallowedTools "Bash(gh pr review --approve*),Bash(gh pr merge*),Bash(gh pr close*)"


### PR DESCRIPTION
## Summary

- Adds `gh api` and `gh pr review --comment` to allowed tools so Claude can actually post inline review comments
- Explicitly blocks `gh pr review --approve`, `gh pr merge`, and `gh pr close`

## Problem

PR #126 fixed the OIDC issue — the review now runs successfully. But Claude couldn't post any comments because the `--allowedTools` list was too restrictive. The run had 10 permission denials and posted 0 comments despite costing $1.45 in API usage.

## Test plan

- [ ] Merge this PR
- [ ] Close and reopen PR #122
- [ ] Verify Claude review posts actual comments on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)