### PR TITLE
chore: remove Python-specific entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,53 +26,12 @@ dist/
 # TypeScript
 *.tsbuildinfo
 
-# Python
-__pycache__/
-*.py[cod]
-*$py.class
-*.so
-.Python
-build/
-develop-eggs/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-
-# Virtual environments
-venv/
-ENV/
-env/
-.venv/
-
 # IDE
 .idea/
 .vscode/
 *.swp
 *.swo
 *~
-
-# Testing
-.coverage
-.pytest_cache/
-htmlcov/
-.tox/
-.nox/
-
-# mypy
-.mypy_cache/
-
-# Distribution
-*.tar.gz
-*.whl
 
 # OS
 .DS_Store


### PR DESCRIPTION
## Summary
- Remove ~40 lines of Python-specific patterns from `.gitignore`
- Includes `__pycache__/`, `*.py[cod]`, `venv/`, `.mypy_cache/`, `*.egg-info/`, `*.whl`, etc.
- These are leftover from the Python-to-TypeScript migration and add clutter
- May confuse contributors about the project's technology stack

## Test plan
- [x] `bun run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)