### PR TITLE
fix: validate tag IDs exist in updateTransaction

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
         run: bun test --coverage --coverage-reporter=lcov tests/unit tests/models tests/core tests/utils
 
       - name: Upload unit test coverage to Codecov
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
         uses: codecov/codecov-action@v5
         with:
           files: coverage/lcov.info
@@ -75,6 +76,7 @@ jobs:
         run: bun test --coverage --coverage-reporter=lcov tests/e2e tests/tools tests/integration
 
       - name: Upload E2E test coverage to Codecov
+        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
         uses: codecov/codecov-action@v5
         with:
           files: coverage/lcov.info

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -4589,7 +4589,7 @@ export function createToolSchemas(): ToolSchema[] {
     {
       name: 'get_investment_performance',
       description:
-        'Get per-security investment performance data. Returns raw performance documents ' +
+        'Get per-security investment performance data. Returns structured performance records ' +
         'from Firestore, enriched with ticker symbol and name from the securities collection. ' +
         'Filter by ticker symbol or security ID.',
       inputSchema: {

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2448,6 +2448,14 @@ export class CopilotMoneyTools {
       for (const tagId of args.tag_ids) {
         validateDocId(tagId, 'tag_id');
       }
+      if (args.tag_ids.length > 0) {
+        const tags = await this.db.getTags();
+        for (const tagId of args.tag_ids) {
+          if (!tags.find((t) => t.tag_id === tagId)) {
+            throw new Error(`Tag not found: ${tagId}`);
+          }
+        }
+      }
     }
     if ('goal_id' in args && args.goal_id !== null && args.goal_id !== undefined) {
       validateDocId(args.goal_id, 'goal_id');

--- a/tests/core/decoder-worker-errors.test.ts
+++ b/tests/core/decoder-worker-errors.test.ts
@@ -2,29 +2,22 @@ import { describe, expect, test } from 'bun:test';
 import { decodeAllCollectionsIsolated } from '../../src/core/decoder';
 
 describe('decodeAllCollectionsIsolated worker error handling', () => {
-  test('rejects with a non-empty Error when db path does not exist', async () => {
+  test('rejects exactly once with a non-empty Error when db path does not exist', async () => {
     const bogusPath = '/tmp/copilot-mcp-test-nonexistent-db-' + Date.now();
 
-    const err = await decodeAllCollectionsIsolated(bogusPath, 10_000).catch((e: unknown) => e);
-    expect(err).toBeInstanceOf(Error);
-    expect((err as Error).message.length).toBeGreaterThan(0);
-  }, 15_000);
-
-  test('settle guard prevents double-rejection (error followed by exit)', async () => {
-    // When the worker encounters an error and then exits, only the first
-    // settle() call wins. We verify this by ensuring the promise rejects
-    // exactly once (i.e., no unhandled rejection from the exit handler).
-    const bogusPath = '/tmp/copilot-mcp-test-double-settle-' + Date.now();
-
+    // Verify the promise rejects with a meaningful Error and that the
+    // settle guard prevents double-rejection (error followed by exit).
     let rejectionCount = 0;
+    let caughtError: Error | undefined;
     try {
       await decodeAllCollectionsIsolated(bogusPath, 10_000);
-    } catch {
+    } catch (e) {
       rejectionCount++;
+      caughtError = e as Error;
     }
 
-    // The promise should have rejected exactly once despite both error and
-    // exit handlers firing.
     expect(rejectionCount).toBe(1);
+    expect(caughtError).toBeInstanceOf(Error);
+    expect(caughtError!.message.length).toBeGreaterThan(0);
   }, 15_000);
 });

--- a/tests/tools/unit-coverage-gaps.test.ts
+++ b/tests/tools/unit-coverage-gaps.test.ts
@@ -281,7 +281,9 @@ describe('cross-tool interactions', () => {
     const tagResult = await tools.createTag({ name: 'urgent' });
     expect(tagResult.success).toBe(true);
 
-    repopulateCache();
+    repopulateCache({
+      tags: [{ tag_id: tagResult.tag_id, name: 'urgent' }],
+    });
 
     const updateResult = await tools.updateTransaction({
       transaction_id: 'txn_cross',

--- a/tests/unit/update-transaction.test.ts
+++ b/tests/unit/update-transaction.test.ts
@@ -37,6 +37,7 @@ function makeTools(overrides?: {
   transactions?: unknown[];
   goals?: unknown[];
   categories?: unknown[];
+  tags?: unknown[];
 }) {
   const mockDb = new CopilotDatabase('/nonexistent');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -66,7 +67,14 @@ function makeTools(overrides?: {
     { category_id: 'groceries', name: 'Groceries' },
   ];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (mockDb as any)._tags = overrides?.tags ?? [
+    { tag_id: 'tag1', name: 'Important' },
+    { tag_id: 'tag2', name: 'Recurring' },
+  ];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (mockDb as any)._allCollectionsLoaded = true;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (mockDb as any)._cacheLoadedAt = Date.now();
 
   const updateCalls: UpdateCall[] = [];
   const mockClient = makeMockFirestoreClient(updateCalls);
@@ -310,6 +318,14 @@ describe('updateTransaction — validation errors', () => {
     expect(updateCalls).toHaveLength(0);
   });
 
+  test('non-existent tag_id throws', async () => {
+    const { tools, updateCalls } = makeTools();
+    await expect(
+      tools.updateTransaction({ transaction_id: 'txn1', tag_ids: ['tag1', 'ghost_tag'] })
+    ).rejects.toThrow(/Tag not found.*ghost_tag/i);
+    expect(updateCalls).toHaveLength(0);
+  });
+
   test('malformed tag_id throws', async () => {
     const { tools, updateCalls } = makeTools();
     await expect(
@@ -452,6 +468,24 @@ describe('updateTransaction — atomicity on validation failure', () => {
       (t: any) => t.transaction_id === 'txn1'
     );
     expect(cachedTxn.category_id).toBe('food'); // unchanged
+  });
+
+  test('valid note + non-existent tag_id: no write, no cache mutation', async () => {
+    const { tools, mockDb, updateCalls } = makeTools();
+    await expect(
+      tools.updateTransaction({
+        transaction_id: 'txn1',
+        note: 'should not persist',
+        tag_ids: ['tag1', 'ghost_tag'],
+      })
+    ).rejects.toThrow(/Tag not found.*ghost_tag/i);
+    expect(updateCalls).toHaveLength(0);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cachedTxn = (mockDb as any)._transactions.find(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (t: any) => t.transaction_id === 'txn1'
+    );
+    expect(cachedTxn.user_note).toBe('pre-existing note'); // unchanged
   });
 
   test('valid note + invalid category_id: no write, no cache mutation', async () => {


### PR DESCRIPTION
## Summary
- Adds existence validation for `tag_ids` in `updateTransaction`, matching the existing pattern for `category_id` and `goal_id` — non-existent tag IDs now return a clear `Tag not found: <id>` error instead of silently succeeding
- Updates `get_investment_performance` description: "raw" → "structured" (cosmetic, matches prior fix to `get_twr_returns`)
- Merges two redundant `decoder-worker-errors` tests into one, saving ~15s CI time
- Skips Codecov upload on fork PRs (forks lack `CODECOV_TOKEN` secret)

Closes #179, #191, #200, #206

## Test plan
- [x] New test: non-existent tag_id throws with descriptive error
- [x] New test: atomicity — valid note + non-existent tag_id produces no write and no cache mutation
- [x] Existing tag_ids tests continue to pass
- [x] Cross-tool test updated to repopulate tag cache after createTag
- [x] Merged decoder-worker test passes (single test, 3 assertions)
- [x] Full test suite: 1560 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)