### PR TITLE
fix: correct package.json main field to dist/server.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=18.0.0"
   },
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/server.js",
   "bin": {
     "copilot-money-mcp": "dist/cli.js"
   },


### PR DESCRIPTION
## Summary
- Fix `package.json` main field from `dist/index.js` (doesn't exist) to `dist/server.js`
- `dist/server.js` is the programmatic entry point; CLI uses `dist/cli.js` via `bin` field
- Anyone doing `import ... from 'copilot-money-mcp'` would get a module-not-found error without this fix

## Test plan
- [x] `bun run check` passes
- [x] `dist/server.js` exists after `bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)