### PR TITLE
feat: add 13 write tools — phase 3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -93,6 +93,22 @@
       "description": "Mark one or more transactions as reviewed (or unreviewed)."
     },
     {
+      "name": "set_transaction_excluded",
+      "description": "Exclude or include a transaction in spending reports."
+    },
+    {
+      "name": "set_transaction_name",
+      "description": "Rename a transaction display name."
+    },
+    {
+      "name": "set_internal_transfer",
+      "description": "Mark or unmark a transaction as an internal transfer."
+    },
+    {
+      "name": "set_transaction_goal",
+      "description": "Link or unlink a transaction to a financial goal."
+    },
+    {
       "name": "create_tag",
       "description": "Create a new user-defined tag for categorizing transactions."
     },
@@ -103,6 +119,42 @@
     {
       "name": "create_category",
       "description": "Create a new custom category in Copilot Money."
+    },
+    {
+      "name": "update_category",
+      "description": "Update an existing user-defined category."
+    },
+    {
+      "name": "delete_category",
+      "description": "Delete a user-defined category."
+    },
+    {
+      "name": "create_budget",
+      "description": "Create a new budget for a spending category."
+    },
+    {
+      "name": "update_budget",
+      "description": "Update an existing budget."
+    },
+    {
+      "name": "delete_budget",
+      "description": "Delete a budget."
+    },
+    {
+      "name": "set_recurring_state",
+      "description": "Change the state of a recurring item (active, paused, archived)."
+    },
+    {
+      "name": "delete_recurring",
+      "description": "Delete a recurring item."
+    },
+    {
+      "name": "update_goal",
+      "description": "Update a financial goal's properties."
+    },
+    {
+      "name": "delete_goal",
+      "description": "Delete a financial goal."
     }
   ],
   "tools_generated": false,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -20,9 +20,14 @@ export {
 
 export { CategorySchema, type Category } from './category.js';
 
-export { RecurringSchema, type Recurring, getRecurringDisplayName } from './recurring.js';
+export {
+  RecurringSchema,
+  type Recurring,
+  getRecurringDisplayName,
+  RECURRING_STATES,
+} from './recurring.js';
 
-export { BudgetSchema, type Budget, getBudgetDisplayName } from './budget.js';
+export { BudgetSchema, type Budget, getBudgetDisplayName, KNOWN_PERIODS } from './budget.js';
 
 export {
   GoalSchema,

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -101,6 +101,9 @@ export const TransactionSchema = z
     // Tags
     tag_ids: z.array(z.string()).optional(),
 
+    // Goal link
+    goal_id: z.string().optional(), // Financial goal this transaction is linked to
+
     // Complex nested data
     internal_tx_match: z.record(z.string(), z.unknown()).optional(),
     venmo_extra_data: z.record(z.string(), z.unknown()).optional(),

--- a/src/server.ts
+++ b/src/server.ts
@@ -97,10 +97,23 @@ export class CopilotMoneyServer {
     'set_transaction_category',
     'set_transaction_note',
     'set_transaction_tags',
+    'set_transaction_excluded',
+    'set_transaction_name',
+    'set_internal_transfer',
+    'set_transaction_goal',
     'review_transactions',
     'create_tag',
     'delete_tag',
     'create_category',
+    'update_category',
+    'delete_category',
+    'create_budget',
+    'update_budget',
+    'delete_budget',
+    'set_recurring_state',
+    'delete_recurring',
+    'update_goal',
+    'delete_goal',
   ]);
 
   async handleCallTool(name: string, typedArgs?: Record<string, unknown>): Promise<CallToolResult> {
@@ -226,6 +239,30 @@ export class CopilotMoneyServer {
           );
           break;
 
+        case 'set_transaction_excluded':
+          result = await this.tools.setTransactionExcluded(
+            typedArgs as Parameters<typeof this.tools.setTransactionExcluded>[0]
+          );
+          break;
+
+        case 'set_transaction_name':
+          result = await this.tools.setTransactionName(
+            typedArgs as Parameters<typeof this.tools.setTransactionName>[0]
+          );
+          break;
+
+        case 'set_internal_transfer':
+          result = await this.tools.setInternalTransfer(
+            typedArgs as Parameters<typeof this.tools.setInternalTransfer>[0]
+          );
+          break;
+
+        case 'set_transaction_goal':
+          result = await this.tools.setTransactionGoal(
+            typedArgs as Parameters<typeof this.tools.setTransactionGoal>[0]
+          );
+          break;
+
         case 'create_tag':
           result = await this.tools.createTag(
             typedArgs as Parameters<typeof this.tools.createTag>[0]
@@ -241,6 +278,60 @@ export class CopilotMoneyServer {
         case 'create_category':
           result = await this.tools.createCategory(
             typedArgs as Parameters<typeof this.tools.createCategory>[0]
+          );
+          break;
+
+        case 'update_category':
+          result = await this.tools.updateCategory(
+            typedArgs as Parameters<typeof this.tools.updateCategory>[0]
+          );
+          break;
+
+        case 'delete_category':
+          result = await this.tools.deleteCategory(
+            typedArgs as Parameters<typeof this.tools.deleteCategory>[0]
+          );
+          break;
+
+        case 'create_budget':
+          result = await this.tools.createBudget(
+            typedArgs as Parameters<typeof this.tools.createBudget>[0]
+          );
+          break;
+
+        case 'update_budget':
+          result = await this.tools.updateBudget(
+            typedArgs as Parameters<typeof this.tools.updateBudget>[0]
+          );
+          break;
+
+        case 'delete_budget':
+          result = await this.tools.deleteBudget(
+            typedArgs as Parameters<typeof this.tools.deleteBudget>[0]
+          );
+          break;
+
+        case 'set_recurring_state':
+          result = await this.tools.setRecurringState(
+            typedArgs as Parameters<typeof this.tools.setRecurringState>[0]
+          );
+          break;
+
+        case 'delete_recurring':
+          result = await this.tools.deleteRecurring(
+            typedArgs as Parameters<typeof this.tools.deleteRecurring>[0]
+          );
+          break;
+
+        case 'update_goal':
+          result = await this.tools.updateGoal(
+            typedArgs as Parameters<typeof this.tools.updateGoal>[0]
+          );
+          break;
+
+        case 'delete_goal':
+          result = await this.tools.deleteGoal(
+            typedArgs as Parameters<typeof this.tools.deleteGoal>[0]
           );
           break;
 

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2586,12 +2586,19 @@ export class CopilotMoneyTools {
     }
 
     const oldGoalId = txn.goal_id || null;
-    // When unlinking, write empty string to Firestore
+    // Write empty string to Firestore when unlinking, but undefined to cache for model consistency
     const firestoreGoalId = goal_id ?? '';
 
-    await this.writeTransactionFields(transaction_id, collectionPath, {
-      goal_id: firestoreGoalId,
-    });
+    const client = this.getFirestoreClient();
+    const firestoreFields = toFirestoreFields({ goal_id: firestoreGoalId });
+    await client.updateDocument(collectionPath, transaction_id, firestoreFields, ['goal_id']);
+    if (
+      !this.db.patchCachedTransaction(transaction_id, {
+        goal_id: goal_id ?? undefined,
+      })
+    ) {
+      this.db.clearCache();
+    }
 
     return {
       success: true,
@@ -2776,6 +2783,9 @@ export class CopilotMoneyTools {
       updateMask.push('emoji');
     }
     if (color !== undefined) {
+      if (!/^#[0-9A-Fa-f]{6}$/.test(color)) {
+        throw new Error(`Invalid color format: ${color} (expected #RRGGBB)`);
+      }
       fieldsToUpdate.color = color;
       updateMask.push('color');
     }
@@ -2785,9 +2795,9 @@ export class CopilotMoneyTools {
     }
     if (parent_category_id !== undefined) {
       if (parent_category_id !== null) {
-        // Validate parent exists
-        if (!/^[A-Za-z0-9_-]+$/.test(parent_category_id)) {
-          throw new Error(`Invalid parent_category_id format: ${parent_category_id}`);
+        validateDocId(parent_category_id, 'parent_category_id');
+        if (parent_category_id === category_id) {
+          throw new Error('A category cannot be its own parent');
         }
         const parent = existingCategories.find((c) => c.category_id === parent_category_id);
         if (!parent) {
@@ -3004,16 +3014,19 @@ export class CopilotMoneyTools {
     }
 
     if (period !== undefined) {
-      const validPeriods = ['monthly', 'yearly', 'weekly', 'daily'];
-      if (!validPeriods.includes(period)) {
-        throw new Error(`Invalid period: ${period}. Must be one of: ${validPeriods.join(', ')}`);
+      if (!(KNOWN_PERIODS as readonly string[]).includes(period)) {
+        throw new Error(`Invalid period: ${period}. Must be one of: ${KNOWN_PERIODS.join(', ')}`);
       }
       updateFields.period = period;
       updatedFieldNames.push('period');
     }
 
     if (name !== undefined) {
-      updateFields.name = name;
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        throw new Error('Budget name must not be empty');
+      }
+      updateFields.name = trimmedName;
       updatedFieldNames.push('name');
     }
 
@@ -3217,7 +3230,14 @@ export class CopilotMoneyTools {
     // Validate goal_id format
     validateDocId(goal_id, 'goal_id');
 
-    // Validate at least one field to update
+    // Validate goal exists first (include inactive goals)
+    const goals = await this.db.getGoals(false);
+    const goal = goals.find((g) => g.goal_id === goal_id);
+    if (!goal) {
+      throw new Error(`Goal not found: ${goal_id}`);
+    }
+
+    // Build dynamic update fields
     const fieldsToUpdate: Record<string, unknown> = {};
     const updateMask: string[] = [];
 
@@ -3233,39 +3253,31 @@ export class CopilotMoneyTools {
       updateMask.push('emoji');
     }
 
-    // Nested savings fields — build a savings sub-object
+    // Nested savings fields — use a single 'savings' mask entry so Firestore
+    // merges the sub-object correctly via the REST PATCH API
     const savingsUpdate: Record<string, unknown> = {};
     if (target_amount !== undefined) {
       if (target_amount <= 0) {
         throw new Error('target_amount must be greater than 0');
       }
       savingsUpdate.target_amount = target_amount;
-      updateMask.push('savings.target_amount');
     }
     if (monthly_contribution !== undefined) {
       if (monthly_contribution < 0) {
         throw new Error('monthly_contribution must be >= 0');
       }
       savingsUpdate.tracking_type_monthly_contribution = monthly_contribution;
-      updateMask.push('savings.tracking_type_monthly_contribution');
     }
     if (status !== undefined) {
       savingsUpdate.status = status;
-      updateMask.push('savings.status');
     }
     if (Object.keys(savingsUpdate).length > 0) {
       fieldsToUpdate.savings = savingsUpdate;
+      updateMask.push('savings');
     }
 
     if (updateMask.length === 0) {
       throw new Error('No fields to update');
-    }
-
-    // Validate goal exists (include inactive goals)
-    const goals = await this.db.getGoals(false);
-    const goal = goals.find((g) => g.goal_id === goal_id);
-    if (!goal) {
-      throw new Error(`Goal not found: ${goal_id}`);
     }
 
     // Resolve user_id

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2524,6 +2524,231 @@ export class CopilotMoneyTools {
   }
 
   /**
+   * Toggle the excluded flag on a transaction (hides/shows in spending reports).
+   *
+   * Validates the transaction exists, writes to Firestore, then patches the cache.
+   */
+  async setTransactionExcluded(args: { transaction_id: string; excluded: boolean }): Promise<{
+    success: boolean;
+    transaction_id: string;
+    excluded: boolean;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { transaction_id, excluded } = args;
+
+    // Validate transaction_id contains only safe characters
+    if (!/^[A-Za-z0-9_-]+$/.test(transaction_id)) {
+      throw new Error(`Invalid transaction_id format: ${transaction_id}`);
+    }
+
+    // Validate transaction exists
+    const transactions = await this.db.getAllTransactions();
+    const txn = transactions.find((t) => t.transaction_id === transaction_id);
+    if (!txn) {
+      throw new Error(`Transaction not found: ${transaction_id}`);
+    }
+
+    // Write to Firestore — transactions are nested: items/{itemId}/accounts/{accountId}/transactions
+    if (!txn.item_id || !txn.account_id) {
+      throw new Error(
+        `Transaction ${transaction_id} is missing item_id or account_id — cannot determine Firestore path`
+      );
+    }
+    const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
+    const firestoreFields = toFirestoreFields({ excluded });
+    await client.updateDocument(collectionPath, transaction_id, firestoreFields, ['excluded']);
+
+    // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
+    if (!this.db.patchCachedTransaction(transaction_id, { excluded })) {
+      this.db.clearCache();
+    }
+
+    return {
+      success: true,
+      transaction_id,
+      excluded,
+    };
+  }
+
+  /**
+   * Rename a transaction's display name.
+   *
+   * Validates the transaction exists, writes to Firestore, then patches the cache.
+   */
+  async setTransactionName(args: { transaction_id: string; name: string }): Promise<{
+    success: boolean;
+    transaction_id: string;
+    old_name: string;
+    new_name: string;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { transaction_id, name } = args;
+
+    // Validate transaction_id contains only safe characters
+    if (!/^[A-Za-z0-9_-]+$/.test(transaction_id)) {
+      throw new Error(`Invalid transaction_id format: ${transaction_id}`);
+    }
+
+    // Validate name is non-empty after trimming
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      throw new Error('Transaction name must not be empty');
+    }
+
+    // Validate transaction exists
+    const transactions = await this.db.getAllTransactions();
+    const txn = transactions.find((t) => t.transaction_id === transaction_id);
+    if (!txn) {
+      throw new Error(`Transaction not found: ${transaction_id}`);
+    }
+
+    const oldName = txn.name ?? txn.original_name ?? '';
+
+    // Write to Firestore — transactions are nested: items/{itemId}/accounts/{accountId}/transactions
+    if (!txn.item_id || !txn.account_id) {
+      throw new Error(
+        `Transaction ${transaction_id} is missing item_id or account_id — cannot determine Firestore path`
+      );
+    }
+    const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
+    const firestoreFields = toFirestoreFields({ name: trimmedName });
+    await client.updateDocument(collectionPath, transaction_id, firestoreFields, ['name']);
+
+    // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
+    if (!this.db.patchCachedTransaction(transaction_id, { name: trimmedName })) {
+      this.db.clearCache();
+    }
+
+    return {
+      success: true,
+      transaction_id,
+      old_name: oldName,
+      new_name: trimmedName,
+    };
+  }
+
+  /**
+   * Mark or unmark a transaction as an internal transfer.
+   *
+   * Validates the transaction exists, writes to Firestore, then patches the cache.
+   */
+  async setInternalTransfer(args: { transaction_id: string; internal_transfer: boolean }): Promise<{
+    success: boolean;
+    transaction_id: string;
+    internal_transfer: boolean;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { transaction_id, internal_transfer } = args;
+
+    // Validate transaction_id contains only safe characters
+    if (!/^[A-Za-z0-9_-]+$/.test(transaction_id)) {
+      throw new Error(`Invalid transaction_id format: ${transaction_id}`);
+    }
+
+    // Validate transaction exists
+    const transactions = await this.db.getAllTransactions();
+    const txn = transactions.find((t) => t.transaction_id === transaction_id);
+    if (!txn) {
+      throw new Error(`Transaction not found: ${transaction_id}`);
+    }
+
+    // Write to Firestore — transactions are nested: items/{itemId}/accounts/{accountId}/transactions
+    if (!txn.item_id || !txn.account_id) {
+      throw new Error(
+        `Transaction ${transaction_id} is missing item_id or account_id — cannot determine Firestore path`
+      );
+    }
+    const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
+    const firestoreFields = toFirestoreFields({ internal_transfer });
+    await client.updateDocument(collectionPath, transaction_id, firestoreFields, [
+      'internal_transfer',
+    ]);
+
+    // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
+    if (!this.db.patchCachedTransaction(transaction_id, { internal_transfer })) {
+      this.db.clearCache();
+    }
+
+    return {
+      success: true,
+      transaction_id,
+      internal_transfer,
+    };
+  }
+
+  /**
+   * Link or unlink a transaction to a financial goal.
+   *
+   * Validates the transaction and goal exist, writes to Firestore, then patches the cache.
+   * Pass goal_id: null to unlink.
+   */
+  async setTransactionGoal(args: { transaction_id: string; goal_id: string | null }): Promise<{
+    success: boolean;
+    transaction_id: string;
+    old_goal_id: string | null;
+    new_goal_id: string | null;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { transaction_id, goal_id } = args;
+
+    // Validate transaction_id contains only safe characters
+    if (!/^[A-Za-z0-9_-]+$/.test(transaction_id)) {
+      throw new Error(`Invalid transaction_id format: ${transaction_id}`);
+    }
+
+    // Validate goal_id format when not unlinking
+    if (goal_id !== null && !/^[A-Za-z0-9_-]+$/.test(goal_id)) {
+      throw new Error(`Invalid goal_id format: ${goal_id}`);
+    }
+
+    // Validate transaction exists
+    const transactions = await this.db.getAllTransactions();
+    const txn = transactions.find((t) => t.transaction_id === transaction_id);
+    if (!txn) {
+      throw new Error(`Transaction not found: ${transaction_id}`);
+    }
+
+    // Validate goal exists when linking
+    if (goal_id !== null) {
+      const goals = await this.db.getGoals();
+      const goal = goals.find((g) => g.goal_id === goal_id);
+      if (!goal) {
+        throw new Error(`Goal not found: ${goal_id}`);
+      }
+    }
+
+    const oldGoalId = txn.goal_id || null;
+
+    // Write to Firestore — transactions are nested: items/{itemId}/accounts/{accountId}/transactions
+    if (!txn.item_id || !txn.account_id) {
+      throw new Error(
+        `Transaction ${transaction_id} is missing item_id or account_id — cannot determine Firestore path`
+      );
+    }
+    const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
+    // When unlinking, write empty string to Firestore
+    const firestoreGoalId = goal_id ?? '';
+    const firestoreFields = toFirestoreFields({ goal_id: firestoreGoalId });
+    await client.updateDocument(collectionPath, transaction_id, firestoreFields, ['goal_id']);
+
+    // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
+    if (!this.db.patchCachedTransaction(transaction_id, { goal_id: firestoreGoalId })) {
+      this.db.clearCache();
+    }
+
+    return {
+      success: true,
+      transaction_id,
+      old_goal_id: oldGoalId,
+      new_goal_id: goal_id,
+    };
+  }
+
+  /**
    * Create a new user-defined tag.
    *
    * Generates a deterministic tag_id from the name, validates it does not
@@ -2639,6 +2864,635 @@ export class CopilotMoneyTools {
       success: true,
       tag_id,
       deleted_name: tag.name ?? tag_id,
+    };
+  }
+
+  /**
+   * Update an existing user-defined category.
+   *
+   * Validates the category exists, applies only the provided fields via
+   * Firestore updateMask, then clears the cache.
+   */
+  async updateCategory(args: {
+    category_id: string;
+    name?: string;
+    emoji?: string;
+    color?: string;
+    excluded?: boolean;
+    parent_category_id?: string | null;
+  }): Promise<{
+    success: boolean;
+    category_id: string;
+    updated_fields: string[];
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { category_id, name, emoji, color, excluded, parent_category_id } = args;
+
+    // Validate category_id format
+    if (!/^[A-Za-z0-9_-]+$/.test(category_id)) {
+      throw new Error(`Invalid category_id format: ${category_id}`);
+    }
+
+    // Validate category exists
+    const existingCategories = await this.db.getUserCategories();
+    const category = existingCategories.find((c) => c.category_id === category_id);
+    if (!category) {
+      throw new Error(`Category not found: ${category_id}`);
+    }
+
+    // Build dynamic update fields
+    const fieldsToUpdate: Record<string, unknown> = {};
+    const updateMask: string[] = [];
+
+    if (name !== undefined) {
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        throw new Error('Category name must not be empty');
+      }
+      // Check for duplicate name among OTHER categories
+      const duplicate = existingCategories.find(
+        (c) => c.category_id !== category_id && c.name?.toLowerCase() === trimmedName.toLowerCase()
+      );
+      if (duplicate) {
+        throw new Error(
+          `Category with name "${trimmedName}" already exists (id: ${duplicate.category_id})`
+        );
+      }
+      fieldsToUpdate.name = trimmedName;
+      updateMask.push('name');
+    }
+    if (emoji !== undefined) {
+      fieldsToUpdate.emoji = emoji;
+      updateMask.push('emoji');
+    }
+    if (color !== undefined) {
+      fieldsToUpdate.color = color;
+      updateMask.push('color');
+    }
+    if (excluded !== undefined) {
+      fieldsToUpdate.excluded = excluded;
+      updateMask.push('excluded');
+    }
+    if (parent_category_id !== undefined) {
+      if (parent_category_id !== null) {
+        // Validate parent exists
+        if (!/^[A-Za-z0-9_-]+$/.test(parent_category_id)) {
+          throw new Error(`Invalid parent_category_id format: ${parent_category_id}`);
+        }
+        const parent = existingCategories.find((c) => c.category_id === parent_category_id);
+        if (!parent) {
+          throw new Error(`Parent category not found: ${parent_category_id}`);
+        }
+      }
+      fieldsToUpdate.parent_category_id = parent_category_id ?? '';
+      updateMask.push('parent_category_id');
+    }
+
+    if (updateMask.length === 0) {
+      throw new Error('No fields to update');
+    }
+
+    // Determine user_id
+    const userIdFromCategories = existingCategories.find((c) => c.user_id)?.user_id;
+    const userId = userIdFromCategories ?? (await client.requireUserId());
+
+    // Write to Firestore
+    const collectionPath = `users/${userId}/categories`;
+    const firestoreFields = toFirestoreFields(fieldsToUpdate);
+    await client.updateDocument(collectionPath, category_id, firestoreFields, updateMask);
+
+    // Clear cache so updates are visible on next query
+    this.db.clearCache();
+    this._userCategoryMap = null;
+
+    return {
+      success: true,
+      category_id,
+      updated_fields: updateMask,
+    };
+  }
+
+  /**
+   * Delete a user-defined category.
+   *
+   * Validates the category exists, deletes from Firestore, then clears
+   * the cache.
+   */
+  async deleteCategory(args: { category_id: string }): Promise<{
+    success: boolean;
+    category_id: string;
+    deleted_name: string;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { category_id } = args;
+
+    // Validate category_id format
+    if (!/^[A-Za-z0-9_-]+$/.test(category_id)) {
+      throw new Error(`Invalid category_id format: ${category_id}`);
+    }
+
+    // Validate category exists
+    const existingCategories = await this.db.getUserCategories();
+    const category = existingCategories.find((c) => c.category_id === category_id);
+    if (!category) {
+      throw new Error(`Category not found: ${category_id}`);
+    }
+
+    // Resolve user_id for the Firestore path users/{user_id}/categories/{category_id}
+    const userIdFromCategories = existingCategories.find((c) => c.user_id)?.user_id;
+    const userId = userIdFromCategories ?? (await client.requireUserId());
+
+    const collectionPath = `users/${userId}/categories`;
+    await client.deleteDocument(collectionPath, category_id);
+
+    // Clear the cache so the next read reflects the deletion
+    this.db.clearCache();
+    this._userCategoryMap = null;
+
+    return {
+      success: true,
+      category_id,
+      deleted_name: category.name ?? category_id,
+    };
+  }
+
+  /**
+   * Create a new budget in Copilot Money.
+   *
+   * Generates a unique budget_id, validates the category exists and has no
+   * existing budget, writes to Firestore, then clears the cache.
+   */
+  async createBudget(args: {
+    category_id: string;
+    amount: number;
+    period?: string;
+    name?: string;
+  }): Promise<{
+    success: boolean;
+    budget_id: string;
+    category_id: string;
+    amount: number;
+    period: string;
+    name?: string;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { category_id, amount, period = 'monthly', name } = args;
+
+    // Validate category_id format
+    if (!/^[A-Za-z0-9_-]+$/.test(category_id)) {
+      throw new Error(`Invalid category_id format: ${category_id}`);
+    }
+
+    // Validate amount is positive
+    if (amount <= 0) {
+      throw new Error('Budget amount must be greater than 0');
+    }
+
+    // Validate period
+    const validPeriods = ['monthly', 'yearly', 'weekly', 'daily'];
+    if (!validPeriods.includes(period)) {
+      throw new Error(`Invalid period: ${period}. Must be one of: ${validPeriods.join(', ')}`);
+    }
+
+    // Validate category exists
+    const categories = await this.db.getUserCategories();
+    const category = categories.find((c) => c.category_id === category_id);
+    if (!category) {
+      throw new Error(`Category not found: ${category_id}`);
+    }
+
+    // Check no existing budget targets the same category
+    const existingBudgets = await this.db.getBudgets();
+    const duplicate = existingBudgets.find((b) => b.category_id === category_id);
+    if (duplicate) {
+      throw new Error(
+        `A budget already exists for category "${category_id}" (budget_id: ${duplicate.budget_id})`
+      );
+    }
+
+    // Generate unique budget_id
+    const budgetId = `budget_${crypto.randomUUID().replace(/-/g, '').slice(0, 16)}`;
+
+    // Resolve user_id
+    const userId = await client.requireUserId();
+
+    // Build document fields
+    const docFields: Record<string, unknown> = {
+      budget_id: budgetId,
+      category_id,
+      amount,
+      period,
+      is_active: true,
+    };
+    if (name) docFields.name = name;
+
+    // Write to Firestore
+    const collectionPath = `users/${userId}/budgets`;
+    const firestoreFields = toFirestoreFields(docFields);
+    await client.createDocument(collectionPath, budgetId, firestoreFields);
+
+    // Clear cache so the new budget is visible on next query
+    this.db.clearCache();
+
+    const result: {
+      success: boolean;
+      budget_id: string;
+      category_id: string;
+      amount: number;
+      period: string;
+      name?: string;
+    } = {
+      success: true,
+      budget_id: budgetId,
+      category_id,
+      amount,
+      period,
+    };
+    if (name) result.name = name;
+
+    return result;
+  }
+
+  /**
+   * Update an existing budget in Copilot Money.
+   *
+   * Validates the budget exists, builds a dynamic update mask for only the
+   * provided fields, writes to Firestore, then clears the cache.
+   */
+  async updateBudget(args: {
+    budget_id: string;
+    amount?: number;
+    period?: string;
+    name?: string;
+    is_active?: boolean;
+  }): Promise<{
+    success: boolean;
+    budget_id: string;
+    updated_fields: string[];
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { budget_id, amount, period, name, is_active } = args;
+
+    // Validate budget_id format
+    if (!/^[A-Za-z0-9_-]+$/.test(budget_id)) {
+      throw new Error(`Invalid budget_id format: ${budget_id}`);
+    }
+
+    // Validate budget exists
+    const existingBudgets = await this.db.getBudgets();
+    const budget = existingBudgets.find((b) => b.budget_id === budget_id);
+    if (!budget) {
+      throw new Error(`Budget not found: ${budget_id}`);
+    }
+
+    // Build update fields — only include fields explicitly provided
+    const updateFields: Record<string, unknown> = {};
+    const updatedFieldNames: string[] = [];
+
+    if (amount !== undefined) {
+      if (amount <= 0) {
+        throw new Error('Budget amount must be greater than 0');
+      }
+      updateFields.amount = amount;
+      updatedFieldNames.push('amount');
+    }
+
+    if (period !== undefined) {
+      const validPeriods = ['monthly', 'yearly', 'weekly', 'daily'];
+      if (!validPeriods.includes(period)) {
+        throw new Error(`Invalid period: ${period}. Must be one of: ${validPeriods.join(', ')}`);
+      }
+      updateFields.period = period;
+      updatedFieldNames.push('period');
+    }
+
+    if (name !== undefined) {
+      updateFields.name = name;
+      updatedFieldNames.push('name');
+    }
+
+    if (is_active !== undefined) {
+      updateFields.is_active = is_active;
+      updatedFieldNames.push('is_active');
+    }
+
+    // Ensure at least one field is being updated
+    if (updatedFieldNames.length === 0) {
+      throw new Error(
+        'No fields to update. Provide at least one of: amount, period, name, is_active'
+      );
+    }
+
+    // Resolve user_id
+    const userId = await client.requireUserId();
+
+    // Write to Firestore with dynamic update mask
+    const collectionPath = `users/${userId}/budgets`;
+    const firestoreFields = toFirestoreFields(updateFields);
+    await client.updateDocument(collectionPath, budget_id, firestoreFields, updatedFieldNames);
+
+    // Clear cache so the updated budget is visible on next query
+    this.db.clearCache();
+
+    return {
+      success: true,
+      budget_id,
+      updated_fields: updatedFieldNames,
+    };
+  }
+
+  /**
+   * Delete an existing budget from Copilot Money.
+   *
+   * Validates the budget exists, deletes from Firestore, then clears the cache.
+   */
+  async deleteBudget(args: { budget_id: string }): Promise<{
+    success: boolean;
+    budget_id: string;
+    deleted_name: string;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { budget_id } = args;
+
+    // Validate budget_id format
+    if (!/^[A-Za-z0-9_-]+$/.test(budget_id)) {
+      throw new Error(`Invalid budget_id format: ${budget_id}`);
+    }
+
+    // Validate budget exists
+    const existingBudgets = await this.db.getBudgets();
+    const budget = existingBudgets.find((b) => b.budget_id === budget_id);
+    if (!budget) {
+      throw new Error(`Budget not found: ${budget_id}`);
+    }
+
+    // Resolve user_id
+    const userId = await client.requireUserId();
+
+    const collectionPath = `users/${userId}/budgets`;
+    await client.deleteDocument(collectionPath, budget_id);
+
+    // Clear the cache so the next read reflects the deletion
+    this.db.clearCache();
+
+    return {
+      success: true,
+      budget_id,
+      deleted_name: budget.name ?? budget.category_id ?? budget_id,
+    };
+  }
+
+  /**
+   * Change the state of a recurring item (activate, pause, or archive).
+   *
+   * Validates the recurring item exists, writes both state and is_active
+   * fields to Firestore, then clears the cache.
+   */
+  async setRecurringState(args: {
+    recurring_id: string;
+    state: 'active' | 'paused' | 'archived';
+  }): Promise<{
+    success: boolean;
+    recurring_id: string;
+    name: string;
+    old_state: string;
+    new_state: string;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { recurring_id, state } = args;
+
+    // Validate recurring_id format
+    if (!/^[A-Za-z0-9_-]+$/.test(recurring_id)) {
+      throw new Error(`Invalid recurring_id format: ${recurring_id}`);
+    }
+
+    // Validate state
+    const validStates = ['active', 'paused', 'archived'];
+    if (!validStates.includes(state)) {
+      throw new Error(`Invalid state: ${state}. Must be one of: ${validStates.join(', ')}`);
+    }
+
+    // Validate recurring exists (false = include inactive)
+    const allRecurring = await this.db.getRecurring(false);
+    const recurring = allRecurring.find((r) => r.recurring_id === recurring_id);
+    if (!recurring) {
+      throw new Error(`Recurring item not found: ${recurring_id}`);
+    }
+
+    const displayName = getRecurringDisplayName(recurring);
+    const oldState = recurring.state ?? (recurring.is_active ? 'active' : 'paused');
+
+    // Resolve user_id for the Firestore path users/{user_id}/recurring/{recurring_id}
+    const userId = await client.requireUserId();
+
+    // Write both state and derived is_active field
+    const is_active = state === 'active';
+    const firestoreFields = toFirestoreFields({ state, is_active });
+    const collectionPath = `users/${userId}/recurring`;
+    await client.updateDocument(collectionPath, recurring_id, firestoreFields, [
+      'state',
+      'is_active',
+    ]);
+
+    // Clear the cache so the next read reflects the change
+    this.db.clearCache();
+
+    return {
+      success: true,
+      recurring_id,
+      name: displayName,
+      old_state: oldState,
+      new_state: state,
+    };
+  }
+
+  /**
+   * Delete a recurring item.
+   *
+   * Validates the recurring item exists, deletes from Firestore,
+   * then clears the cache.
+   */
+  async deleteRecurring(args: { recurring_id: string }): Promise<{
+    success: boolean;
+    recurring_id: string;
+    deleted_name: string;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { recurring_id } = args;
+
+    // Validate recurring_id format
+    if (!/^[A-Za-z0-9_-]+$/.test(recurring_id)) {
+      throw new Error(`Invalid recurring_id format: ${recurring_id}`);
+    }
+
+    // Validate recurring exists
+    const allRecurring = await this.db.getRecurring(false);
+    const recurring = allRecurring.find((r) => r.recurring_id === recurring_id);
+    if (!recurring) {
+      throw new Error(`Recurring item not found: ${recurring_id}`);
+    }
+
+    const displayName = getRecurringDisplayName(recurring);
+
+    // Resolve user_id for the Firestore path users/{user_id}/recurring/{recurring_id}
+    const userId = await client.requireUserId();
+
+    const collectionPath = `users/${userId}/recurring`;
+    await client.deleteDocument(collectionPath, recurring_id);
+
+    // Clear the cache so the next read reflects the deletion
+    this.db.clearCache();
+
+    return {
+      success: true,
+      recurring_id,
+      deleted_name: displayName,
+    };
+  }
+
+  /**
+   * Update a financial goal's properties.
+   *
+   * Validates the goal exists, builds a dynamic update mask from the provided
+   * fields, writes to Firestore, then clears the cache.
+   */
+  async updateGoal(args: {
+    goal_id: string;
+    name?: string;
+    emoji?: string;
+    target_amount?: number;
+    monthly_contribution?: number;
+    status?: 'active' | 'paused';
+  }): Promise<{
+    success: boolean;
+    goal_id: string;
+    updated_fields: string[];
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { goal_id, name, emoji, target_amount, monthly_contribution, status } = args;
+
+    // Validate goal_id format
+    if (!/^[A-Za-z0-9_-]+$/.test(goal_id)) {
+      throw new Error(`Invalid goal_id format: ${goal_id}`);
+    }
+
+    // Validate at least one field to update
+    const fieldsToUpdate: Record<string, unknown> = {};
+    const updateMask: string[] = [];
+
+    if (name !== undefined) {
+      if (!name.trim()) {
+        throw new Error('Goal name must not be empty');
+      }
+      fieldsToUpdate.name = name.trim();
+      updateMask.push('name');
+    }
+    if (emoji !== undefined) {
+      fieldsToUpdate.emoji = emoji;
+      updateMask.push('emoji');
+    }
+
+    // Nested savings fields — build a savings sub-object
+    const savingsUpdate: Record<string, unknown> = {};
+    if (target_amount !== undefined) {
+      if (target_amount <= 0) {
+        throw new Error('target_amount must be greater than 0');
+      }
+      savingsUpdate.target_amount = target_amount;
+      updateMask.push('savings.target_amount');
+    }
+    if (monthly_contribution !== undefined) {
+      if (monthly_contribution < 0) {
+        throw new Error('monthly_contribution must be >= 0');
+      }
+      savingsUpdate.tracking_type_monthly_contribution = monthly_contribution;
+      updateMask.push('savings.tracking_type_monthly_contribution');
+    }
+    if (status !== undefined) {
+      savingsUpdate.status = status;
+      updateMask.push('savings.status');
+    }
+    if (Object.keys(savingsUpdate).length > 0) {
+      fieldsToUpdate.savings = savingsUpdate;
+    }
+
+    if (updateMask.length === 0) {
+      throw new Error('No fields to update');
+    }
+
+    // Validate goal exists (include inactive goals)
+    const goals = await this.db.getGoals(false);
+    const goal = goals.find((g) => g.goal_id === goal_id);
+    if (!goal) {
+      throw new Error(`Goal not found: ${goal_id}`);
+    }
+
+    // Resolve user_id
+    const userId = await client.requireUserId();
+
+    // Write to Firestore
+    const collectionPath = `users/${userId}/financial_goals`;
+    const firestoreFields = toFirestoreFields(fieldsToUpdate);
+    await client.updateDocument(collectionPath, goal_id, firestoreFields, updateMask);
+
+    // Clear cache so next read picks up the change
+    this.db.clearCache();
+
+    return {
+      success: true,
+      goal_id,
+      updated_fields: updateMask,
+    };
+  }
+
+  /**
+   * Delete a financial goal.
+   *
+   * Validates the goal exists in the local cache, deletes from Firestore,
+   * then clears the cache.
+   */
+  async deleteGoal(args: { goal_id: string }): Promise<{
+    success: boolean;
+    goal_id: string;
+    deleted_name: string;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { goal_id } = args;
+
+    // Validate goal_id format
+    if (!/^[A-Za-z0-9_-]+$/.test(goal_id)) {
+      throw new Error(`Invalid goal_id format: ${goal_id}`);
+    }
+
+    // Validate goal exists (include inactive goals)
+    const goals = await this.db.getGoals(false);
+    const goal = goals.find((g) => g.goal_id === goal_id);
+    if (!goal) {
+      throw new Error(`Goal not found: ${goal_id}`);
+    }
+
+    // Resolve user_id
+    const userId = await client.requireUserId();
+
+    const collectionPath = `users/${userId}/financial_goals`;
+    await client.deleteDocument(collectionPath, goal_id);
+
+    // Clear the cache so the next read reflects the deletion
+    this.db.clearCache();
+
+    return {
+      success: true,
+      goal_id,
+      deleted_name: goal.name ?? goal_id,
     };
   }
 }
@@ -3248,6 +4102,107 @@ export function createWriteToolSchemas(): ToolSchema[] {
       },
     },
     {
+      name: 'set_transaction_excluded',
+      description:
+        'Exclude or include a transaction in spending reports. ' +
+        'Requires transaction_id (from get_transactions). Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          transaction_id: {
+            type: 'string',
+            description: 'Transaction ID to update (from get_transactions results)',
+          },
+          excluded: {
+            type: 'boolean',
+            description: 'Set to true to exclude from spending reports, false to include.',
+          },
+        },
+        required: ['transaction_id', 'excluded'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'set_transaction_name',
+      description:
+        'Rename a transaction display name. ' +
+        'Requires transaction_id (from get_transactions). Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          transaction_id: {
+            type: 'string',
+            description: 'Transaction ID to update (from get_transactions results)',
+          },
+          name: {
+            type: 'string',
+            description: 'New display name for the transaction. Must be non-empty.',
+          },
+        },
+        required: ['transaction_id', 'name'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'set_internal_transfer',
+      description:
+        'Mark or unmark a transaction as an internal transfer between accounts. ' +
+        'Requires transaction_id (from get_transactions). Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          transaction_id: {
+            type: 'string',
+            description: 'Transaction ID to update (from get_transactions results)',
+          },
+          internal_transfer: {
+            type: 'boolean',
+            description: 'Set to true to mark as internal transfer, false to unmark.',
+          },
+        },
+        required: ['transaction_id', 'internal_transfer'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'set_transaction_goal',
+      description:
+        'Link or unlink a transaction to a financial goal. ' +
+        'Requires transaction_id (from get_transactions) and goal_id (from get_goals). ' +
+        'Pass goal_id: null to unlink. Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          transaction_id: {
+            type: 'string',
+            description: 'Transaction ID to update (from get_transactions results)',
+          },
+          goal_id: {
+            type: ['string', 'null'],
+            description: 'Goal ID to link (from get_goals results), or null to unlink.',
+          },
+        },
+        required: ['transaction_id', 'goal_id'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    {
       name: 'create_tag',
       description:
         'Create a new user-defined tag for categorizing transactions. Tags appear in the ' +
@@ -3339,6 +4294,278 @@ export function createWriteToolSchemas(): ToolSchema[] {
         readOnlyHint: false,
         destructiveHint: false,
         idempotentHint: false,
+      },
+    },
+    {
+      name: 'update_category',
+      description:
+        'Update an existing user-defined category. Provide category_id (required) and any ' +
+        'fields to change: name, emoji, color, excluded, or parent_category_id (null to ungroup). ' +
+        'Only the specified fields are updated. Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          category_id: {
+            type: 'string',
+            description: 'Category ID to update (from get_categories results)',
+          },
+          name: {
+            type: 'string',
+            description: 'New display name for the category',
+          },
+          emoji: {
+            type: 'string',
+            description: 'New emoji icon for the category (e.g., "🎬")',
+          },
+          color: {
+            type: 'string',
+            description: 'New hex color code for the category (e.g., "#FF5733")',
+          },
+          excluded: {
+            type: 'boolean',
+            description: 'Exclude this category from spending totals',
+          },
+          parent_category_id: {
+            type: ['string', 'null'],
+            description:
+              'Parent category ID to nest under, or null to ungroup. ' +
+              'Use get_categories to find valid parent IDs.',
+          },
+        },
+        required: ['category_id'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'delete_category',
+      description:
+        'Delete a user-defined category. The category_id can be obtained from get_categories. ' +
+        'Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          category_id: {
+            type: 'string',
+            description: 'Category ID to delete',
+          },
+        },
+        required: ['category_id'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'create_budget',
+      description:
+        'Create a new budget in Copilot Money. Requires a category_id and amount. ' +
+        'Only one budget per category is allowed. Optionally set a period (default: monthly) ' +
+        'and a display name. Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          category_id: {
+            type: 'string',
+            description: 'Category ID to budget for (from get_categories)',
+          },
+          amount: {
+            type: 'number',
+            description: 'Budget amount (must be greater than 0)',
+          },
+          period: {
+            type: 'string',
+            description: 'Budget period: monthly, yearly, weekly, or daily (default: monthly)',
+            enum: ['monthly', 'yearly', 'weekly', 'daily'],
+          },
+          name: {
+            type: 'string',
+            description: 'Optional display name for the budget',
+          },
+        },
+        required: ['category_id', 'amount'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+      },
+    },
+    {
+      name: 'update_budget',
+      description:
+        'Update an existing budget in Copilot Money. Requires budget_id and at least one ' +
+        'field to update (amount, period, name, or is_active). Only provided fields are changed.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          budget_id: {
+            type: 'string',
+            description: 'Budget ID to update (from get_budgets)',
+          },
+          amount: {
+            type: 'number',
+            description: 'New budget amount (must be greater than 0)',
+          },
+          period: {
+            type: 'string',
+            description: 'New budget period: monthly, yearly, weekly, or daily',
+            enum: ['monthly', 'yearly', 'weekly', 'daily'],
+          },
+          name: {
+            type: 'string',
+            description: 'New display name for the budget',
+          },
+          is_active: {
+            type: 'boolean',
+            description: 'Set to false to deactivate the budget, true to reactivate',
+          },
+        },
+        required: ['budget_id'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'delete_budget',
+      description:
+        'Delete a budget from Copilot Money. Requires the budget_id (from get_budgets). ' +
+        'This permanently removes the budget. Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          budget_id: {
+            type: 'string',
+            description: 'Budget ID to delete (from get_budgets)',
+          },
+        },
+        required: ['budget_id'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'set_recurring_state',
+      description:
+        'Change the state of a recurring item (subscription/charge). ' +
+        'Set to active, paused, or archived. Requires recurring_id (from get_recurring_transactions). ' +
+        'Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          recurring_id: {
+            type: 'string',
+            description: 'Recurring item ID to update (from get_recurring_transactions results)',
+          },
+          state: {
+            type: 'string',
+            enum: ['active', 'paused', 'archived'],
+            description: 'New state for the recurring item',
+          },
+        },
+        required: ['recurring_id', 'state'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'delete_recurring',
+      description:
+        'Delete a recurring item (subscription/charge). ' +
+        'Requires recurring_id (from get_recurring_transactions). ' +
+        'Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          recurring_id: {
+            type: 'string',
+            description: 'Recurring item ID to delete (from get_recurring_transactions results)',
+          },
+        },
+        required: ['recurring_id'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'update_goal',
+      description:
+        "Update a financial goal's properties. Provide goal_id (required) and any combination " +
+        'of name, emoji, target_amount, monthly_contribution, or status. Only the fields you ' +
+        'provide will be updated. Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          goal_id: {
+            type: 'string',
+            description: 'Goal ID to update (from get_goals results)',
+          },
+          name: {
+            type: 'string',
+            description: 'New display name for the goal',
+          },
+          emoji: {
+            type: 'string',
+            description: 'New emoji icon for the goal',
+          },
+          target_amount: {
+            type: 'number',
+            description: 'New target savings amount (must be > 0)',
+          },
+          monthly_contribution: {
+            type: 'number',
+            description: 'New monthly contribution amount (must be >= 0)',
+          },
+          status: {
+            type: 'string',
+            enum: ['active', 'paused'],
+            description: 'Set goal status to active or paused',
+          },
+        },
+        required: ['goal_id'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'delete_goal',
+      description:
+        'Delete a financial goal. The goal_id can be obtained from get_goals results. ' +
+        'Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          goal_id: {
+            type: 'string',
+            description: 'Goal ID to delete',
+          },
+        },
+        required: ['goal_id'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
       },
     },
   ];

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -15,7 +15,12 @@ import {
   isKnownPlaidCategory,
 } from '../utils/categories.js';
 import type { Transaction, Account, InvestmentPrice, InvestmentSplit } from '../models/index.js';
-import { getTransactionDisplayName, getRecurringDisplayName } from '../models/index.js';
+import {
+  getTransactionDisplayName,
+  getRecurringDisplayName,
+  KNOWN_PERIODS,
+  RECURRING_STATES,
+} from '../models/index.js';
 import { isItemHealthy, itemNeedsAttention, getItemDisplayName } from '../models/item.js';
 import {
   getRootCategories,
@@ -28,6 +33,19 @@ import {
 // ============================================
 // Category Constants
 // ============================================
+
+// ============================================
+// Shared Validation Helpers
+// ============================================
+
+const SAFE_ID_RE = /^[A-Za-z0-9_-]+$/;
+
+/** Validate that a document ID contains only safe characters. */
+function validateDocId(id: string, label: string): void {
+  if (!SAFE_ID_RE.test(id)) {
+    throw new Error(`Invalid ${label} format: ${id}`);
+  }
+}
 
 /**
  * Plaid category ID for foreign transaction fees (snake_case format).
@@ -2211,9 +2229,7 @@ export class CopilotMoneyTools {
 
     // Validate parent_category_id if provided
     if (parent_category_id) {
-      if (!/^[A-Za-z0-9_-]+$/.test(parent_category_id)) {
-        throw new Error(`Invalid parent_category_id format: ${parent_category_id}`);
-      }
+      validateDocId(parent_category_id, 'parent_category_id');
       const parent = existingCategories.find((c) => c.category_id === parent_category_id);
       if (!parent) {
         throw new Error(`Parent category not found: ${parent_category_id}`);
@@ -2278,6 +2294,50 @@ export class CopilotMoneyTools {
   }
 
   /**
+   * Resolve a transaction by ID: validate format, find in cache, verify Firestore path fields.
+   * Returns the transaction and its Firestore collection path.
+   */
+  private async resolveTransaction(transactionId: string): Promise<{
+    txn: Transaction;
+    collectionPath: string;
+  }> {
+    validateDocId(transactionId, 'transaction_id');
+
+    const transactions = await this.db.getAllTransactions();
+    const txn = transactions.find((t) => t.transaction_id === transactionId);
+    if (!txn) {
+      throw new Error(`Transaction not found: ${transactionId}`);
+    }
+    if (!txn.item_id || !txn.account_id) {
+      throw new Error(
+        `Transaction ${transactionId} is missing item_id or account_id — cannot determine Firestore path`
+      );
+    }
+    return {
+      txn,
+      collectionPath: `items/${txn.item_id}/accounts/${txn.account_id}/transactions`,
+    };
+  }
+
+  /**
+   * Write a partial update to a transaction and patch the cache.
+   */
+  private async writeTransactionFields(
+    transactionId: string,
+    collectionPath: string,
+    fields: Record<string, unknown>
+  ): Promise<void> {
+    const client = this.getFirestoreClient();
+    const firestoreFields = toFirestoreFields(fields);
+    const updateMask = Object.keys(fields);
+    await client.updateDocument(collectionPath, transactionId, firestoreFields, updateMask);
+
+    if (!this.db.patchCachedTransaction(transactionId, fields as Partial<Transaction>)) {
+      this.db.clearCache();
+    }
+  }
+
+  /**
    * Change the category of a transaction.
    *
    * Validates both IDs exist, writes to Firestore, then patches the cache.
@@ -2290,24 +2350,10 @@ export class CopilotMoneyTools {
     old_category_name: string;
     new_category_name: string;
   }> {
-    const client = this.getFirestoreClient();
-
     const { transaction_id, category_id } = args;
+    validateDocId(category_id, 'category_id');
 
-    // Validate IDs contain only safe characters
-    if (!/^[A-Za-z0-9_-]+$/.test(transaction_id)) {
-      throw new Error(`Invalid transaction_id format: ${transaction_id}`);
-    }
-    if (!/^[A-Za-z0-9_-]+$/.test(category_id)) {
-      throw new Error(`Invalid category_id format: ${category_id}`);
-    }
-
-    // Validate transaction exists
-    const transactions = await this.db.getAllTransactions();
-    const txn = transactions.find((t) => t.transaction_id === transaction_id);
-    if (!txn) {
-      throw new Error(`Transaction not found: ${transaction_id}`);
-    }
+    const { txn, collectionPath } = await this.resolveTransaction(transaction_id);
 
     // Validate category exists
     const categories = await this.db.getUserCategories();
@@ -2323,20 +2369,7 @@ export class CopilotMoneyTools {
       : 'Uncategorized';
     const newCategoryName = getCategoryName(category_id, userCategoryMap);
 
-    // Write to Firestore — transactions are nested: items/{itemId}/accounts/{accountId}/transactions
-    if (!txn.item_id || !txn.account_id) {
-      throw new Error(
-        `Transaction ${transaction_id} is missing item_id or account_id — cannot determine Firestore path`
-      );
-    }
-    const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
-    const firestoreFields = toFirestoreFields({ category_id });
-    await client.updateDocument(collectionPath, transaction_id, firestoreFields, ['category_id']);
-
-    // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
-    if (!this.db.patchCachedTransaction(transaction_id, { category_id })) {
-      this.db.clearCache();
-    }
+    await this.writeTransactionFields(transaction_id, collectionPath, { category_id });
 
     return {
       success: true,
@@ -2359,38 +2392,11 @@ export class CopilotMoneyTools {
     old_note: string;
     new_note: string;
   }> {
-    const client = this.getFirestoreClient();
-
     const { transaction_id, note } = args;
-
-    // Validate transaction_id contains only safe characters
-    if (!/^[A-Za-z0-9_-]+$/.test(transaction_id)) {
-      throw new Error(`Invalid transaction_id format: ${transaction_id}`);
-    }
-
-    // Validate transaction exists
-    const transactions = await this.db.getAllTransactions();
-    const txn = transactions.find((t) => t.transaction_id === transaction_id);
-    if (!txn) {
-      throw new Error(`Transaction not found: ${transaction_id}`);
-    }
-
+    const { txn, collectionPath } = await this.resolveTransaction(transaction_id);
     const oldNote = txn.user_note ?? '';
 
-    // Write to Firestore — transactions are nested: items/{itemId}/accounts/{accountId}/transactions
-    if (!txn.item_id || !txn.account_id) {
-      throw new Error(
-        `Transaction ${transaction_id} is missing item_id or account_id — cannot determine Firestore path`
-      );
-    }
-    const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
-    const firestoreFields = toFirestoreFields({ user_note: note });
-    await client.updateDocument(collectionPath, transaction_id, firestoreFields, ['user_note']);
-
-    // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
-    if (!this.db.patchCachedTransaction(transaction_id, { user_note: note })) {
-      this.db.clearCache();
-    }
+    await this.writeTransactionFields(transaction_id, collectionPath, { user_note: note });
 
     return {
       success: true,
@@ -2411,44 +2417,15 @@ export class CopilotMoneyTools {
     old_tag_ids: string[];
     new_tag_ids: string[];
   }> {
-    const client = this.getFirestoreClient();
-
     const { transaction_id, tag_ids } = args;
-
-    // Validate IDs contain only safe characters
-    if (!/^[A-Za-z0-9_-]+$/.test(transaction_id)) {
-      throw new Error(`Invalid transaction_id format: ${transaction_id}`);
-    }
     for (const tagId of tag_ids) {
-      if (!/^[A-Za-z0-9_-]+$/.test(tagId)) {
-        throw new Error(`Invalid tag_id format: ${tagId}`);
-      }
+      validateDocId(tagId, 'tag_id');
     }
 
-    // Validate transaction exists
-    const transactions = await this.db.getAllTransactions();
-    const txn = transactions.find((t) => t.transaction_id === transaction_id);
-    if (!txn) {
-      throw new Error(`Transaction not found: ${transaction_id}`);
-    }
-
-    // Write to Firestore — transactions are nested: items/{itemId}/accounts/{accountId}/transactions
-    if (!txn.item_id || !txn.account_id) {
-      throw new Error(
-        `Transaction ${transaction_id} is missing item_id or account_id — cannot determine Firestore path`
-      );
-    }
-
+    const { txn, collectionPath } = await this.resolveTransaction(transaction_id);
     const oldTagIds = txn.tag_ids || [];
 
-    const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
-    const firestoreFields = toFirestoreFields({ tag_ids });
-    await client.updateDocument(collectionPath, transaction_id, firestoreFields, ['tag_ids']);
-
-    // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
-    if (!this.db.patchCachedTransaction(transaction_id, { tag_ids })) {
-      this.db.clearCache();
-    }
+    await this.writeTransactionFields(transaction_id, collectionPath, { tag_ids });
 
     return {
       success: true,
@@ -2477,11 +2454,8 @@ export class CopilotMoneyTools {
       throw new Error('transaction_ids must be a non-empty array');
     }
 
-    // Validate all IDs contain only safe characters
     for (const id of transaction_ids) {
-      if (!/^[A-Za-z0-9_-]+$/.test(id)) {
-        throw new Error(`Invalid transaction_id format: ${id}`);
-      }
+      validateDocId(id, 'transaction_id');
     }
 
     // Validate all transactions exist and collect them
@@ -2533,42 +2507,12 @@ export class CopilotMoneyTools {
     transaction_id: string;
     excluded: boolean;
   }> {
-    const client = this.getFirestoreClient();
-
     const { transaction_id, excluded } = args;
+    const { collectionPath } = await this.resolveTransaction(transaction_id);
 
-    // Validate transaction_id contains only safe characters
-    if (!/^[A-Za-z0-9_-]+$/.test(transaction_id)) {
-      throw new Error(`Invalid transaction_id format: ${transaction_id}`);
-    }
+    await this.writeTransactionFields(transaction_id, collectionPath, { excluded });
 
-    // Validate transaction exists
-    const transactions = await this.db.getAllTransactions();
-    const txn = transactions.find((t) => t.transaction_id === transaction_id);
-    if (!txn) {
-      throw new Error(`Transaction not found: ${transaction_id}`);
-    }
-
-    // Write to Firestore — transactions are nested: items/{itemId}/accounts/{accountId}/transactions
-    if (!txn.item_id || !txn.account_id) {
-      throw new Error(
-        `Transaction ${transaction_id} is missing item_id or account_id — cannot determine Firestore path`
-      );
-    }
-    const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
-    const firestoreFields = toFirestoreFields({ excluded });
-    await client.updateDocument(collectionPath, transaction_id, firestoreFields, ['excluded']);
-
-    // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
-    if (!this.db.patchCachedTransaction(transaction_id, { excluded })) {
-      this.db.clearCache();
-    }
-
-    return {
-      success: true,
-      transaction_id,
-      excluded,
-    };
+    return { success: true, transaction_id, excluded };
   }
 
   /**
@@ -2582,51 +2526,19 @@ export class CopilotMoneyTools {
     old_name: string;
     new_name: string;
   }> {
-    const client = this.getFirestoreClient();
-
     const { transaction_id, name } = args;
 
-    // Validate transaction_id contains only safe characters
-    if (!/^[A-Za-z0-9_-]+$/.test(transaction_id)) {
-      throw new Error(`Invalid transaction_id format: ${transaction_id}`);
-    }
-
-    // Validate name is non-empty after trimming
     const trimmedName = name.trim();
     if (!trimmedName) {
       throw new Error('Transaction name must not be empty');
     }
 
-    // Validate transaction exists
-    const transactions = await this.db.getAllTransactions();
-    const txn = transactions.find((t) => t.transaction_id === transaction_id);
-    if (!txn) {
-      throw new Error(`Transaction not found: ${transaction_id}`);
-    }
-
+    const { txn, collectionPath } = await this.resolveTransaction(transaction_id);
     const oldName = txn.name ?? txn.original_name ?? '';
 
-    // Write to Firestore — transactions are nested: items/{itemId}/accounts/{accountId}/transactions
-    if (!txn.item_id || !txn.account_id) {
-      throw new Error(
-        `Transaction ${transaction_id} is missing item_id or account_id — cannot determine Firestore path`
-      );
-    }
-    const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
-    const firestoreFields = toFirestoreFields({ name: trimmedName });
-    await client.updateDocument(collectionPath, transaction_id, firestoreFields, ['name']);
+    await this.writeTransactionFields(transaction_id, collectionPath, { name: trimmedName });
 
-    // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
-    if (!this.db.patchCachedTransaction(transaction_id, { name: trimmedName })) {
-      this.db.clearCache();
-    }
-
-    return {
-      success: true,
-      transaction_id,
-      old_name: oldName,
-      new_name: trimmedName,
-    };
+    return { success: true, transaction_id, old_name: oldName, new_name: trimmedName };
   }
 
   /**
@@ -2639,44 +2551,12 @@ export class CopilotMoneyTools {
     transaction_id: string;
     internal_transfer: boolean;
   }> {
-    const client = this.getFirestoreClient();
-
     const { transaction_id, internal_transfer } = args;
+    const { collectionPath } = await this.resolveTransaction(transaction_id);
 
-    // Validate transaction_id contains only safe characters
-    if (!/^[A-Za-z0-9_-]+$/.test(transaction_id)) {
-      throw new Error(`Invalid transaction_id format: ${transaction_id}`);
-    }
+    await this.writeTransactionFields(transaction_id, collectionPath, { internal_transfer });
 
-    // Validate transaction exists
-    const transactions = await this.db.getAllTransactions();
-    const txn = transactions.find((t) => t.transaction_id === transaction_id);
-    if (!txn) {
-      throw new Error(`Transaction not found: ${transaction_id}`);
-    }
-
-    // Write to Firestore — transactions are nested: items/{itemId}/accounts/{accountId}/transactions
-    if (!txn.item_id || !txn.account_id) {
-      throw new Error(
-        `Transaction ${transaction_id} is missing item_id or account_id — cannot determine Firestore path`
-      );
-    }
-    const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
-    const firestoreFields = toFirestoreFields({ internal_transfer });
-    await client.updateDocument(collectionPath, transaction_id, firestoreFields, [
-      'internal_transfer',
-    ]);
-
-    // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
-    if (!this.db.patchCachedTransaction(transaction_id, { internal_transfer })) {
-      this.db.clearCache();
-    }
-
-    return {
-      success: true,
-      transaction_id,
-      internal_transfer,
-    };
+    return { success: true, transaction_id, internal_transfer };
   }
 
   /**
@@ -2691,26 +2571,10 @@ export class CopilotMoneyTools {
     old_goal_id: string | null;
     new_goal_id: string | null;
   }> {
-    const client = this.getFirestoreClient();
-
     const { transaction_id, goal_id } = args;
+    if (goal_id !== null) validateDocId(goal_id, 'goal_id');
 
-    // Validate transaction_id contains only safe characters
-    if (!/^[A-Za-z0-9_-]+$/.test(transaction_id)) {
-      throw new Error(`Invalid transaction_id format: ${transaction_id}`);
-    }
-
-    // Validate goal_id format when not unlinking
-    if (goal_id !== null && !/^[A-Za-z0-9_-]+$/.test(goal_id)) {
-      throw new Error(`Invalid goal_id format: ${goal_id}`);
-    }
-
-    // Validate transaction exists
-    const transactions = await this.db.getAllTransactions();
-    const txn = transactions.find((t) => t.transaction_id === transaction_id);
-    if (!txn) {
-      throw new Error(`Transaction not found: ${transaction_id}`);
-    }
+    const { txn, collectionPath } = await this.resolveTransaction(transaction_id);
 
     // Validate goal exists when linking
     if (goal_id !== null) {
@@ -2722,23 +2586,12 @@ export class CopilotMoneyTools {
     }
 
     const oldGoalId = txn.goal_id || null;
-
-    // Write to Firestore — transactions are nested: items/{itemId}/accounts/{accountId}/transactions
-    if (!txn.item_id || !txn.account_id) {
-      throw new Error(
-        `Transaction ${transaction_id} is missing item_id or account_id — cannot determine Firestore path`
-      );
-    }
-    const collectionPath = `items/${txn.item_id}/accounts/${txn.account_id}/transactions`;
     // When unlinking, write empty string to Firestore
     const firestoreGoalId = goal_id ?? '';
-    const firestoreFields = toFirestoreFields({ goal_id: firestoreGoalId });
-    await client.updateDocument(collectionPath, transaction_id, firestoreFields, ['goal_id']);
 
-    // Optimistic cache update — if the transaction was evicted, clear cache to force re-read
-    if (!this.db.patchCachedTransaction(transaction_id, { goal_id: firestoreGoalId })) {
-      this.db.clearCache();
-    }
+    await this.writeTransactionFields(transaction_id, collectionPath, {
+      goal_id: firestoreGoalId,
+    });
 
     return {
       success: true,
@@ -2840,9 +2693,7 @@ export class CopilotMoneyTools {
     const { tag_id } = args;
 
     // Validate tag_id format
-    if (!/^[A-Za-z0-9_-]+$/.test(tag_id)) {
-      throw new Error(`Invalid tag_id format: ${tag_id}`);
-    }
+    validateDocId(tag_id, 'tag_id');
 
     // Validate tag exists
     const existingTags = await this.db.getTags();
@@ -2890,9 +2741,7 @@ export class CopilotMoneyTools {
     const { category_id, name, emoji, color, excluded, parent_category_id } = args;
 
     // Validate category_id format
-    if (!/^[A-Za-z0-9_-]+$/.test(category_id)) {
-      throw new Error(`Invalid category_id format: ${category_id}`);
-    }
+    validateDocId(category_id, 'category_id');
 
     // Validate category exists
     const existingCategories = await this.db.getUserCategories();
@@ -2989,9 +2838,7 @@ export class CopilotMoneyTools {
     const { category_id } = args;
 
     // Validate category_id format
-    if (!/^[A-Za-z0-9_-]+$/.test(category_id)) {
-      throw new Error(`Invalid category_id format: ${category_id}`);
-    }
+    validateDocId(category_id, 'category_id');
 
     // Validate category exists
     const existingCategories = await this.db.getUserCategories();
@@ -3042,9 +2889,7 @@ export class CopilotMoneyTools {
     const { category_id, amount, period = 'monthly', name } = args;
 
     // Validate category_id format
-    if (!/^[A-Za-z0-9_-]+$/.test(category_id)) {
-      throw new Error(`Invalid category_id format: ${category_id}`);
-    }
+    validateDocId(category_id, 'category_id');
 
     // Validate amount is positive
     if (amount <= 0) {
@@ -3052,9 +2897,8 @@ export class CopilotMoneyTools {
     }
 
     // Validate period
-    const validPeriods = ['monthly', 'yearly', 'weekly', 'daily'];
-    if (!validPeriods.includes(period)) {
-      throw new Error(`Invalid period: ${period}. Must be one of: ${validPeriods.join(', ')}`);
+    if (!(KNOWN_PERIODS as readonly string[]).includes(period)) {
+      throw new Error(`Invalid period: ${period}. Must be one of: ${KNOWN_PERIODS.join(', ')}`);
     }
 
     // Validate category exists
@@ -3138,9 +2982,7 @@ export class CopilotMoneyTools {
     const { budget_id, amount, period, name, is_active } = args;
 
     // Validate budget_id format
-    if (!/^[A-Za-z0-9_-]+$/.test(budget_id)) {
-      throw new Error(`Invalid budget_id format: ${budget_id}`);
-    }
+    validateDocId(budget_id, 'budget_id');
 
     // Validate budget exists
     const existingBudgets = await this.db.getBudgets();
@@ -3220,9 +3062,7 @@ export class CopilotMoneyTools {
     const { budget_id } = args;
 
     // Validate budget_id format
-    if (!/^[A-Za-z0-9_-]+$/.test(budget_id)) {
-      throw new Error(`Invalid budget_id format: ${budget_id}`);
-    }
+    validateDocId(budget_id, 'budget_id');
 
     // Validate budget exists
     const existingBudgets = await this.db.getBudgets();
@@ -3268,14 +3108,11 @@ export class CopilotMoneyTools {
     const { recurring_id, state } = args;
 
     // Validate recurring_id format
-    if (!/^[A-Za-z0-9_-]+$/.test(recurring_id)) {
-      throw new Error(`Invalid recurring_id format: ${recurring_id}`);
-    }
+    validateDocId(recurring_id, 'recurring_id');
 
     // Validate state
-    const validStates = ['active', 'paused', 'archived'];
-    if (!validStates.includes(state)) {
-      throw new Error(`Invalid state: ${state}. Must be one of: ${validStates.join(', ')}`);
+    if (!(RECURRING_STATES as readonly string[]).includes(state)) {
+      throw new Error(`Invalid state: ${state}. Must be one of: ${RECURRING_STATES.join(', ')}`);
     }
 
     // Validate recurring exists (false = include inactive)
@@ -3328,9 +3165,7 @@ export class CopilotMoneyTools {
     const { recurring_id } = args;
 
     // Validate recurring_id format
-    if (!/^[A-Za-z0-9_-]+$/.test(recurring_id)) {
-      throw new Error(`Invalid recurring_id format: ${recurring_id}`);
-    }
+    validateDocId(recurring_id, 'recurring_id');
 
     // Validate recurring exists
     const allRecurring = await this.db.getRecurring(false);
@@ -3380,9 +3215,7 @@ export class CopilotMoneyTools {
     const { goal_id, name, emoji, target_amount, monthly_contribution, status } = args;
 
     // Validate goal_id format
-    if (!/^[A-Za-z0-9_-]+$/.test(goal_id)) {
-      throw new Error(`Invalid goal_id format: ${goal_id}`);
-    }
+    validateDocId(goal_id, 'goal_id');
 
     // Validate at least one field to update
     const fieldsToUpdate: Record<string, unknown> = {};
@@ -3469,9 +3302,7 @@ export class CopilotMoneyTools {
     const { goal_id } = args;
 
     // Validate goal_id format
-    if (!/^[A-Za-z0-9_-]+$/.test(goal_id)) {
-      throw new Error(`Invalid goal_id format: ${goal_id}`);
-    }
+    validateDocId(goal_id, 'goal_id');
 
     // Validate goal exists (include inactive goals)
     const goals = await this.db.getGoals(false);

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -47,6 +47,15 @@ function validateDocId(id: string, label: string): void {
   }
 }
 
+const HEX_COLOR_RE = /^#[0-9A-Fa-f]{6}$/;
+
+/** Validate that a color string is a valid #RRGGBB hex code. */
+function validateHexColor(color: string): void {
+  if (!HEX_COLOR_RE.test(color)) {
+    throw new Error(`Invalid color format: ${color} (expected #RRGGBB)`);
+  }
+}
+
 /**
  * Plaid category ID for foreign transaction fees (snake_case format).
  * @see https://plaid.com/docs/api/products/transactions/#categoriesget
@@ -2260,7 +2269,10 @@ export class CopilotMoneyTools {
       excluded,
     };
     if (emoji) docFields.emoji = emoji;
-    if (color) docFields.color = color;
+    if (color) {
+      validateHexColor(color);
+      docFields.color = color;
+    }
     if (parent_category_id) docFields.parent_category_id = parent_category_id;
 
     // Write to Firestore
@@ -2641,10 +2653,7 @@ export class CopilotMoneyTools {
       throw new Error(`Cannot generate a valid tag_id from name: ${trimmedName}`);
     }
 
-    // Validate hex_color format if provided
-    if (hex_color !== undefined && !/^#[0-9A-Fa-f]{6}$/.test(hex_color)) {
-      throw new Error(`Invalid hex_color format: ${hex_color} (expected #RRGGBB)`);
-    }
+    if (hex_color !== undefined) validateHexColor(hex_color);
 
     // Check for duplicate tag
     const existingTags = await this.db.getTags();
@@ -2783,9 +2792,7 @@ export class CopilotMoneyTools {
       updateMask.push('emoji');
     }
     if (color !== undefined) {
-      if (!/^#[0-9A-Fa-f]{6}$/.test(color)) {
-        throw new Error(`Invalid color format: ${color} (expected #RRGGBB)`);
-      }
+      validateHexColor(color);
       fieldsToUpdate.color = color;
       updateMask.push('color');
     }

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -2857,13 +2857,13 @@ describe('createTag', () => {
 
   test('throws on invalid hex_color format', async () => {
     await expect(tools.createTag({ name: 'test', hex_color: 'red' })).rejects.toThrow(
-      'Invalid hex_color format'
+      'Invalid color format'
     );
   });
 
   test('throws on short hex_color', async () => {
     await expect(tools.createTag({ name: 'test', hex_color: '#FFF' })).rejects.toThrow(
-      'Invalid hex_color format'
+      'Invalid color format'
     );
   });
 

--- a/tests/unit/server.test.ts
+++ b/tests/unit/server.test.ts
@@ -247,9 +247,22 @@ describe('CopilotMoneyServer write mode', () => {
     expect(toolNames).toContain('get_transactions');
     expect(toolNames).toContain('set_transaction_category');
     expect(toolNames).toContain('set_transaction_note');
+    expect(toolNames).toContain('set_transaction_excluded');
+    expect(toolNames).toContain('set_transaction_name');
+    expect(toolNames).toContain('set_internal_transfer');
+    expect(toolNames).toContain('set_transaction_goal');
     expect(toolNames).toContain('create_tag');
     expect(toolNames).toContain('delete_tag');
     expect(toolNames).toContain('create_category');
+    expect(toolNames).toContain('update_category');
+    expect(toolNames).toContain('delete_category');
+    expect(toolNames).toContain('create_budget');
+    expect(toolNames).toContain('update_budget');
+    expect(toolNames).toContain('delete_budget');
+    expect(toolNames).toContain('set_recurring_state');
+    expect(toolNames).toContain('delete_recurring');
+    expect(toolNames).toContain('update_goal');
+    expect(toolNames).toContain('delete_goal');
   });
 
   test('write tool has correct annotations', () => {
@@ -352,6 +365,137 @@ describe('CopilotMoneyServer write mode', () => {
     expect((result.content[0] as { text: string }).text).toContain('--write mode');
   });
 
+  test('handleCallTool rejects set_transaction_excluded when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('set_transaction_excluded', {
+      transaction_id: 'txn1',
+      excluded: true,
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects set_transaction_name when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('set_transaction_name', {
+      transaction_id: 'txn1',
+      name: 'New Name',
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects set_internal_transfer when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('set_internal_transfer', {
+      transaction_id: 'txn1',
+      internal_transfer: true,
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects set_transaction_goal when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('set_transaction_goal', {
+      transaction_id: 'txn1',
+      goal_id: 'goal1',
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects update_category when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('update_category', {
+      category_id: 'test',
+      name: 'New Name',
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects delete_category when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('delete_category', { category_id: 'test' });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects create_budget when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('create_budget', {
+      category_id: 'food',
+      amount: 500,
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects update_budget when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('update_budget', {
+      budget_id: 'budget_123',
+      amount: 600,
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects delete_budget when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('delete_budget', { budget_id: 'budget_123' });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects set_recurring_state when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('set_recurring_state', {
+      recurring_id: 'rec_123',
+      state: 'paused',
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects delete_recurring when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('delete_recurring', { recurring_id: 'rec_123' });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects update_goal when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('update_goal', {
+      goal_id: 'goal_123',
+      name: 'New Name',
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
+  test('handleCallTool rejects delete_goal when not in write mode', async () => {
+    const server = new CopilotMoneyServer();
+    const result = await server.handleCallTool('delete_goal', { goal_id: 'goal_123' });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toContain('--write mode');
+  });
+
   test('handleListTools includes create_category when writeEnabled', () => {
     const server = new CopilotMoneyServer(undefined, undefined, true);
     const result = server.handleListTools();
@@ -364,7 +508,7 @@ describe('CopilotMoneyServer write mode', () => {
 describe('createWriteToolSchemas', () => {
   test('returns write tool schemas with proper annotations', () => {
     const schemas = createWriteToolSchemas();
-    expect(schemas.length).toBeGreaterThanOrEqual(7);
+    expect(schemas.length).toBeGreaterThanOrEqual(20);
 
     const setCat = schemas.find((s) => s.name === 'set_transaction_category');
     expect(setCat).toBeDefined();


### PR DESCRIPTION
## Summary

- Adds 13 new write tools across 5 categories, bringing the total to 20 write tools (32 tools overall)
- **Transaction tools** (4): `set_transaction_excluded`, `set_transaction_name`, `set_internal_transfer`, `set_transaction_goal`
- **Category tools** (2): `update_category`, `delete_category`
- **Budget tools** (3): `create_budget`, `update_budget`, `delete_budget`
- **Recurring tools** (2): `set_recurring_state`, `delete_recurring`
- **Goal tools** (2): `update_goal`, `delete_goal`

All tools follow the established pattern: validate inputs, write via Firestore REST API, optimistically patch or clear cache. Each tool is gated behind `--write` mode.

## Test plan

- [x] All 1139 tests pass (`bun run check`)
- [x] Typecheck, lint, format all clean
- [x] Manifest synced (32 tools)
- [x] Write-mode rejection tests for all 20 write tools
- [x] Schema validation tests for all write tool schemas
- [ ] Manual verification of Firestore writes for new entity types (budgets, recurring, goals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)