### PR TITLE
fix: address review nits in decoder coverage tests

### DIFF
--- a/tests/core/decoder-coverage.test.ts
+++ b/tests/core/decoder-coverage.test.ts
@@ -699,7 +699,7 @@ describe('decoder coverage', () => {
 
       const histories = await decodeGoalHistory(dbPath);
 
-      // Should be sorted by goal_id, then month (newest first)
+      // Sorted by goal_id ASC, then month DESC (newest first within each goal)
       expect(histories.length).toBe(3);
       expect(histories[0]?.goal_id).toBe('goal1');
       expect(histories[0]?.month).toBe('2024-02');
@@ -709,7 +709,131 @@ describe('decoder coverage', () => {
     });
   });
 
+  describe('decodeTransactions', () => {
+    test('reconciles pending/posted pairs', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'decode-txns-pending-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'transactions',
+          id: 'pending-1',
+          fields: {
+            transaction_id: 'pending-1',
+            amount: 50.0,
+            date: '2024-01-15',
+            name: 'BRIGHT HORIZONS PAYMENT',
+            pending: true,
+          },
+        },
+        {
+          collection: 'transactions',
+          id: 'posted-1',
+          fields: {
+            transaction_id: 'posted-1',
+            amount: 50.0,
+            date: '2024-01-15',
+            name: 'BRIGHT HORIZONS',
+            pending: false,
+            pending_transaction_id: 'pending-1',
+          },
+        },
+      ]);
+
+      const txns = await decodeTransactions(dbPath);
+      expect(txns.length).toBe(1);
+      expect(txns[0]?.transaction_id).toBe('posted-1');
+    });
+
+    test('extracts all new transaction fields', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'txn-new-fields-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'transactions',
+          id: 'txn-full',
+          fields: {
+            transaction_id: 'txn-full',
+            amount: 42.5,
+            date: '2024-03-10',
+            name: 'Coffee Shop',
+            original_name: 'COFFEE SHOP #123',
+            original_clean_name: 'Coffee Shop',
+            name_override: 'My Coffee',
+            original_transaction_id: 'orig-txn-1',
+            created_timestamp: { __type: 'timestamp', seconds: 1710000000, nanos: 0 },
+            user_note: 'Weekly coffee',
+            plaid_category_strings: ['Food and Drink', 'Coffee Shop'],
+            is_manual: false,
+            recurring: true,
+            recurring_id: 'rec-123',
+            skip_balance_adjust: false,
+            intelligence_suggested_category_ids: ['cat-1', 'cat-2'],
+            intelligence_chosen_category_id: 'cat-1',
+            intelligence_powered: true,
+            pending_amount: 40.0,
+            plaid_pending_transaction_id: 'plaid-pending-1',
+            posted_transaction_id: 'posted-txn-1',
+            tag_ids: ['tag-a', 'tag-b'],
+            internal_tx_match: { match_id: 'match-1', confidence: 0.95 },
+            old_category_id: 'old-cat-1',
+            venmo_extra_data: { sender: 'alice', note: 'lunch' },
+            _origin: 'plaid',
+            account_type: 'checking',
+            user_deleted: false,
+            from_investment: 'true_string',
+          },
+        },
+        {
+          // Test from_investment as boolean
+          collection: 'transactions',
+          id: 'txn-invest-bool',
+          fields: {
+            transaction_id: 'txn-invest-bool',
+            amount: 100.0,
+            date: '2024-03-11',
+            from_investment: true,
+          },
+        },
+      ]);
+
+      const txns = await decodeTransactions(dbPath);
+      expect(txns.length).toBe(2);
+
+      const full = txns.find((t) => t.transaction_id === 'txn-full')!;
+      expect(full).toBeDefined();
+      expect(full.original_clean_name).toBe('Coffee Shop');
+      expect(full.name_override).toBe('My Coffee');
+      expect(full.original_transaction_id).toBe('orig-txn-1');
+      expect(full.created_timestamp).toBe('2024-03-09');
+      expect(full.user_note).toBe('Weekly coffee');
+      expect(full.plaid_category_strings).toEqual(['Food and Drink', 'Coffee Shop']);
+      expect(full.is_manual).toBe(false);
+      expect(full.recurring).toBe(true);
+      expect(full.recurring_id).toBe('rec-123');
+      expect(full.skip_balance_adjust).toBe(false);
+      expect(full.intelligence_suggested_category_ids).toEqual(['cat-1', 'cat-2']);
+      expect(full.intelligence_chosen_category_id).toBe('cat-1');
+      expect(full.intelligence_powered).toBe(true);
+      expect(full.pending_amount).toBe(40.0);
+      expect(full.plaid_pending_transaction_id).toBe('plaid-pending-1');
+      expect(full.posted_transaction_id).toBe('posted-txn-1');
+      expect(full.tag_ids).toEqual(['tag-a', 'tag-b']);
+      expect(full.internal_tx_match).toEqual({ match_id: 'match-1', confidence: 0.95 });
+      expect(full.old_category_id).toBe('old-cat-1');
+      expect(full.venmo_extra_data).toEqual({ sender: 'alice', note: 'lunch' });
+      expect(full._origin).toBe('plaid');
+      expect(full.account_type).toBe('checking');
+      expect(full.user_deleted).toBe(false);
+      expect(full.from_investment).toBe('true_string');
+
+      // Test from_investment as boolean fallback
+      const investBool = txns.find((t) => t.transaction_id === 'txn-invest-bool')!;
+      expect(investBool).toBeDefined();
+      expect(investBool.from_investment).toBe(true);
+    });
+  });
+
   describe('decodeAllCollections', () => {
+    // Integration smoke test: verifies the single-pass fanout routes each
+    // collection type correctly. Individual collections are tested above.
     test('decodes all collection types in a single pass', async () => {
       const dbPath = path.join(FIXTURES_DIR, 'all-collections-db');
       await createTestDatabase(dbPath, [
@@ -971,126 +1095,6 @@ describe('decoder coverage', () => {
       // Pending transaction with no posted counterpart should be kept
       expect(result.transactions.length).toBe(1);
       expect(result.transactions[0]?.pending).toBe(true);
-    });
-
-    test('decodeTransactions: reconciles pending/posted pairs', async () => {
-      const dbPath = path.join(FIXTURES_DIR, 'decode-txns-pending-db');
-      await createTestDatabase(dbPath, [
-        {
-          collection: 'transactions',
-          id: 'pending-1',
-          fields: {
-            transaction_id: 'pending-1',
-            amount: 50.0,
-            date: '2024-01-15',
-            name: 'BRIGHT HORIZONS PAYMENT',
-            pending: true,
-          },
-        },
-        {
-          collection: 'transactions',
-          id: 'posted-1',
-          fields: {
-            transaction_id: 'posted-1',
-            amount: 50.0,
-            date: '2024-01-15',
-            name: 'BRIGHT HORIZONS',
-            pending: false,
-            pending_transaction_id: 'pending-1',
-          },
-        },
-      ]);
-
-      const txns = await decodeTransactions(dbPath);
-      expect(txns.length).toBe(1);
-      expect(txns[0]?.transaction_id).toBe('posted-1');
-    });
-
-    test('extracts all new transaction fields', async () => {
-      const dbPath = path.join(FIXTURES_DIR, 'txn-new-fields-db');
-      await createTestDatabase(dbPath, [
-        {
-          collection: 'transactions',
-          id: 'txn-full',
-          fields: {
-            transaction_id: 'txn-full',
-            amount: 42.5,
-            date: '2024-03-10',
-            name: 'Coffee Shop',
-            original_name: 'COFFEE SHOP #123',
-            original_clean_name: 'Coffee Shop',
-            name_override: 'My Coffee',
-            original_transaction_id: 'orig-txn-1',
-            created_timestamp: { __type: 'timestamp', seconds: 1710000000, nanos: 0 },
-            user_note: 'Weekly coffee',
-            plaid_category_strings: ['Food and Drink', 'Coffee Shop'],
-            is_manual: false,
-            recurring: true,
-            recurring_id: 'rec-123',
-            skip_balance_adjust: false,
-            intelligence_suggested_category_ids: ['cat-1', 'cat-2'],
-            intelligence_chosen_category_id: 'cat-1',
-            intelligence_powered: true,
-            pending_amount: 40.0,
-            plaid_pending_transaction_id: 'plaid-pending-1',
-            posted_transaction_id: 'posted-txn-1',
-            tag_ids: ['tag-a', 'tag-b'],
-            internal_tx_match: { match_id: 'match-1', confidence: 0.95 },
-            old_category_id: 'old-cat-1',
-            venmo_extra_data: { sender: 'alice', note: 'lunch' },
-            _origin: 'plaid',
-            account_type: 'checking',
-            user_deleted: false,
-            from_investment: 'true_string',
-          },
-        },
-        {
-          // Test from_investment as boolean
-          collection: 'transactions',
-          id: 'txn-invest-bool',
-          fields: {
-            transaction_id: 'txn-invest-bool',
-            amount: 100.0,
-            date: '2024-03-11',
-            from_investment: true,
-          },
-        },
-      ]);
-
-      const txns = await decodeTransactions(dbPath);
-      expect(txns.length).toBe(2);
-
-      const full = txns.find((t) => t.transaction_id === 'txn-full')!;
-      expect(full).toBeDefined();
-      expect(full.original_clean_name).toBe('Coffee Shop');
-      expect(full.name_override).toBe('My Coffee');
-      expect(full.original_transaction_id).toBe('orig-txn-1');
-      expect(full.created_timestamp).toBe('2024-03-09');
-      expect(full.user_note).toBe('Weekly coffee');
-      expect(full.plaid_category_strings).toEqual(['Food and Drink', 'Coffee Shop']);
-      expect(full.is_manual).toBe(false);
-      expect(full.recurring).toBe(true);
-      expect(full.recurring_id).toBe('rec-123');
-      expect(full.skip_balance_adjust).toBe(false);
-      expect(full.intelligence_suggested_category_ids).toEqual(['cat-1', 'cat-2']);
-      expect(full.intelligence_chosen_category_id).toBe('cat-1');
-      expect(full.intelligence_powered).toBe(true);
-      expect(full.pending_amount).toBe(40.0);
-      expect(full.plaid_pending_transaction_id).toBe('plaid-pending-1');
-      expect(full.posted_transaction_id).toBe('posted-txn-1');
-      expect(full.tag_ids).toEqual(['tag-a', 'tag-b']);
-      expect(full.internal_tx_match).toEqual({ match_id: 'match-1', confidence: 0.95 });
-      expect(full.old_category_id).toBe('old-cat-1');
-      expect(full.venmo_extra_data).toEqual({ sender: 'alice', note: 'lunch' });
-      expect(full._origin).toBe('plaid');
-      expect(full.account_type).toBe('checking');
-      expect(full.user_deleted).toBe(false);
-      expect(full.from_investment).toBe('true_string');
-
-      // Test from_investment as boolean fallback
-      const investBool = txns.find((t) => t.transaction_id === 'txn-invest-bool')!;
-      expect(investBool).toBeDefined();
-      expect(investBool.from_investment).toBe(true);
     });
 
     test('handles empty database', async () => {


### PR DESCRIPTION
## Summary
- Move `decodeTransactions` tests into their own `describe` block (were incorrectly nested inside `decodeAllCollections`)
- Add integration smoke test comment to the mega all-collections test
- Clarify goal history sort order comment (`goal_id ASC, month DESC`)

Follow-up to #169.

## Test plan
- [x] All 1000 tests pass
- [x] `bun run check` green
- [x] Test-only change, no production code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)