### PR TITLE
feat(skill): add /finance-trip and /finance orchestrator

### DIFF
--- a/skills/finance-trip/SKILL.md
+++ b/skills/finance-trip/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: finance-trip
+description: "Use when the user wants to track trip expenses, tag travel transactions, find late-posting charges from a trip, or get a trip spending summary. Example: 'tag my Tahiti trip expenses' or 'how much did I spend in Whistler?'"
+---
+
+# Finance Trip
+
+Track trip expenses by finding transactions in a date range, using location and merchant data to suggest which ones belong to the trip, and tagging confirmed ones. Can re-run to catch stragglers.
+
+## Phase 1 — Scope the Trip
+
+1. **Read the user profile.** Open `skills/user-profile.md`. If it doesn't exist, copy `skills/user-profile.template.md` to `skills/user-profile.md` first. Check Trip Tracking preferences and any existing trips.
+
+2. **Get trip parameters.** Ask the user or infer from context:
+   - **Trip name:** e.g., "French Polynesia", "Whistler Weekend"
+   - **Date range:** start and end date. If the user says "my Tahiti trip" and you know dates from prior conversation or tagged transactions, use those.
+   - **Location hint:** country, city, or region (optional — helps filter)
+
+3. **Check for existing trip tag.** Use `get_transactions` with `tag` filter to see if a tag already exists for this trip. If it does, this is a **re-run** to find stragglers — note which transactions are already tagged.
+
+## Phase 2 — Find Trip Transactions
+
+1. **Pull transactions for the date range.** Use `get_transactions` with `start_date`/`end_date`, `exclude_transfers: true`. Paginate if needed.
+
+2. **Also pull a 2-week buffer after the trip end date.** Late-posting charges (hotels, rental cars, foreign transactions) often settle days or weeks after the trip. Use a separate `get_transactions` call for `end_date + 1` through `end_date + 14`.
+
+3. **Score each transaction.** Use Python via Bash. For each transaction, compute a trip-likelihood score based on:
+
+   **Strong signals (high confidence):**
+   - Location match: transaction's `city`, `region`, or `country` field matches the trip location
+   - Merchant type matches travel categories: Hotels, Airplane Tickets, Car (rental), Transportation (rideshare/taxi)
+   - Foreign currency or foreign transaction fee during trip dates
+
+   **Medium signals:**
+   - Merchant name contains trip location keywords (e.g., "PAPEETE", "MOOREA", "WHISTLER")
+   - Category is travel-adjacent: Restaurants, Bars & Pubs, Tickets & Shows, Gas (road trips)
+   - Transaction is in the buffer window (post-trip) from a merchant that also appears during the trip
+
+   **Weak signals (include but flag as uncertain):**
+   - Online purchases during trip dates (could be coincidental)
+   - Generic merchants (Amazon, grocery stores) during trip dates
+
+   **Exclude:**
+   - Recurring charges that happen regardless of travel (subscriptions, rent, utilities, phone)
+   - Transactions already tagged with this trip (if re-run)
+   - Internal transfers
+
+4. **Group into tiers:**
+   - **Definitely trip:** Strong signals. Will be auto-suggested.
+   - **Probably trip:** Medium signals. Present for confirmation.
+   - **Maybe trip:** Weak signals. Mention but don't push.
+
+## Phase 3 — Present & Confirm
+
+**Tone:** Match `skills/user-profile.md` Communication Style. Default: blunt, simple, dollar amounts.
+
+1. **Show the trip summary first** (before asking about individual transactions):
+
+   > **[Trip Name]: [Start Date] – [End Date]**
+   > Found [N] transactions totaling $[X]
+   >
+   > | Category | Amount | Count |
+   > |----------|--------|-------|
+   > | Hotels   | $X     | N     |
+   > | Restaurants | $X  | N     |
+   > | ...      | ...    | ...   |
+
+2. **Present transactions for confirmation in batches:**
+   - "Definitely trip" items: present as a batch for quick approval ("These 15 look like trip expenses — approve all?")
+   - "Probably trip" items: present individually or in small groups with context
+   - "Maybe trip" items: mention briefly ("Also found 3 Amazon orders during your trip — include any?")
+
+3. **Show full merchant names.** Always use `name` or `original_name`, not `normalized_merchant`.
+
+4. **For re-runs (stragglers):** Only show NEW transactions not already tagged. Frame as: "Found 3 late-posting charges from your [Trip Name] trip:"
+
+## Phase 4 — Tag & Summarize
+
+1. **Create the trip tag** if it doesn't exist. Use `create_tag` with the trip name (e.g., "frenchpolynesia", "whistler-jan-2026"). Use lowercase, no spaces.
+
+2. **Tag confirmed transactions.** Use `set_transaction_tags` for each approved transaction.
+
+3. **Show final summary:**
+
+   > **[Trip Name] — Final Tally**
+   > Tagged [N] transactions, total: $[X]
+   >
+   > | Category | Amount | Count |
+   > |----------|--------|-------|
+   > | Flights  | $X     | N     |
+   > | Hotels   | $X     | N     |
+   > | Food     | $X     | N     |
+   > | Transport| $X     | N     |
+   > | Activities| $X    | N     |
+   > | Other    | $X     | N     |
+   >
+   > Per-day average: $[X/days]
+
+4. **Update user profile.** Add the trip to the Trip Tracking section:
+   ```
+   - [Trip Name]: [dates], $[total], [N] transactions
+   ```
+
+## Phase 5 — Straggler Follow-up (optional)
+
+If the trip ended recently (within 3 weeks), suggest a follow-up:
+> "Some charges may still be posting. Want me to check again in a week or two?"
+
+If the user agrees, note it in the conversation for future reference. The user can re-invoke `/finance-trip [trip name]` anytime.
+
+## Rules
+
+1. **User confirms before tagging.** Never tag a transaction without the user approving it first. "Definitely trip" items can be batch-approved, but the batch must be presented first.
+2. **Use Python for aggregations.** Category totals, per-day averages, scoring — all via Bash with Python.
+3. **Show full merchant names.** Always `name` or `original_name`, never truncated `normalized_merchant`.
+4. **Respect existing tags.** If transactions already have tags, add the trip tag alongside them — don't replace.
+5. **Recurring charges are not trip expenses.** Subscriptions, rent, utilities, and other recurring charges that happen regardless of travel should be excluded even if they fall within the trip dates.
+6. **Buffer for late charges.** Always check 2 weeks after the trip end date for late-posting charges (hotels, car rentals, foreign transactions).
+7. **Re-runs are safe.** The skill can be re-run on the same trip without double-tagging — it skips already-tagged transactions.

--- a/skills/finance/SKILL.md
+++ b/skills/finance/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: finance
+description: "Use for open-ended financial questions: 'can I afford X?', 'should I buy X?', 'how much can I spend on Y?', or any affordability, budgeting, or financial planning question. Also use when the user asks a financial question that doesn't fit /finance-cleanup, /finance-pulse, or /finance-trip."
+---
+
+# Finance — Financial Advisor
+
+Answer open-ended financial questions using transaction data, account balances, and the user's financial profile. This is the thinking skill — it reasons about affordability, tradeoffs, and financial decisions.
+
+## Phase 1 — Understand the Question
+
+1. **Read the user profile.** Open `skills/user-profile.md`. If it doesn't exist, copy `skills/user-profile.template.md` to `skills/user-profile.md` first. You need:
+   - Income & Obligations (for Free Money calculation)
+   - Savings & Goals
+   - Irregular Expenses
+   - Account roles (which account pays for what)
+
+   If the profile is mostly empty, suggest: "I need some baseline numbers to answer this well. Want to run `/finance-pulse` first to set up your profile?"
+
+2. **Classify the question by magnitude:**
+   - **Small (<$50):** Quick check. One sentence answer.
+   - **Medium ($50-500):** Budget context. Does it fit in Free Money?
+   - **Large ($500-5K):** Full dual-check (budget + cash flow) + tradeoff analysis.
+   - **Major (>$5K):** Multi-month projection, impact on savings goals, seasonal context.
+
+3. **Pull relevant data.** Based on the question:
+   - `get_accounts` — current balances
+   - `get_transactions` with `period: "this_month"` — month-to-date spending
+   - `get_recurring_transactions` — upcoming obligations
+   - `get_categories` — spending patterns for the relevant category
+   - `get_goals` — savings targets that might be affected
+
+## Phase 2 — Analyze
+
+### 2.1 Budget Check
+
+Does the purchase fit within Free Money?
+
+```
+Free Money = Net Monthly Income
+           − Fixed Obligations
+           − Savings Target
+           − Amortized Irregular Expenses
+           − Already Spent This Month (actual merchant charges, not profile estimates)
+```
+
+Use the same computation as `/finance-pulse`. If the profile has these numbers, use them. If not, compute from transaction data using Python via Bash.
+
+### 2.2 Cash Flow Check (for Large and Major only)
+
+Will account balances stay above a safe buffer after the purchase clears?
+
+1. Start with current checking balance
+2. Add expected income before the purchase date (next payroll deposit)
+3. Subtract known upcoming obligations (rent, credit card autopays, recurring charges due before the purchase date)
+4. Subtract the purchase amount
+5. Check: is the remaining balance above a safe buffer? (10% of monthly income for stable income, 20% for variable)
+
+If budget check says "yes" but cash flow says "no" (or vice versa), explain the contradiction:
+- "You have room in your budget, but your checking balance would dip to $X after this clears — that's below your $Y buffer. Wait until after your next paycheck on [date]."
+- "Your checking can handle it right now, but it would eat your entire remaining discretionary budget for the month."
+
+### 2.3 Tradeoff Analysis (for Large and Major only)
+
+What would the user need to give up or adjust?
+
+- "You'd need to cut dining by $X/week for the rest of the month"
+- "This would use 60% of your remaining Free Money — you'd have $Y/day for the next Z days"
+- "This is equivalent to 3 months of your Netflix subscription"
+
+Scale the comparison to something relatable. Don't just show numbers — show what they mean.
+
+### 2.4 Risk Flags
+
+Proactively flag relevant context:
+- **Upcoming irregular expenses:** "Your car insurance renewal ($X) is due next month"
+- **Seasonal spending:** October-December → holiday spending ahead. Summer → utility spikes.
+- **Variable income:** If income type is variable, use conservative (25th percentile) baseline and say so explicitly.
+- **Credit card timing:** If paying by credit card, note the float — "Charged today, you have until [statement date] before it hits your checking"
+- **Recent large expenses:** "You already spent $X on [category] this month, which is 2x your average"
+
+## Phase 3 — Present
+
+**Tone:** Match `skills/user-profile.md` Communication Style. Default: blunt, dollar amounts.
+
+**Never give binary yes/no.** Always present:
+
+1. **Signal:** One of three levels:
+   - "Comfortably affordable" — fits in budget AND cash flow, no tradeoffs needed
+   - "Tight but possible" — fits but requires adjustment or awareness
+   - "Would create strain" — doesn't fit without significant changes
+
+2. **Key number:** The most important figure for the decision:
+   - "You'd have $X left for the rest of the month" (remaining Free Money after purchase)
+   - "Your daily budget would drop from $X to $Y" (impact on pace)
+
+3. **Tradeoffs** (if any): What adjustments would be needed.
+
+4. **Risk flags** (if any): Context that might change the decision.
+
+**Scaling output to magnitude:**
+- **Small:** One sentence. "That's fine — you have $X in Free Money this month."
+- **Medium:** 2-3 sentences. Signal + key number + one tradeoff if relevant.
+- **Large:** Full analysis. Signal + key number + tradeoffs + risk flags. ~10 lines.
+- **Major:** Full analysis + multi-month projection + savings impact. Up to 20 lines.
+
+### Examples of good responses:
+
+**Small ($30 book):**
+> That's fine. You have $2,449 left this month — $144/day for 17 days. A $30 book barely moves the needle.
+
+**Medium ($200 dinner):**
+> Tight but possible. You have $2,449 left this month ($144/day). A $200 dinner drops that to $2,249 ($132/day) — still workable, but restaurants are already at $630 this month vs your $300 budget.
+
+**Large ($1,500 weekend trip):**
+> Would create strain. You have $2,449 in Free Money this month. A $1,500 trip would leave $949 for the remaining 17 days ($56/day vs your usual $187/day pace).
+>
+> Your next paycheck ($4,611) lands around Apr 17, which helps — but your rent ($3,142), credit card autopays, and subscriptions will eat most of it.
+>
+> If you want to do this: push discretionary spending to near-zero for the rest of April, and you'll be fine by May 1.
+
+## Phase 4 — Follow-up
+
+If the user asks "what if" variations, re-run the analysis with the new parameters. Keep the conversation flowing — don't re-pull all data unless the question changes significantly.
+
+If the question reveals new financial context (e.g., "I'm getting a raise next month"), offer to update the profile: "Want me to update your income in the profile?"
+
+## Rules
+
+1. **Read-only.** This skill never writes to Copilot Money. It reads data and reasons about it.
+2. **Never binary yes/no.** Always signal + key number + context.
+3. **Pre-compute, don't interrogate.** Use profile and transaction data to compute answers. Confirm assumptions ("I see you earn ~$X/month — is that right?") rather than asking the user to provide numbers.
+4. **Use Python for math.** All arithmetic via Bash with Python. No mental math on >10 numbers.
+5. **Scale depth to magnitude.** A $30 purchase doesn't need a 20-line analysis.
+6. **Show full merchant names.** Always `name` or `original_name`, never truncated.
+7. **Explicit about limitations.** "I'm working from your transaction history — I don't know about cash income, side gigs, or expenses paid outside these accounts."
+8. **Not financial advice.** If the question ventures into investment advice, tax strategy, or legal territory, say: "This is data-informed reasoning, not certified financial advice. Talk to a professional for [specific topic]."
+9. **Invoke sub-skills when appropriate.** If the user's question would be better served by `/finance-pulse`, `/finance-cleanup`, or `/finance-trip`, suggest it. Don't try to replicate their functionality.


### PR DESCRIPTION
## Summary
Final two skills from the finance skills design spec (Plans 3 & 4).

### /finance-trip — Trip Expense Tracking
- Takes trip name + date range, finds transactions using location/merchant/category scoring
- 3-tier presentation: definitely trip / probably trip / maybe trip
- Tags confirmed transactions, shows category breakdown + per-day average
- Supports re-runs with 2-week buffer for late-posting charges (hotels, foreign transactions)
- Skips recurring charges that happen regardless of travel

### /finance — Financial Advisor Orchestrator
- Answers "can I afford X?" with dual-check model: budget check (Free Money) + cash flow check (will balances stay positive?)
- Scales analysis depth by magnitude: small (<$50) → 1 sentence, major (>$5K) → full projection
- Never binary yes/no — always: signal (comfortable/tight/strain) + key number + tradeoffs + risk flags
- Pre-computes from profile rather than interrogating the user
- Routes to sub-skills when appropriate (/finance-pulse, /finance-cleanup, /finance-trip)

## Test plan
- [x] All 1571 tests pass
- [x] No code changes — skill prompts only
- [ ] Smoke test /finance-trip against French Polynesia data (can be done in follow-up)
- [ ] Smoke test /finance with affordability question

🤖 Generated with [Claude Code](https://claude.com/claude-code)