### PR TITLE
test: close coverage gaps — firestore-rest, browser-token, database

### DIFF
--- a/tests/core/auth/browser-token.test.ts
+++ b/tests/core/auth/browser-token.test.ts
@@ -4,7 +4,7 @@ import {
   BROWSER_CONFIGS,
   type BrowserConfig,
 } from '../../../src/core/auth/browser-token.js';
-import { mkdtempSync, writeFileSync, rmSync, mkdirSync, symlinkSync } from 'fs';
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync, symlinkSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -251,14 +251,17 @@ describe('extractRefreshToken', () => {
     // Create a real file then revoke read permission — statSync succeeds but readFileSync throws EACCES
     const filePath = join(safariDir, 'token.db');
     writeFileSync(filePath, 'some content');
-    const { chmodSync } = await import('fs');
     chmodSync(filePath, 0o000);
 
     const overrides: BrowserConfig[] = [{ name: 'Safari', paths: [safariDir], type: 'safari' }];
 
-    await expect(extractRefreshToken(overrides)).rejects.toThrow('No Copilot Money session found');
-    // Restore permissions for cleanup
-    chmodSync(filePath, 0o644);
+    try {
+      await expect(extractRefreshToken(overrides)).rejects.toThrow(
+        'No Copilot Money session found'
+      );
+    } finally {
+      chmodSync(filePath, 0o644);
+    }
   });
 
   test('safari: handles unreadable top-level dir (outer catch)', async () => {

--- a/tests/core/auth/browser-token.test.ts
+++ b/tests/core/auth/browser-token.test.ts
@@ -248,12 +248,17 @@ describe('extractRefreshToken', () => {
   test('safari: handles unreadable file (readFileSync/statSync catch)', async () => {
     const safariDir = join(tempDir, 'safari-unreadable');
     mkdirSync(safariDir, { recursive: true });
-    // Create a symlink to a non-existent file — statSync will throw
-    symlinkSync('/nonexistent/target', join(safariDir, 'token.db'));
+    // Create a real file then revoke read permission — statSync succeeds but readFileSync throws EACCES
+    const filePath = join(safariDir, 'token.db');
+    writeFileSync(filePath, 'some content');
+    const { chmodSync } = await import('fs');
+    chmodSync(filePath, 0o000);
 
     const overrides: BrowserConfig[] = [{ name: 'Safari', paths: [safariDir], type: 'safari' }];
 
     await expect(extractRefreshToken(overrides)).rejects.toThrow('No Copilot Money session found');
+    // Restore permissions for cleanup
+    chmodSync(filePath, 0o644);
   });
 
   test('safari: handles unreadable top-level dir (outer catch)', async () => {

--- a/tests/core/database-errors.test.ts
+++ b/tests/core/database-errors.test.ts
@@ -279,6 +279,18 @@ describe('CopilotDatabase error handling', () => {
       // @ts-expect-error - accessing private method for testing
       expect(db.isCacheStale()).toBe(false);
     });
+
+    test('negative COPILOT_CACHE_TTL_MINUTES falls back to default', () => {
+      process.env.COPILOT_CACHE_TTL_MINUTES = '-5';
+
+      const db = new CopilotDatabase();
+      // @ts-expect-error - accessing private property for testing
+      db._cacheLoadedAt = Date.now();
+
+      // Negative value should be rejected, fall back to default 5 min TTL
+      // @ts-expect-error - accessing private method for testing
+      expect(db.isCacheStale()).toBe(false);
+    });
   });
 });
 

--- a/tests/core/format/firestore-rest.test.ts
+++ b/tests/core/format/firestore-rest.test.ts
@@ -128,4 +128,17 @@ describe('fromFirestoreValue additional coverage', () => {
   test('decodes false boolean', () => {
     expect(fromFirestoreValue({ booleanValue: false })).toBe(false);
   });
+
+  test('decodes timestampValue', () => {
+    expect(fromFirestoreValue({ timestampValue: '2024-01-15T12:00:00Z' })).toBe(
+      '2024-01-15T12:00:00Z'
+    );
+  });
+
+  test('throws on unknown Firestore value type', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => fromFirestoreValue({ unknownType: 'value' } as any)).toThrow(
+      'Unknown Firestore value type'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- `firestore-rest.ts`: 100%/97.73% → **100%/100%** — added `timestampValue` decode and unknown type error tests
- `browser-token.ts`: 76.92%/98.60% → 76.92%/**100%** — fixed Safari unreadable file test (chmod instead of broken symlink)
- `database.ts`: added negative `COPILOT_CACHE_TTL_MINUTES` test for `minutes >= 0` branch

### Remaining gaps (not addressable without mocking internals):
| File | Branch | Line | Why |
|------|--------|------|-----|
| browser-token.ts | 76.92% | 100% | Branch-only: each test hits one switch case |
| server.ts | 88.89% | 100% | Branch-only: `\|\|`/`??` on covered lines |
| tools.ts | 93.78% | 100% | Branch-only: `\|\|`/`??`/ternary on covered lines |
| decoder.ts | 97.85% | 99.67% | Worker error/exit events — can't trigger without mocking Worker |
| protobuf-parser.ts | 100% | 99.58% | Line 103 is unreachable dead code |

## Test plan
- [x] All 1563 tests pass
- [x] No production code changes
- [x] Typecheck, lint, format all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)