### PR TITLE
ci: skip AI code review on forked PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   review:
-    # Skip draft PRs
-    if: github.event.pull_request.draft == false
+    # Skip draft PRs and forked PRs (secrets are unavailable for forks)
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Skip the AI code review workflow when the PR comes from a fork, since secrets (`OP_SERVICE_ACCOUNT_TOKEN`) are not available in that context
- Adds a condition checking `head.repo.full_name == github.repository` alongside the existing draft PR skip

## Test plan
- [x] Verified condition syntax matches GitHub Actions docs for `pull_request` event payloads
- [x] Internal PRs (same repo) will continue to get AI reviews as before
- [x] Forked PRs will simply skip the job instead of failing on the 1Password secrets step

🤖 Generated with [Claude Code](https://claude.com/claude-code)