### PR TITLE
Document opt-in write mode and Firebase/Firestore network access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Write mode (opt-in via `--write`)**: 24 new write tools for managing Copilot Money data. Read-only remains the default — write tools are completely disabled unless the server is started with `--write`.
+  - Transactions: `set_transaction_category`, `set_transaction_name`, `set_transaction_note`, `set_transaction_tags`, `set_transaction_excluded`, `set_transaction_goal`, `set_internal_transfer`, `review_transactions`
+  - Tags: `create_tag`, `update_tag`, `delete_tag`
+  - Categories: `create_category`, `update_category`, `delete_category`
+  - Budgets: `create_budget`, `update_budget`, `delete_budget`
+  - Goals: `create_goal`, `update_goal`, `delete_goal`
+  - Recurring: `create_recurring`, `update_recurring`, `set_recurring_state`, `delete_recurring`
+- **Firestore REST client** (`src/core/firestore-client.ts`): Authenticates to Copilot Money's Firebase/Firestore backend using a Firebase refresh token extracted from the local Copilot Money session. Write tools send authenticated requests directly to Google's Firestore REST API — the same backend the Copilot Money app itself uses. No third-party services or project-operated servers are involved.
+- Tool count increased from 17 to 41 (17 read + 24 write).
+
+### Changed
+- **[PRIVACY.md](PRIVACY.md)** updated to document opt-in write mode and the Firebase/Firestore network access required for writes. Default read-only mode remains 100% local with zero network requests.
+
 ### Fixed
 - **Total balance calculation**: Fixed `getAccounts()` total balance calculation to properly subtract debt from assets instead of adding all balances as positive values. This resolves inflated balance calculations for users with loans, mortgages, and credit cards.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tool count increased from 17 to 41 (17 read + 24 write).
 
 ### Changed
-- **[PRIVACY.md](PRIVACY.md)** updated to document opt-in write mode and the Firebase/Firestore network access required for writes. Default read-only mode remains 100% local with zero network requests.
+- **Documentation**: [PRIVACY.md](PRIVACY.md), [README.md](README.md), [SECURITY.md](SECURITY.md), [CLAUDE.md](CLAUDE.md), [docs/TESTING_GUIDE.md](docs/TESTING_GUIDE.md), [docs/MCPB_COMPLIANCE.md](docs/MCPB_COMPLIANCE.md), and [docs/REVERSE_ENGINEERING_FINDING.md](docs/REVERSE_ENGINEERING_FINDING.md) updated to accurately reflect opt-in write mode and the Firebase/Firestore network access required for writes. Default read-only mode remains 100% local with zero network requests.
 
 ### Fixed
 - **Total balance calculation**: Fixed `getAccounts()` total balance calculation to properly subtract debt from assets instead of adding all balances as positive values. This resolves inflated balance calculations for users with loans, mortgages, and credit cards.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Each MCP tool follows this pattern:
 
 ## Important Notes
 
-- **Privacy First**: 100% local processing, zero network requests
+- **Privacy First**: Reads are 100% local with zero network requests. Opt-in writes (`--write`) send authenticated requests directly to Copilot Money's own Firebase/Firestore backend via `src/core/firestore-client.ts` — no third-party services, no project-operated servers.
 - **Read-Only by Default**: Write tools require `--write` flag
 - **Database Location**: `~/Library/Containers/com.copilot.production/Data/Library/Application Support/firestore/__FIRAPP_DEFAULT/copilot-production-22904/main`
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy for Copilot Money MCP Server
 
-**Last Updated:** January 12, 2026
+**Last Updated:** April 11, 2026
 
 ## Disclaimer
 
@@ -10,16 +10,21 @@
 
 The Copilot Money MCP Server is designed with privacy as a core principle. This document outlines our privacy practices and commitments.
 
+The server operates in two modes:
+- **Read-only mode (default):** Reads data exclusively from your local Copilot Money database cache. No network requests are made.
+- **Write mode (opt-in, `--write` flag):** Adds the ability to modify your Copilot Money data. Because Copilot Money is backed by Google Firebase/Firestore, write operations require authenticated network requests to Firebase/Firestore on your behalf. See the [Write Mode and Network Access](#write-mode-and-network-access) section below.
+
 ## Data Collection
 
-**We do not collect, store, or transmit any of your data.**
+**We do not collect, store, or transmit any of your data to our servers or any third party.** The server has no backend, no analytics, and no telemetry.
 
 The Copilot Money MCP Server:
-- Operates entirely on your local machine
+- Operates on your local machine
 - Reads data only from your local Copilot Money database cache
-- Never sends your financial data to external servers
-- Never transmits data over the internet
+- Never sends your financial data to servers operated by this project (we don't have servers)
 - Does not include any analytics or telemetry
+- Makes zero network requests in the default read-only mode
+- In opt-in write mode, makes network requests **only** to Google Firebase/Firestore (the same backend Copilot Money itself uses) to apply the changes you request
 
 ## Data Access
 
@@ -33,14 +38,16 @@ The server reads from your local Copilot Money database, which is stored at:
 This database contains:
 - Transaction records (amounts, dates, merchant names, categories)
 - Account information (balances, account types, institution names)
-- Category data
+- Budgets, goals, tags, categories, and recurring transactions
+- Investment holdings, prices, and performance data
 
 ### How We Access Data
 
-- **Read-Only:** The server only reads data; it never modifies your Copilot Money database
-- **Local Processing:** All data processing happens on your machine
-- **No Network Requests:** The server makes zero network requests
-- **No External APIs:** No connections to third-party services
+- **Local Reads:** All data reads happen against your local Copilot Money database cache
+- **Local Processing:** All query processing, filtering, and aggregation happens on your machine
+- **Read-Only by Default:** In the default mode, the server only reads data and makes zero network requests
+- **No Third-Party Analytics:** No connections to analytics, tracking, or telemetry services
+- **Opt-In Writes:** Write operations are disabled unless you explicitly start the server with `--write`. When enabled, writes are sent directly to Google Firebase/Firestore — the same backend Copilot Money itself uses — and not to any intermediary operated by this project
 
 ## Data Usage
 
@@ -49,24 +56,31 @@ Data read from your local database is used exclusively to:
 2. Perform local calculations (e.g., spending aggregations, category summaries)
 3. Filter and search transactions based on your requests
 
-All processing happens in memory on your local machine and is never persisted outside of the existing Copilot Money database.
+If you explicitly enable write mode with `--write`, data you ask the server to modify is additionally used to:
+4. Construct authenticated Firestore REST API requests that apply your requested changes to your own Copilot Money account
+
+All processing happens in memory on your local machine. No data is persisted outside of the existing Copilot Money database and its native Firebase/Firestore backend.
 
 ## Data Sharing
 
 **We do not share your data with anyone.**
 
 - No data is sent to our servers (we don't have servers)
-- No data is sent to third parties
+- No data is sent to third parties for analytics, advertising, or tracking
 - No data is sent to Anthropic (beyond what Claude Desktop processes locally)
 - No analytics or crash reports are transmitted
+
+In opt-in write mode, requested changes are sent directly from your machine to Google Firebase/Firestore using your own Copilot Money credentials. This is the same backend Copilot Money itself uses to persist your data — no intermediary server operated by this project is involved. This traffic is governed by Google's and Copilot Money's own privacy policies.
 
 ## Data Security
 
 ### Technical Safeguards
 
-- **Local-Only Architecture:** All operations are performed locally
-- **No Network Access:** The server does not make network requests
-- **Read-Only Access:** Cannot modify or delete your financial data
+- **Local-First Architecture:** All queries, filtering, and aggregation happen locally
+- **No Network Access in Default Mode:** With read-only mode (default), the server makes zero network requests
+- **Opt-In Writes:** Write tools are disabled unless you explicitly start the server with `--write`
+- **Authenticated Writes Only:** When write mode is enabled, network requests go only to Google Firebase/Firestore, authenticated with your own Copilot Money credentials over HTTPS
+- **No Third-Party Network Destinations:** The server never contacts destinations other than Google's Firebase/Firestore endpoints (and only in write mode)
 - **macOS Sandbox Compliance:** Respects macOS file system permissions
 
 ### Your Control
@@ -76,6 +90,31 @@ You maintain full control over your data:
 - You can stop the server at any time by closing Claude Desktop
 - You can uninstall the server at any time
 - Your Copilot Money data remains in its original location
+- **Write mode is strictly opt-in:** Write tools are unavailable unless you explicitly start the server with `--write`. Without this flag, the server cannot modify your Copilot Money data even if instructed to do so
+
+## Write Mode and Network Access
+
+By default, the server starts in read-only mode and makes zero network requests. If you explicitly enable write mode by starting the server with the `--write` flag, the following additional behavior applies:
+
+### What Happens in Write Mode
+
+- The server can execute write tools that modify your Copilot Money data (categorizing transactions, creating budgets, editing goals, etc.)
+- To apply those changes, the server authenticates to Google Firebase using a Firebase refresh token extracted from your local Copilot Money session, then sends Firestore REST API requests directly to `https://firestore.googleapis.com`
+- These requests go to the **same Firebase/Firestore backend that Copilot Money itself uses** — your changes reach your own Copilot Money account, just as they would if you had made them in the Copilot Money app
+- No write traffic passes through any server operated by this project
+
+### What Does Not Happen
+
+- No write traffic is ever sent to servers operated by this project (we don't have any)
+- No write traffic is sent to Anthropic or any third party other than Google (Firebase/Firestore)
+- The server never initiates writes on its own — every write is the direct result of a tool call you (or an AI assistant on your behalf) issued
+- Your Firebase credentials are held only in memory and are never logged, persisted, or transmitted to anyone other than Google's token-exchange endpoint
+
+### Governing Policies
+
+Network traffic in write mode is subject to:
+- [Google's Privacy Policy](https://policies.google.com/privacy) (as Firebase/Firestore is operated by Google)
+- Copilot Money's own terms and privacy policy (as you are modifying data on their backend)
 
 ## Claude Desktop Integration
 
@@ -89,7 +128,8 @@ When integrated with Claude Desktop:
 
 This server does not integrate with any third-party services beyond:
 - **Claude Desktop** (optional, required for AI-powered queries)
-- **Copilot Money** (reads local database created by the app)
+- **Copilot Money** (reads the local database created by the app)
+- **Google Firebase / Firestore** (only in opt-in write mode; this is Copilot Money's own backend, accessed directly with your own Copilot Money credentials)
 
 ## Children's Privacy
 
@@ -103,7 +143,7 @@ We may update this privacy policy from time to time. Changes will be reflected i
 
 This server is open source. You can:
 - Review the source code at https://github.com/ignaciohermosillacornejo/copilot-money-mcp
-- Verify that no data is transmitted externally
+- Verify exactly which network destinations (if any) are contacted in each mode
 - Audit the data access patterns
 - Contribute improvements
 
@@ -115,4 +155,4 @@ For privacy-related questions or concerns:
 
 ## Summary
 
-**In short:** This server is a local-only tool that reads your Copilot Money data to enable AI-powered queries via Claude Desktop. Your data never leaves your machine, and we never collect, store, or transmit your financial information.
+**In short:** This server is a local-first tool that reads your Copilot Money data to enable AI-powered queries via Claude Desktop. In its default read-only mode, your data never leaves your machine. If you explicitly opt in to write mode with the `--write` flag, the server can additionally apply your requested changes by talking directly to Copilot Money's own Firebase/Firestore backend using your own credentials. We never collect, store, or transmit your financial information to servers operated by this project — we don't have any.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Overview
 
-An [MCP](https://modelcontextprotocol.io/) server that gives AI assistants access to your Copilot Money personal finance data. It reads from the locally cached Firestore database (LevelDB + Protocol Buffers) on your Mac — **100% local processing**, no network requests, all data stays on your machine.
+An [MCP](https://modelcontextprotocol.io/) server that gives AI assistants access to your Copilot Money personal finance data. It reads from the locally cached Firestore database (LevelDB + Protocol Buffers) on your Mac. **Reads are 100% local with zero network requests.** Optional write mode (opt-in via `--write`) sends your requested changes directly to Copilot Money's Firebase/Firestore backend — the same backend the Copilot Money app itself uses — authenticated with your own credentials, never through any third-party service.
 
 **41 tools** across spending, investments, budgets, goals, and more:
 
@@ -25,12 +25,12 @@ An [MCP](https://modelcontextprotocol.io/) server that gives AI assistants acces
 
 ## Privacy First
 
-Your financial data never leaves your machine. See our [Privacy Policy](PRIVACY.md) for details.
+We never collect, store, or transmit your data to any server operated by this project — we don't have any. See our [Privacy Policy](PRIVACY.md) for details.
 
-- No data collection or transmission
-- No external API calls (write mode uses local Firestore REST API only)
-- No analytics or telemetry
-- Read-only by default
+- No analytics, telemetry, or tracking of any kind
+- Reads are fully local — zero network requests
+- Read-only by default (write tools disabled unless you pass `--write`)
+- In opt-in write mode, requests go directly from your machine to Copilot Money's own Firebase/Firestore backend using your own credentials — never through any third-party service
 - Open source — verify the code yourself
 
 ## Quick Start
@@ -198,7 +198,7 @@ By default, the server starts in **read-only mode**. To enable write tools, star
 }
 ```
 
-Write tools modify your Copilot Money data via the local Firestore cache. Changes sync back to Copilot Money when the app is open.
+Write tools modify your Copilot Money data by sending authenticated requests directly to Copilot Money's Firebase/Firestore backend — the same backend the Copilot Money app uses — so your changes are immediately reflected in your account. Writes authenticate using a Firebase refresh token extracted from your local Copilot Money session; your credentials never leave your machine except in the authenticated request to Google's Firebase/Firestore endpoints. No third-party services are involved. See [PRIVACY.md](PRIVACY.md) for full details.
 
 ## Configuration
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,12 +42,13 @@ Instead, please report security issues via one of these methods:
 
 This project implements several security measures:
 
-1. **Local Processing Only**: All data processing happens locally. No network requests are made.
-2. **Read-Only Access**: The MCP server cannot modify the Copilot Money database.
-3. **No Data Exfiltration**: No telemetry, analytics, or data transmission.
-4. **OIDC Publishing**: npm packages are published using OIDC trusted publishing with provenance.
-5. **Code Review**: All PRs require owner approval for security-critical paths.
-6. **Dependency Auditing**: Regular security audits of dependencies.
+1. **Local-First Processing**: All query processing happens locally. In the default read-only mode, zero network requests are made.
+2. **Read-Only by Default**: Write tools are disabled unless the server is explicitly started with the `--write` flag. When enabled, writes are sent only to Copilot Money's own Firebase/Firestore backend, authenticated over HTTPS with the user's own credentials — no third-party services.
+3. **No Data Exfiltration**: No telemetry, analytics, or tracking. No data is ever sent to any server operated by this project.
+4. **In-Memory Credentials**: In write mode, the Firebase refresh token is held only in memory and is never logged, persisted, or transmitted to anyone other than Google's Firebase token-exchange endpoint.
+5. **OIDC Publishing**: npm packages are published using OIDC trusted publishing with provenance.
+6. **Code Review**: All PRs require owner approval for security-critical paths.
+7. **Dependency Auditing**: Regular security audits of dependencies.
 
 ### Scope
 

--- a/docs/MCPB_COMPLIANCE.md
+++ b/docs/MCPB_COMPLIANCE.md
@@ -78,10 +78,10 @@ We do not collect, store, or transmit any of your data.
 We do not share your data with anyone.
 ```
 
-**Our Status:** ✅ PRIVACY.md exists (4,174 bytes)
+**Our Status:** ✅ PRIVACY.md exists
 - Location: `/PRIVACY.md`
-- Covers: Data collection, access, usage, sharing, security
-- Commitments: 100% local, read-only, no transmission, no telemetry
+- Covers: Data collection, access, usage, sharing, security, opt-in write mode, Firebase/Firestore network access
+- Commitments: Read-only by default with zero network requests; opt-in `--write` mode sends authenticated requests directly to Copilot Money's own Firebase/Firestore backend (no third-party services); no telemetry or analytics
 
 **B. manifest.json v0.3 with privacy_policies array**
 ```json
@@ -103,19 +103,20 @@ We do not share your data with anyone.
 
 **C. README.md privacy section**
 ```markdown
-## Privacy & Security
+## Privacy First
 
-Your data never leaves your machine. See our [Privacy Policy](PRIVACY.md).
+We never collect, store, or transmit your data to any server operated by this project. See our [Privacy Policy](PRIVACY.md).
 
-- ✅ No data collection or transmission
-- ✅ No external API calls
-- ✅ Read-only access
+- ✅ No analytics, telemetry, or tracking
+- ✅ Reads are fully local — zero network requests
+- ✅ Read-only by default (write tools disabled unless `--write` is passed)
+- ✅ Opt-in writes go directly to Copilot Money's own Firebase/Firestore backend — never through a third party
 ```
 
 **Our Status:** ✅ README.md has privacy section
-- Section: "Privacy First" (lines 20-28)
+- Section: "Privacy First"
 - Link to PRIVACY.md
-- Clear privacy commitments listed
+- Clear privacy commitments listed (reads fully local, read-only by default, opt-in writes go only to Copilot Money's own Firebase/Firestore backend)
 
 **Verification:**
 ```bash
@@ -439,8 +440,9 @@ Expected: Specific account details with balance
 - [ ] No errors or crashes
 - [ ] Performance <5s per query
 - [ ] Error messages are helpful
-- [ ] No network requests (verify with Activity Monitor)
-- [ ] Privacy: Data stays local
+- [ ] No network requests in default read-only mode (verify with Activity Monitor)
+- [ ] In `--write` mode, network traffic should go only to `*.googleapis.com` (Firebase/Firestore) — no other destinations
+- [ ] Privacy: Read data stays local; write data goes only to Copilot Money's own Firebase/Firestore backend
 - [ ] No console errors in Claude Desktop logs
 
 ---
@@ -489,7 +491,7 @@ Edit `servers.json`:
     {
       "id": "copilot-money-mcp",
       "name": "Copilot Money MCP Server",
-      "description": "AI-powered personal finance queries using local Copilot Money data. 100% local processing, no data transmission.",
+      "description": "AI-powered personal finance queries and management using locally cached Copilot Money data. Reads are 100% local with zero network requests; opt-in write mode (--write) sends changes directly to Copilot Money's own Firebase/Firestore backend.",
       "repository": "https://github.com/ignaciohermosillacornejo/copilot-money-mcp",
       "mcpb_url": "https://github.com/ignaciohermosillacornejo/copilot-money-mcp/releases/download/v1.0.0/copilot-money-mcp.mcpb",
       "privacy_policy": "https://github.com/ignaciohermosillacornejo/copilot-money-mcp/blob/main/PRIVACY.md",
@@ -527,7 +529,7 @@ gh pr create \
 - ✅ 142 tests passing
 - ✅ Tested in Claude Desktop
 
-**Privacy:** 100% local processing, no data transmission, read-only access"
+**Privacy:** Read-only by default with zero network requests; opt-in --write mode sends changes directly to Copilot Money's own Firebase/Firestore backend (no third-party services, no project-operated servers)."
 ```
 
 **5. Wait for Review**

--- a/docs/REVERSE_ENGINEERING_FINDING.md
+++ b/docs/REVERSE_ENGINEERING_FINDING.md
@@ -960,9 +960,9 @@ CMD ["copilot-money-mcp"]
 
 ## Security Considerations
 
-1. **Data is local only** - No network requests, all data stays on your machine
-2. **Read-only access** - We only read from LevelDB, never write
-3. **No credentials stored** - No API keys or auth tokens needed
+1. **Reads are local only** - In the default read-only mode, zero network requests are made; all data stays on your machine
+2. **Read-only by default** - Write tools are disabled unless the server is explicitly started with `--write`. When enabled, writes go only to Copilot Money's own Firebase/Firestore backend — never to any third-party service
+3. **In-memory credentials** - Write mode uses a Firebase refresh token extracted from the local Copilot Money session; held only in memory, never logged or persisted
 4. **File permissions** - Respects macOS sandbox (data is in user's Library folder)
 
 ## Limitations

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -459,7 +459,22 @@ Verify that in read-only mode the server doesn't modify data:
 - No new transactions created
 - All data remains unchanged
 
-> In **write mode** (`--write`), the server *can* legitimately modify your Copilot Money data through the Firestore REST API. Write tests belong in the write-tool test suite, not here.
+> In **write mode** (`--write`), the server *can* legitimately modify your Copilot Money data through the Firestore REST API. Write tests belong in the write-tool test suite (see below), not here.
+
+### Write Mode Testing (Future Work)
+
+A dedicated end-to-end write-mode testing guide does not yet exist and is expected follow-up work. For now, the automated write-tool test suite under `tests/tools/` exercises the write code paths against a mocked `FirestoreClient`, and contributors adding new write tools should follow the existing patterns there.
+
+When an end-to-end guide is added, it should cover at minimum:
+
+1. **Safe environment setup**: Use a disposable Copilot Money account (or a non-production database copy) — writes *will* hit the real Firebase/Firestore backend and modify real data.
+2. **Start the server with `--write`**: Verify write tools are registered, and that attempting a write without `--write` returns the gating error message.
+3. **Credential handling**: Confirm the Firebase refresh token is held only in memory, is never written to disk or logs, and that the server exits cleanly without leaking credentials in error output.
+4. **Network destinations**: Use Activity Monitor / `tcpdump` / a proxy to confirm write-mode traffic is limited to `*.googleapis.com` (`securetoken.googleapis.com` for auth, `firestore.googleapis.com` for writes). No other destinations should appear.
+5. **Per-tool round-trips**: For each write tool, execute the tool, verify the change is visible in the Copilot Money app after sync, then revert it (cleanup). Document any tools that cannot be reverted via another tool.
+6. **Failure modes**: Expired / invalid refresh tokens, Firestore permission errors, and malformed document IDs should all surface clear, non-sensitive error messages.
+
+Contributions welcome — see [CONTRIBUTING.md](../CONTRIBUTING.md) for the "Adding a New Write Tool" pattern.
 
 ---
 

--- a/docs/TESTING_GUIDE.md
+++ b/docs/TESTING_GUIDE.md
@@ -422,28 +422,33 @@ Show me spending on category "INVALID_CATEGORY"
 
 ## Privacy & Security Tests
 
-### Test 1: No Network Requests
+> **Note:** These tests assume the default **read-only mode**. If you start the server with `--write`, write tools are enabled and the server will make authenticated HTTPS requests to Copilot Money's Firebase/Firestore backend to apply your requested changes — so Tests 1 and 2 below will not hold. Run these tests without the `--write` flag.
 
-1. **Disconnect from the internet**:
+### Test 1: No Network Requests (Read-Only Mode)
+
+1. **Start the server without `--write`** (default mode).
+
+2. **Disconnect from the internet**:
    - Turn off Wi-Fi
    - Or use Network Link Conditioner to block all traffic
 
-2. **Try several queries**:
-   - All queries should still work
+3. **Try several read queries**:
+   - All read queries should still work
    - No "network error" messages
 
-3. **Expected Result**:
-   - All tools work offline
+4. **Expected Result**:
+   - All read tools work offline
    - No network requests attempted
 
-### Test 2: Read-Only Access
+### Test 2: Read-Only Access (Default Mode)
 
-Verify the server doesn't modify data:
+Verify that in read-only mode the server doesn't modify data:
 
-1. **Note current transaction count** in Copilot Money
-2. **Run multiple queries** through Claude Desktop
-3. **Check Copilot Money** - transaction count should be unchanged
-4. **Check database files**:
+1. **Start the server without `--write`** (default mode).
+2. **Note current transaction count** in Copilot Money
+3. **Run multiple read queries** through Claude Desktop
+4. **Check Copilot Money** - transaction count should be unchanged
+5. **Check database files**:
    ```bash
    ls -l ~/Library/Containers/com.copilot.production/Data/Library/Application\ Support/firestore/__FIRAPP_DEFAULT/copilot-production-22904/main/*.ldb
    ```
@@ -453,6 +458,8 @@ Verify the server doesn't modify data:
 - Database files not modified by MCP
 - No new transactions created
 - All data remains unchanged
+
+> In **write mode** (`--write`), the server *can* legitimately modify your Copilot Money data through the Firestore REST API. Write tests belong in the write-tool test suite, not here.
 
 ---
 
@@ -574,7 +581,7 @@ Before considering testing complete, verify:
 - [ ] Memory usage is reasonable (<100MB)
 - [ ] Error handling is graceful
 - [ ] No crashes or hangs
-- [ ] Privacy is maintained (no network requests)
+- [ ] Privacy is maintained (no network requests in default read-only mode)
 - [ ] Data accuracy matches Copilot Money
 - [ ] Complex queries are handled well
 - [ ] Server survives multiple queries


### PR DESCRIPTION
## Summary

This PR updates documentation and policy files to accurately reflect the addition of opt-in write mode functionality. The changes clarify that the server operates in two distinct modes: a default read-only mode with zero network requests, and an optional write mode (enabled via `--write` flag) that makes authenticated requests directly to Copilot Money's Firebase/Firestore backend.

## Key Changes

- **PRIVACY.md**: Comprehensively updated to document:
  - Two operational modes (read-only default vs. opt-in write mode)
  - Clarification that read-only mode makes zero network requests
  - Explanation of write mode's Firebase/Firestore authentication and network behavior
  - New section "Write Mode and Network Access" detailing what happens, what doesn't happen, and governing policies
  - Emphasis that write traffic never passes through project-operated servers

- **README.md**: Updated privacy section to reflect:
  - Read-only default with zero network requests
  - Opt-in write mode that sends requests directly to Copilot Money's own Firebase/Firestore backend
  - Clarification that no third-party services are involved

- **SECURITY.md**: Revised security measures to document:
  - Local-first processing with zero network requests in default mode
  - Read-only by default with opt-in write capability
  - In-memory credential handling for write mode (Firebase refresh token)

- **TESTING_GUIDE.md**: Updated privacy & security tests to:
  - Clarify that tests assume read-only mode
  - Note that `--write` mode enables network requests to Firebase/Firestore
  - Separate read-only and write-mode test expectations

- **MCPB_COMPLIANCE.md**: Updated compliance documentation to reflect:
  - Write mode and Firebase/Firestore network access in privacy commitments
  - Updated server description for MCPB registry
  - Clarified privacy verification points

- **CHANGELOG.md**: Added unreleased section documenting:
  - 24 new write tools across transactions, tags, categories, budgets, goals, and recurring items
  - Firestore REST client implementation
  - Tool count increase from 17 to 41

- **docs/REVERSE_ENGINEERING_FINDING.md** and **CLAUDE.md**: Updated security notes to reflect read-only default and opt-in write mode behavior

## Notable Implementation Details

- All documentation maintains the core privacy principle: **no data is collected, stored, or transmitted to any server operated by this project**
- Write mode is strictly opt-in and requires explicit `--write` flag at startup
- Write operations authenticate directly to Google Firebase/Firestore using credentials extracted from the local Copilot Money session
- No intermediary servers or third-party services are involved in any operation
- Default read-only mode remains completely local with zero network requests

https://claude.ai/code/session_01JS3s5uz1QuvYc2v3CSm22s