### PR TITLE
fix(ci): skip Codecov upload for Dependabot PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         run: bun test --coverage --coverage-reporter=lcov tests/unit tests/models tests/core tests/utils
 
       - name: Upload unit test coverage to Codecov
-        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+        if: (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push') && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5
         with:
           files: coverage/lcov.info
@@ -76,7 +76,7 @@ jobs:
         run: bun test --coverage --coverage-reporter=lcov tests/e2e tests/tools tests/integration
 
       - name: Upload E2E test coverage to Codecov
-        if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
+        if: (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push') && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5
         with:
           files: coverage/lcov.info


### PR DESCRIPTION
## Summary
- Dependabot PRs come from the same repo, so the existing fork check (`head.repo.full_name == github.repository`) passes
- But Dependabot doesn't have access to `CODECOV_TOKEN`, so the upload fails with "Token required because branch is protected"
- With `fail_ci_if_error: true`, this fails the entire Unit Tests and E2E Tests jobs
- Fix: add `&& github.actor != 'dependabot[bot]'` to both Codecov upload step conditions

## Test plan
- [x] All 4 open Dependabot PRs (#218, #219, #220, #221) currently fail due to this
- [ ] After merge, rebase Dependabot PRs — they should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)