### PR TITLE
feat: add 3 write tools — updateTag, createRecurring, createGoal

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -155,6 +155,18 @@
     {
       "name": "delete_goal",
       "description": "Delete a financial goal."
+    },
+    {
+      "name": "update_tag",
+      "description": "Update an existing tag's name or color."
+    },
+    {
+      "name": "create_recurring",
+      "description": "Create a new recurring/subscription item."
+    },
+    {
+      "name": "create_goal",
+      "description": "Create a new financial goal."
     }
   ],
   "tools_generated": false,

--- a/src/server.ts
+++ b/src/server.ts
@@ -114,6 +114,9 @@ export class CopilotMoneyServer {
     'delete_recurring',
     'update_goal',
     'delete_goal',
+    'update_tag',
+    'create_recurring',
+    'create_goal',
   ]);
 
   async handleCallTool(name: string, typedArgs?: Record<string, unknown>): Promise<CallToolResult> {
@@ -332,6 +335,24 @@ export class CopilotMoneyServer {
         case 'delete_goal':
           result = await this.tools.deleteGoal(
             typedArgs as Parameters<typeof this.tools.deleteGoal>[0]
+          );
+          break;
+
+        case 'update_tag':
+          result = await this.tools.updateTag(
+            typedArgs as Parameters<typeof this.tools.updateTag>[0]
+          );
+          break;
+
+        case 'create_recurring':
+          result = await this.tools.createRecurring(
+            typedArgs as Parameters<typeof this.tools.createRecurring>[0]
+          );
+          break;
+
+        case 'create_goal':
+          result = await this.tools.createGoal(
+            typedArgs as Parameters<typeof this.tools.createGoal>[0]
           );
           break;
 

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3473,6 +3473,9 @@ export class CopilotMoneyTools {
     if (category_id !== undefined) validateDocId(category_id, 'category_id');
     if (account_id !== undefined) validateDocId(account_id, 'account_id');
 
+    // Validate start_date format
+    if (start_date !== undefined) validateDate(start_date, 'start_date');
+
     // Generate unique recurring_id
     const recurringId = crypto.randomUUID();
 
@@ -3550,6 +3553,9 @@ export class CopilotMoneyTools {
       throw new Error('monthly_contribution must be >= 0');
     }
 
+    // Validate start_date format
+    if (start_date !== undefined) validateDate(start_date, 'start_date');
+
     // Generate unique goal_id
     const goalId = crypto.randomUUID();
 
@@ -3565,7 +3571,7 @@ export class CopilotMoneyTools {
         type: 'savings',
         status: 'active',
         target_amount,
-        tracking_type: monthly_contribution ? 'monthly_contribution' : 'manual',
+        tracking_type: monthly_contribution !== undefined ? 'monthly_contribution' : 'manual',
         tracking_type_monthly_contribution: monthly_contribution ?? 0,
         start_date: start_date ?? today,
         is_ongoing: false,

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -110,6 +110,12 @@ export const UNREALISTIC_AMOUNT_THRESHOLD = 1_000_000;
  */
 export const MAX_VALID_AMOUNT = 10_000_000;
 
+/**
+ * Accepted frequency values for creating recurring items.
+ * Subset of KNOWN_FREQUENCIES from the model -- only user-facing values.
+ */
+const VALID_RECURRING_FREQUENCIES = ['weekly', 'biweekly', 'monthly', 'yearly'] as const;
+
 // ============================================
 // Validation Helpers
 // ============================================
@@ -3345,6 +3351,243 @@ export class CopilotMoneyTools {
       deleted_name: goal.name ?? goal_id,
     };
   }
+
+  /**
+   * Update an existing tag's name and/or color.
+   *
+   * Validates the tag exists, builds a dynamic update mask for only the
+   * provided fields, writes to Firestore, then clears the cache.
+   */
+  async updateTag(args: {
+    tag_id: string;
+    name?: string;
+    color_name?: string;
+    hex_color?: string;
+  }): Promise<{
+    success: boolean;
+    tag_id: string;
+    updated_fields: string[];
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { tag_id, name, color_name, hex_color } = args;
+
+    // Validate tag_id format
+    validateDocId(tag_id, 'tag_id');
+
+    // Validate tag exists
+    const existingTags = await this.db.getTags();
+    const tag = existingTags.find((t) => t.tag_id === tag_id);
+    if (!tag) {
+      throw new Error(`Tag not found: ${tag_id}`);
+    }
+
+    // Build dynamic update fields
+    const fieldsToUpdate: Record<string, unknown> = {};
+    const updateMask: string[] = [];
+
+    if (name !== undefined) {
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        throw new Error('Tag name must not be empty');
+      }
+      fieldsToUpdate.name = trimmedName;
+      updateMask.push('name');
+    }
+    if (color_name !== undefined) {
+      fieldsToUpdate.color_name = color_name;
+      updateMask.push('color_name');
+    }
+    if (hex_color !== undefined) {
+      validateHexColor(hex_color);
+      fieldsToUpdate.hex_color = hex_color;
+      updateMask.push('hex_color');
+    }
+
+    if (updateMask.length === 0) {
+      throw new Error('No fields to update. Provide at least one of: name, color_name, hex_color');
+    }
+
+    // Resolve user_id
+    const userId = await client.requireUserId();
+
+    // Write to Firestore with dynamic update mask
+    const collectionPath = `users/${userId}/tags`;
+    const firestoreFields = toFirestoreFields(fieldsToUpdate);
+    await client.updateDocument(collectionPath, tag_id, firestoreFields, updateMask);
+
+    // Clear cache so the updated tag is visible on next query
+    this.db.clearCache();
+
+    return {
+      success: true,
+      tag_id,
+      updated_fields: updateMask,
+    };
+  }
+
+  /**
+   * Create a new recurring/subscription item.
+   *
+   * Generates a unique recurring_id, writes to Firestore, then clears the cache
+   * so the new recurring item is visible on next query.
+   */
+  async createRecurring(args: {
+    name: string;
+    amount: number;
+    frequency: string;
+    category_id?: string;
+    account_id?: string;
+    merchant_name?: string;
+    start_date?: string;
+  }): Promise<{
+    success: boolean;
+    recurring_id: string;
+    name: string;
+    amount: number;
+    frequency: string;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { name, amount, frequency, category_id, account_id, merchant_name, start_date } = args;
+
+    // Validate name is non-empty
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      throw new Error('Recurring name must not be empty');
+    }
+
+    // Validate amount is positive
+    if (amount <= 0) {
+      throw new Error('Recurring amount must be greater than 0');
+    }
+
+    // Validate frequency
+    if (!(VALID_RECURRING_FREQUENCIES as readonly string[]).includes(frequency)) {
+      throw new Error(
+        `Invalid frequency: ${frequency}. Must be one of: ${VALID_RECURRING_FREQUENCIES.join(', ')}`
+      );
+    }
+
+    // Validate optional IDs
+    if (category_id !== undefined) validateDocId(category_id, 'category_id');
+    if (account_id !== undefined) validateDocId(account_id, 'account_id');
+
+    // Generate unique recurring_id
+    const recurringId = crypto.randomUUID();
+
+    // Resolve user_id
+    const userId = await client.requireUserId();
+
+    // Build document fields
+    const today = new Date().toISOString().slice(0, 10);
+    const docFields: Record<string, unknown> = {
+      recurring_id: recurringId,
+      name: trimmedName,
+      amount,
+      frequency,
+      is_active: true,
+      state: 'active',
+      latest_date: start_date ?? today,
+    };
+    if (category_id !== undefined) docFields.category_id = category_id;
+    if (account_id !== undefined) docFields.account_id = account_id;
+    if (merchant_name !== undefined) docFields.merchant_name = merchant_name;
+    if (start_date !== undefined) docFields.start_date = start_date;
+
+    // Write to Firestore
+    const collectionPath = `users/${userId}/recurring`;
+    const firestoreFields = toFirestoreFields(docFields);
+    await client.createDocument(collectionPath, recurringId, firestoreFields);
+
+    // Clear cache so the new recurring item is visible on next query
+    this.db.clearCache();
+
+    return {
+      success: true,
+      recurring_id: recurringId,
+      name: trimmedName,
+      amount,
+      frequency,
+    };
+  }
+
+  /**
+   * Create a new financial goal.
+   *
+   * Generates a unique goal_id, writes to Firestore with a savings sub-object,
+   * then clears the cache so the new goal is visible on next query.
+   */
+  async createGoal(args: {
+    name: string;
+    target_amount: number;
+    emoji?: string;
+    monthly_contribution?: number;
+    start_date?: string;
+  }): Promise<{
+    success: boolean;
+    goal_id: string;
+    name: string;
+    target_amount: number;
+  }> {
+    const client = this.getFirestoreClient();
+
+    const { name, target_amount, emoji, monthly_contribution, start_date } = args;
+
+    // Validate name is non-empty
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      throw new Error('Goal name must not be empty');
+    }
+
+    // Validate target_amount is positive
+    if (target_amount <= 0) {
+      throw new Error('target_amount must be greater than 0');
+    }
+
+    // Validate monthly_contribution if provided
+    if (monthly_contribution !== undefined && monthly_contribution < 0) {
+      throw new Error('monthly_contribution must be >= 0');
+    }
+
+    // Generate unique goal_id
+    const goalId = crypto.randomUUID();
+
+    // Resolve user_id
+    const userId = await client.requireUserId();
+
+    // Build document fields
+    const today = new Date().toISOString().slice(0, 10);
+    const docFields: Record<string, unknown> = {
+      goal_id: goalId,
+      name: trimmedName,
+      savings: {
+        type: 'savings',
+        status: 'active',
+        target_amount,
+        tracking_type: monthly_contribution ? 'monthly_contribution' : 'manual',
+        tracking_type_monthly_contribution: monthly_contribution ?? 0,
+        start_date: start_date ?? today,
+        is_ongoing: false,
+      },
+    };
+    if (emoji !== undefined) docFields.emoji = emoji;
+
+    // Write to Firestore
+    const collectionPath = `users/${userId}/financial_goals`;
+    const firestoreFields = toFirestoreFields(docFields);
+    await client.createDocument(collectionPath, goalId, firestoreFields);
+
+    // Clear cache so the new goal is visible on next query
+    this.db.clearCache();
+
+    return {
+      success: true,
+      goal_id: goalId,
+      name: trimmedName,
+      target_amount,
+    };
+  }
 }
 
 /**
@@ -4416,6 +4659,127 @@ export function createWriteToolSchemas(): ToolSchema[] {
         readOnlyHint: false,
         destructiveHint: true,
         idempotentHint: true,
+      },
+    },
+    {
+      name: 'update_tag',
+      description:
+        'Update an existing tag. Provide tag_id (required) and at least one of name, ' +
+        'color_name, or hex_color. Only the specified fields are updated. ' +
+        'Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          tag_id: {
+            type: 'string',
+            description: 'Tag ID to update',
+          },
+          name: {
+            type: 'string',
+            description: 'New display name for the tag',
+          },
+          color_name: {
+            type: 'string',
+            description: 'New color name (e.g. "blue", "red")',
+          },
+          hex_color: {
+            type: 'string',
+            description: 'New hex color code (e.g. "#FF5733")',
+          },
+        },
+        required: ['tag_id'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+      },
+    },
+    {
+      name: 'create_recurring',
+      description:
+        'Create a new recurring/subscription item. Requires a name, amount, and frequency. ' +
+        'Optionally set category, account, merchant name, or start date. ' +
+        'Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Name of the recurring item (e.g. "Netflix", "Gym Membership")',
+          },
+          amount: {
+            type: 'number',
+            description: 'Recurring amount (must be greater than 0)',
+          },
+          frequency: {
+            type: 'string',
+            enum: ['weekly', 'biweekly', 'monthly', 'yearly'],
+            description: 'How often the charge recurs',
+          },
+          category_id: {
+            type: 'string',
+            description: 'Category ID for this recurring item (from get_categories)',
+          },
+          account_id: {
+            type: 'string',
+            description: 'Account ID for this recurring item (from get_accounts)',
+          },
+          merchant_name: {
+            type: 'string',
+            description: 'Merchant name for the recurring charge',
+          },
+          start_date: {
+            type: 'string',
+            description: 'Start date in ISO format (YYYY-MM-DD). Defaults to today.',
+          },
+        },
+        required: ['name', 'amount', 'frequency'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+      },
+    },
+    {
+      name: 'create_goal',
+      description:
+        'Create a new financial goal. Requires a name and target amount. ' +
+        'Optionally set an emoji, monthly contribution, or start date. ' +
+        'Writes directly to Copilot Money via Firestore.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'Name of the financial goal (e.g. "Emergency Fund", "Vacation")',
+          },
+          target_amount: {
+            type: 'number',
+            description: 'Target savings amount (must be greater than 0)',
+          },
+          emoji: {
+            type: 'string',
+            description: 'Emoji icon for the goal (e.g. "🏖️")',
+          },
+          monthly_contribution: {
+            type: 'number',
+            description:
+              'Monthly contribution amount (must be >= 0). ' +
+              'Sets tracking to monthly_contribution mode when provided.',
+          },
+          start_date: {
+            type: 'string',
+            description: 'Start date in ISO format (YYYY-MM-DD). Defaults to today.',
+          },
+        },
+        required: ['name', 'target_amount'],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
       },
     },
   ];

--- a/tests/tools/write-tools-phase3.test.ts
+++ b/tests/tools/write-tools-phase3.test.ts
@@ -1,0 +1,573 @@
+/**
+ * Unit tests for Phase 3 write tools: updateTag, createRecurring, createGoal.
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { CopilotMoneyTools } from '../../src/tools/tools.js';
+import { CopilotDatabase } from '../../src/core/database.js';
+
+// ============================================
+// updateTag
+// ============================================
+
+describe('updateTag', () => {
+  let tools: CopilotMoneyTools;
+  let mockDb: CopilotDatabase;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let updateCalls: { collection: string; docId: string; fields: any; mask: string[] }[];
+
+  beforeEach(() => {
+    mockDb = new CopilotDatabase('/nonexistent');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any).dbPath = '/fake';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._allCollectionsLoaded = true;
+    (mockDb as any)._cacheLoadedAt = Date.now();
+    (mockDb as any)._tags = [
+      { tag_id: 'vacation', name: 'Vacation' },
+      { tag_id: 'business', name: 'Business', color_name: 'blue', hex_color: '#0000FF' },
+    ];
+
+    updateCalls = [];
+    const mockFirestoreClient = {
+      requireUserId: async () => 'user123',
+      getUserId: () => 'user123',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createDocument: async () => {},
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      updateDocument: async (collection: string, docId: string, fields: any, mask: string[]) => {
+        updateCalls.push({ collection, docId, fields, mask });
+      },
+      deleteDocument: async () => {},
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools = new CopilotMoneyTools(mockDb, mockFirestoreClient as any);
+  });
+
+  test('updates tag name', async () => {
+    const result = await tools.updateTag({ tag_id: 'vacation', name: 'Holiday' });
+    expect(result.success).toBe(true);
+    expect(result.tag_id).toBe('vacation');
+    expect(result.updated_fields).toEqual(['name']);
+  });
+
+  test('updates tag color', async () => {
+    const result = await tools.updateTag({
+      tag_id: 'vacation',
+      color_name: 'red',
+      hex_color: '#FF0000',
+    });
+    expect(result.success).toBe(true);
+    expect(result.updated_fields).toContain('color_name');
+    expect(result.updated_fields).toContain('hex_color');
+  });
+
+  test('updates all fields at once', async () => {
+    const result = await tools.updateTag({
+      tag_id: 'vacation',
+      name: 'Trip',
+      color_name: 'green',
+      hex_color: '#00FF00',
+    });
+    expect(result.success).toBe(true);
+    expect(result.updated_fields).toEqual(['name', 'color_name', 'hex_color']);
+  });
+
+  test('calls Firestore updateDocument with correct path and mask', async () => {
+    await tools.updateTag({ tag_id: 'vacation', name: 'Holiday' });
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].collection).toBe('users/user123/tags');
+    expect(updateCalls[0].docId).toBe('vacation');
+    expect(updateCalls[0].mask).toEqual(['name']);
+    expect(updateCalls[0].fields).toEqual({
+      name: { stringValue: 'Holiday' },
+    });
+  });
+
+  test('clears cache after update', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions = [{ transaction_id: 'txn1', amount: 10, date: '2024-01-01' }];
+    await tools.updateTag({ tag_id: 'vacation', name: 'Holiday' });
+    // clearCache sets _transactions to null
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockDb as any)._transactions).toBeNull();
+  });
+
+  test('throws when no fields provided', async () => {
+    await expect(tools.updateTag({ tag_id: 'vacation' })).rejects.toThrow('No fields to update');
+  });
+
+  test('throws on invalid tag_id format', async () => {
+    await expect(tools.updateTag({ tag_id: 'bad/id', name: 'test' })).rejects.toThrow(
+      'Invalid tag_id format'
+    );
+  });
+
+  test('throws when tag not found', async () => {
+    await expect(tools.updateTag({ tag_id: 'nonexistent', name: 'test' })).rejects.toThrow(
+      'Tag not found: nonexistent'
+    );
+  });
+
+  test('throws on empty name', async () => {
+    await expect(tools.updateTag({ tag_id: 'vacation', name: '' })).rejects.toThrow(
+      'Tag name must not be empty'
+    );
+  });
+
+  test('throws on whitespace-only name', async () => {
+    await expect(tools.updateTag({ tag_id: 'vacation', name: '   ' })).rejects.toThrow(
+      'Tag name must not be empty'
+    );
+  });
+
+  test('throws on invalid hex_color format', async () => {
+    await expect(tools.updateTag({ tag_id: 'vacation', hex_color: 'red' })).rejects.toThrow(
+      'Invalid color format'
+    );
+  });
+
+  test('throws on short hex_color', async () => {
+    await expect(tools.updateTag({ tag_id: 'vacation', hex_color: '#FFF' })).rejects.toThrow(
+      'Invalid color format'
+    );
+  });
+
+  test('trims whitespace from name', async () => {
+    await tools.updateTag({ tag_id: 'vacation', name: '  Holiday  ' });
+    expect(updateCalls[0].fields).toEqual({
+      name: { stringValue: 'Holiday' },
+    });
+  });
+
+  test('throws when no Firestore client configured (read-only mode)', async () => {
+    const readOnlyTools = new CopilotMoneyTools(mockDb);
+    await expect(readOnlyTools.updateTag({ tag_id: 'vacation', name: 'test' })).rejects.toThrow(
+      'Write mode is not enabled'
+    );
+  });
+});
+
+// ============================================
+// createRecurring
+// ============================================
+
+describe('createRecurring', () => {
+  let tools: CopilotMoneyTools;
+  let mockDb: CopilotDatabase;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let createCalls: { collection: string; docId: string; fields: any }[];
+
+  beforeEach(() => {
+    mockDb = new CopilotDatabase('/nonexistent');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any).dbPath = '/fake';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._allCollectionsLoaded = true;
+    (mockDb as any)._cacheLoadedAt = Date.now();
+    (mockDb as any)._recurring = [];
+
+    createCalls = [];
+    const mockFirestoreClient = {
+      requireUserId: async () => 'user123',
+      getUserId: () => 'user123',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createDocument: async (collection: string, docId: string, fields: any) => {
+        createCalls.push({ collection, docId, fields });
+      },
+      updateDocument: async () => {},
+      deleteDocument: async () => {},
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools = new CopilotMoneyTools(mockDb, mockFirestoreClient as any);
+  });
+
+  test('creates a recurring item with required fields only', async () => {
+    const result = await tools.createRecurring({
+      name: 'Netflix',
+      amount: 15.99,
+      frequency: 'monthly',
+    });
+    expect(result.success).toBe(true);
+    expect(result.recurring_id).toBeDefined();
+    expect(result.name).toBe('Netflix');
+    expect(result.amount).toBe(15.99);
+    expect(result.frequency).toBe('monthly');
+  });
+
+  test('creates a recurring item with all fields', async () => {
+    const result = await tools.createRecurring({
+      name: 'Gym Membership',
+      amount: 50,
+      frequency: 'monthly',
+      category_id: 'fitness',
+      account_id: 'acc1',
+      merchant_name: 'Planet Fitness',
+      start_date: '2024-01-01',
+    });
+    expect(result.success).toBe(true);
+    expect(result.name).toBe('Gym Membership');
+    expect(result.amount).toBe(50);
+    expect(result.frequency).toBe('monthly');
+  });
+
+  test('calls Firestore createDocument with correct path', async () => {
+    const result = await tools.createRecurring({
+      name: 'Netflix',
+      amount: 15.99,
+      frequency: 'monthly',
+    });
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].collection).toBe('users/user123/recurring');
+    expect(createCalls[0].docId).toBe(result.recurring_id);
+  });
+
+  test('includes optional fields in Firestore document', async () => {
+    await tools.createRecurring({
+      name: 'Gym',
+      amount: 50,
+      frequency: 'monthly',
+      category_id: 'fitness',
+      account_id: 'acc1',
+      merchant_name: 'Planet Fitness',
+      start_date: '2024-06-01',
+    });
+    const fields = createCalls[0].fields;
+    expect(fields.category_id).toEqual({ stringValue: 'fitness' });
+    expect(fields.account_id).toEqual({ stringValue: 'acc1' });
+    expect(fields.merchant_name).toEqual({ stringValue: 'Planet Fitness' });
+    expect(fields.start_date).toEqual({ stringValue: '2024-06-01' });
+    expect(fields.latest_date).toEqual({ stringValue: '2024-06-01' });
+  });
+
+  test('sets latest_date to today when no start_date provided', async () => {
+    await tools.createRecurring({
+      name: 'Netflix',
+      amount: 15.99,
+      frequency: 'monthly',
+    });
+    const fields = createCalls[0].fields;
+    const today = new Date().toISOString().slice(0, 10);
+    expect(fields.latest_date).toEqual({ stringValue: today });
+  });
+
+  test('sets is_active and state fields', async () => {
+    await tools.createRecurring({
+      name: 'Netflix',
+      amount: 15.99,
+      frequency: 'monthly',
+    });
+    const fields = createCalls[0].fields;
+    expect(fields.is_active).toEqual({ booleanValue: true });
+    expect(fields.state).toEqual({ stringValue: 'active' });
+  });
+
+  test('clears cache after creating recurring item', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions = [{ transaction_id: 'txn1', amount: 10, date: '2024-01-01' }];
+    await tools.createRecurring({ name: 'Netflix', amount: 15.99, frequency: 'monthly' });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockDb as any)._transactions).toBeNull();
+  });
+
+  test('throws on empty name', async () => {
+    await expect(
+      tools.createRecurring({ name: '', amount: 15.99, frequency: 'monthly' })
+    ).rejects.toThrow('Recurring name must not be empty');
+  });
+
+  test('throws on whitespace-only name', async () => {
+    await expect(
+      tools.createRecurring({ name: '   ', amount: 15.99, frequency: 'monthly' })
+    ).rejects.toThrow('Recurring name must not be empty');
+  });
+
+  test('throws on zero amount', async () => {
+    await expect(
+      tools.createRecurring({ name: 'Netflix', amount: 0, frequency: 'monthly' })
+    ).rejects.toThrow('Recurring amount must be greater than 0');
+  });
+
+  test('throws on negative amount', async () => {
+    await expect(
+      tools.createRecurring({ name: 'Netflix', amount: -10, frequency: 'monthly' })
+    ).rejects.toThrow('Recurring amount must be greater than 0');
+  });
+
+  test('throws on invalid frequency', async () => {
+    await expect(
+      tools.createRecurring({ name: 'Netflix', amount: 15.99, frequency: 'daily' })
+    ).rejects.toThrow('Invalid frequency: daily');
+  });
+
+  test('throws on invalid category_id format', async () => {
+    await expect(
+      tools.createRecurring({
+        name: 'Netflix',
+        amount: 15.99,
+        frequency: 'monthly',
+        category_id: 'bad/id',
+      })
+    ).rejects.toThrow('Invalid category_id format');
+  });
+
+  test('throws on invalid account_id format', async () => {
+    await expect(
+      tools.createRecurring({
+        name: 'Netflix',
+        amount: 15.99,
+        frequency: 'monthly',
+        account_id: 'bad id',
+      })
+    ).rejects.toThrow('Invalid account_id format');
+  });
+
+  test('trims whitespace from name', async () => {
+    const result = await tools.createRecurring({
+      name: '  Netflix  ',
+      amount: 15.99,
+      frequency: 'monthly',
+    });
+    expect(result.name).toBe('Netflix');
+  });
+
+  test('accepts all valid frequencies', async () => {
+    for (const freq of ['weekly', 'biweekly', 'monthly', 'yearly']) {
+      const result = await tools.createRecurring({ name: 'Test', amount: 10, frequency: freq });
+      expect(result.frequency).toBe(freq);
+    }
+  });
+
+  test('throws when no Firestore client configured (read-only mode)', async () => {
+    const readOnlyTools = new CopilotMoneyTools(mockDb);
+    await expect(
+      readOnlyTools.createRecurring({ name: 'Netflix', amount: 15.99, frequency: 'monthly' })
+    ).rejects.toThrow('Write mode is not enabled');
+  });
+});
+
+// ============================================
+// createGoal
+// ============================================
+
+describe('createGoal', () => {
+  let tools: CopilotMoneyTools;
+  let mockDb: CopilotDatabase;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let createCalls: { collection: string; docId: string; fields: any }[];
+
+  beforeEach(() => {
+    mockDb = new CopilotDatabase('/nonexistent');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any).dbPath = '/fake';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._allCollectionsLoaded = true;
+    (mockDb as any)._cacheLoadedAt = Date.now();
+    (mockDb as any)._goals = [];
+
+    createCalls = [];
+    const mockFirestoreClient = {
+      requireUserId: async () => 'user123',
+      getUserId: () => 'user123',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createDocument: async (collection: string, docId: string, fields: any) => {
+        createCalls.push({ collection, docId, fields });
+      },
+      updateDocument: async () => {},
+      deleteDocument: async () => {},
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    tools = new CopilotMoneyTools(mockDb, mockFirestoreClient as any);
+  });
+
+  test('creates a goal with required fields only', async () => {
+    const result = await tools.createGoal({
+      name: 'Emergency Fund',
+      target_amount: 10000,
+    });
+    expect(result.success).toBe(true);
+    expect(result.goal_id).toBeDefined();
+    expect(result.name).toBe('Emergency Fund');
+    expect(result.target_amount).toBe(10000);
+  });
+
+  test('creates a goal with all fields', async () => {
+    const result = await tools.createGoal({
+      name: 'Vacation',
+      target_amount: 5000,
+      emoji: '🏖️',
+      monthly_contribution: 200,
+      start_date: '2024-01-01',
+    });
+    expect(result.success).toBe(true);
+    expect(result.name).toBe('Vacation');
+    expect(result.target_amount).toBe(5000);
+  });
+
+  test('calls Firestore createDocument with correct path', async () => {
+    const result = await tools.createGoal({
+      name: 'Emergency Fund',
+      target_amount: 10000,
+    });
+    expect(createCalls).toHaveLength(1);
+    expect(createCalls[0].collection).toBe('users/user123/financial_goals');
+    expect(createCalls[0].docId).toBe(result.goal_id);
+  });
+
+  test('builds savings sub-object with manual tracking by default', async () => {
+    await tools.createGoal({
+      name: 'Emergency Fund',
+      target_amount: 10000,
+    });
+    const fields = createCalls[0].fields;
+    const savings = fields.savings?.mapValue?.fields;
+    expect(savings).toBeDefined();
+    expect(savings.type).toEqual({ stringValue: 'savings' });
+    expect(savings.status).toEqual({ stringValue: 'active' });
+    expect(savings.target_amount).toEqual({ integerValue: '10000' });
+    expect(savings.tracking_type).toEqual({ stringValue: 'manual' });
+    expect(savings.tracking_type_monthly_contribution).toEqual({ integerValue: '0' });
+    expect(savings.is_ongoing).toEqual({ booleanValue: false });
+  });
+
+  test('sets tracking_type to monthly_contribution when provided', async () => {
+    await tools.createGoal({
+      name: 'Vacation',
+      target_amount: 5000,
+      monthly_contribution: 200,
+    });
+    const fields = createCalls[0].fields;
+    const savings = fields.savings?.mapValue?.fields;
+    expect(savings.tracking_type).toEqual({ stringValue: 'monthly_contribution' });
+    expect(savings.tracking_type_monthly_contribution).toEqual({ integerValue: '200' });
+  });
+
+  test('uses start_date in savings when provided', async () => {
+    await tools.createGoal({
+      name: 'Vacation',
+      target_amount: 5000,
+      start_date: '2024-06-01',
+    });
+    const fields = createCalls[0].fields;
+    const savings = fields.savings?.mapValue?.fields;
+    expect(savings.start_date).toEqual({ stringValue: '2024-06-01' });
+  });
+
+  test('uses today as default start_date in savings', async () => {
+    await tools.createGoal({
+      name: 'Emergency Fund',
+      target_amount: 10000,
+    });
+    const fields = createCalls[0].fields;
+    const savings = fields.savings?.mapValue?.fields;
+    const today = new Date().toISOString().slice(0, 10);
+    expect(savings.start_date).toEqual({ stringValue: today });
+  });
+
+  test('includes emoji in document when provided', async () => {
+    await tools.createGoal({
+      name: 'Vacation',
+      target_amount: 5000,
+      emoji: '🏖️',
+    });
+    const fields = createCalls[0].fields;
+    expect(fields.emoji).toEqual({ stringValue: '🏖️' });
+  });
+
+  test('omits emoji from document when not provided', async () => {
+    await tools.createGoal({
+      name: 'Emergency Fund',
+      target_amount: 10000,
+    });
+    const fields = createCalls[0].fields;
+    expect(fields.emoji).toBeUndefined();
+  });
+
+  test('clears cache after creating goal', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions = [{ transaction_id: 'txn1', amount: 10, date: '2024-01-01' }];
+    await tools.createGoal({ name: 'Emergency Fund', target_amount: 10000 });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockDb as any)._transactions).toBeNull();
+  });
+
+  test('throws on empty name', async () => {
+    await expect(tools.createGoal({ name: '', target_amount: 10000 })).rejects.toThrow(
+      'Goal name must not be empty'
+    );
+  });
+
+  test('throws on whitespace-only name', async () => {
+    await expect(tools.createGoal({ name: '   ', target_amount: 10000 })).rejects.toThrow(
+      'Goal name must not be empty'
+    );
+  });
+
+  test('throws on zero target_amount', async () => {
+    await expect(tools.createGoal({ name: 'Emergency Fund', target_amount: 0 })).rejects.toThrow(
+      'target_amount must be greater than 0'
+    );
+  });
+
+  test('throws on negative target_amount', async () => {
+    await expect(
+      tools.createGoal({ name: 'Emergency Fund', target_amount: -1000 })
+    ).rejects.toThrow('target_amount must be greater than 0');
+  });
+
+  test('throws on negative monthly_contribution', async () => {
+    await expect(
+      tools.createGoal({ name: 'Emergency Fund', target_amount: 10000, monthly_contribution: -50 })
+    ).rejects.toThrow('monthly_contribution must be >= 0');
+  });
+
+  test('allows zero monthly_contribution', async () => {
+    const result = await tools.createGoal({
+      name: 'Emergency Fund',
+      target_amount: 10000,
+      monthly_contribution: 0,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test('trims whitespace from name', async () => {
+    const result = await tools.createGoal({
+      name: '  Emergency Fund  ',
+      target_amount: 10000,
+    });
+    expect(result.name).toBe('Emergency Fund');
+  });
+
+  test('throws when no Firestore client configured (read-only mode)', async () => {
+    const readOnlyTools = new CopilotMoneyTools(mockDb);
+    await expect(
+      readOnlyTools.createGoal({ name: 'Emergency Fund', target_amount: 10000 })
+    ).rejects.toThrow('Write mode is not enabled');
+  });
+
+  test('does not modify cache on Firestore error', async () => {
+    const failingClient = {
+      requireUserId: async () => 'user123',
+      getUserId: () => 'user123',
+      createDocument: async () => {
+        throw new Error('Firestore create failed (500)');
+      },
+      updateDocument: async () => {},
+      deleteDocument: async () => {},
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const failTools = new CopilotMoneyTools(mockDb, failingClient as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (mockDb as any)._transactions = [{ transaction_id: 'txn1' }];
+
+    await expect(
+      failTools.createGoal({ name: 'Emergency Fund', target_amount: 10000 })
+    ).rejects.toThrow('Firestore create failed');
+    // Cache should NOT have been cleared since error happened before clearCache
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((mockDb as any)._transactions).not.toBeNull();
+  });
+});

--- a/tests/tools/write-tools-phase3.test.ts
+++ b/tests/tools/write-tools-phase3.test.ts
@@ -340,6 +340,27 @@ describe('createRecurring', () => {
     }
   });
 
+  test('throws on invalid start_date format', async () => {
+    await expect(
+      tools.createRecurring({
+        name: 'Netflix',
+        amount: 15.99,
+        frequency: 'monthly',
+        start_date: 'not-a-date',
+      })
+    ).rejects.toThrow('Invalid start_date format');
+  });
+
+  test('accepts valid start_date format', async () => {
+    const result = await tools.createRecurring({
+      name: 'Netflix',
+      amount: 15.99,
+      frequency: 'monthly',
+      start_date: '2024-06-15',
+    });
+    expect(result.success).toBe(true);
+  });
+
   test('throws when no Firestore client configured (read-only mode)', async () => {
     const readOnlyTools = new CopilotMoneyTools(mockDb);
     await expect(
@@ -524,13 +545,17 @@ describe('createGoal', () => {
     ).rejects.toThrow('monthly_contribution must be >= 0');
   });
 
-  test('allows zero monthly_contribution', async () => {
+  test('allows zero monthly_contribution and sets tracking_type to monthly_contribution', async () => {
     const result = await tools.createGoal({
       name: 'Emergency Fund',
       target_amount: 10000,
       monthly_contribution: 0,
     });
     expect(result.success).toBe(true);
+    const fields = createCalls[0].fields;
+    const savings = fields.savings?.mapValue?.fields;
+    expect(savings.tracking_type).toEqual({ stringValue: 'monthly_contribution' });
+    expect(savings.tracking_type_monthly_contribution).toEqual({ integerValue: '0' });
   });
 
   test('trims whitespace from name', async () => {
@@ -546,6 +571,21 @@ describe('createGoal', () => {
     await expect(
       readOnlyTools.createGoal({ name: 'Emergency Fund', target_amount: 10000 })
     ).rejects.toThrow('Write mode is not enabled');
+  });
+
+  test('throws on invalid start_date format', async () => {
+    await expect(
+      tools.createGoal({ name: 'Emergency Fund', target_amount: 10000, start_date: 'not-a-date' })
+    ).rejects.toThrow('Invalid start_date format');
+  });
+
+  test('accepts valid start_date format', async () => {
+    const result = await tools.createGoal({
+      name: 'Emergency Fund',
+      target_amount: 10000,
+      start_date: '2024-06-15',
+    });
+    expect(result.success).toBe(true);
   });
 
   test('does not modify cache on Firestore error', async () => {


### PR DESCRIPTION
## Summary

- **updateTag**: Rename tags and/or change their color (color_name/hex_color). Validates tag_id, requires at least one field to update.
- **createRecurring**: Create new recurring/subscription items with name, amount, frequency (weekly/biweekly/monthly/yearly), and optional category/account/merchant/start_date.
- **createGoal**: Create new financial goals with name, target_amount, and optional emoji/monthly_contribution/start_date. Builds proper savings sub-object for Copilot Money.

Each tool follows the established Phase 2 write tool pattern: Zod schema in `createWriteToolSchemas()`, async method in `CopilotMoneyTools`, server.ts switch case + WRITE_TOOLS set entry, and manifest.json entry.

**Files changed:** 4 files, +970 lines
- `src/tools/tools.ts` — 3 new methods + 3 schemas (+364 lines)
- `src/server.ts` — 3 switch cases + 3 WRITE_TOOLS entries (+21 lines)
- `manifest.json` — 3 tool entries (+12 lines)
- `tests/tools/write-tools-phase3.test.ts` — new test file (+573 lines)

## Test plan

- [x] All 1189 tests pass (`bun run check` — typecheck + lint + format + tests)
- [x] Happy path tests for each tool with all fields and minimal required fields
- [x] Validation error tests (missing required fields, invalid values, bad IDs)
- [x] Edge cases: updateTag with no fields, createRecurring frequency validation, createGoal target_amount validation
- [x] Firestore write assertions verify correct document paths and field values

🤖 Generated with [Claude Code](https://claude.com/claude-code)