### PR TITLE
fix(ci): skip AI code review on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   review:
-    # Skip draft PRs and forked PRs (secrets are unavailable for forks)
-    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository
+    # Skip draft PRs, forked PRs, and Dependabot PRs (secrets are unavailable)
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Dependabot PRs don't have access to repository secrets, so the 1Password `load-secrets` step fails trying to fetch `CLAUDE_CODE_OAUTH_TOKEN`
- This was causing the "AI Code Review" check to fail on all Dependabot PRs (e.g. #136, #137)
- Added `github.actor != 'dependabot[bot]'` condition alongside the existing fork check

## Test plan
- [ ] Verify this PR's review job is skipped (since it only touches the workflow file)
- [ ] Re-run or wait for next Dependabot PR to confirm the review step is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)