### PR TITLE
chore: bump version to 1.5.0 and update docs for investment tools release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Total balance calculation**: Fixed `getAccounts()` total balance calculation to properly subtract debt from assets instead of adding all balances as positive values. This resolves inflated balance calculations for users with loans, mortgages, and credit cards.
 
+## [1.5.0] - 2026-03-29
+
+### Added
+- **`get_holdings` tool**: Current investment positions with ticker, name, quantity, price, average cost, and total return per holding
+- **`get_investment_prices` tool**: Historical price data (daily + high-frequency) for stocks, ETFs, mutual funds, and crypto
+- **`get_investment_splits` tool**: Stock split history with ratios, dates, and multipliers
+- Database accessors for securities and holdings history collections
+- Full decode coverage for all 35 Firestore collection paths (securities, balance_history, holdings_history, investment_performance, tags, amazon, changes, user profile, app metadata)
+
+### Changed
+- Tool count increased from 9 to 12
+- Ticker symbol filters are now case-insensitive across all investment tools
+
+### Fixed
+- Date range filter now correctly handles daily prices that use month format (`p.month` fallback)
+- Division guard prevents `Infinity` when holding quantity is zero
+
 ## [1.4.0] - 2026-03-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **Total balance calculation**: Fixed `getAccounts()` total balance calculation to properly subtract debt from assets instead of adding all balances as positive values. This resolves inflated balance calculations for users with loans, mortgages, and credit cards.
 
-## [1.5.0] - 2026-03-29
+## [1.5.0] - 2026-04-05
 
 ### Added
 - **`get_holdings` tool**: Current investment positions with ticker, name, quantity, price, average cost, and total return per holding

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ src/
 
 ## Key Files
 
-- **`src/tools/tools.ts`** - All 8 MCP tools are implemented here as async methods in the `CopilotMoneyTools` class.
+- **`src/tools/tools.ts`** - All 12 MCP tools are implemented here as async methods in the `CopilotMoneyTools` class. Includes investment tools (`get_holdings`, `get_investment_prices`, `get_investment_splits`).
 - **`src/core/database.ts`** - `CopilotDatabase` class with methods like `getTransactions()`, `getAccounts()`, `getIncome()`, etc.
 - **`src/core/decoder.ts`** - Binary decoder that reads LevelDB files and parses Firestore Protocol Buffers.
 - **`manifest.json`** - MCP bundle metadata for .mcpb packaging.

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ After installing the MCP server, Claude Desktop will request **one-time approval
 
 ## Available Tools
 
-The MCP server provides **8 read-only tools** for querying your financial data:
+The MCP server provides **12 read-only tools** for querying your financial data:
 
 | Tool | Description |
 |------|-------------|
@@ -197,6 +197,10 @@ The MCP server provides **8 read-only tools** for querying your financial data:
 | `get_recurring_transactions` | Identify subscriptions and recurring charges with frequency, monthly cost, and next expected date. Filter by name for detailed view. |
 | `get_budgets` | Get budgets from Copilot's native budget tracking with spending vs. limit comparisons. |
 | `get_goals` | Get financial goals with progress tracking, monthly history, and savings status. |
+| `get_connection_status` | Check bank sync/connection health for linked financial institutions, including last sync timestamps and error states. |
+| `get_holdings` | Get current investment holdings with ticker, quantity, price, average cost, and total return per holding. |
+| `get_investment_prices` | Get historical price data (daily + high-frequency) for stocks, ETFs, mutual funds, and crypto. |
+| `get_investment_splits` | Get stock split history with ratios, dates, and multipliers for accurate historical calculations. |
 | `get_cache_info` | Get information about the local data cache, including date range and transaction count. |
 | `refresh_database` | Refresh the in-memory cache to pick up newly synced data from Copilot Money. Cache auto-refreshes every 5 minutes. |
 

--- a/docs/EXAMPLE_QUERIES.md
+++ b/docs/EXAMPLE_QUERIES.md
@@ -176,6 +176,35 @@ This guide provides example natural language queries you can use with the Copilo
 
 ---
 
+## Investment Portfolio
+
+### Current Holdings
+
+```
+"What are my current holdings?"
+"Show my portfolio by account"
+"Which holdings have the best total return?"
+"What's the total value of my investments?"
+```
+
+### Price History
+
+```
+"What's the price history of AAPL?"
+"Show me the daily prices for VTI this year"
+"How has my crypto performed in the last 90 days?"
+```
+
+### Stock Splits
+
+```
+"Show me any stock splits"
+"Have any of my holdings had splits recently?"
+"What stock splits happened in the last year?"
+```
+
+---
+
 ## Subscriptions & Recurring
 
 ### Finding Subscriptions
@@ -509,7 +538,7 @@ While the MCP server returns data, you can ask Claude to:
 
 ## Tool Reference (Behind the Scenes)
 
-When you ask questions, Claude uses these 8 tools automatically:
+When you ask questions, Claude uses these 12 tools automatically:
 
 | Your Question | Tool Used |
 |---------------|-----------|
@@ -521,6 +550,10 @@ When you ask questions, Claude uses these 8 tools automatically:
 | "Find subscriptions" | `get_recurring_transactions` |
 | "Show my budgets" | `get_budgets` |
 | "What are my goals?" | `get_goals` |
+| "Check bank connection status" | `get_connection_status` |
+| "What are my holdings?" | `get_holdings` |
+| "Price history of AAPL" | `get_investment_prices` |
+| "Show stock splits" | `get_investment_splits` |
 | "Check cache status" | `get_cache_info` |
 | "Refresh database" | `refresh_database` |
 

--- a/docs/firestore-collections.md
+++ b/docs/firestore-collections.md
@@ -4,7 +4,7 @@ Complete documentation of all Firestore collections cached locally by Copilot Mo
 
 **Last verified:** 2026-04-05 | **App version:** macOS (App Store) | **Total documents:** ~55,953 across ~35 unique collection patterns
 
-**Decode coverage:** 100% (55,953 / 55,953 documents) — all 35 collection paths decoded
+**Decode coverage:** 100% — all 35 collection paths fully decoded (document counts vary per user database)
 
 ## Database Location
 

--- a/docs/firestore-collections.md
+++ b/docs/firestore-collections.md
@@ -2,9 +2,9 @@
 
 Complete documentation of all Firestore collections cached locally by Copilot Money. This is the authoritative reference for understanding the local LevelDB data, derived from systematic app screenshots and raw Firestore document inspection.
 
-**Last verified:** 2026-04-02 | **App version:** macOS (App Store) | **Total documents:** ~55,953 across ~35 unique collection patterns
+**Last verified:** 2026-04-05 | **App version:** macOS (App Store) | **Total documents:** ~55,953 across ~35 unique collection patterns
 
-**Decode coverage:** 55.3% (30,941 / 55,953 documents) — run `bun run scripts/decode-coverage.ts` for latest numbers
+**Decode coverage:** 100% (55,953 / 55,953 documents) — all 35 collection paths decoded
 
 ## Database Location
 
@@ -47,23 +47,23 @@ collection === target || collection.endsWith(`/${target}`)
 | `investment_prices/{hash}/hf` | ~850 | Yes | High-frequency price subcollection |
 | `investment_splits` | ~17 | Yes | Stock split records |
 | `items` | ~13 | Yes | Plaid item connections |
-| `items/{id}/accounts/{id}` | ~6,867 | No | Plaid account docs (with holdings) |
-| `items/{id}/accounts/{id}/balance_history` | ~4,945 | No | Daily account balance history |
-| `items/{id}/accounts/{id}/transactions` | ~1,367 | No | Plaid raw transactions |
-| `items/{id}/accounts/{id}/holdings_history/{hash}` | ~630 | No | Holdings snapshot metadata |
-| `items/{id}/accounts/{id}/holdings_history/{hash}/history` | ~84 | No | Daily holdings price/quantity |
-| `items/{id}/accounts` | ~23 | No | Plaid account listing per item |
-| `investment_performance` | ~10 | No | Performance tracking metadata |
-| `investment_performance/{hash}` | ~8,088 | No | Performance data per security |
-| `investment_performance/{hash}/twr_holding` | ~887 | No | Time-weighted return per holding |
-| `securities` | ~17 | No | Security master data |
-| `amazon/{id}` | ~72 | No | Amazon integration metadata |
-| `amazon/{id}/orders` | ~72 | No | Amazon order details |
-| `changes/{id}` | ~995 | No | Sync/change tracking |
-| `changes/{id}/t` | ~535 | No | Transaction changes |
-| `changes/{id}/a` | ~381 | No | Account changes |
-| `users/{user_id}/tags` | ~8 | No | Transaction tags |
-| `users` | 1 | No | User profile/settings |
+| `items/{id}/accounts/{id}` | ~6,867 | Yes | Plaid account docs (with holdings) |
+| `items/{id}/accounts/{id}/balance_history` | ~4,945 | Yes | Daily account balance history |
+| `items/{id}/accounts/{id}/transactions` | ~1,367 | Yes | Plaid raw transactions |
+| `items/{id}/accounts/{id}/holdings_history/{hash}` | ~630 | Yes | Holdings snapshot metadata |
+| `items/{id}/accounts/{id}/holdings_history/{hash}/history` | ~84 | Yes | Daily holdings price/quantity |
+| `items/{id}/accounts` | ~23 | Yes | Plaid account listing per item |
+| `investment_performance` | ~10 | Yes | Performance tracking metadata |
+| `investment_performance/{hash}` | ~8,088 | Yes | Performance data per security |
+| `investment_performance/{hash}/twr_holding` | ~887 | Yes | Time-weighted return per holding |
+| `securities` | ~17 | Yes | Security master data |
+| `amazon/{id}` | ~72 | Yes | Amazon integration metadata |
+| `amazon/{id}/orders` | ~72 | Yes | Amazon order details |
+| `changes/{id}` | ~995 | Yes | Sync/change tracking |
+| `changes/{id}/t` | ~535 | Yes | Transaction changes |
+| `changes/{id}/a` | ~381 | Yes | Account changes |
+| `users/{user_id}/tags` | ~8 | Yes | Transaction tags |
+| `users` | 1 | Yes | User profile/settings |
 | `subscriptions` | 1 | Yes | App subscription data |
 | `invites` | 2 | Yes | Referral invite codes |
 | `user_items` | 1 | Yes | User-to-item mapping |

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "copilot-money-mcp",
   "display_name": "Copilot Money MCP Server",
   "description": "AI-powered personal finance queries using local Copilot Money data. Query transactions, analyze spending, and track accounts with natural language.",
-  "version": "1.2.3",
+  "version": "1.5.0",
   "icon": "icon.png",
   "author": {
     "name": "Ignacio Hermosilla",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-money-mcp",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "MCP server for Copilot Money - AI-powered personal finance queries using local data",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary

- Bump version 1.4.0 → 1.5.0 in package.json and manifest.json (was 1.2.3, now synced)
- Add CHANGELOG.md entry for 1.5.0 (3 new tools, full decode coverage, fixes)
- Update README.md tool count (8 → 12) and add missing tools to table
- Update CLAUDE.md tool count and mention investment tools
- Add investment portfolio examples to docs/EXAMPLE_QUERIES.md
- Update docs/firestore-collections.md decode coverage to 100%

## Test plan
- [x] 979 tests pass, 0 fail
- [x] All docs reviewed for consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)