### PR TITLE
ci: auto-create GitHub release on version bump

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,8 +10,11 @@ jobs:
   release:
     name: Create release on version bump
     runs-on: ubuntu-latest
-    # Only trusted publishers can trigger releases
-    if: github.event.head_commit.author.username == 'ignaciohermosillacornejo'
+    # Only the repo owner can trigger releases
+    if: github.actor == 'ignaciohermosillacornejo'
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       contents: write
 
@@ -49,6 +52,8 @@ jobs:
       - name: Extract changelog
         if: steps.version.outputs.changed == 'true'
         id: changelog
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           VERSION="${{ steps.version.outputs.current }}"
           # Extract the section for this version from CHANGELOG.md
@@ -64,12 +69,11 @@ jobs:
 
           if [ -z "$NOTES" ]; then
             echo "No changelog entry found for $VERSION, using commit message"
-            NOTES="${{ github.event.head_commit.message }}"
+            NOTES="$COMMIT_MSG"
           fi
 
           # Write to file to avoid escaping issues
           echo "$NOTES" > /tmp/release-notes.md
-          echo "has_notes=true" >> "$GITHUB_OUTPUT"
 
       - name: Create release
         if: steps.version.outputs.changed == 'true'

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,83 @@
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+
+jobs:
+  release:
+    name: Create release on version bump
+    runs-on: ubuntu-latest
+    # Only trusted publishers can trigger releases
+    if: github.event.head_commit.author.username == 'ignaciohermosillacornejo'
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2  # Need previous commit to detect version change
+
+      - name: Check for version bump
+        id: version
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+
+          # Check if tag already exists
+          if git rev-parse "v$CURRENT_VERSION" >/dev/null 2>&1; then
+            echo "Tag v$CURRENT_VERSION already exists, skipping"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Check if version actually changed in this push
+          git show HEAD~1:package.json > /tmp/old-package.json 2>/dev/null || true
+          OLD_VERSION=$(node -p "try { require('/tmp/old-package.json').version } catch { '' }")
+
+          if [ "$CURRENT_VERSION" != "$OLD_VERSION" ]; then
+            echo "Version changed: $OLD_VERSION -> $CURRENT_VERSION"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version unchanged ($CURRENT_VERSION), skipping"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract changelog
+        if: steps.version.outputs.changed == 'true'
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.current }}"
+          # Extract the section for this version from CHANGELOG.md
+          # Matches from "## [x.y.z]" until the next "## [" or end of file
+          NOTES=$(awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) found=1
+              next
+            }
+            found { print }
+          ' CHANGELOG.md)
+
+          if [ -z "$NOTES" ]; then
+            echo "No changelog entry found for $VERSION, using commit message"
+            NOTES="${{ github.event.head_commit.message }}"
+          fi
+
+          # Write to file to avoid escaping issues
+          echo "$NOTES" > /tmp/release-notes.md
+          echo "has_notes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        if: steps.version.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.current }}"
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --notes-file /tmp/release-notes.md \
+            --target "${{ github.sha }}"


### PR DESCRIPTION
## Summary
- Adds a workflow that watches for `package.json` version changes on `main`
- Extracts release notes from `CHANGELOG.md` and creates a GitHub release
- The existing `npm-publish.yml` workflow chains automatically (triggers on `release: published`)

## How it works
1. Push to `main` changes `package.json` → workflow runs
2. Compares current version against previous commit — skips if unchanged or tag exists
3. Parses `CHANGELOG.md` for the matching `## [x.y.z]` section
4. Creates `vX.Y.Z` tag + GitHub release → npm publish triggers

## Test plan
- [ ] Merge this PR, then do a version bump PR to verify the full chain works
- [ ] Verify it skips when `package.json` changes don't touch `version`
- [ ] Verify it skips when the tag already exists (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)