### PR TITLE
fix(ci): use github.event.before for version detection in auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -23,16 +23,19 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Fetch pre-push state for version comparison
+        env:
+          BEFORE: ${{ github.event.before }}
         run: |
           # Fetch the commit that was HEAD before this push, so we can compare
           # package.json across the entire push (not just HEAD vs HEAD~1).
-          BEFORE="${{ github.event.before }}"
           if [ "$BEFORE" != "0000000000000000000000000000000000000000" ] && [ -n "$BEFORE" ]; then
-            git fetch --depth=1 origin "$BEFORE"
+            git fetch --depth=1 origin "$BEFORE" || true
           fi
 
       - name: Check for version bump
         id: version
+        env:
+          BEFORE: ${{ github.event.before }}
         run: |
           CURRENT_VERSION=$(node -p "require('./package.json').version")
           echo "current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
@@ -46,7 +49,6 @@ jobs:
           fi
 
           # Compare against the state before this push (handles multi-commit pushes)
-          BEFORE="${{ github.event.before }}"
           if [ "$BEFORE" = "0000000000000000000000000000000000000000" ] || [ -z "$BEFORE" ]; then
             echo "Initial push, treating as version change"
             OLD_VERSION=""

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -21,8 +21,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 2  # Need previous commit to detect version change
+
+      - name: Fetch pre-push state for version comparison
+        run: |
+          # Fetch the commit that was HEAD before this push, so we can compare
+          # package.json across the entire push (not just HEAD vs HEAD~1).
+          BEFORE="${{ github.event.before }}"
+          if [ "$BEFORE" != "0000000000000000000000000000000000000000" ] && [ -n "$BEFORE" ]; then
+            git fetch --depth=1 origin "$BEFORE"
+          fi
 
       - name: Check for version bump
         id: version
@@ -30,16 +37,23 @@ jobs:
           CURRENT_VERSION=$(node -p "require('./package.json').version")
           echo "current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
 
-          # Check if tag already exists
+          # Check if tag already exists (fetch tags first)
+          git fetch --tags --quiet
           if git rev-parse "v$CURRENT_VERSION" >/dev/null 2>&1; then
             echo "Tag v$CURRENT_VERSION already exists, skipping"
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Check if version actually changed in this push
-          git show HEAD~1:package.json > /tmp/old-package.json 2>/dev/null || true
-          OLD_VERSION=$(node -p "try { require('/tmp/old-package.json').version } catch { '' }")
+          # Compare against the state before this push (handles multi-commit pushes)
+          BEFORE="${{ github.event.before }}"
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ] || [ -z "$BEFORE" ]; then
+            echo "Initial push, treating as version change"
+            OLD_VERSION=""
+          else
+            git show "$BEFORE":package.json > /tmp/old-package.json 2>/dev/null || true
+            OLD_VERSION=$(node -p "try { require('/tmp/old-package.json').version } catch { '' }")
+          fi
 
           if [ "$CURRENT_VERSION" != "$OLD_VERSION" ]; then
             echo "Version changed: $OLD_VERSION -> $CURRENT_VERSION"

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,6 @@ env:
 
 permissions:
   contents: read
-  packages: write
   id-token: write  # Required for npm OIDC trusted publishing
 
 jobs:
@@ -105,16 +104,3 @@ jobs:
       - name: Publish to npm
         if: github.event.inputs.dry_run != 'true'
         run: npm publish --provenance --access public --verbose
-
-      - name: Publish to GitHub Packages
-        if: github.event.inputs.dry_run != 'true'
-        run: |
-          # GitHub Packages requires a scoped name matching the repo owner
-          node -e "
-            const pkg = require('./package.json');
-            pkg.name = '@ignaciohermosillacornejo/copilot-money-mcp';
-            require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-          npm publish --registry https://npm.pkg.github.com
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,6 +18,7 @@ env:
 
 permissions:
   contents: read
+  packages: write
   id-token: write  # Required for npm OIDC trusted publishing
 
 jobs:
@@ -104,3 +105,16 @@ jobs:
       - name: Publish to npm
         if: github.event.inputs.dry_run != 'true'
         run: npm publish --provenance --access public --verbose
+
+      - name: Publish to GitHub Packages
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          # GitHub Packages requires a scoped name matching the repo owner
+          node -e "
+            const pkg = require('./package.json');
+            pkg.name = '@ignaciohermosillacornejo/copilot-money-mcp';
+            require('fs').writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          npm publish --registry https://npm.pkg.github.com
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The auto-release workflow compared `HEAD` vs `HEAD~1` to detect version bumps, which silently fails on multi-commit pushes (e.g., squash-merged PRs) where the version bump isn't the final commit
- Now uses `github.event.before` (the pre-push HEAD SHA) so the comparison spans the entire push
- Also fetches tags before the "tag already exists" check — previously `fetch-tags: false` made that guard a no-op

This is why v1.6.0 never released: the bump was buried in a batch push, and HEAD~1 already had 1.6.0.

## Test plan
- [x] Verified v1.6.0 bump commit (`5a4cbfd`) was pushed alongside ~10 other commits, confirming the root cause
- [x] Verified the auto-release run at that time logged "Version unchanged (1.6.0), skipping"
- [ ] After merge, manually create v1.6.0 release to unblock current version

🤖 Generated with [Claude Code](https://claude.com/claude-code)