### PR TITLE
fix: prevent promise hang when decode worker exits without sending result

### DIFF
--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -1570,11 +1570,15 @@ export function decodeAllCollectionsIsolated(
     });
 
     worker.on('exit', (code: number) => {
-      settle(() => {
-        if (code !== 0) {
-          reject(new Error(`Decode worker exited with code ${code}`));
-        }
-      });
+      settle(() =>
+        reject(
+          new Error(
+            code === 0
+              ? 'Decode worker exited without sending result'
+              : `Decode worker exited with code ${code}`
+          )
+        )
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- Fixes a bug in `decodeAllCollectionsIsolated` where the promise hangs forever if the worker exits cleanly (code 0) without sending a result message
- The `exit` handler now always rejects — in the happy path, `settle` is already a no-op because the result message arrives before exit fires
- Addresses [AI review feedback from PR #128](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/pull/128#discussion_r2920786569)

## Test plan
- [x] All 775 tests pass
- [x] Typecheck, lint, and format checks pass
- [ ] Verify worker isolation still works correctly with real database (`RUN_REAL_DB_TESTS=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)