### PR TITLE
fix: create_category writes app-compatible documents

### DIFF
--- a/src/core/firestore-client.ts
+++ b/src/core/firestore-client.ts
@@ -10,7 +10,7 @@
  */
 
 import type { FirebaseAuth } from './auth/firebase-auth.js';
-import type { FirestoreFields } from './format/firestore-rest.js';
+import type { FirestoreFields, FirestoreRestValue } from './format/firestore-rest.js';
 
 const FIRESTORE_PROJECT_ID = 'copilot-production-22904';
 const FIRESTORE_BASE_URL = 'https://firestore.googleapis.com/v1';
@@ -76,15 +76,45 @@ export class FirestoreClient {
    *
    * @see https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/createDocument
    */
+  /**
+   * Read a single document from Firestore.
+   *
+   * @see https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/get
+   */
+  async getDocument(
+    collectionPath: string,
+    documentId: string
+  ): Promise<Record<string, FirestoreRestValue>> {
+    const idToken = await this.auth.getIdToken();
+    const docPath = `projects/${FIRESTORE_PROJECT_ID}/databases/(default)/documents/${collectionPath}/${documentId}`;
+
+    const response = await fetch(`${FIRESTORE_BASE_URL}/${docPath}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${idToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(`Firestore get failed (${response.status}): ${errorBody}`);
+    }
+
+    const doc = (await response.json()) as { fields?: Record<string, FirestoreRestValue> };
+    return doc.fields ?? {};
+  }
+
   async createDocument(
     collectionPath: string,
-    documentId: string,
+    documentId: string | undefined,
     fields: FirestoreFields
-  ): Promise<void> {
+  ): Promise<string> {
     const idToken = await this.auth.getIdToken();
     const parentPath = `projects/${FIRESTORE_PROJECT_ID}/databases/(default)/documents`;
     const url = new URL(`${FIRESTORE_BASE_URL}/${parentPath}/${collectionPath}`);
-    url.searchParams.set('documentId', documentId);
+    if (documentId) {
+      url.searchParams.set('documentId', documentId);
+    }
 
     const response = await fetch(url.toString(), {
       method: 'POST',
@@ -99,6 +129,11 @@ export class FirestoreClient {
       const errorBody = await response.text();
       throw new Error(`Firestore create failed (${response.status}): ${errorBody}`);
     }
+
+    const doc = (await response.json()) as { name: string };
+    // Extract document ID from the full resource name
+    // e.g. "projects/.../documents/users/uid/categories/abc123" → "abc123"
+    return doc.name.split('/').pop()!;
   }
 
   /**

--- a/src/core/firestore-client.ts
+++ b/src/core/firestore-client.ts
@@ -69,14 +69,6 @@ export class FirestoreClient {
   }
 
   /**
-   * Create a new document in a Firestore collection.
-   *
-   * Uses the Firestore REST API createDocument endpoint with a client-supplied
-   * document ID.
-   *
-   * @see https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/createDocument
-   */
-  /**
    * Read a single document from Firestore.
    *
    * @see https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/get

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -77,6 +77,21 @@ function validateHexColor(color: string): void {
 }
 
 /**
+ * Derive a light background tint from a hex color, matching the Copilot app's
+ * `bg_color` convention (e.g. #BC00E3 → #FDF5FE).
+ * Blends the color at ~5% opacity over white.
+ */
+function hexToBgColor(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  const t = 0.05; // tint strength
+  const blend = (c: number) => Math.round(255 - t * (255 - c));
+  const toHex = (n: number) => n.toString(16).padStart(2, '0').toUpperCase();
+  return `#${toHex(blend(r))}${toHex(blend(g))}${toHex(blend(b))}`;
+}
+
+/**
  * Plaid category ID for foreign transaction fees (snake_case format).
  * @see https://plaid.com/docs/api/products/transactions/#categoriesget
  */
@@ -2294,30 +2309,47 @@ export class CopilotMoneyTools {
       );
     }
 
-    // Generate a unique category_id
-    const categoryId = `custom_${crypto.randomUUID().replace(/-/g, '').slice(0, 16)}`;
-
     // Determine user_id: prefer existing categories, fall back to auth layer
     const userIdFromCategories = existingCategories.find((c) => c.user_id)?.user_id;
     const userId = userIdFromCategories ?? (await client.requireUserId());
 
-    // Build document fields
+    // Compute next order value (max existing order + 1)
+    const maxOrder = existingCategories.reduce(
+      (max, c) => Math.max(max, typeof c.order === 'number' ? c.order : -1),
+      -1
+    );
+
+    // Build document fields matching app-created category structure.
+    // The app requires: id, name, emoji, color, bg_color, order, excluded,
+    // is_other, auto_budget_lock, auto_delete_lock, and empty arrays for
+    // plaid_category_ids and partial_name_rules.
+    const trimmedName = name.trim();
+    const categoryColor = color ?? '#808080';
+    if (color) validateHexColor(color);
     const docFields: Record<string, unknown> = {
-      category_id: categoryId,
-      name: name.trim(),
+      name: trimmedName,
+      emoji: emoji ?? '📁',
+      color: categoryColor,
+      bg_color: hexToBgColor(categoryColor),
+      order: maxOrder + 1,
       excluded,
+      is_other: false,
+      auto_budget_lock: false,
+      auto_delete_lock: false,
+      plaid_category_ids: [],
+      partial_name_rules: [],
     };
-    if (emoji) docFields.emoji = emoji;
-    if (color) {
-      validateHexColor(color);
-      docFields.color = color;
-    }
     if (parent_category_id) docFields.parent_category_id = parent_category_id;
 
-    // Write to Firestore
+    // Write to Firestore with auto-generated document ID (matching app behavior)
     const collectionPath = `users/${userId}/categories`;
     const firestoreFields = toFirestoreFields(docFields);
-    await client.createDocument(collectionPath, categoryId, firestoreFields);
+    const categoryId = await client.createDocument(collectionPath, undefined, firestoreFields);
+
+    // Patch the `id` field to match the auto-generated document ID.
+    // App-created categories store `id` equal to the Firestore document ID.
+    const idFields = toFirestoreFields({ id: categoryId });
+    await client.updateDocument(collectionPath, categoryId, idFields, ['id']);
 
     // Clear cache so the new category is visible on next query
     this.db.clearCache();
@@ -2334,11 +2366,11 @@ export class CopilotMoneyTools {
     } = {
       success: true,
       category_id: categoryId,
-      name: name.trim(),
+      name: trimmedName,
       excluded,
     };
-    if (emoji) result.emoji = emoji;
-    if (color) result.color = color;
+    if (emoji ?? '📁') result.emoji = emoji ?? '📁';
+    if (categoryColor) result.color = categoryColor;
     if (parent_category_id) result.parent_category_id = parent_category_id;
 
     return result;

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2274,8 +2274,8 @@ export class CopilotMoneyTools {
     success: boolean;
     category_id: string;
     name: string;
-    emoji?: string;
-    color?: string;
+    emoji: string;
+    color: string;
     parent_category_id?: string;
     excluded: boolean;
   }> {
@@ -2324,11 +2324,12 @@ export class CopilotMoneyTools {
     // is_other, auto_budget_lock, auto_delete_lock, and empty arrays for
     // plaid_category_ids and partial_name_rules.
     const trimmedName = name.trim();
-    const categoryColor = color ?? '#808080';
     if (color) validateHexColor(color);
+    const categoryColor = color ?? '#808080';
+    const categoryEmoji = emoji ?? '📁';
     const docFields: Record<string, unknown> = {
       name: trimmedName,
-      emoji: emoji ?? '📁',
+      emoji: categoryEmoji,
       color: categoryColor,
       bg_color: hexToBgColor(categoryColor),
       order: maxOrder + 1,
@@ -2359,18 +2360,18 @@ export class CopilotMoneyTools {
       success: boolean;
       category_id: string;
       name: string;
-      emoji?: string;
-      color?: string;
+      emoji: string;
+      color: string;
       parent_category_id?: string;
       excluded: boolean;
     } = {
       success: true,
       category_id: categoryId,
       name: trimmedName,
+      emoji: categoryEmoji,
+      color: categoryColor,
       excluded,
     };
-    if (emoji ?? '📁') result.emoji = emoji ?? '📁';
-    if (categoryColor) result.color = categoryColor;
     if (parent_category_id) result.parent_category_id = parent_category_id;
 
     return result;
@@ -2797,7 +2798,8 @@ export class CopilotMoneyTools {
     if (color !== undefined) {
       validateHexColor(color);
       fieldsToUpdate.color = color;
-      updateMask.push('color');
+      fieldsToUpdate.bg_color = hexToBgColor(color);
+      updateMask.push('color', 'bg_color');
     }
     if (excluded !== undefined) {
       fieldsToUpdate.excluded = excluded;

--- a/tests/core/firestore-client.test.ts
+++ b/tests/core/firestore-client.test.ts
@@ -154,11 +154,14 @@ describe('FirestoreClient', () => {
   // --- createDocument ---
 
   test('createDocument sends POST with documentId query param', async () => {
-    mockFetch({ name: 'doc', fields: {} });
-    await client.createDocument('users/u1/tags', 'my_tag', {
+    mockFetch({
+      name: 'projects/copilot-production-22904/databases/(default)/documents/users/u1/tags/my_tag',
+    });
+    const returnedId = await client.createDocument('users/u1/tags', 'my_tag', {
       name: { stringValue: 'My Tag' },
     });
 
+    expect(returnedId).toBe('my_tag');
     expect(fetchCalls).toHaveLength(1);
     const url = new URL(fetchCalls[0].url);
     expect(url.pathname).toContain('/users/u1/tags');
@@ -170,8 +173,24 @@ describe('FirestoreClient', () => {
     restoreFetch();
   });
 
+  test('createDocument without documentId uses auto-generated ID', async () => {
+    mockFetch({
+      name: 'projects/copilot-production-22904/databases/(default)/documents/users/uid/categories/AbCdEfGh12345678',
+    });
+    const returnedId = await client.createDocument('users/uid/categories', undefined, {
+      name: { stringValue: 'Test' },
+    });
+
+    expect(returnedId).toBe('AbCdEfGh12345678');
+    const url = new URL(fetchCalls[0].url);
+    expect(url.searchParams.has('documentId')).toBe(false);
+    restoreFetch();
+  });
+
   test('createDocument sends correct JSON body', async () => {
-    mockFetch({ name: 'doc', fields: {} });
+    mockFetch({
+      name: 'projects/copilot-production-22904/databases/(default)/documents/users/uid/categories/cat_123',
+    });
     await client.createDocument('users/uid/categories', 'cat_123', {
       name: { stringValue: 'Test' },
       excluded: { booleanValue: false },
@@ -192,6 +211,45 @@ describe('FirestoreClient', () => {
     await expect(
       client.createDocument('users/u1/tags', 'dup', { name: { stringValue: 'Dup' } })
     ).rejects.toThrow('Firestore create failed');
+    restoreFetch();
+  });
+
+  // --- getDocument ---
+
+  test('getDocument sends GET with correct path', async () => {
+    mockFetch({
+      name: 'projects/copilot-production-22904/databases/(default)/documents/users/u1/categories/cat1',
+      fields: {
+        name: { stringValue: 'Food' },
+        excluded: { booleanValue: false },
+      },
+    });
+    const fields = await client.getDocument('users/u1/categories', 'cat1');
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0].options.method).toBe('GET');
+    const url = new URL(fetchCalls[0].url);
+    expect(url.pathname).toContain('/users/u1/categories/cat1');
+    expect(fields).toEqual({
+      name: { stringValue: 'Food' },
+      excluded: { booleanValue: false },
+    });
+    restoreFetch();
+  });
+
+  test('getDocument returns empty object when no fields', async () => {
+    mockFetch({
+      name: 'projects/copilot-production-22904/databases/(default)/documents/users/u1/categories/cat1',
+    });
+    const fields = await client.getDocument('users/u1/categories', 'cat1');
+    expect(fields).toEqual({});
+    restoreFetch();
+  });
+
+  test('getDocument throws on non-OK response', async () => {
+    mockFetch({ error: { code: 404, message: 'Not found' } }, 404);
+    await expect(client.getDocument('users/u1/categories', 'missing')).rejects.toThrow(
+      'Firestore get failed'
+    );
     restoreFetch();
   });
 

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -557,7 +557,7 @@ function createMockFirestoreClient(): FirestoreClient {
     requireUserId: async () => 'test-user-123',
     getUserId: () => 'test-user-123',
     updateDocument: async () => {},
-    createDocument: async () => {},
+    createDocument: async (_col: string, docId: string | undefined) => docId ?? 'auto_generated_id',
     deleteDocument: async () => {},
   };
   return mock as unknown as FirestoreClient;

--- a/tests/integration/tools.test.ts
+++ b/tests/integration/tools.test.ts
@@ -341,7 +341,7 @@ function createMockDatabase(overrides?: {
 function createMockFirestoreClient() {
   return {
     requireUserId: async () => 'test-user-123',
-    createDocument: async () => {},
+    createDocument: async (_col: string, docId: string | undefined) => docId ?? 'auto_generated_id',
     updateDocument: async () => {},
     deleteDocument: async () => {},
   } as any;
@@ -1020,7 +1020,7 @@ describe('CopilotMoneyTools Integration', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(result.category_id).toMatch(/^custom_/);
+      expect(result.category_id).toBe('auto_generated_id');
       expect(result.name).toBe('Pet Supplies');
     });
 

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -2687,7 +2687,9 @@ describe('createCategory', () => {
   let tools: CopilotMoneyTools;
   let mockDb: CopilotDatabase;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let createCalls: { collection: string; docId: string; fields: any }[];
+  let createCalls: { collection: string; docId: string | undefined; fields: any }[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let updateCalls: { collection: string; docId: string; fields: any; mask: string[] }[];
 
   beforeEach(() => {
     mockDb = new CopilotDatabase('/nonexistent');
@@ -2695,17 +2697,39 @@ describe('createCategory', () => {
     (mockDb as any).dbPath = '/fake';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockDb as any)._userCategories = [
-      { category_id: 'food_and_drink', name: 'Food & Drink', excluded: false, user_id: 'user123' },
-      { category_id: 'shopping', name: 'Shopping', excluded: false, user_id: 'user123' },
+      {
+        category_id: 'food_and_drink',
+        name: 'Food & Drink',
+        excluded: false,
+        user_id: 'user123',
+        order: 0,
+      },
+      {
+        category_id: 'shopping',
+        name: 'Shopping',
+        excluded: false,
+        user_id: 'user123',
+        order: 5,
+      },
     ];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockDb as any)._allCollectionsLoaded = true;
 
     createCalls = [];
+    updateCalls = [];
     const mockFirestoreClient = {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      createDocument: async (collection: string, docId: string, fields: any) => {
+      createDocument: async (
+        collection: string,
+        docId: string | undefined,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        fields: any
+      ) => {
         createCalls.push({ collection, docId, fields });
+        return 'auto_generated_id_123';
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      updateDocument: async (collection: string, docId: string, fields: any, mask: string[]) => {
+        updateCalls.push({ collection, docId, fields, mask });
       },
       requireUserId: async () => 'user123',
     };
@@ -2718,8 +2742,11 @@ describe('createCategory', () => {
     const result = await tools.createCategory({ name: 'Entertainment' });
     expect(result.success).toBe(true);
     expect(result.name).toBe('Entertainment');
-    expect(result.category_id).toMatch(/^custom_[a-f0-9]{16}$/);
+    expect(result.category_id).toBe('auto_generated_id_123');
     expect(result.excluded).toBe(false);
+    // Default emoji and color should be set
+    expect(result.emoji).toBe('📁');
+    expect(result.color).toBe('#808080');
   });
 
   test('creates category with all optional fields', async () => {
@@ -2738,16 +2765,34 @@ describe('createCategory', () => {
     expect(result.excluded).toBe(true);
   });
 
-  test('calls Firestore createDocument with correct collection path', async () => {
+  test('calls Firestore createDocument with auto-generated ID and app-compatible fields', async () => {
     await tools.createCategory({ name: 'Test Category' });
     expect(createCalls).toHaveLength(1);
     expect(createCalls[0].collection).toBe('users/user123/categories');
-    expect(createCalls[0].docId).toMatch(/^custom_[a-f0-9]{16}$/);
-    expect(createCalls[0].fields).toHaveProperty('name');
-    expect(createCalls[0].fields.name).toEqual({ stringValue: 'Test Category' });
-    expect(createCalls[0].fields.category_id).toEqual({
-      stringValue: createCalls[0].docId,
-    });
+    // docId should be undefined for Firestore auto-generated ID
+    expect(createCalls[0].docId).toBeUndefined();
+    // Check app-required fields are present
+    const fields = createCalls[0].fields;
+    expect(fields.name).toEqual({ stringValue: 'Test Category' });
+    expect(fields.emoji).toEqual({ stringValue: '📁' });
+    expect(fields.color).toEqual({ stringValue: '#808080' });
+    expect(fields.bg_color).toBeDefined();
+    expect(fields.order).toEqual({ integerValue: '6' }); // max(0, 5) + 1
+    expect(fields.excluded).toEqual({ booleanValue: false });
+    expect(fields.is_other).toEqual({ booleanValue: false });
+    expect(fields.auto_budget_lock).toEqual({ booleanValue: false });
+    expect(fields.auto_delete_lock).toEqual({ booleanValue: false });
+    expect(fields.plaid_category_ids).toEqual({ arrayValue: { values: [] } });
+    expect(fields.partial_name_rules).toEqual({ arrayValue: { values: [] } });
+  });
+
+  test('patches id field after creation', async () => {
+    await tools.createCategory({ name: 'Test' });
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].collection).toBe('users/user123/categories');
+    expect(updateCalls[0].docId).toBe('auto_generated_id_123');
+    expect(updateCalls[0].fields.id).toEqual({ stringValue: 'auto_generated_id_123' });
+    expect(updateCalls[0].mask).toEqual(['id']);
   });
 
   test('clears cache after successful create', async () => {
@@ -2791,11 +2836,11 @@ describe('createCategory', () => {
     expect(createCalls[0].fields.name).toEqual({ stringValue: 'Entertainment' });
   });
 
-  test('does not include optional fields when not provided', async () => {
+  test('includes default emoji, color, and app fields when not provided', async () => {
     await tools.createCategory({ name: 'Minimal' });
     const fields = createCalls[0].fields;
-    expect(fields).not.toHaveProperty('emoji');
-    expect(fields).not.toHaveProperty('color');
+    expect(fields.emoji).toEqual({ stringValue: '📁' });
+    expect(fields.color).toEqual({ stringValue: '#808080' });
     expect(fields).not.toHaveProperty('parent_category_id');
   });
 
@@ -2809,6 +2854,7 @@ describe('createCategory', () => {
       createDocument: async () => {
         throw new Error('Firestore create failed (500)');
       },
+      updateDocument: async () => {},
       requireUserId: async () => 'user123',
     };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2834,9 +2880,18 @@ describe('createCategory', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (mockDb as any)._userCategories = [{ category_id: 'food', name: 'Food', excluded: false }];
     const mockFirestoreClient = {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      createDocument: async (collection: string, docId: string, fields: any) => {
+      createDocument: async (
+        collection: string,
+        docId: string | undefined,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        fields: any
+      ) => {
         createCalls.push({ collection, docId, fields });
+        return 'auto_generated_id_456';
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      updateDocument: async (collection: string, docId: string, fields: any, mask: string[]) => {
+        updateCalls.push({ collection, docId, fields, mask });
       },
       requireUserId: async () => 'auth-user-456',
     };

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -2776,7 +2776,7 @@ describe('createCategory', () => {
     expect(fields.name).toEqual({ stringValue: 'Test Category' });
     expect(fields.emoji).toEqual({ stringValue: '📁' });
     expect(fields.color).toEqual({ stringValue: '#808080' });
-    expect(fields.bg_color).toBeDefined();
+    expect(fields.bg_color).toEqual({ stringValue: '#F9F9F9' });
     expect(fields.order).toEqual({ integerValue: '6' }); // max(0, 5) + 1
     expect(fields.excluded).toEqual({ booleanValue: false });
     expect(fields.is_other).toEqual({ booleanValue: false });

--- a/tests/tools/unit-coverage-gaps.test.ts
+++ b/tests/tools/unit-coverage-gaps.test.ts
@@ -54,7 +54,7 @@ function createMockClient() {
   return {
     requireUserId: async () => 'test-user-123',
     getUserId: () => 'test-user-123',
-    createDocument: async () => {},
+    createDocument: async (_col: string, docId: string | undefined) => docId ?? 'auto_generated_id',
     updateDocument: async () => {},
     deleteDocument: async () => {},
   } as any;

--- a/tests/tools/write-tools-phase3.test.ts
+++ b/tests/tools/write-tools-phase3.test.ts
@@ -33,7 +33,8 @@ describe('updateTag', () => {
       requireUserId: async () => 'user123',
       getUserId: () => 'user123',
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      createDocument: async () => {},
+      createDocument: async (_col: string, docId: string | undefined) =>
+        docId ?? 'auto_generated_id',
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       updateDocument: async (collection: string, docId: string, fields: any, mask: string[]) => {
         updateCalls.push({ collection, docId, fields, mask });
@@ -173,8 +174,9 @@ describe('createRecurring', () => {
       requireUserId: async () => 'user123',
       getUserId: () => 'user123',
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      createDocument: async (collection: string, docId: string, fields: any) => {
+      createDocument: async (collection: string, docId: string | undefined, fields: any) => {
         createCalls.push({ collection, docId, fields });
+        return docId ?? 'auto_generated_id';
       },
       updateDocument: async () => {},
       deleteDocument: async () => {},
@@ -393,8 +395,9 @@ describe('createGoal', () => {
       requireUserId: async () => 'user123',
       getUserId: () => 'user123',
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      createDocument: async (collection: string, docId: string, fields: any) => {
+      createDocument: async (collection: string, docId: string | undefined, fields: any) => {
         createCalls.push({ collection, docId, fields });
+        return docId ?? 'auto_generated_id';
       },
       updateDocument: async () => {},
       deleteDocument: async () => {},

--- a/tests/tools/write-tools-phase4.test.ts
+++ b/tests/tools/write-tools-phase4.test.ts
@@ -49,8 +49,9 @@ function makeMockFirestoreClient(opts?: {
       updateCalls.push({ collection, docId, fields, mask });
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    createDocument: async (collection: string, docId: string, fields: any) => {
+    createDocument: async (collection: string, docId: string | undefined, fields: any) => {
       createCalls.push({ collection, docId, fields });
+      return docId ?? 'auto_generated_id';
     },
     deleteDocument: async (collection: string, docId: string) => {
       deleteCalls.push({ collection, docId });
@@ -437,7 +438,7 @@ describe('createCategory', () => {
   test('creates a category with name only', async () => {
     const result = await tools.createCategory({ name: 'Hobbies' });
     expect(result.success).toBe(true);
-    expect(result.category_id).toMatch(/^custom_/);
+    expect(result.category_id).toBe('auto_generated_id');
     expect(result.name).toBe('Hobbies');
     expect(result.excluded).toBe(false);
   });
@@ -458,11 +459,12 @@ describe('createCategory', () => {
     expect(result.excluded).toBe(true);
   });
 
-  test('calls Firestore createDocument with correct path', async () => {
-    const result = await tools.createCategory({ name: 'Hobbies' });
+  test('calls Firestore createDocument with correct path and auto-generated ID', async () => {
+    await tools.createCategory({ name: 'Hobbies' });
     expect(createCalls).toHaveLength(1);
     expect(createCalls[0].collection).toBe('users/user123/categories');
-    expect(createCalls[0].docId).toBe(result.category_id);
+    // docId should be undefined — Firestore auto-generates the ID
+    expect(createCalls[0].docId).toBeUndefined();
   });
 
   test('includes optional fields in Firestore document', async () => {
@@ -477,11 +479,11 @@ describe('createCategory', () => {
     expect(fields.color).toEqual({ stringValue: '#FF5500' });
   });
 
-  test('omits optional fields from Firestore when not provided', async () => {
+  test('uses default emoji and color when not provided', async () => {
     await tools.createCategory({ name: 'Hobbies' });
     const fields = createCalls[0].fields;
-    expect(fields.emoji).toBeUndefined();
-    expect(fields.color).toBeUndefined();
+    expect(fields.emoji).toEqual({ stringValue: '📁' });
+    expect(fields.color).toEqual({ stringValue: '#808080' });
     expect(fields.parent_category_id).toBeUndefined();
   });
 

--- a/tests/tools/write-tools.test.ts
+++ b/tests/tools/write-tools.test.ts
@@ -51,8 +51,9 @@ function makeMockFirestoreClient(opts?: {
       updateCalls.push({ collection, docId, fields, mask });
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    createDocument: async (collection: string, docId: string, fields: any) => {
+    createDocument: async (collection: string, docId: string | undefined, fields: any) => {
       createCalls.push({ collection, docId, fields });
+      return docId ?? 'auto_generated_id';
     },
     deleteDocument: async (collection: string, docId: string) => {
       deleteCalls.push({ collection, docId });

--- a/tests/tools/write-tools.test.ts
+++ b/tests/tools/write-tools.test.ts
@@ -132,7 +132,7 @@ describe('updateCategory', () => {
     // Valid color should succeed
     const result = await tools.updateCategory({ category_id: 'cat1', color: '#FF5733' });
     expect(result.success).toBe(true);
-    expect(result.updated_fields).toEqual(['color']);
+    expect(result.updated_fields).toEqual(['color', 'bg_color']);
   });
 
   test('updates excluded field', async () => {

--- a/tests/unit/update-transaction.test.ts
+++ b/tests/unit/update-transaction.test.ts
@@ -28,7 +28,7 @@ function makeMockFirestoreClient(updateCalls: UpdateCall[]) {
       updateCalls.push({ collection, docId, fields, mask });
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    createDocument: async () => {},
+    createDocument: async (_col: string, docId: string | undefined) => docId ?? 'auto_generated_id',
     deleteDocument: async () => {},
   };
 }


### PR DESCRIPTION
## Summary

Fixes #232 — MCP-created categories were invisible to the Copilot Money app.

**Root cause:** The MCP wrote category documents with only 3 fields (`category_id`, `name`, `excluded`) and a `custom_*` ID format, while the app expects ~12 fields and Firestore-auto-generated IDs.

- Use Firestore auto-generated document IDs instead of `custom_` prefix
- Write all app-required fields: `id`, `emoji`, `color`, `bg_color`, `order`, `is_other`, `auto_budget_lock`, `auto_delete_lock`, `plaid_category_ids`, `partial_name_rules`
- Default emoji (📁) and color (#808080) when not provided by the caller
- Add `FirestoreClient.getDocument()` for reading documents from Firestore REST API
- Update `createDocument` to support auto-generated IDs and return the created document ID

**Data cleanup** (done via MCP tools in this session):
- Reassigned 3 orphaned transactions to "Other" category
- Deleted broken `custom_0cabee4a986540ca` category from Firestore

## Test plan

- [x] All 1576 tests pass (0 fail, 26 skip)
- [x] `bun run check` passes (typecheck + lint + format + tests)
- [ ] Create a category via MCP with `--write` flag, verify it appears in the Copilot Money app
- [ ] Verify the 3 previously-orphaned transactions now show under "Other" in the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)