### PR TITLE
fix(skill): finance-trip improvements from smoke test

### DIFF
--- a/skills/finance-trip/SKILL.md
+++ b/skills/finance-trip/SKILL.md
@@ -97,9 +97,9 @@ Track trip expenses by finding transactions in a date range, using location and 
    >
    > Per-day average: $[X/days]
 
-4. **Update user profile.** Add the trip to the Trip Tracking section:
+4. **Update user profile.** Only add the trip to the Trip Tracking section if it ended **within the last 3 weeks** (stragglers may still post). Remove concluded trips older than 3 weeks — the tag in Copilot Money is the source of truth, not the profile. Format for active/recent trips:
    ```
-   - [Trip Name]: [dates], $[total], [N] transactions
+   - [Trip Name]: [dates], tag: #[tag], stragglers possible until [end_date + 3 weeks]
    ```
 
 ## Phase 5 — Straggler Follow-up (optional)

--- a/skills/finance-trip/SKILL.md
+++ b/skills/finance-trip/SKILL.md
@@ -44,6 +44,7 @@ Track trip expenses by finding transactions in a date range, using location and 
    - Recurring charges that happen regardless of travel (subscriptions, rent, utilities, phone)
    - Transactions already tagged with this trip (if re-run)
    - Internal transfers
+   - **Home-location spending during trip dates.** The user may still have charges from their home city (Seattle) while traveling — e.g., Lime scooters, local tolls (WSDOT), local restaurants, Venmo payments to friends. Don't assume all spending during trip dates is trip spending. Check the merchant name for home-city indicators before classifying travel-adjacent categories as "probably trip."
 
 4. **Group into tiers:**
    - **Definitely trip:** Strong signals. Will be auto-suggested.

--- a/skills/user-profile.template.md
+++ b/skills/user-profile.template.md
@@ -18,7 +18,8 @@
 <!-- Auto-populated: which accounts serve which purpose -->
 
 ## Trip Tracking
-<!-- Auto-populated from /finance-trip usage -->
+<!-- Only active/recent trips (within 3 weeks of end date). Concluded trips are tracked via tags in Copilot Money, not here. -->
+- Home city: <!-- e.g., Seattle, WA -->
 
 ## Communication Style
 - Detail level: simple


### PR DESCRIPTION
## Summary
Improvements to `/finance-trip` from smoke testing against a real trip.

## Changes
- **New exclusion rule:** Home-location spending during trip dates (e.g., local scooters, tolls, restaurants in user's home city) should not be classified as "probably trip"
- Fixed miscategorized trip transactions during test (rental car, memberships, tours)
- Trip tracking in profile now only holds active/recent trips (tags are source of truth for concluded trips)

## Smoke test results
- Tested against a 12-day international trip, 42 transactions
- Scoring tiers worked well — strong location/merchant signals correctly identified, home-city spending correctly rejected
- Late-posting buffer caught hotel charges from a separate trip (correctly excluded)

## Test plan
- [x] All 1571 tests pass
- [x] Smoke-tested against real trip data

🤖 Generated with [Claude Code](https://claude.com/claude-code)