### PR TITLE
docs: remove hardcoded test count from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ MCP (Model Context Protocol) server that enables AI-powered queries of Copilot M
 
 ```bash
 bun install          # Install dependencies
-bun test             # Run tests (772 tests)
+bun test             # Run tests
 bun run build        # Build for production
 bun run pack:mcpb    # Create .mcpb bundle for Claude Desktop
 bun run check        # Run typecheck + lint + format:check + test


### PR DESCRIPTION
## Summary
- Remove `(772 tests)` from `bun test` command in CLAUDE.md quick reference
- The count was already stale (actual: 775) and will keep drifting
- Since CLAUDE.md is the primary onboarding doc for AI agents, accuracy matters

## Test plan
- [x] `bun run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)