### PR TITLE
test: increase code coverage to ~100% across codebase

### DIFF
--- a/tests/core/database-errors.test.ts
+++ b/tests/core/database-errors.test.ts
@@ -244,7 +244,7 @@ describe('CopilotDatabase error handling', () => {
       }
     });
 
-    test('cache TTL=0 means always reload (isCacheStale returns true)', async () => {
+    test('cache TTL=0 means always reload (isCacheStale returns true)', () => {
       process.env.COPILOT_CACHE_TTL_MINUTES = '0';
 
       const db = new CopilotDatabase();
@@ -256,7 +256,7 @@ describe('CopilotDatabase error handling', () => {
       expect(db.isCacheStale()).toBe(true);
     });
 
-    test('valid COPILOT_CACHE_TTL_MINUTES env var is used', async () => {
+    test('valid COPILOT_CACHE_TTL_MINUTES env var is used', () => {
       process.env.COPILOT_CACHE_TTL_MINUTES = '10';
 
       const db = new CopilotDatabase();
@@ -268,7 +268,7 @@ describe('CopilotDatabase error handling', () => {
       expect(db.isCacheStale()).toBe(false);
     });
 
-    test('invalid COPILOT_CACHE_TTL_MINUTES falls back to default', async () => {
+    test('invalid COPILOT_CACHE_TTL_MINUTES falls back to default', () => {
       process.env.COPILOT_CACHE_TTL_MINUTES = 'not-a-number';
 
       const db = new CopilotDatabase();

--- a/tests/core/database-errors.test.ts
+++ b/tests/core/database-errors.test.ts
@@ -5,7 +5,7 @@
  * to trigger in normal operation.
  */
 
-import { describe, test, expect, beforeEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { CopilotDatabase } from '../../src/core/database.js';
 import { extractValue } from '../../src/core/decoder.js';
 import type { FirestoreValue } from '../../src/core/protobuf-parser.js';
@@ -226,6 +226,58 @@ describe('CopilotDatabase error handling', () => {
       // @ts-expect-error - setting to empty string
       db.dbPath = '';
       expect(db.isAvailable()).toBe(false);
+    });
+  });
+
+  describe('getCacheTTLMs via COPILOT_CACHE_TTL_MINUTES env var', () => {
+    let originalEnv: string | undefined;
+
+    beforeEach(() => {
+      originalEnv = process.env.COPILOT_CACHE_TTL_MINUTES;
+    });
+
+    afterEach(() => {
+      if (originalEnv === undefined) {
+        delete process.env.COPILOT_CACHE_TTL_MINUTES;
+      } else {
+        process.env.COPILOT_CACHE_TTL_MINUTES = originalEnv;
+      }
+    });
+
+    test('cache TTL=0 means always reload (isCacheStale returns true)', async () => {
+      process.env.COPILOT_CACHE_TTL_MINUTES = '0';
+
+      const db = new CopilotDatabase();
+      // @ts-expect-error - accessing private property for testing
+      db._cacheLoadedAt = Date.now(); // Simulate recently loaded cache
+
+      // isCacheStale should return true because TTL=0 means always reload
+      // @ts-expect-error - accessing private method for testing
+      expect(db.isCacheStale()).toBe(true);
+    });
+
+    test('valid COPILOT_CACHE_TTL_MINUTES env var is used', async () => {
+      process.env.COPILOT_CACHE_TTL_MINUTES = '10';
+
+      const db = new CopilotDatabase();
+      // @ts-expect-error - accessing private property for testing
+      db._cacheLoadedAt = Date.now(); // Just loaded
+
+      // With 10 minute TTL, cache should NOT be stale
+      // @ts-expect-error - accessing private method for testing
+      expect(db.isCacheStale()).toBe(false);
+    });
+
+    test('invalid COPILOT_CACHE_TTL_MINUTES falls back to default', async () => {
+      process.env.COPILOT_CACHE_TTL_MINUTES = 'not-a-number';
+
+      const db = new CopilotDatabase();
+      // @ts-expect-error - accessing private property for testing
+      db._cacheLoadedAt = Date.now(); // Just loaded
+
+      // Should use default 5 min TTL, cache should NOT be stale
+      // @ts-expect-error - accessing private method for testing
+      expect(db.isCacheStale()).toBe(false);
     });
   });
 });

--- a/tests/core/decoder-coverage.test.ts
+++ b/tests/core/decoder-coverage.test.ts
@@ -12,6 +12,10 @@ import {
   decodeAllCollections,
   decodeGoalHistory,
   decodeTransactions,
+  decodeAccounts,
+  decodeRecurring,
+  decodeBudgets,
+  decodeGoals,
   decodeCategories,
   getDecodeTimeoutMs,
 } from '../../src/core/decoder.js';
@@ -3495,6 +3499,203 @@ describe('decoder coverage', () => {
       expect(splits.length).toBe(1);
       expect(splits[0]!.split_id).toBe('split-empty1');
       expect(splits[0]!.adjustments).toBeUndefined();
+    });
+  });
+
+  describe('schema parse catch blocks', () => {
+    test('processTransaction catch: amount exceeding 10M fails schema refine', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'txn-schema-fail-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'transactions',
+          id: 'txn-valid',
+          fields: {
+            transaction_id: 'txn-valid',
+            amount: 50.0,
+            date: '2024-01-15',
+            name: 'Valid Transaction',
+          },
+        },
+        {
+          collection: 'transactions',
+          id: 'txn-huge',
+          fields: {
+            transaction_id: 'txn-huge',
+            amount: 20000000, // Exceeds 10M refine limit
+            date: '2024-01-15',
+            name: 'Huge Transaction',
+          },
+        },
+      ]);
+
+      const txns = await decodeTransactions(dbPath);
+      // The huge transaction should be silently dropped by the catch block
+      expect(txns.length).toBe(1);
+      expect(txns[0]?.transaction_id).toBe('txn-valid');
+    });
+
+    test('processRecurring catch: invalid date format fails schema regex', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'rec-schema-fail-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'recurring',
+          id: 'rec-valid',
+          fields: {
+            recurring_id: 'rec-valid',
+            name: 'Netflix',
+            amount: 15.99,
+          },
+        },
+        {
+          collection: 'recurring',
+          id: 'rec-bad-date',
+          fields: {
+            recurring_id: 'rec-bad-date',
+            name: 'Bad Date Recurring',
+            next_date: 'not-a-date', // Fails DATE_REGEX in schema
+          },
+        },
+      ]);
+
+      const recurring = await decodeRecurring(dbPath);
+      expect(recurring.length).toBe(1);
+      expect(recurring[0]?.recurring_id).toBe('rec-valid');
+    });
+
+    test('processBudget catch: invalid period enum fails schema', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'budget-schema-fail-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'budgets',
+          id: 'bud-valid',
+          fields: {
+            budget_id: 'bud-valid',
+            name: 'Food',
+            amount: 500,
+          },
+        },
+        {
+          collection: 'budgets',
+          id: 'bud-bad-period',
+          fields: {
+            budget_id: 'bud-bad-period',
+            name: 'Bad Budget',
+            period: 'biweekly', // Not in the enum
+          },
+        },
+      ]);
+
+      const budgets = await decodeBudgets(dbPath);
+      expect(budgets.length).toBe(1);
+      expect(budgets[0]?.budget_id).toBe('bud-valid');
+    });
+
+    test('processAccount catch: NaN balance fails schema number validation', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'acc-schema-fail-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'accounts',
+          id: 'acc-valid',
+          fields: {
+            account_id: 'acc-valid',
+            name: 'Valid Account',
+            current_balance: 1000.0,
+          },
+        },
+        {
+          collection: 'accounts',
+          id: 'acc-nan',
+          fields: {
+            account_id: 'acc-nan',
+            name: 'NaN Account',
+            current_balance: NaN, // z.number() rejects NaN
+          },
+        },
+      ]);
+
+      const accounts = await decodeAccounts(dbPath);
+      expect(accounts.length).toBe(1);
+      expect(accounts[0]?.account_id).toBe('acc-valid');
+    });
+
+    test('processGoalHistory catch: invalid created_date format fails schema regex', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'goal-hist-schema-fail-db');
+      await createDeepTestDatabase(dbPath, [
+        {
+          collection: 'financial_goals/goal1/financial_goal_history',
+          id: '2024-01',
+          fields: {
+            goal_id: 'goal1',
+            current_amount: 5000,
+          },
+        },
+        {
+          collection: 'financial_goals/goal2/financial_goal_history',
+          id: '2024-02',
+          fields: {
+            goal_id: 'goal2',
+            current_amount: 3000,
+            created_date: 'not-a-date', // Fails DATE_REGEX in schema
+          },
+        },
+      ]);
+
+      const histories = await decodeGoalHistory(dbPath);
+      expect(histories.length).toBe(1);
+      expect(histories[0]?.goal_id).toBe('goal1');
+    });
+
+    test('processGoal catch: invalid created_date format fails schema regex', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'goal-schema-fail-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'financial_goals',
+          id: 'goal-valid',
+          fields: {
+            goal_id: 'goal-valid',
+            name: 'Emergency Fund',
+          },
+        },
+        {
+          collection: 'financial_goals',
+          id: 'goal-bad-date',
+          fields: {
+            goal_id: 'goal-bad-date',
+            name: 'Bad Goal',
+            created_date: 'January 1st', // Fails DATE_REGEX
+          },
+        },
+      ]);
+
+      const goals = await decodeGoals(dbPath);
+      expect(goals.length).toBe(1);
+      expect(goals[0]?.goal_id).toBe('goal-valid');
+    });
+  });
+
+  describe('processPlaidAccount field coverage', () => {
+    test('plaid account with numeric limit and string verification_status', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'plaid-acc-fields-db');
+      // Use 5-segment path so binary key routing picks up /accounts/ in the middle
+      await createDeepTestDatabase(dbPath, [
+        {
+          collection: 'items/item1/accounts/pacc1',
+          id: 'data',
+          fields: {
+            name: 'Chase Credit',
+            type: 'credit',
+            subtype: 'credit card',
+            current_balance: 1500.0,
+            limit: 5000,
+            verification_status: 'automatically_verified',
+          },
+        },
+      ]);
+
+      const result = await decodeAllCollections(dbPath);
+      expect(result.plaidAccounts.length).toBe(1);
+      expect(result.plaidAccounts[0]?.limit).toBe(5000);
+      expect(result.plaidAccounts[0]?.verification_status).toBe('automatically_verified');
     });
   });
 });

--- a/tests/models/tag.test.ts
+++ b/tests/models/tag.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { TagSchema } from '../../src/models/tag.js';
+import { TagSchema, getTagDisplayName } from '../../src/models/tag.js';
 
 describe('TagSchema', () => {
   test('validates minimal document with just tag_id', () => {
@@ -48,5 +48,19 @@ describe('TagSchema', () => {
       name: 'Vacation',
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe('getTagDisplayName', () => {
+  test('returns name when available', () => {
+    expect(getTagDisplayName({ tag_id: 'tag-1', name: 'Vacation' })).toBe('Vacation');
+  });
+
+  test('falls back to tag_id when name is undefined', () => {
+    expect(getTagDisplayName({ tag_id: 'tag-abc123' })).toBe('tag-abc123');
+  });
+
+  test('falls back to tag_id when name is empty string', () => {
+    expect(getTagDisplayName({ tag_id: 'tag-1', name: '' })).toBe('tag-1');
   });
 });

--- a/tests/unit/investment-split.test.ts
+++ b/tests/unit/investment-split.test.ts
@@ -472,6 +472,7 @@ describe('formatSplitDate', () => {
     expect(formatted).toContain('2022');
   });
 
+  // Safe to monkey-patch: Bun runs tests within a file serially
   test('catch block: returns raw date when toLocaleDateString throws', () => {
     const original = Date.prototype.toLocaleDateString;
     Date.prototype.toLocaleDateString = () => {

--- a/tests/unit/investment-split.test.ts
+++ b/tests/unit/investment-split.test.ts
@@ -4,7 +4,7 @@
  * Tests the investment split model, schema validation, and helper functions.
  */
 
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, mock } from 'bun:test';
 import {
   InvestmentSplitSchema,
   parseSplitRatio,
@@ -470,6 +470,22 @@ describe('formatSplitDate', () => {
     expect(formatted).toContain('July');
     expect(formatted).toContain('15');
     expect(formatted).toContain('2022');
+  });
+
+  test('catch block: returns raw date when toLocaleDateString throws', () => {
+    const original = Date.prototype.toLocaleDateString;
+    Date.prototype.toLocaleDateString = () => {
+      throw new Error('locale not supported');
+    };
+    try {
+      const split: InvestmentSplit = {
+        split_id: 'split_1',
+        split_date: '2020-08-31',
+      };
+      expect(formatSplitDate(split)).toBe('2020-08-31');
+    } finally {
+      Date.prototype.toLocaleDateString = original;
+    }
   });
 });
 

--- a/tests/unit/item.test.ts
+++ b/tests/unit/item.test.ts
@@ -367,6 +367,7 @@ describe('getItemAccountCount', () => {
 });
 
 describe('formatLastUpdate', () => {
+  // Safe to monkey-patch: Bun runs tests within a file serially
   test('catch block: returns raw timestamp when toLocaleDateString throws', () => {
     const original = Date.prototype.toLocaleDateString;
     Date.prototype.toLocaleDateString = () => {

--- a/tests/unit/item.test.ts
+++ b/tests/unit/item.test.ts
@@ -367,6 +367,22 @@ describe('getItemAccountCount', () => {
 });
 
 describe('formatLastUpdate', () => {
+  test('catch block: returns raw timestamp when toLocaleDateString throws', () => {
+    const original = Date.prototype.toLocaleDateString;
+    Date.prototype.toLocaleDateString = () => {
+      throw new Error('locale not supported');
+    };
+    try {
+      const item: Item = {
+        item_id: 'item_1',
+        last_successful_update: '2024-01-15T10:30:00Z',
+      };
+      expect(formatLastUpdate(item)).toBe('2024-01-15T10:30:00Z');
+    } finally {
+      Date.prototype.toLocaleDateString = original;
+    }
+  });
+
   test('formats last_successful_update', () => {
     const item: Item = {
       item_id: 'item_1',
@@ -413,6 +429,31 @@ describe('formatLastUpdate', () => {
 });
 
 describe('isConsentExpiringSoon', () => {
+  test('catch block: returns false when Date constructor throws', () => {
+    const OriginalDate = globalThis.Date;
+    const MockDate = function (...args: unknown[]) {
+      if (args.length > 0 && args[0] === 'THROW_TRIGGER') {
+        throw new Error('invalid date');
+      }
+      // @ts-expect-error - forwarding constructor
+      return new OriginalDate(...args);
+    } as unknown as DateConstructor;
+    MockDate.now = OriginalDate.now;
+    MockDate.parse = OriginalDate.parse;
+    MockDate.UTC = OriginalDate.UTC;
+    MockDate.prototype = OriginalDate.prototype;
+    globalThis.Date = MockDate;
+    try {
+      const item: Item = {
+        item_id: 'item_1',
+        consent_expiration_time: 'THROW_TRIGGER',
+      };
+      expect(isConsentExpiringSoon(item)).toBe(false);
+    } finally {
+      globalThis.Date = OriginalDate;
+    }
+  });
+
   test('returns false when no consent_expiration_time', () => {
     const item: Item = {
       item_id: 'item_1',


### PR DESCRIPTION
## Summary
- Add 16 tests targeting uncovered lines across decoder, database, and model files
- **decoder.ts**: 98.93% → 99.58% — schema catch blocks (amount >10M, NaN balance, bad dates, invalid enums) + plaid account `limit`/`verification_status` fields
- **database.ts**: 97.29% → 99.84% — `COPILOT_CACHE_TTL_MINUTES` env var parsing + TTL=0 always-reload path
- **tag.ts**: 90% → 100% — `getTagDisplayName` function coverage
- **investment-split.ts**: 98.04% → 100% — `formatSplitDate` catch block
- **item.ts**: 98.04% → 100% — `formatLastUpdate` + `isConsentExpiringSoon` catch blocks
- Overall: functions 94.85% → 98.04%, lines 97.18% → 97.72%

## Test plan
- [x] `bun test` — all 955 tests pass, 0 failures
- [x] `bun run check` — typecheck + lint + format + tests all green
- [x] No production code changes — test-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)