### PR TITLE
fix: make decode timeout configurable, raise default to 5 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,39 @@ COPILOT_CACHE_TTL_MINUTES=0 copilot-money-mcp
 
 You can also manually refresh the cache using the `refresh_database` tool.
 
+### Decode Timeout
+
+For large databases (500MB+), you may need to increase the decode timeout. The default is 5 minutes (300,000ms).
+
+**Via environment variable:**
+```bash
+DECODE_TIMEOUT_MS=600000 copilot-money-mcp
+```
+
+**Via CLI flag:**
+```bash
+copilot-money-mcp --timeout 600000
+```
+
+**In Claude Desktop config** (with increased Node.js memory for 1GB+ databases):
+```json
+{
+  "mcpServers": {
+    "copilot-money": {
+      "command": "node",
+      "args": [
+        "--max-old-space-size=4096",
+        "/path/to/copilot-money-mcp/dist/cli.js",
+        "--db-path",
+        "/path/to/your/database",
+        "--timeout",
+        "600000"
+      ]
+    }
+  }
+}
+```
+
 ## Known Limitations
 
 ### Local Cache Size
@@ -358,6 +391,14 @@ If you see "Database not available":
 2. Check database location: `~/Library/Containers/com.copilot.production/Data/Library/Application Support/firestore/__FIRAPP_DEFAULT/copilot-production-22904/main`
 3. Verify `.ldb` files exist in the directory
 4. Provide custom path: `copilot-money-mcp --db-path /path/to/database`
+
+### Decode Worker Timed Out (Large Databases)
+
+If you see `Decode worker timed out after 300000ms`:
+1. Your database may be too large for the default 5-minute timeout
+2. Increase the timeout: `copilot-money-mcp --timeout 600000` (10 minutes)
+3. For databases over 1GB, also increase Node.js memory: `node --max-old-space-size=4096 dist/cli.js --timeout 600000`
+4. Set via environment variable: `DECODE_TIMEOUT_MS=600000`
 
 ### No Transactions Found
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,16 +8,26 @@ import { runServer } from './server.js';
 /**
  * Parse command-line arguments.
  */
-function parseArgs(): { dbPath?: string; verbose: boolean } {
+function parseArgs(): { dbPath?: string; verbose: boolean; timeoutMs?: number } {
   const args = process.argv.slice(2);
   let dbPath: string | undefined;
   let verbose = false;
+  let timeoutMs: number | undefined;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
 
     if (arg === '--db-path' && i + 1 < args.length) {
       dbPath = args[i + 1];
+      i++;
+    } else if (arg === '--timeout' && i + 1 < args.length) {
+      const ms = parseInt(args[i + 1], 10);
+      if (!isNaN(ms) && ms > 0) {
+        timeoutMs = ms;
+      } else {
+        console.error(`Invalid --timeout value: ${args[i + 1]} (must be a positive integer in milliseconds)`);
+        process.exit(1);
+      }
       i++;
     } else if (arg === '--verbose' || arg === '-v') {
       verbose = true;
@@ -30,10 +40,12 @@ Usage:
 
 Options:
   --db-path <path>    Path to LevelDB database (default: Copilot Money's default location)
+  --timeout <ms>      Decode timeout in milliseconds (default: 300000 = 5 minutes)
   --verbose, -v       Enable verbose logging
   --help, -h          Show this help message
 
 Environment:
+  DECODE_TIMEOUT_MS   Override decode timeout (same as --timeout flag)
   The server uses stdio transport and logs to stderr.
   Claude Desktop will communicate with it via stdin/stdout.
 `);
@@ -41,7 +53,7 @@ Environment:
     }
   }
 
-  return { dbPath, verbose };
+  return { dbPath, verbose, timeoutMs };
 }
 
 /**
@@ -70,7 +82,12 @@ function configureLogging(verbose: boolean): void {
  * Main entry point.
  */
 async function main(): Promise<void> {
-  const { dbPath, verbose } = parseArgs();
+  const { dbPath, verbose, timeoutMs } = parseArgs();
+
+  // Set decode timeout env var if provided via CLI flag
+  if (timeoutMs !== undefined) {
+    process.env.DECODE_TIMEOUT_MS = String(timeoutMs);
+  }
 
   // Configure logging
   configureLogging(verbose);

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -1520,6 +1520,21 @@ export async function decodeAllCollections(dbPath: string): Promise<AllCollectio
 }
 
 /**
+ * Get the decode timeout in milliseconds from environment or default.
+ * Can be set via DECODE_TIMEOUT_MS environment variable or --timeout CLI flag.
+ */
+function getDecodeTimeoutMs(): number {
+  const envValue = process.env.DECODE_TIMEOUT_MS;
+  if (envValue !== undefined) {
+    const ms = parseInt(envValue, 10);
+    if (!isNaN(ms) && ms > 0) {
+      return ms;
+    }
+  }
+  return 300_000; // 5 minutes default (was 30s)
+}
+
+/**
  * Decode all collections in an isolated worker thread.
  *
  * This wraps `decodeAllCollections` in a worker thread to prevent memory leaks
@@ -1539,7 +1554,7 @@ export async function decodeAllCollections(dbPath: string): Promise<AllCollectio
  */
 export function decodeAllCollectionsIsolated(
   dbPath: string,
-  timeoutMs = 30_000
+  timeoutMs = getDecodeTimeoutMs()
 ): Promise<AllCollectionsResult> {
   return new Promise((resolve, reject) => {
     const selfUrl = import.meta.url;


### PR DESCRIPTION
## Summary

The hard-coded 30-second timeout in `decodeAllCollectionsIsolated()` causes the decode worker to crash on databases over ~500MB. The server copies the entire LevelDB to `/tmp` then iterates and parses every protobuf entry — on a 2.2GB database, the `/tmp` copy alone takes ~10-15 seconds, leaving insufficient time for the actual decode.

This PR:
- **Raises the default timeout from 30s to 5 minutes** (300,000ms), which should handle most databases without any configuration
- **Makes the timeout configurable** via `DECODE_TIMEOUT_MS` environment variable and `--timeout <ms>` CLI flag, so users with very large databases can tune it further
- **Documents the configuration** in the README (Configuration section + Troubleshooting section), including an example Claude Desktop config with `--max-old-space-size=4096` for databases over 1GB

### Files changed
- `src/core/decoder.ts` — new `getDecodeTimeoutMs()` helper, default parameter reads from env
- `src/cli.ts` — `--timeout <ms>` flag with validation, sets `DECODE_TIMEOUT_MS` env var
- `README.md` — "Decode Timeout" config section + "Decode Worker Timed Out" troubleshooting section

## Test plan
- [x] `bun test` — 788 tests pass, 0 failures
- [x] Verified `--help` output shows new `--timeout` flag and `DECODE_TIMEOUT_MS` env var
- [x] Tested against a real 2.2GB database with `--timeout 600000` — server starts and responds to MCP queries successfully
- [x] Confirmed backward compatibility: omitting `--timeout` uses the new 5-minute default

🤖 Generated with [Claude Code](https://claude.com/claude-code)