### PR TITLE
feat: add 6 write tools — review, notes, tags, tag CRUD, categories

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -79,6 +79,30 @@
     {
       "name": "set_transaction_category",
       "description": "Change the category of a transaction."
+    },
+    {
+      "name": "set_transaction_note",
+      "description": "Set or clear the user note on a transaction."
+    },
+    {
+      "name": "set_transaction_tags",
+      "description": "Set the tags on a transaction."
+    },
+    {
+      "name": "review_transactions",
+      "description": "Mark one or more transactions as reviewed (or unreviewed)."
+    },
+    {
+      "name": "create_tag",
+      "description": "Create a new user-defined tag for categorizing transactions."
+    },
+    {
+      "name": "delete_tag",
+      "description": "Delete a user-defined tag."
+    },
+    {
+      "name": "create_category",
+      "description": "Create a new custom category in Copilot Money."
     }
   ],
   "tools_generated": false,

--- a/src/core/auth/browser-token.ts
+++ b/src/core/auth/browser-token.ts
@@ -54,7 +54,14 @@ export const BROWSER_CONFIGS: BrowserConfig[] = [
   },
   {
     name: 'Safari',
-    paths: [join(homedir(), 'Library/Safari/Databases')],
+    paths: [
+      // Safari 17+ stores IndexedDB in the app container with hashed directory names
+      join(
+        homedir(),
+        'Library/Containers/com.apple.Safari/Data/Library/WebKit/WebsiteData/Default'
+      ),
+      join(homedir(), 'Library/Safari/Databases'),
+    ],
     type: 'safari',
   },
   {

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -37,7 +37,7 @@ import {
   Item,
   getTransactionDisplayName,
 } from '../models/index.js';
-import type { Security, HoldingsHistory } from '../models/index.js';
+import type { Security, HoldingsHistory, Tag } from '../models/index.js';
 import { getCategoryName } from '../utils/categories.js';
 
 /**
@@ -157,6 +157,7 @@ export class CopilotDatabase {
   private _userAccounts: UserAccountCustomization[] | null = null;
   private _accountNameMap: Map<string, string> | null = null;
   private _securities: Security[] | null = null;
+  private _tags: Tag[] | null = null;
   private _holdingsHistory: HoldingsHistory[] | null = null;
 
   // Promises for in-flight loads to prevent duplicate loading
@@ -275,6 +276,7 @@ export class CopilotDatabase {
     this._accountNameMap = null;
     this._securities = null;
     this._holdingsHistory = null;
+    this._tags = null;
 
     // Clear in-flight loading promises
     this._loadingTransactions = null;
@@ -381,6 +383,7 @@ export class CopilotDatabase {
       this._userAccounts = result.userAccounts;
       this._securities = result.securities;
       this._holdingsHistory = result.holdingsHistory;
+      this._tags = result.tags;
 
       this._allCollectionsLoaded = true;
       this._cacheLoadedAt = Date.now();
@@ -982,6 +985,11 @@ export class CopilotDatabase {
   async getUserCategories(): Promise<Category[]> {
     const userCategories = await this.loadUserCategories();
     return [...userCategories];
+  }
+
+  async getTags(): Promise<Tag[]> {
+    await this.loadAllCollections();
+    return [...(this._tags ?? [])];
   }
 
   /**

--- a/src/core/firestore-client.ts
+++ b/src/core/firestore-client.ts
@@ -2,9 +2,11 @@
  * Firestore REST API client for document writes.
  *
  * Thin wrapper around the Firestore REST API using native fetch.
- * Uses PATCH with updateMask for partial document updates.
+ * Uses PATCH with updateMask for partial document updates and
+ * POST for creating new documents with client-specified IDs.
  *
  * @see https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/patch
+ * @see https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/createDocument
  */
 
 import type { FirebaseAuth } from './auth/firebase-auth.js';
@@ -15,6 +17,28 @@ const FIRESTORE_BASE_URL = 'https://firestore.googleapis.com/v1';
 
 export class FirestoreClient {
   constructor(private auth: FirebaseAuth) {}
+
+  /**
+   * Return the authenticated user's Firebase UID (available after first token exchange).
+   */
+  getUserId(): string | null {
+    return this.auth.getUserId();
+  }
+
+  /**
+   * Return the authenticated user's Firebase UID, triggering a token exchange if needed.
+   *
+   * Throws if the user ID is unavailable even after authentication.
+   */
+  async requireUserId(): Promise<string> {
+    // Ensure at least one token exchange has occurred so userId is populated
+    await this.auth.getIdToken();
+    const uid = this.auth.getUserId();
+    if (!uid) {
+      throw new Error('Firebase user ID unavailable after authentication');
+    }
+    return uid;
+  }
 
   async updateDocument(
     collectionPath: string,
@@ -41,6 +65,61 @@ export class FirestoreClient {
     if (!response.ok) {
       const errorBody = await response.text();
       throw new Error(`Firestore update failed (${response.status}): ${errorBody}`);
+    }
+  }
+
+  /**
+   * Create a new document in a Firestore collection.
+   *
+   * Uses the Firestore REST API createDocument endpoint with a client-supplied
+   * document ID.
+   *
+   * @see https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/createDocument
+   */
+  async createDocument(
+    collectionPath: string,
+    documentId: string,
+    fields: FirestoreFields
+  ): Promise<void> {
+    const idToken = await this.auth.getIdToken();
+    const parentPath = `projects/${FIRESTORE_PROJECT_ID}/databases/(default)/documents`;
+    const url = new URL(`${FIRESTORE_BASE_URL}/${parentPath}/${collectionPath}`);
+    url.searchParams.set('documentId', documentId);
+
+    const response = await fetch(url.toString(), {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${idToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ fields }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Firestore create failed (${response.status}): ${errorBody}`);
+    }
+  }
+
+  /**
+   * Delete a document from Firestore.
+   *
+   * @see https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/delete
+   */
+  async deleteDocument(collectionPath: string, documentId: string): Promise<void> {
+    const idToken = await this.auth.getIdToken();
+    const docPath = `projects/${FIRESTORE_PROJECT_ID}/databases/(default)/documents/${collectionPath}/${documentId}`;
+
+    const response = await fetch(`${FIRESTORE_BASE_URL}/${docPath}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${idToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Firestore delete failed (${response.status}): ${errorBody}`);
     }
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -93,7 +93,15 @@ export class CopilotMoneyServer {
    * @param name - Tool name
    * @param typedArgs - Tool arguments
    */
-  private static readonly WRITE_TOOLS = new Set(['set_transaction_category']);
+  private static readonly WRITE_TOOLS = new Set([
+    'set_transaction_category',
+    'set_transaction_note',
+    'set_transaction_tags',
+    'review_transactions',
+    'create_tag',
+    'delete_tag',
+    'create_category',
+  ]);
 
   async handleCallTool(name: string, typedArgs?: Record<string, unknown>): Promise<CallToolResult> {
     // Block write tools when not in write mode (before db check so the error is clear)
@@ -197,6 +205,42 @@ export class CopilotMoneyServer {
         case 'set_transaction_category':
           result = await this.tools.setTransactionCategory(
             typedArgs as Parameters<typeof this.tools.setTransactionCategory>[0]
+          );
+          break;
+
+        case 'set_transaction_note':
+          result = await this.tools.setTransactionNote(
+            typedArgs as Parameters<typeof this.tools.setTransactionNote>[0]
+          );
+          break;
+
+        case 'set_transaction_tags':
+          result = await this.tools.setTransactionTags(
+            typedArgs as Parameters<typeof this.tools.setTransactionTags>[0]
+          );
+          break;
+
+        case 'review_transactions':
+          result = await this.tools.reviewTransactions(
+            typedArgs as Parameters<typeof this.tools.reviewTransactions>[0]
+          );
+          break;
+
+        case 'create_tag':
+          result = await this.tools.createTag(
+            typedArgs as Parameters<typeof this.tools.createTag>[0]
+          );
+          break;
+
+        case 'delete_tag':
+          result = await this.tools.deleteTag(
+            typedArgs as Parameters<typeof this.tools.deleteTag>[0]
+          );
+          break;
+
+        case 'create_category':
+          result = await this.tools.createCategory(
+            typedArgs as Parameters<typeof this.tools.createCategory>[0]
           );
           break;
 

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2207,20 +2207,20 @@ export class CopilotMoneyTools {
       throw new Error('Category name must not be empty');
     }
 
+    const existingCategories = await this.db.getUserCategories();
+
     // Validate parent_category_id if provided
     if (parent_category_id) {
       if (!/^[A-Za-z0-9_-]+$/.test(parent_category_id)) {
         throw new Error(`Invalid parent_category_id format: ${parent_category_id}`);
       }
-      const categories = await this.db.getUserCategories();
-      const parent = categories.find((c) => c.category_id === parent_category_id);
+      const parent = existingCategories.find((c) => c.category_id === parent_category_id);
       if (!parent) {
         throw new Error(`Parent category not found: ${parent_category_id}`);
       }
     }
 
     // Check for duplicate name
-    const existingCategories = await this.db.getUserCategories();
     const duplicate = existingCategories.find(
       (c) => c.name?.toLowerCase() === name.trim().toLowerCase()
     );
@@ -2502,19 +2502,19 @@ export class CopilotMoneyTools {
       resolvedTxns.push(txn);
     }
 
-    // Write to Firestore and patch cache for each transaction
+    // Write to Firestore in parallel and patch cache
     const firestoreFields = toFirestoreFields({ user_reviewed: reviewed });
-    for (const txn of resolvedTxns) {
-      const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
-      await client.updateDocument(collectionPath, txn.transaction_id, firestoreFields, [
-        'user_reviewed',
-      ]);
-
-      // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
-      if (!this.db.patchCachedTransaction(txn.transaction_id, { user_reviewed: reviewed })) {
-        this.db.clearCache();
-      }
-    }
+    await Promise.all(
+      resolvedTxns.map(async (txn) => {
+        const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
+        await client.updateDocument(collectionPath, txn.transaction_id, firestoreFields, [
+          'user_reviewed',
+        ]);
+        if (!this.db.patchCachedTransaction(txn.transaction_id, { user_reviewed: reviewed })) {
+          this.db.clearCache();
+        }
+      })
+    );
 
     return {
       success: true,
@@ -2559,6 +2559,13 @@ export class CopilotMoneyTools {
     // Validate hex_color format if provided
     if (hex_color !== undefined && !/^#[0-9A-Fa-f]{6}$/.test(hex_color)) {
       throw new Error(`Invalid hex_color format: ${hex_color} (expected #RRGGBB)`);
+    }
+
+    // Check for duplicate tag
+    const existingTags = await this.db.getTags();
+    const duplicate = existingTags.find((t) => t.tag_id === tag_id);
+    if (duplicate) {
+      throw new Error(`Tag "${trimmedName}" already exists (id: ${tag_id})`);
     }
 
     // Resolve user_id for the Firestore path users/{user_id}/tags/{tag_id}
@@ -2612,6 +2619,13 @@ export class CopilotMoneyTools {
       throw new Error(`Invalid tag_id format: ${tag_id}`);
     }
 
+    // Validate tag exists
+    const existingTags = await this.db.getTags();
+    const tag = existingTags.find((t) => t.tag_id === tag_id);
+    if (!tag) {
+      throw new Error(`Tag not found: ${tag_id}`);
+    }
+
     // Resolve user_id for the Firestore path users/{user_id}/tags/{tag_id}
     const userId = await client.requireUserId();
 
@@ -2624,7 +2638,7 @@ export class CopilotMoneyTools {
     return {
       success: true,
       tag_id,
-      deleted_name: tag_id,
+      deleted_name: tag.name ?? tag_id,
     };
   }
 }
@@ -3260,7 +3274,7 @@ export function createWriteToolSchemas(): ToolSchema[] {
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
-        idempotentHint: true,
+        idempotentHint: false,
       },
     },
     {

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2178,6 +2178,106 @@ export class CopilotMoneyTools {
   }
 
   /**
+   * Create a new user-defined category in Copilot Money.
+   *
+   * Generates a unique category_id, writes to Firestore, then clears the cache
+   * so the new category is visible on next query.
+   */
+  async createCategory(args: {
+    name: string;
+    emoji?: string;
+    color?: string;
+    parent_category_id?: string;
+    excluded?: boolean;
+  }): Promise<{
+    success: boolean;
+    category_id: string;
+    name: string;
+    emoji?: string;
+    color?: string;
+    parent_category_id?: string;
+    excluded: boolean;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { name, emoji, color, parent_category_id, excluded = false } = args;
+
+    // Validate name is non-empty
+    if (!name.trim()) {
+      throw new Error('Category name must not be empty');
+    }
+
+    // Validate parent_category_id if provided
+    if (parent_category_id) {
+      if (!/^[A-Za-z0-9_-]+$/.test(parent_category_id)) {
+        throw new Error(`Invalid parent_category_id format: ${parent_category_id}`);
+      }
+      const categories = await this.db.getUserCategories();
+      const parent = categories.find((c) => c.category_id === parent_category_id);
+      if (!parent) {
+        throw new Error(`Parent category not found: ${parent_category_id}`);
+      }
+    }
+
+    // Check for duplicate name
+    const existingCategories = await this.db.getUserCategories();
+    const duplicate = existingCategories.find(
+      (c) => c.name?.toLowerCase() === name.trim().toLowerCase()
+    );
+    if (duplicate) {
+      throw new Error(
+        `Category with name "${name.trim()}" already exists (id: ${duplicate.category_id})`
+      );
+    }
+
+    // Generate a unique category_id
+    const categoryId = `custom_${crypto.randomUUID().replace(/-/g, '').slice(0, 16)}`;
+
+    // Determine user_id: prefer existing categories, fall back to auth layer
+    const userIdFromCategories = existingCategories.find((c) => c.user_id)?.user_id;
+    const userId = userIdFromCategories ?? (await client.requireUserId());
+
+    // Build document fields
+    const docFields: Record<string, unknown> = {
+      category_id: categoryId,
+      name: name.trim(),
+      excluded,
+    };
+    if (emoji) docFields.emoji = emoji;
+    if (color) docFields.color = color;
+    if (parent_category_id) docFields.parent_category_id = parent_category_id;
+
+    // Write to Firestore
+    const collectionPath = `users/${userId}/categories`;
+    const firestoreFields = toFirestoreFields(docFields);
+    await client.createDocument(collectionPath, categoryId, firestoreFields);
+
+    // Clear cache so the new category is visible on next query
+    this.db.clearCache();
+    this._userCategoryMap = null;
+
+    const result: {
+      success: boolean;
+      category_id: string;
+      name: string;
+      emoji?: string;
+      color?: string;
+      parent_category_id?: string;
+      excluded: boolean;
+    } = {
+      success: true,
+      category_id: categoryId,
+      name: name.trim(),
+      excluded,
+    };
+    if (emoji) result.emoji = emoji;
+    if (color) result.color = color;
+    if (parent_category_id) result.parent_category_id = parent_category_id;
+
+    return result;
+  }
+
+  /**
    * Change the category of a transaction.
    *
    * Validates both IDs exist, writes to Firestore, then patches the cache.
@@ -2245,6 +2345,286 @@ export class CopilotMoneyTools {
       new_category_id: category_id,
       old_category_name: oldCategoryName,
       new_category_name: newCategoryName,
+    };
+  }
+
+  /**
+   * Set or clear the user note on a transaction.
+   *
+   * Validates the transaction exists, writes to Firestore, then patches the cache.
+   */
+  async setTransactionNote(args: { transaction_id: string; note: string }): Promise<{
+    success: boolean;
+    transaction_id: string;
+    old_note: string;
+    new_note: string;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { transaction_id, note } = args;
+
+    // Validate transaction_id contains only safe characters
+    if (!/^[A-Za-z0-9_-]+$/.test(transaction_id)) {
+      throw new Error(`Invalid transaction_id format: ${transaction_id}`);
+    }
+
+    // Validate transaction exists
+    const transactions = await this.db.getAllTransactions();
+    const txn = transactions.find((t) => t.transaction_id === transaction_id);
+    if (!txn) {
+      throw new Error(`Transaction not found: ${transaction_id}`);
+    }
+
+    const oldNote = txn.user_note ?? '';
+
+    // Write to Firestore — transactions are nested: items/{itemId}/accounts/{accountId}/transactions
+    if (!txn.item_id || !txn.account_id) {
+      throw new Error(
+        `Transaction ${transaction_id} is missing item_id or account_id — cannot determine Firestore path`
+      );
+    }
+    const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
+    const firestoreFields = toFirestoreFields({ user_note: note });
+    await client.updateDocument(collectionPath, transaction_id, firestoreFields, ['user_note']);
+
+    // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
+    if (!this.db.patchCachedTransaction(transaction_id, { user_note: note })) {
+      this.db.clearCache();
+    }
+
+    return {
+      success: true,
+      transaction_id,
+      old_note: oldNote,
+      new_note: note,
+    };
+  }
+
+  /**
+   * Set the tags on a transaction.
+   *
+   * Validates transaction exists, writes tag_ids to Firestore, then patches the cache.
+   */
+  async setTransactionTags(args: { transaction_id: string; tag_ids: string[] }): Promise<{
+    success: boolean;
+    transaction_id: string;
+    old_tag_ids: string[];
+    new_tag_ids: string[];
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { transaction_id, tag_ids } = args;
+
+    // Validate IDs contain only safe characters
+    if (!/^[A-Za-z0-9_-]+$/.test(transaction_id)) {
+      throw new Error(`Invalid transaction_id format: ${transaction_id}`);
+    }
+    for (const tagId of tag_ids) {
+      if (!/^[A-Za-z0-9_-]+$/.test(tagId)) {
+        throw new Error(`Invalid tag_id format: ${tagId}`);
+      }
+    }
+
+    // Validate transaction exists
+    const transactions = await this.db.getAllTransactions();
+    const txn = transactions.find((t) => t.transaction_id === transaction_id);
+    if (!txn) {
+      throw new Error(`Transaction not found: ${transaction_id}`);
+    }
+
+    // Write to Firestore — transactions are nested: items/{itemId}/accounts/{accountId}/transactions
+    if (!txn.item_id || !txn.account_id) {
+      throw new Error(
+        `Transaction ${transaction_id} is missing item_id or account_id — cannot determine Firestore path`
+      );
+    }
+
+    const oldTagIds = txn.tag_ids || [];
+
+    const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
+    const firestoreFields = toFirestoreFields({ tag_ids });
+    await client.updateDocument(collectionPath, transaction_id, firestoreFields, ['tag_ids']);
+
+    // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
+    if (!this.db.patchCachedTransaction(transaction_id, { tag_ids })) {
+      this.db.clearCache();
+    }
+
+    return {
+      success: true,
+      transaction_id,
+      old_tag_ids: oldTagIds,
+      new_tag_ids: tag_ids,
+    };
+  }
+
+  /**
+   * Mark one or more transactions as reviewed (or unreviewed).
+   *
+   * Validates all transaction IDs, writes user_reviewed to Firestore for each,
+   * then patches the in-memory cache.
+   */
+  async reviewTransactions(args: { transaction_ids: string[]; reviewed?: boolean }): Promise<{
+    success: boolean;
+    reviewed_count: number;
+    transaction_ids: string[];
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { transaction_ids, reviewed = true } = args;
+
+    if (!Array.isArray(transaction_ids) || transaction_ids.length === 0) {
+      throw new Error('transaction_ids must be a non-empty array');
+    }
+
+    // Validate all IDs contain only safe characters
+    for (const id of transaction_ids) {
+      if (!/^[A-Za-z0-9_-]+$/.test(id)) {
+        throw new Error(`Invalid transaction_id format: ${id}`);
+      }
+    }
+
+    // Validate all transactions exist and collect them
+    const allTransactions = await this.db.getAllTransactions();
+    const txnMap = new Map(allTransactions.map((t) => [t.transaction_id, t]));
+
+    const resolvedTxns = [];
+    for (const id of transaction_ids) {
+      const txn = txnMap.get(id);
+      if (!txn) {
+        throw new Error(`Transaction not found: ${id}`);
+      }
+      if (!txn.item_id || !txn.account_id) {
+        throw new Error(
+          `Transaction ${id} is missing item_id or account_id — cannot determine Firestore path`
+        );
+      }
+      resolvedTxns.push(txn);
+    }
+
+    // Write to Firestore and patch cache for each transaction
+    const firestoreFields = toFirestoreFields({ user_reviewed: reviewed });
+    for (const txn of resolvedTxns) {
+      const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
+      await client.updateDocument(collectionPath, txn.transaction_id, firestoreFields, [
+        'user_reviewed',
+      ]);
+
+      // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
+      if (!this.db.patchCachedTransaction(txn.transaction_id, { user_reviewed: reviewed })) {
+        this.db.clearCache();
+      }
+    }
+
+    return {
+      success: true,
+      reviewed_count: resolvedTxns.length,
+      transaction_ids: resolvedTxns.map((t) => t.transaction_id),
+    };
+  }
+
+  /**
+   * Create a new user-defined tag.
+   *
+   * Generates a deterministic tag_id from the name, validates it does not
+   * already exist, writes to Firestore, then clears the cache so the next
+   * read picks up the new tag.
+   */
+  async createTag(args: { name: string; color_name?: string; hex_color?: string }): Promise<{
+    success: boolean;
+    tag_id: string;
+    name: string;
+    color_name?: string;
+    hex_color?: string;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { name, color_name, hex_color } = args;
+
+    // Validate name is non-empty
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      throw new Error('Tag name must not be empty');
+    }
+
+    // Generate deterministic tag_id from name (lowercase, spaces to underscores, strip special chars)
+    const tag_id = trimmedName
+      .toLowerCase()
+      .replace(/\s+/g, '_')
+      .replace(/[^a-z0-9_-]/g, '');
+    if (!tag_id) {
+      throw new Error(`Cannot generate a valid tag_id from name: ${trimmedName}`);
+    }
+
+    // Validate hex_color format if provided
+    if (hex_color !== undefined && !/^#[0-9A-Fa-f]{6}$/.test(hex_color)) {
+      throw new Error(`Invalid hex_color format: ${hex_color} (expected #RRGGBB)`);
+    }
+
+    // Resolve user_id for the Firestore path users/{user_id}/tags/{tag_id}
+    const userId = await client.requireUserId();
+
+    // Build fields for Firestore
+    const docFields: Record<string, unknown> = { name: trimmedName };
+    if (color_name !== undefined) docFields.color_name = color_name;
+    if (hex_color !== undefined) docFields.hex_color = hex_color;
+
+    const firestoreFields = toFirestoreFields(docFields);
+    const collectionPath = `users/${userId}/tags`;
+    await client.createDocument(collectionPath, tag_id, firestoreFields);
+
+    // Clear the cache so the next read picks up the new tag from LevelDB
+    this.db.clearCache();
+
+    const result: {
+      success: boolean;
+      tag_id: string;
+      name: string;
+      color_name?: string;
+      hex_color?: string;
+    } = {
+      success: true,
+      tag_id,
+      name: trimmedName,
+    };
+    if (color_name !== undefined) result.color_name = color_name;
+    if (hex_color !== undefined) result.hex_color = hex_color;
+    return result;
+  }
+
+  /**
+   * Delete an existing user-defined tag.
+   *
+   * Validates the tag exists in the local cache, deletes from Firestore,
+   * then clears the cache.
+   */
+  async deleteTag(args: { tag_id: string }): Promise<{
+    success: boolean;
+    tag_id: string;
+    deleted_name: string;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { tag_id } = args;
+
+    // Validate tag_id format
+    if (!/^[A-Za-z0-9_-]+$/.test(tag_id)) {
+      throw new Error(`Invalid tag_id format: ${tag_id}`);
+    }
+
+    // Resolve user_id for the Firestore path users/{user_id}/tags/{tag_id}
+    const userId = await client.requireUserId();
+
+    const collectionPath = `users/${userId}/tags`;
+    await client.deleteDocument(collectionPath, tag_id);
+
+    // Clear the cache so the next read reflects the deletion
+    this.db.clearCache();
+
+    return {
+      success: true,
+      tag_id,
+      deleted_name: tag_id,
     };
   }
 }
@@ -2775,6 +3155,176 @@ export function createWriteToolSchemas(): ToolSchema[] {
         readOnlyHint: false,
         destructiveHint: false,
         idempotentHint: true,
+      },
+    },
+    {
+      name: 'set_transaction_note',
+      description:
+        'Set or clear the user note on a transaction. Pass an empty string to clear the note. ' +
+        'Requires transaction_id (from get_transactions). Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          transaction_id: {
+            type: 'string',
+            description: 'Transaction ID to update (from get_transactions results)',
+          },
+          note: {
+            type: 'string',
+            description: 'Note text. Pass empty string to clear.',
+          },
+        },
+        required: ['transaction_id', 'note'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'set_transaction_tags',
+      description:
+        'Set the tags on a transaction. Pass an array of tag_ids. Pass empty array to clear all tags.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          transaction_id: {
+            type: 'string',
+            description: 'Transaction ID to update (from get_transactions results)',
+          },
+          tag_ids: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Array of tag IDs to set on the transaction. Pass empty array to clear.',
+          },
+        },
+        required: ['transaction_id', 'tag_ids'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'review_transactions',
+      description:
+        'Mark one or more transactions as reviewed (or unreviewed). ' +
+        'Accepts an array of transaction_ids. Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          transaction_ids: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Transaction IDs to mark as reviewed',
+          },
+          reviewed: {
+            type: 'boolean',
+            description: 'Set to true to mark as reviewed, false to unmark. Defaults to true.',
+          },
+        },
+        required: ['transaction_ids'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'create_tag',
+      description:
+        'Create a new user-defined tag for categorizing transactions. Tags appear in the ' +
+        'Copilot Money app and can be referenced via hashtags in transaction names (e.g. #vacation). ' +
+        'Optionally set a color. Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Tag name (e.g. "vacation", "business expense")',
+          },
+          color_name: {
+            type: 'string',
+            description: 'Optional color name (e.g. "blue", "red")',
+          },
+          hex_color: {
+            type: 'string',
+            description: 'Optional hex color code (e.g. "#FF5733")',
+          },
+        },
+        required: ['name'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'delete_tag',
+      description:
+        'Delete a user-defined tag. The tag_id can be obtained from transaction names ' +
+        '(hashtags like #vacation) or from the tag definitions in the local cache. ' +
+        'Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          tag_id: {
+            type: 'string',
+            description: 'Tag ID to delete',
+          },
+        },
+        required: ['tag_id'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'create_category',
+      description:
+        'Create a new custom category in Copilot Money. Provide a name (required) ' +
+        'and optionally an emoji, color, parent category, or excluded flag. ' +
+        'Returns the generated category_id. The new category can then be used ' +
+        'with set_transaction_category.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Display name for the new category (e.g., "Subscriptions")',
+          },
+          emoji: {
+            type: 'string',
+            description: 'Emoji icon for the category (e.g., "🎬")',
+          },
+          color: {
+            type: 'string',
+            description: 'Hex color code for the category (e.g., "#FF5733")',
+          },
+          parent_category_id: {
+            type: 'string',
+            description:
+              'Parent category ID to nest under (from get_categories). ' +
+              'Creates a subcategory when provided.',
+          },
+          excluded: {
+            type: 'boolean',
+            description: 'Exclude this category from spending totals (default: false)',
+            default: false,
+          },
+        },
+        required: ['name'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
       },
     },
   ];

--- a/tests/core/firestore-client.test.ts
+++ b/tests/core/firestore-client.test.ts
@@ -118,4 +118,109 @@ describe('FirestoreClient', () => {
     ).rejects.toThrow('Firestore update failed');
     restoreFetch();
   });
+
+  // --- getUserId / requireUserId ---
+
+  test('getUserId delegates to auth', () => {
+    expect(client.getUserId()).toBe('user123');
+  });
+
+  test('getUserId returns null when auth has no userId', () => {
+    const noIdAuth = createMockAuth('token', undefined as unknown as string);
+    // Simulate null userId — getUserId on our mock returns the passed value
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (noIdAuth as any).getUserId = () => null;
+    const c = new FirestoreClient(noIdAuth);
+    expect(c.getUserId()).toBeNull();
+  });
+
+  test('requireUserId returns userId after token exchange', async () => {
+    mockFetch({});
+    const uid = await client.requireUserId();
+    expect(uid).toBe('user123');
+    restoreFetch();
+  });
+
+  test('requireUserId throws when userId is null after exchange', async () => {
+    const badAuth = createMockAuth('token');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (badAuth as any).getUserId = () => null;
+    const c = new FirestoreClient(badAuth);
+    mockFetch({});
+    await expect(c.requireUserId()).rejects.toThrow('Firebase user ID unavailable');
+    restoreFetch();
+  });
+
+  // --- createDocument ---
+
+  test('createDocument sends POST with documentId query param', async () => {
+    mockFetch({ name: 'doc', fields: {} });
+    await client.createDocument('users/u1/tags', 'my_tag', {
+      name: { stringValue: 'My Tag' },
+    });
+
+    expect(fetchCalls).toHaveLength(1);
+    const url = new URL(fetchCalls[0].url);
+    expect(url.pathname).toContain('/users/u1/tags');
+    expect(url.searchParams.get('documentId')).toBe('my_tag');
+    expect(fetchCalls[0].options.method).toBe('POST');
+
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body).toEqual({ fields: { name: { stringValue: 'My Tag' } } });
+    restoreFetch();
+  });
+
+  test('createDocument sends correct JSON body', async () => {
+    mockFetch({ name: 'doc', fields: {} });
+    await client.createDocument('users/uid/categories', 'cat_123', {
+      name: { stringValue: 'Test' },
+      excluded: { booleanValue: false },
+    });
+
+    const body = JSON.parse(fetchCalls[0].options.body as string);
+    expect(body).toEqual({
+      fields: {
+        name: { stringValue: 'Test' },
+        excluded: { booleanValue: false },
+      },
+    });
+    restoreFetch();
+  });
+
+  test('createDocument throws on non-OK response', async () => {
+    mockFetch({ error: { code: 409, message: 'Already exists' } }, 409);
+    await expect(
+      client.createDocument('users/u1/tags', 'dup', { name: { stringValue: 'Dup' } })
+    ).rejects.toThrow('Firestore create failed');
+    restoreFetch();
+  });
+
+  // --- deleteDocument ---
+
+  test('deleteDocument sends DELETE with correct path', async () => {
+    mockFetch({});
+    await client.deleteDocument('users/u1/tags', 'my_tag');
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].options.method).toBe('DELETE');
+    const url = new URL(fetchCalls[0].url);
+    expect(url.pathname).toContain('/users/u1/tags/my_tag');
+    restoreFetch();
+  });
+
+  test('deleteDocument sends Authorization header', async () => {
+    mockFetch({});
+    await client.deleteDocument('users/u1/tags', 'my_tag');
+    const headers = fetchCalls[0].options.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer test-id-token');
+    restoreFetch();
+  });
+
+  test('deleteDocument throws on non-OK response', async () => {
+    mockFetch({ error: { code: 404, message: 'Not found' } }, 404);
+    await expect(client.deleteDocument('users/u1/tags', 'missing')).rejects.toThrow(
+      'Firestore delete failed'
+    );
+    restoreFetch();
+  });
 });

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -2203,3 +2203,953 @@ describe('setTransactionCategory', () => {
     ).rejects.toThrow('Write mode is not enabled');
   });
 });
+
+describe('setTransactionNote', () => {
+  let tools: CopilotMoneyTools;
+  let mockDb: CopilotDatabase;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let updateCalls: { collection: string; docId: string; fields: any; mask: string[] }[];
+
+  beforeEach(() => {
+    mockDb = new CopilotDatabase('/nonexistent');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any).dbPath = '/fake';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions = [
+      {
+        transaction_id: 'txn1',
+        amount: 50,
+        date: '2024-01-15',
+        name: 'Coffee Shop',
+        category_id: 'food_and_drink_coffee',
+        user_note: 'original note',
+        user_id: 'user123',
+        item_id: 'item1',
+        account_id: 'acct1',
+      },
+      {
+        transaction_id: 'txn2',
+        amount: 100,
+        date: '2024-01-16',
+        name: 'Gas Station',
+        category_id: 'transportation_gas',
+        user_id: 'user123',
+        item_id: 'item1',
+        account_id: 'acct2',
+      },
+    ];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._userCategories = [
+      { category_id: 'food_and_drink_coffee', name: 'Coffee', excluded: false },
+    ];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._allCollectionsLoaded = true;
+
+    updateCalls = [];
+    const mockFirestoreClient = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      updateDocument: async (collection: string, docId: string, fields: any, mask: string[]) => {
+        updateCalls.push({ collection, docId, fields, mask });
+      },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools = new CopilotMoneyTools(mockDb, mockFirestoreClient as any);
+  });
+
+  test('sets note on transaction successfully', async () => {
+    const result = await tools.setTransactionNote({
+      transaction_id: 'txn1',
+      note: 'new note',
+    });
+    expect(result.success).toBe(true);
+    expect(result.transaction_id).toBe('txn1');
+    expect(result.old_note).toBe('original note');
+    expect(result.new_note).toBe('new note');
+  });
+
+  test('clears note when empty string is passed', async () => {
+    const result = await tools.setTransactionNote({
+      transaction_id: 'txn1',
+      note: '',
+    });
+    expect(result.success).toBe(true);
+    expect(result.old_note).toBe('original note');
+    expect(result.new_note).toBe('');
+  });
+
+  test('returns empty string for old_note when user_note is undefined', async () => {
+    const result = await tools.setTransactionNote({
+      transaction_id: 'txn2',
+      note: 'first note',
+    });
+    expect(result.success).toBe(true);
+    expect(result.old_note).toBe('');
+    expect(result.new_note).toBe('first note');
+  });
+
+  test('calls Firestore with correct parameters', async () => {
+    await tools.setTransactionNote({
+      transaction_id: 'txn1',
+      note: 'test note',
+    });
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].collection).toBe('items/item1/accounts/acct1/transactions');
+    expect(updateCalls[0].docId).toBe('txn1');
+    expect(updateCalls[0].mask).toEqual(['user_note']);
+    expect(updateCalls[0].fields).toEqual({
+      user_note: { stringValue: 'test note' },
+    });
+  });
+
+  test('patches cache after successful write', async () => {
+    await tools.setTransactionNote({
+      transaction_id: 'txn1',
+      note: 'cached note',
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const txn = (mockDb as any)._transactions.find((t: any) => t.transaction_id === 'txn1');
+    expect(txn.user_note).toBe('cached note');
+  });
+
+  test('throws when transaction_id not found', async () => {
+    await expect(
+      tools.setTransactionNote({
+        transaction_id: 'nonexistent',
+        note: 'some note',
+      })
+    ).rejects.toThrow('Transaction not found: nonexistent');
+  });
+
+  test('throws on invalid transaction_id format', async () => {
+    await expect(
+      tools.setTransactionNote({
+        transaction_id: 'txn/../evil',
+        note: 'some note',
+      })
+    ).rejects.toThrow('Invalid transaction_id format');
+  });
+
+  test('throws when transaction is missing item_id', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions = [
+      {
+        transaction_id: 'txn_no_item',
+        amount: 50,
+        date: '2024-01-15',
+        name: 'Test',
+        user_id: 'user123',
+        account_id: 'acct1',
+      },
+    ];
+    await expect(
+      tools.setTransactionNote({
+        transaction_id: 'txn_no_item',
+        note: 'some note',
+      })
+    ).rejects.toThrow('missing item_id or account_id');
+  });
+
+  test('does not modify cache on Firestore error', async () => {
+    const failingClient = {
+      updateDocument: async () => {
+        throw new Error('Firestore update failed (500)');
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const failTools = new CopilotMoneyTools(mockDb, failingClient as any);
+
+    await expect(
+      failTools.setTransactionNote({
+        transaction_id: 'txn1',
+        note: 'should not persist',
+      })
+    ).rejects.toThrow('Firestore update failed');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const txn = (mockDb as any)._transactions.find((t: any) => t.transaction_id === 'txn1');
+    expect(txn.user_note).toBe('original note');
+  });
+
+  test('throws when no Firestore client configured (read-only mode)', async () => {
+    const readOnlyTools = new CopilotMoneyTools(mockDb);
+    await expect(
+      readOnlyTools.setTransactionNote({
+        transaction_id: 'txn1',
+        note: 'some note',
+      })
+    ).rejects.toThrow('Write mode is not enabled');
+  });
+});
+
+describe('setTransactionTags', () => {
+  let tools: CopilotMoneyTools;
+  let mockDb: CopilotDatabase;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let updateCalls: { collection: string; docId: string; fields: any; mask: string[] }[];
+
+  beforeEach(() => {
+    mockDb = new CopilotDatabase('/nonexistent');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any).dbPath = '/fake';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions = [
+      {
+        transaction_id: 'txn1',
+        amount: 50,
+        date: '2024-01-15',
+        name: 'Coffee Shop',
+        category_id: 'food_and_drink_coffee',
+        tag_ids: ['tag1', 'tag2'],
+        user_id: 'user123',
+        item_id: 'item1',
+        account_id: 'acct1',
+      },
+      {
+        transaction_id: 'txn2',
+        amount: 100,
+        date: '2024-01-16',
+        name: 'Gas Station',
+        category_id: 'transportation_gas',
+        user_id: 'user123',
+        item_id: 'item1',
+        account_id: 'acct2',
+      },
+    ];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._allCollectionsLoaded = true;
+
+    updateCalls = [];
+    const mockFirestoreClient = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      updateDocument: async (collection: string, docId: string, fields: any, mask: string[]) => {
+        updateCalls.push({ collection, docId, fields, mask });
+      },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools = new CopilotMoneyTools(mockDb, mockFirestoreClient as any);
+  });
+
+  test('sets tags on a transaction successfully', async () => {
+    const result = await tools.setTransactionTags({
+      transaction_id: 'txn1',
+      tag_ids: ['tag3', 'tag4'],
+    });
+    expect(result.success).toBe(true);
+    expect(result.transaction_id).toBe('txn1');
+    expect(result.old_tag_ids).toEqual(['tag1', 'tag2']);
+    expect(result.new_tag_ids).toEqual(['tag3', 'tag4']);
+  });
+
+  test('clears tags with empty array', async () => {
+    const result = await tools.setTransactionTags({
+      transaction_id: 'txn1',
+      tag_ids: [],
+    });
+    expect(result.success).toBe(true);
+    expect(result.old_tag_ids).toEqual(['tag1', 'tag2']);
+    expect(result.new_tag_ids).toEqual([]);
+  });
+
+  test('returns empty old_tag_ids when transaction has no tags', async () => {
+    const result = await tools.setTransactionTags({
+      transaction_id: 'txn2',
+      tag_ids: ['tag1'],
+    });
+    expect(result.success).toBe(true);
+    expect(result.old_tag_ids).toEqual([]);
+    expect(result.new_tag_ids).toEqual(['tag1']);
+  });
+
+  test('calls Firestore with correct parameters', async () => {
+    await tools.setTransactionTags({
+      transaction_id: 'txn1',
+      tag_ids: ['tag3'],
+    });
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].collection).toBe('items/item1/accounts/acct1/transactions');
+    expect(updateCalls[0].docId).toBe('txn1');
+    expect(updateCalls[0].mask).toEqual(['tag_ids']);
+    expect(updateCalls[0].fields).toEqual({
+      tag_ids: { arrayValue: { values: [{ stringValue: 'tag3' }] } },
+    });
+  });
+
+  test('calls Firestore with empty array fields', async () => {
+    await tools.setTransactionTags({
+      transaction_id: 'txn1',
+      tag_ids: [],
+    });
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].fields).toEqual({
+      tag_ids: { arrayValue: { values: [] } },
+    });
+  });
+
+  test('patches cache after successful write', async () => {
+    await tools.setTransactionTags({
+      transaction_id: 'txn1',
+      tag_ids: ['tag5'],
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const txn = (mockDb as any)._transactions.find((t: any) => t.transaction_id === 'txn1');
+    expect(txn.tag_ids).toEqual(['tag5']);
+  });
+
+  test('throws when transaction_id not found', async () => {
+    await expect(
+      tools.setTransactionTags({
+        transaction_id: 'nonexistent',
+        tag_ids: ['tag1'],
+      })
+    ).rejects.toThrow('Transaction not found: nonexistent');
+  });
+
+  test('throws when transaction_id has invalid format', async () => {
+    await expect(
+      tools.setTransactionTags({
+        transaction_id: 'invalid/id',
+        tag_ids: ['tag1'],
+      })
+    ).rejects.toThrow('Invalid transaction_id format');
+  });
+
+  test('throws when a tag_id has invalid format', async () => {
+    await expect(
+      tools.setTransactionTags({
+        transaction_id: 'txn1',
+        tag_ids: ['valid-tag', 'invalid/tag'],
+      })
+    ).rejects.toThrow('Invalid tag_id format');
+  });
+
+  test('throws when transaction is missing item_id', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions.push({
+      transaction_id: 'txn_no_item',
+      amount: 10,
+      date: '2024-01-17',
+      name: 'Orphan',
+      account_id: 'acct1',
+    });
+    await expect(
+      tools.setTransactionTags({
+        transaction_id: 'txn_no_item',
+        tag_ids: ['tag1'],
+      })
+    ).rejects.toThrow('missing item_id or account_id');
+  });
+
+  test('does not modify cache on Firestore error', async () => {
+    const failingClient = {
+      updateDocument: async () => {
+        throw new Error('Firestore update failed (500)');
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const failTools = new CopilotMoneyTools(mockDb, failingClient as any);
+
+    await expect(
+      failTools.setTransactionTags({
+        transaction_id: 'txn1',
+        tag_ids: ['tag5'],
+      })
+    ).rejects.toThrow('Firestore update failed');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const txn = (mockDb as any)._transactions.find((t: any) => t.transaction_id === 'txn1');
+    expect(txn.tag_ids).toEqual(['tag1', 'tag2']);
+  });
+
+  test('throws when no Firestore client configured (read-only mode)', async () => {
+    const readOnlyTools = new CopilotMoneyTools(mockDb);
+    await expect(
+      readOnlyTools.setTransactionTags({
+        transaction_id: 'txn1',
+        tag_ids: ['tag1'],
+      })
+    ).rejects.toThrow('Write mode is not enabled');
+  });
+});
+
+describe('reviewTransactions', () => {
+  let tools: CopilotMoneyTools;
+  let mockDb: CopilotDatabase;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let updateCalls: { collection: string; docId: string; fields: any; mask: string[] }[];
+
+  beforeEach(() => {
+    mockDb = new CopilotDatabase('/nonexistent');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any).dbPath = '/fake';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions = [
+      {
+        transaction_id: 'txn1',
+        amount: 50,
+        date: '2024-01-15',
+        name: 'Coffee Shop',
+        category_id: 'food_and_drink_coffee',
+        user_id: 'user123',
+        item_id: 'item1',
+        account_id: 'acct1',
+        user_reviewed: false,
+      },
+      {
+        transaction_id: 'txn2',
+        amount: 100,
+        date: '2024-01-16',
+        name: 'Gas Station',
+        category_id: 'transportation_gas',
+        user_id: 'user123',
+        item_id: 'item1',
+        account_id: 'acct2',
+        user_reviewed: false,
+      },
+      {
+        transaction_id: 'txn3',
+        amount: 25,
+        date: '2024-01-17',
+        name: 'Bookstore',
+        category_id: 'shopping_general',
+        user_id: 'user123',
+        item_id: 'item2',
+        account_id: 'acct3',
+      },
+    ];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._allCollectionsLoaded = true;
+
+    updateCalls = [];
+    const mockFirestoreClient = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      updateDocument: async (collection: string, docId: string, fields: any, mask: string[]) => {
+        updateCalls.push({ collection, docId, fields, mask });
+      },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools = new CopilotMoneyTools(mockDb, mockFirestoreClient as any);
+  });
+
+  test('marks a single transaction as reviewed', async () => {
+    const result = await tools.reviewTransactions({
+      transaction_ids: ['txn1'],
+    });
+    expect(result.success).toBe(true);
+    expect(result.reviewed_count).toBe(1);
+    expect(result.transaction_ids).toEqual(['txn1']);
+  });
+
+  test('marks multiple transactions as reviewed', async () => {
+    const result = await tools.reviewTransactions({
+      transaction_ids: ['txn1', 'txn2', 'txn3'],
+    });
+    expect(result.success).toBe(true);
+    expect(result.reviewed_count).toBe(3);
+    expect(result.transaction_ids).toEqual(['txn1', 'txn2', 'txn3']);
+  });
+
+  test('calls Firestore with correct nested paths and fields', async () => {
+    await tools.reviewTransactions({
+      transaction_ids: ['txn1', 'txn2'],
+    });
+    expect(updateCalls).toHaveLength(2);
+    expect(updateCalls[0].collection).toBe('items/item1/accounts/acct1/transactions');
+    expect(updateCalls[0].docId).toBe('txn1');
+    expect(updateCalls[0].mask).toEqual(['user_reviewed']);
+    expect(updateCalls[0].fields).toEqual({
+      user_reviewed: { booleanValue: true },
+    });
+    expect(updateCalls[1].collection).toBe('items/item1/accounts/acct2/transactions');
+    expect(updateCalls[1].docId).toBe('txn2');
+  });
+
+  test('supports reviewed=false to unmark transactions', async () => {
+    const result = await tools.reviewTransactions({
+      transaction_ids: ['txn1'],
+      reviewed: false,
+    });
+    expect(result.success).toBe(true);
+    expect(updateCalls[0].fields).toEqual({
+      user_reviewed: { booleanValue: false },
+    });
+  });
+
+  test('defaults reviewed to true when not specified', async () => {
+    await tools.reviewTransactions({
+      transaction_ids: ['txn1'],
+    });
+    expect(updateCalls[0].fields).toEqual({
+      user_reviewed: { booleanValue: true },
+    });
+  });
+
+  test('patches cache after successful write', async () => {
+    await tools.reviewTransactions({
+      transaction_ids: ['txn1', 'txn2'],
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const txn1 = (mockDb as any)._transactions.find((t: any) => t.transaction_id === 'txn1');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const txn2 = (mockDb as any)._transactions.find((t: any) => t.transaction_id === 'txn2');
+    expect(txn1.user_reviewed).toBe(true);
+    expect(txn2.user_reviewed).toBe(true);
+  });
+
+  test('throws when transaction_id not found', async () => {
+    await expect(
+      tools.reviewTransactions({
+        transaction_ids: ['nonexistent'],
+      })
+    ).rejects.toThrow('Transaction not found: nonexistent');
+  });
+
+  test('throws when transaction_ids is empty', async () => {
+    await expect(
+      tools.reviewTransactions({
+        transaction_ids: [],
+      })
+    ).rejects.toThrow('transaction_ids must be a non-empty array');
+  });
+
+  test('throws on invalid transaction_id format', async () => {
+    await expect(
+      tools.reviewTransactions({
+        transaction_ids: ['valid_id', 'invalid/id'],
+      })
+    ).rejects.toThrow('Invalid transaction_id format: invalid/id');
+  });
+
+  test('throws when transaction is missing item_id', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions.push({
+      transaction_id: 'txn_no_item',
+      amount: 10,
+      date: '2024-01-18',
+      name: 'Mystery',
+      account_id: 'acct1',
+    });
+    await expect(
+      tools.reviewTransactions({
+        transaction_ids: ['txn_no_item'],
+      })
+    ).rejects.toThrow('missing item_id or account_id');
+  });
+
+  test('does not modify cache on Firestore error', async () => {
+    const failingClient = {
+      updateDocument: async () => {
+        throw new Error('Firestore update failed (500)');
+      },
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const failTools = new CopilotMoneyTools(mockDb, failingClient as any);
+
+    await expect(
+      failTools.reviewTransactions({
+        transaction_ids: ['txn1'],
+      })
+    ).rejects.toThrow('Firestore update failed');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const txn = (mockDb as any)._transactions.find((t: any) => t.transaction_id === 'txn1');
+    expect(txn.user_reviewed).toBe(false);
+  });
+
+  test('throws when no Firestore client configured (read-only mode)', async () => {
+    const readOnlyTools = new CopilotMoneyTools(mockDb);
+    await expect(
+      readOnlyTools.reviewTransactions({
+        transaction_ids: ['txn1'],
+      })
+    ).rejects.toThrow('Write mode is not enabled');
+  });
+});
+
+describe('createTag', () => {
+  let tools: CopilotMoneyTools;
+  let mockDb: CopilotDatabase;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let createCalls: { collection: string; docId: string; fields: any }[];
+
+  beforeEach(() => {
+    mockDb = new CopilotDatabase('/nonexistent');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any).dbPath = '/fake';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._allCollectionsLoaded = true;
+
+    createCalls = [];
+    const mockFirestoreClient = {
+      requireUserId: async () => 'user123',
+      getUserId: () => 'user123',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createDocument: async (collection: string, docId: string, fields: any) => {
+        createCalls.push({ collection, docId, fields });
+      },
+      updateDocument: async () => {},
+      deleteDocument: async () => {},
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools = new CopilotMoneyTools(mockDb, mockFirestoreClient as any);
+  });
+
+  test('creates a tag with name only', async () => {
+    const result = await tools.createTag({ name: 'vacation' });
+    expect(result.success).toBe(true);
+    expect(result.tag_id).toBe('vacation');
+    expect(result.name).toBe('vacation');
+    expect(result.color_name).toBeUndefined();
+    expect(result.hex_color).toBeUndefined();
+  });
+
+  test('creates a tag with color', async () => {
+    const result = await tools.createTag({
+      name: 'Business',
+      color_name: 'blue',
+      hex_color: '#0000FF',
+    });
+    expect(result.success).toBe(true);
+    expect(result.tag_id).toBe('business');
+    expect(result.name).toBe('Business');
+    expect(result.color_name).toBe('blue');
+    expect(result.hex_color).toBe('#0000FF');
+  });
+
+  test('generates tag_id from multi-word name', async () => {
+    const result = await tools.createTag({ name: 'business expense' });
+    expect(result.tag_id).toBe('business_expense');
+  });
+
+  test('calls Firestore createDocument with correct path', async () => {
+    await tools.createTag({ name: 'test', color_name: 'red' });
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].collection).toBe('users/user123/tags');
+    expect(createCalls[0].docId).toBe('test');
+    expect(createCalls[0].fields).toEqual({
+      name: { stringValue: 'test' },
+      color_name: { stringValue: 'red' },
+    });
+  });
+
+  test('clears cache after creating tag', async () => {
+    // Seed cache
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions = [{ transaction_id: 'txn1', amount: 10, date: '2024-01-01' }];
+    await tools.createTag({ name: 'test' });
+    // clearCache sets _transactions to null
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockDb as any)._transactions).toBeNull();
+  });
+
+  test('throws on empty name', async () => {
+    await expect(tools.createTag({ name: '' })).rejects.toThrow('Tag name must not be empty');
+  });
+
+  test('throws on whitespace-only name', async () => {
+    await expect(tools.createTag({ name: '   ' })).rejects.toThrow('Tag name must not be empty');
+  });
+
+  test('throws on invalid hex_color format', async () => {
+    await expect(tools.createTag({ name: 'test', hex_color: 'red' })).rejects.toThrow(
+      'Invalid hex_color format'
+    );
+  });
+
+  test('throws on short hex_color', async () => {
+    await expect(tools.createTag({ name: 'test', hex_color: '#FFF' })).rejects.toThrow(
+      'Invalid hex_color format'
+    );
+  });
+
+  test('does not modify cache on Firestore error', async () => {
+    const failingClient = {
+      requireUserId: async () => 'user123',
+      getUserId: () => 'user123',
+      createDocument: async () => {
+        throw new Error('Firestore create failed (500)');
+      },
+      updateDocument: async () => {},
+      deleteDocument: async () => {},
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const failTools = new CopilotMoneyTools(mockDb, failingClient as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions = [{ transaction_id: 'txn1' }];
+
+    await expect(failTools.createTag({ name: 'test' })).rejects.toThrow('Firestore create failed');
+    // Cache should NOT have been cleared since error happened before clearCache
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockDb as any)._transactions).not.toBeNull();
+  });
+
+  test('throws when no Firestore client configured (read-only mode)', async () => {
+    const readOnlyTools = new CopilotMoneyTools(mockDb);
+    await expect(readOnlyTools.createTag({ name: 'test' })).rejects.toThrow(
+      'Write mode is not enabled'
+    );
+  });
+
+  test('trims whitespace from name', async () => {
+    const result = await tools.createTag({ name: '  vacation  ' });
+    expect(result.name).toBe('vacation');
+    expect(result.tag_id).toBe('vacation');
+  });
+});
+
+describe('deleteTag', () => {
+  let tools: CopilotMoneyTools;
+  let mockDb: CopilotDatabase;
+  let deleteCalls: { collection: string; docId: string }[];
+
+  beforeEach(() => {
+    mockDb = new CopilotDatabase('/nonexistent');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any).dbPath = '/fake';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._allCollectionsLoaded = true;
+
+    deleteCalls = [];
+    const mockFirestoreClient = {
+      requireUserId: async () => 'user123',
+      getUserId: () => 'user123',
+      deleteDocument: async (collection: string, docId: string) => {
+        deleteCalls.push({ collection, docId });
+      },
+      updateDocument: async () => {},
+      createDocument: async () => {},
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools = new CopilotMoneyTools(mockDb, mockFirestoreClient as any);
+  });
+
+  test('deletes a tag successfully', async () => {
+    const result = await tools.deleteTag({ tag_id: 'vacation' });
+    expect(result.success).toBe(true);
+    expect(result.tag_id).toBe('vacation');
+    expect(result.deleted_name).toBe('vacation');
+  });
+
+  test('calls Firestore deleteDocument with correct path', async () => {
+    await tools.deleteTag({ tag_id: 'test_tag' });
+    expect(deleteCalls).toHaveLength(1);
+    expect(deleteCalls[0].collection).toBe('users/user123/tags');
+    expect(deleteCalls[0].docId).toBe('test_tag');
+  });
+
+  test('clears cache after deleting tag', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions = [{ transaction_id: 'txn1', amount: 10, date: '2024-01-01' }];
+    await tools.deleteTag({ tag_id: 'test' });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockDb as any)._transactions).toBeNull();
+  });
+
+  test('throws on invalid tag_id format', async () => {
+    await expect(tools.deleteTag({ tag_id: 'bad/id' })).rejects.toThrow(
+      'Invalid tag_id format: bad/id'
+    );
+  });
+
+  test('throws on tag_id with spaces', async () => {
+    await expect(tools.deleteTag({ tag_id: 'bad id' })).rejects.toThrow('Invalid tag_id format');
+  });
+
+  test('does not modify cache on Firestore error', async () => {
+    const failingClient = {
+      requireUserId: async () => 'user123',
+      getUserId: () => 'user123',
+      deleteDocument: async () => {
+        throw new Error('Firestore delete failed (500)');
+      },
+      updateDocument: async () => {},
+      createDocument: async () => {},
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const failTools = new CopilotMoneyTools(mockDb, failingClient as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions = [{ transaction_id: 'txn1' }];
+
+    await expect(failTools.deleteTag({ tag_id: 'test' })).rejects.toThrow(
+      'Firestore delete failed'
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockDb as any)._transactions).not.toBeNull();
+  });
+
+  test('throws when no Firestore client configured (read-only mode)', async () => {
+    const readOnlyTools = new CopilotMoneyTools(mockDb);
+    await expect(readOnlyTools.deleteTag({ tag_id: 'test' })).rejects.toThrow(
+      'Write mode is not enabled'
+    );
+  });
+});
+
+describe('createCategory', () => {
+  let tools: CopilotMoneyTools;
+  let mockDb: CopilotDatabase;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let createCalls: { collection: string; docId: string; fields: any }[];
+
+  beforeEach(() => {
+    mockDb = new CopilotDatabase('/nonexistent');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any).dbPath = '/fake';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._userCategories = [
+      { category_id: 'food_and_drink', name: 'Food & Drink', excluded: false, user_id: 'user123' },
+      { category_id: 'shopping', name: 'Shopping', excluded: false, user_id: 'user123' },
+    ];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._allCollectionsLoaded = true;
+
+    createCalls = [];
+    const mockFirestoreClient = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createDocument: async (collection: string, docId: string, fields: any) => {
+        createCalls.push({ collection, docId, fields });
+      },
+      requireUserId: async () => 'user123',
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools = new CopilotMoneyTools(mockDb, mockFirestoreClient as any);
+  });
+
+  test('creates category with name only', async () => {
+    const result = await tools.createCategory({ name: 'Entertainment' });
+    expect(result.success).toBe(true);
+    expect(result.name).toBe('Entertainment');
+    expect(result.category_id).toMatch(/^custom_[a-f0-9]{16}$/);
+    expect(result.excluded).toBe(false);
+  });
+
+  test('creates category with all optional fields', async () => {
+    const result = await tools.createCategory({
+      name: 'Streaming',
+      emoji: '🎬',
+      color: '#FF5733',
+      parent_category_id: 'shopping',
+      excluded: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.name).toBe('Streaming');
+    expect(result.emoji).toBe('🎬');
+    expect(result.color).toBe('#FF5733');
+    expect(result.parent_category_id).toBe('shopping');
+    expect(result.excluded).toBe(true);
+  });
+
+  test('calls Firestore createDocument with correct collection path', async () => {
+    await tools.createCategory({ name: 'Test Category' });
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].collection).toBe('users/user123/categories');
+    expect(createCalls[0].docId).toMatch(/^custom_[a-f0-9]{16}$/);
+    expect(createCalls[0].fields).toHaveProperty('name');
+    expect(createCalls[0].fields.name).toEqual({ stringValue: 'Test Category' });
+    expect(createCalls[0].fields.category_id).toEqual({
+      stringValue: createCalls[0].docId,
+    });
+  });
+
+  test('clears cache after successful create', async () => {
+    // Load categories first to populate cache
+    await mockDb.getUserCategories();
+    await tools.createCategory({ name: 'New Cat' });
+    // After clearing, _userCategories should be null
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockDb as any)._userCategories).toBeNull();
+  });
+
+  test('throws when name is empty', async () => {
+    await expect(tools.createCategory({ name: '' })).rejects.toThrow(
+      'Category name must not be empty'
+    );
+    await expect(tools.createCategory({ name: '   ' })).rejects.toThrow(
+      'Category name must not be empty'
+    );
+  });
+
+  test('throws when category name already exists (case-insensitive)', async () => {
+    await expect(tools.createCategory({ name: 'Shopping' })).rejects.toThrow('already exists');
+    await expect(tools.createCategory({ name: 'SHOPPING' })).rejects.toThrow('already exists');
+  });
+
+  test('throws when parent_category_id not found', async () => {
+    await expect(
+      tools.createCategory({ name: 'Sub', parent_category_id: 'nonexistent' })
+    ).rejects.toThrow('Parent category not found: nonexistent');
+  });
+
+  test('throws when parent_category_id has invalid format', async () => {
+    await expect(
+      tools.createCategory({ name: 'Sub', parent_category_id: 'bad/id' })
+    ).rejects.toThrow('Invalid parent_category_id format');
+  });
+
+  test('trims whitespace from name', async () => {
+    const result = await tools.createCategory({ name: '  Entertainment  ' });
+    expect(result.name).toBe('Entertainment');
+    expect(createCalls[0].fields.name).toEqual({ stringValue: 'Entertainment' });
+  });
+
+  test('does not include optional fields when not provided', async () => {
+    await tools.createCategory({ name: 'Minimal' });
+    const fields = createCalls[0].fields;
+    expect(fields).not.toHaveProperty('emoji');
+    expect(fields).not.toHaveProperty('color');
+    expect(fields).not.toHaveProperty('parent_category_id');
+  });
+
+  test('does not write to Firestore on validation error', async () => {
+    await expect(tools.createCategory({ name: '' })).rejects.toThrow();
+    expect(createCalls).toHaveLength(0);
+  });
+
+  test('does not clear cache on Firestore error', async () => {
+    const failingClient = {
+      createDocument: async () => {
+        throw new Error('Firestore create failed (500)');
+      },
+      requireUserId: async () => 'user123',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const failTools = new CopilotMoneyTools(mockDb, failingClient as any);
+
+    await expect(failTools.createCategory({ name: 'Fail Cat' })).rejects.toThrow(
+      'Firestore create failed'
+    );
+
+    // Cache should NOT have been cleared since create failed
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockDb as any)._userCategories).not.toBeNull();
+  });
+
+  test('throws when no Firestore client configured (read-only mode)', async () => {
+    const readOnlyTools = new CopilotMoneyTools(mockDb);
+    await expect(readOnlyTools.createCategory({ name: 'Test' })).rejects.toThrow(
+      'Write mode is not enabled'
+    );
+  });
+
+  test('falls back to auth userId when no categories have user_id', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._userCategories = [{ category_id: 'food', name: 'Food', excluded: false }];
+    const mockFirestoreClient = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createDocument: async (collection: string, docId: string, fields: any) => {
+        createCalls.push({ collection, docId, fields });
+      },
+      requireUserId: async () => 'auth-user-456',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const authTools = new CopilotMoneyTools(mockDb, mockFirestoreClient as any);
+
+    await authTools.createCategory({ name: 'New Category' });
+    expect(createCalls[createCalls.length - 1].collection).toBe('users/auth-user-456/categories');
+  });
+});

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -2900,6 +2900,11 @@ describe('createTag', () => {
     expect(result.name).toBe('vacation');
     expect(result.tag_id).toBe('vacation');
   });
+
+  test('throws when tag already exists', async () => {
+    (mockDb as any)._tags = [{ tag_id: 'vacation', name: 'Vacation' }];
+    await expect(tools.createTag({ name: 'vacation' })).rejects.toThrow('already exists');
+  });
 });
 
 describe('deleteTag', () => {

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -2780,6 +2780,8 @@ describe('createTag', () => {
     (mockDb as any).dbPath = '/fake';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockDb as any)._allCollectionsLoaded = true;
+    (mockDb as any)._cacheLoadedAt = Date.now();
+    (mockDb as any)._tags = [];
 
     createCalls = [];
     const mockFirestoreClient = {
@@ -2911,6 +2913,11 @@ describe('deleteTag', () => {
     (mockDb as any).dbPath = '/fake';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockDb as any)._allCollectionsLoaded = true;
+    (mockDb as any)._cacheLoadedAt = Date.now();
+    (mockDb as any)._tags = [
+      { tag_id: 'vacation', name: 'Vacation' },
+      { tag_id: 'business', name: 'Business Expense' },
+    ];
 
     deleteCalls = [];
     const mockFirestoreClient = {
@@ -2931,20 +2938,20 @@ describe('deleteTag', () => {
     const result = await tools.deleteTag({ tag_id: 'vacation' });
     expect(result.success).toBe(true);
     expect(result.tag_id).toBe('vacation');
-    expect(result.deleted_name).toBe('vacation');
+    expect(result.deleted_name).toBe('Vacation');
   });
 
   test('calls Firestore deleteDocument with correct path', async () => {
-    await tools.deleteTag({ tag_id: 'test_tag' });
+    await tools.deleteTag({ tag_id: 'business' });
     expect(deleteCalls).toHaveLength(1);
     expect(deleteCalls[0].collection).toBe('users/user123/tags');
-    expect(deleteCalls[0].docId).toBe('test_tag');
+    expect(deleteCalls[0].docId).toBe('business');
   });
 
   test('clears cache after deleting tag', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockDb as any)._transactions = [{ transaction_id: 'txn1', amount: 10, date: '2024-01-01' }];
-    await tools.deleteTag({ tag_id: 'test' });
+    await tools.deleteTag({ tag_id: 'vacation' });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((mockDb as any)._transactions).toBeNull();
   });
@@ -2957,6 +2964,12 @@ describe('deleteTag', () => {
 
   test('throws on tag_id with spaces', async () => {
     await expect(tools.deleteTag({ tag_id: 'bad id' })).rejects.toThrow('Invalid tag_id format');
+  });
+
+  test('throws when tag not found', async () => {
+    await expect(tools.deleteTag({ tag_id: 'nonexistent' })).rejects.toThrow(
+      'Tag not found: nonexistent'
+    );
   });
 
   test('does not modify cache on Firestore error', async () => {
@@ -2974,7 +2987,7 @@ describe('deleteTag', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockDb as any)._transactions = [{ transaction_id: 'txn1' }];
 
-    await expect(failTools.deleteTag({ tag_id: 'test' })).rejects.toThrow(
+    await expect(failTools.deleteTag({ tag_id: 'vacation' })).rejects.toThrow(
       'Firestore delete failed'
     );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -234,6 +234,9 @@ describe('CopilotMoneyServer write mode', () => {
 
     expect(toolNames).toContain('get_transactions');
     expect(toolNames).not.toContain('set_transaction_category');
+    expect(toolNames).not.toContain('set_transaction_note');
+    expect(toolNames).not.toContain('create_tag');
+    expect(toolNames).not.toContain('delete_tag');
   });
 
   test('handleListTools returns read + write tools when writeEnabled', () => {
@@ -243,6 +246,10 @@ describe('CopilotMoneyServer write mode', () => {
 
     expect(toolNames).toContain('get_transactions');
     expect(toolNames).toContain('set_transaction_category');
+    expect(toolNames).toContain('set_transaction_note');
+    expect(toolNames).toContain('create_tag');
+    expect(toolNames).toContain('delete_tag');
+    expect(toolNames).toContain('create_category');
   });
 
   test('write tool has correct annotations', () => {
@@ -258,6 +265,45 @@ describe('CopilotMoneyServer write mode', () => {
     });
   });
 
+  test('create_tag has correct annotations', () => {
+    const server = new CopilotMoneyServer(undefined, undefined, true);
+    const result = server.handleListTools();
+    const tool = result.tools.find((t) => t.name === 'create_tag');
+
+    expect(tool).toBeDefined();
+    expect(tool!.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+    });
+  });
+
+  test('delete_tag has destructiveHint set', () => {
+    const server = new CopilotMoneyServer(undefined, undefined, true);
+    const result = server.handleListTools();
+    const tool = result.tools.find((t) => t.name === 'delete_tag');
+
+    expect(tool).toBeDefined();
+    expect(tool!.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+    });
+  });
+
+  test('create_category has correct annotations', () => {
+    const server = new CopilotMoneyServer(undefined, undefined, true);
+    const result = server.handleListTools();
+    const tool = result.tools.find((t) => t.name === 'create_category');
+
+    expect(tool).toBeDefined();
+    expect(tool!.annotations).toEqual({
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    });
+  });
+
   test('handleCallTool rejects write tool when not in write mode', async () => {
     const server = new CopilotMoneyServer();
     const result = await server.handleCallTool('set_transaction_category', {
@@ -268,17 +314,96 @@ describe('CopilotMoneyServer write mode', () => {
     expect(result.isError).toBe(true);
     expect((result.content[0] as { text: string }).text).toContain('--write mode');
   });
+
+  test('handleCallTool rejects set_transaction_note when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('set_transaction_note', {
+      transaction_id: 'txn1',
+      note: 'test',
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects create_tag when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('create_tag', { name: 'test' });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects delete_tag when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('delete_tag', { tag_id: 'test' });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects create_category when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('create_category', {
+      name: 'Test',
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleListTools includes create_category when writeEnabled', () => {
+    const server = new CopilotMoneyServer(undefined, undefined, true);
+    const result = server.handleListTools();
+    const toolNames = result.tools.map((t) => t.name);
+
+    expect(toolNames).toContain('create_category');
+  });
 });
 
 describe('createWriteToolSchemas', () => {
   test('returns write tool schemas with proper annotations', () => {
     const schemas = createWriteToolSchemas();
-    expect(schemas.length).toBeGreaterThanOrEqual(1);
+    expect(schemas.length).toBeGreaterThanOrEqual(7);
 
     const setCat = schemas.find((s) => s.name === 'set_transaction_category');
     expect(setCat).toBeDefined();
     expect(setCat!.annotations?.readOnlyHint).toBe(false);
     expect(setCat!.inputSchema.required).toContain('transaction_id');
     expect(setCat!.inputSchema.required).toContain('category_id');
+
+    const setNote = schemas.find((s) => s.name === 'set_transaction_note');
+    expect(setNote).toBeDefined();
+    expect(setNote!.annotations?.readOnlyHint).toBe(false);
+    expect(setNote!.annotations?.idempotentHint).toBe(true);
+    expect(setNote!.inputSchema.required).toContain('transaction_id');
+    expect(setNote!.inputSchema.required).toContain('note');
+  });
+
+  test('create_tag schema requires name', () => {
+    const schemas = createWriteToolSchemas();
+    const createTag = schemas.find((s) => s.name === 'create_tag');
+    expect(createTag).toBeDefined();
+    expect(createTag!.inputSchema.required).toEqual(['name']);
+    expect(createTag!.inputSchema.properties).toHaveProperty('name');
+    expect(createTag!.inputSchema.properties).toHaveProperty('color_name');
+    expect(createTag!.inputSchema.properties).toHaveProperty('hex_color');
+  });
+
+  test('delete_tag schema requires tag_id', () => {
+    const schemas = createWriteToolSchemas();
+    const deleteTag = schemas.find((s) => s.name === 'delete_tag');
+    expect(deleteTag).toBeDefined();
+    expect(deleteTag!.inputSchema.required).toEqual(['tag_id']);
+    expect(deleteTag!.inputSchema.properties).toHaveProperty('tag_id');
+  });
+
+  test('includes create_category schema', () => {
+    const schemas = createWriteToolSchemas();
+    const createCat = schemas.find((s) => s.name === 'create_category');
+    expect(createCat).toBeDefined();
+    expect(createCat!.annotations?.readOnlyHint).toBe(false);
+    expect(createCat!.annotations?.idempotentHint).toBe(false);
+    expect(createCat!.inputSchema.required).toEqual(['name']);
   });
 });

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -274,7 +274,7 @@ describe('CopilotMoneyServer write mode', () => {
     expect(tool!.annotations).toEqual({
       readOnlyHint: false,
       destructiveHint: false,
-      idempotentHint: true,
+      idempotentHint: false,
     });
   });
 


### PR DESCRIPTION
## Summary

Adds 6 new write tools to the MCP server (phases 2–7 from the [write operations spec](docs/superpowers/specs/2026-04-05-firestore-write-operations-design.md)). All require the `--write` flag.

- **`review_transactions`** — batch mark transactions as reviewed/unreviewed (PATCH `user_reviewed`)
- **`set_transaction_note`** — set or clear user notes on a transaction (PATCH `user_note`)
- **`set_transaction_tags`** — set tag IDs on a transaction, array field (PATCH `tag_ids`)
- **`create_tag`** — create a new user-defined tag (POST to `users/{uid}/tags`)
- **`delete_tag`** — delete a tag from the collection (DELETE from `users/{uid}/tags/{id}`)
- **`create_category`** — create a new user-defined category (POST to `users/{uid}/categories`)

Also extends `FirestoreClient` with `createDocument()`, `deleteDocument()`, `getUserId()`, and `requireUserId()`.

**Depends on:** #177 (set_transaction_category + write infrastructure)

## E2E Verification

Each tool was verified end-to-end against the **real Copilot Money Firestore database** — not just mocks. We run throwaway scripts that write real data, verify the result, then revert:

| Tool | E2E Test Procedure |
|------|-------------------|
| `review_transactions` | Found a real transaction → marked as reviewed → verified Firestore write + cache update → reverted to original state. Also tested batch mode (multiple transactions). |
| `set_transaction_note` | Found a real transaction → set note to "E2E test note" → verified Firestore write + cache update → cleared note (empty string) → verified clearing works. |
| `set_transaction_tags` | Found a real transaction → set tag IDs → verified Firestore write (array encoding: `{ arrayValue: { values: [...] } }`) + cache update → reverted to original tags. |
| `create_tag` + `delete_tag` | Created "E2E Test Tag" via POST → verified it appeared in the tags collection → deleted it via DELETE → verified it was removed. |
| `create_category` | Created "[E2E Test] 2026-04-07" via POST → verified it appeared after cache reload (33 categories, up from 32). |

This E2E testing approach caught **3 critical bugs** in Phase 1 (`set_transaction_category`) that unit tests missed:
1. **Wrong Firebase API key** — iOS key vs web platform key caused `PROJECT_NUMBER_MISMATCH`
2. **Wrong Firestore document path** — transactions are nested at `items/{itemId}/accounts/{accountId}/transactions`, not flat `transactions/`
3. **Wrong token source** — browser token extractor searched Chrome Local Storage instead of IndexedDB where Firebase v9+ stores auth

All 3 were fixed before these tools were implemented, so the Phase 2 E2E tests passed cleanly.

## Test plan
- [x] 1124 unit tests pass (88 new), 0 failures
- [x] E2E verified against real Firestore (see table above)
- [x] All tools gated behind `--write` flag
- [x] Input validation (regex, existence checks, missing field guards)
- [x] Optimistic cache patching with `clearCache()` fallback
- [x] Manifest synced (19 tools total)
- [ ] Manual smoke test of each tool via MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)