### PR TITLE
fix: get_categories uses user categories instead of Plaid taxonomy

### DIFF
--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -25,7 +25,7 @@ import type { InvestmentPerformance, TwrHolding } from '../models/investment-per
 import type { Security } from '../models/security.js';
 import type { GoalHistory } from '../models/goal-history.js';
 import { isItemHealthy, itemNeedsAttention, getItemDisplayName } from '../models/item.js';
-import type { Category } from '../models/category.js';
+import { type Category, getCategoryDisplayName } from '../models/category.js';
 
 // ============================================
 // Category Constants
@@ -1149,10 +1149,10 @@ export class CopilotMoneyTools {
         count: children.length,
         data: {
           parent_id: parent.category_id,
-          parent_name: parent.name,
+          parent_name: getCategoryDisplayName(parent),
           subcategories: children.map((child) => ({
             category_id: child.category_id,
-            category_name: child.name,
+            category_name: getCategoryDisplayName(child),
             emoji: child.emoji ?? null,
           })),
         },
@@ -1179,11 +1179,11 @@ export class CopilotMoneyTools {
           const children = childMap.get(root.category_id) ?? [];
           return {
             category_id: root.category_id,
-            category_name: root.name,
+            category_name: getCategoryDisplayName(root),
             emoji: root.emoji ?? null,
             children: children.map((child) => ({
               category_id: child.category_id,
-              category_name: child.name,
+              category_name: getCategoryDisplayName(child),
               emoji: child.emoji ?? null,
             })),
           };
@@ -1214,7 +1214,7 @@ export class CopilotMoneyTools {
             query: query.trim(),
             categories: matches.map((cat) => ({
               category_id: cat.category_id,
-              category_name: cat.name,
+              category_name: getCategoryDisplayName(cat),
               emoji: cat.emoji ?? null,
               parent_category_id: cat.parent_category_id ?? null,
             })),
@@ -1264,9 +1264,13 @@ export class CopilotMoneyTools {
               return {
                 category_id,
                 category_name: await this.resolveCategoryName(category_id),
-                parent_id: userCat?.parent_category_id ?? null,
+                parent_category_id: userCat?.parent_category_id ?? null,
                 parent_name: userCat?.parent_category_id
-                  ? (userCatMap.get(userCat.parent_category_id)?.name ?? null)
+                  ? getCategoryDisplayName(
+                      userCatMap.get(userCat.parent_category_id) ?? {
+                        category_id: userCat.parent_category_id,
+                      }
+                    )
                   : null,
                 transaction_count: stats.count,
                 total_amount: roundAmount(stats.totalAmount),

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -25,13 +25,7 @@ import type { InvestmentPerformance, TwrHolding } from '../models/investment-per
 import type { Security } from '../models/security.js';
 import type { GoalHistory } from '../models/goal-history.js';
 import { isItemHealthy, itemNeedsAttention, getItemDisplayName } from '../models/item.js';
-import {
-  getRootCategories,
-  getCategoryChildren,
-  getCategory,
-  getCategoryParent,
-  searchCategories as searchCategoriesInHierarchy,
-} from '../models/category-full.js';
+import type { Category } from '../models/category.js';
 
 // ============================================
 // Category Constants
@@ -1120,7 +1114,6 @@ export class CopilotMoneyTools {
       view?: 'list' | 'tree' | 'search';
       parent_id?: string;
       query?: string;
-      type?: 'income' | 'expense' | 'transfer';
       period?: string;
       start_date?: string;
       end_date?: string;
@@ -1131,7 +1124,7 @@ export class CopilotMoneyTools {
     period?: string;
     data: unknown;
   }> {
-    const { view = 'list', parent_id, query, type, period } = options;
+    const { view = 'list', parent_id, query, period } = options;
     let start_date = validateDate(options.start_date, 'start_date');
     let end_date = validateDate(options.end_date, 'end_date');
 
@@ -1142,27 +1135,25 @@ export class CopilotMoneyTools {
 
     // If parent_id is specified, get subcategories
     if (parent_id) {
-      const rootCats = getRootCategories();
-      const parent = rootCats.find((cat) => cat.id === parent_id);
+      const allUserCats = await this.db.getUserCategories();
+      const parent = allUserCats.find((c) => c.category_id === parent_id);
 
       if (!parent) {
-        throw new Error(`Category not found or has no subcategories: ${parent_id}`);
+        throw new Error(`Category not found: ${parent_id}`);
       }
 
-      const children = getCategoryChildren(parent_id);
+      const children = allUserCats.filter((c) => c.parent_category_id === parent_id);
 
       return {
         view: 'subcategories',
         count: children.length,
         data: {
-          parent_id: parent.id,
-          parent_name: parent.display_name,
+          parent_id: parent.category_id,
+          parent_name: parent.name,
           subcategories: children.map((child) => ({
-            id: child.id,
-            name: child.name,
-            display_name: child.display_name,
-            path: child.path,
-            type: child.type,
+            category_id: child.category_id,
+            category_name: child.name,
+            emoji: child.emoji ?? null,
           })),
         },
       };
@@ -1170,25 +1161,30 @@ export class CopilotMoneyTools {
 
     switch (view) {
       case 'tree': {
-        // Get root categories, optionally filtered by type
-        let rootCats = getRootCategories();
-        if (type) {
-          rootCats = rootCats.filter((cat) => cat.type === type);
+        // Build hierarchy from user categories
+        const allUserCats = await this.db.getUserCategories();
+
+        // Separate root categories (no parent) and children
+        const roots = allUserCats.filter((c) => !c.parent_category_id);
+        const childMap = new Map<string, Category[]>();
+        for (const cat of allUserCats) {
+          if (cat.parent_category_id) {
+            const siblings = childMap.get(cat.parent_category_id) ?? [];
+            siblings.push(cat);
+            childMap.set(cat.parent_category_id, siblings);
+          }
         }
 
-        // Build hierarchy
-        const categories = rootCats.map((root) => {
-          const children = getCategoryChildren(root.id);
+        const categories = roots.map((root) => {
+          const children = childMap.get(root.category_id) ?? [];
           return {
-            id: root.id,
-            name: root.name,
-            display_name: root.display_name,
-            type: root.type,
+            category_id: root.category_id,
+            category_name: root.name,
+            emoji: root.emoji ?? null,
             children: children.map((child) => ({
-              id: child.id,
-              name: child.name,
-              display_name: child.display_name,
-              path: child.path,
+              category_id: child.category_id,
+              category_name: child.name,
+              emoji: child.emoji ?? null,
             })),
           };
         });
@@ -1198,10 +1194,7 @@ export class CopilotMoneyTools {
         return {
           view: 'tree',
           count: totalCount,
-          data: {
-            type_filter: type,
-            categories,
-          },
+          data: { categories },
         };
       }
 
@@ -1210,21 +1203,20 @@ export class CopilotMoneyTools {
           throw new Error('Search query is required for search view');
         }
 
-        const results = searchCategoriesInHierarchy(query.trim());
+        const searchTerm = query.trim().toLowerCase();
+        const userCats = await this.db.getUserCategories();
+        const matches = userCats.filter((c) => c.name?.toLowerCase().includes(searchTerm));
 
         return {
           view: 'search',
-          count: results.length,
+          count: matches.length,
           data: {
             query: query.trim(),
-            categories: results.map((cat) => ({
-              id: cat.id,
-              name: cat.name,
-              display_name: cat.display_name,
-              path: cat.path,
-              type: cat.type,
-              depth: cat.depth,
-              is_leaf: cat.is_leaf,
+            categories: matches.map((cat) => ({
+              category_id: cat.category_id,
+              category_name: cat.name,
+              emoji: cat.emoji ?? null,
+              parent_category_id: cat.parent_category_id ?? null,
             })),
           },
         };
@@ -1253,36 +1245,32 @@ export class CopilotMoneyTools {
           categoryStats.set(categoryId, stats);
         }
 
-        // Include all known categories, even those with $0 (like UI does)
-        const allKnownCategories = getRootCategories();
-        for (const rootCat of allKnownCategories) {
-          // Add root category if not already present
-          if (!categoryStats.has(rootCat.id)) {
-            categoryStats.set(rootCat.id, { count: 0, totalAmount: 0 });
-          }
-          // Add all child categories
-          const children = getCategoryChildren(rootCat.id);
-          for (const child of children) {
-            if (!categoryStats.has(child.id)) {
-              categoryStats.set(child.id, { count: 0, totalAmount: 0 });
-            }
+        // Include all user-created categories, even those with $0 (matching app UI)
+        const userCategories = await this.db.getUserCategories();
+        for (const cat of userCategories) {
+          if (!categoryStats.has(cat.category_id)) {
+            categoryStats.set(cat.category_id, { count: 0, totalAmount: 0 });
           }
         }
 
-        // Convert to list with parent category info
+        // Build a lookup from user categories for parent/emoji info
+        const userCatMap = new Map(userCategories.map((c) => [c.category_id, c]));
+
+        // Convert to list
         const categories = (
           await Promise.all(
             Array.from(categoryStats.entries()).map(async ([category_id, stats]) => {
-              const categoryNode = getCategory(category_id);
-              const parentNode = getCategoryParent(category_id);
+              const userCat = userCatMap.get(category_id);
               return {
                 category_id,
                 category_name: await this.resolveCategoryName(category_id),
-                parent_id: parentNode?.id ?? null,
-                parent_name: parentNode?.display_name ?? null,
+                parent_id: userCat?.parent_category_id ?? null,
+                parent_name: userCat?.parent_category_id
+                  ? (userCatMap.get(userCat.parent_category_id)?.name ?? null)
+                  : null,
                 transaction_count: stats.count,
                 total_amount: roundAmount(stats.totalAmount),
-                type: categoryNode?.type ?? null,
+                emoji: userCat?.emoji ?? null,
               };
             })
           )
@@ -4333,9 +4321,9 @@ export function createToolSchemas(): ToolSchema[] {
       name: 'get_categories',
       description:
         'Unified category retrieval tool. Supports multiple views: ' +
-        'list (default) - categories with transaction counts/amounts for a time period; ' +
-        'tree - full Plaid category taxonomy as hierarchical tree; ' +
-        'search - search categories by keyword. Use parent_id to get subcategories. ' +
+        'list (default) - user categories with transaction counts/amounts for a time period; ' +
+        'tree - user categories as hierarchical tree; ' +
+        'search - search user categories by keyword. Use parent_id to get subcategories. ' +
         'For list view, use period (e.g., "this_month") or start_date/end_date to filter by date. ' +
         'Includes all categories, even those with $0 spent (matching UI behavior).',
       inputSchema: {
@@ -4345,7 +4333,7 @@ export function createToolSchemas(): ToolSchema[] {
             type: 'string',
             enum: ['list', 'tree', 'search'],
             description:
-              'View mode: list (categories in transactions), tree (full hierarchy), search (find by keyword)',
+              'View mode: list (categories with spend totals), tree (parent/child hierarchy), search (find by keyword)',
           },
           period: {
             type: 'string',
@@ -4368,11 +4356,6 @@ export function createToolSchemas(): ToolSchema[] {
           query: {
             type: 'string',
             description: "Search query (required for 'search' view)",
-          },
-          type: {
-            type: 'string',
-            enum: ['income', 'expense', 'transfer'],
-            description: "Filter by category type (for 'tree' view)",
           },
         },
       },

--- a/tests/integration/tools.test.ts
+++ b/tests/integration/tools.test.ts
@@ -324,12 +324,27 @@ function createMockDatabase(overrides?: {
   (db as any)._investmentPrices = overrides?.investmentPrices ?? [];
   (db as any)._investmentSplits = overrides?.investmentSplits ?? [];
   (db as any)._items = overrides?.items ?? [];
-  (db as any)._userCategories = overrides?.userCategories ?? [];
+  const defaultUserCategories: Category[] = [
+    { category_id: 'food_dining', name: 'Food & Dining', emoji: '🍔', order: 0 },
+    {
+      category_id: 'groceries',
+      name: 'Groceries',
+      emoji: '🥑',
+      parent_category_id: 'food_dining',
+      order: 1,
+    },
+    { category_id: 'income', name: 'Income', emoji: '💰', order: 2 },
+    { category_id: 'shopping', name: 'Shopping', emoji: '🛍', order: 3 },
+  ];
+  (db as any)._userCategories = overrides?.userCategories ?? [...defaultUserCategories];
   (db as any)._userAccounts = [];
   (db as any)._tags = overrides?.tags ?? [];
   (db as any)._securities = overrides?.securities ?? [];
   (db as any)._holdingsHistory = [];
-  (db as any)._categoryNameMap = new Map<string, string>();
+  const cats = (db as any)._userCategories as Category[];
+  (db as any)._categoryNameMap = new Map<string, string>(
+    cats.filter((c: Category) => c.name).map((c: Category) => [c.category_id, c.name!])
+  );
   (db as any)._accountNameMap = new Map<string, string>();
   // Mark as loaded so individual getters don't trigger disk reload
   (db as any)._allCollectionsLoaded = true;
@@ -676,9 +691,9 @@ describe('CopilotMoneyTools Integration', () => {
       expect(result.count).toBeGreaterThan(0);
       const data = result.data as { categories: any[] };
       expect(data.categories.length).toBeGreaterThan(0);
-      // Each root should have an id, name, and children array
+      // Each root should have a category_id, category_name, and children array
       const root = data.categories[0];
-      expect(root.id).toBeDefined();
+      expect(root.category_id).toBeDefined();
       expect(root.children).toBeDefined();
     });
 
@@ -689,6 +704,7 @@ describe('CopilotMoneyTools Integration', () => {
       const data = result.data as { query: string; categories: any[] };
       expect(data.query).toBe('food');
       expect(data.categories.length).toBeGreaterThan(0);
+      expect(data.categories[0].category_name).toContain('Food');
     });
   });
 

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -209,9 +209,33 @@ describe('CopilotMoneyTools', () => {
     (db as any)._investmentPrices = [];
     (db as any)._investmentSplits = [];
     (db as any)._items = [];
-    (db as any)._userCategories = [];
+    (db as any)._userCategories = [
+      { category_id: 'food_and_drink', name: 'Food & Drink', emoji: '🍔', order: 0 },
+      {
+        category_id: 'groceries',
+        name: 'Groceries',
+        emoji: '🥑',
+        parent_category_id: 'food_and_drink',
+        order: 1,
+      },
+      {
+        category_id: 'restaurants',
+        name: 'Restaurants',
+        emoji: '🍽',
+        parent_category_id: 'food_and_drink',
+        order: 2,
+      },
+      { category_id: 'shopping', name: 'Shopping', emoji: '🛍', order: 3 },
+      { category_id: 'education', name: 'Education & Coaching', emoji: '💸', order: 4 },
+    ];
     (db as any)._userAccounts = [];
-    (db as any)._categoryNameMap = new Map<string, string>();
+    (db as any)._categoryNameMap = new Map<string, string>([
+      ['food_and_drink', 'Food & Drink'],
+      ['groceries', 'Groceries'],
+      ['restaurants', 'Restaurants'],
+      ['shopping', 'Shopping'],
+      ['education', 'Education & Coaching'],
+    ]);
     (db as any)._accountNameMap = new Map<string, string>();
     // Mock data for new tools
     (db as any)._securities = [
@@ -791,13 +815,21 @@ describe('CopilotMoneyTools', () => {
 
       expect(result.view).toBe('tree');
       expect(result.count).toBeGreaterThan(0);
-      const data = result.data as { categories: { id: string; children: unknown[] }[] };
+      const data = result.data as {
+        categories: { category_id: string; category_name: string; children: unknown[] }[];
+      };
       expect(data.categories).toBeDefined();
       expect(Array.isArray(data.categories)).toBe(true);
 
+      // Root categories should be those without parent_category_id
+      const foodDrink = data.categories.find((c) => c.category_id === 'food_and_drink');
+      expect(foodDrink).toBeDefined();
+      expect(foodDrink!.category_name).toBe('Food & Drink');
+      expect(foodDrink!.children.length).toBe(2); // Groceries, Restaurants
+
       // Each root category should have children array
       for (const cat of data.categories) {
-        expect(cat.id).toBeDefined();
+        expect(cat.category_id).toBeDefined();
         expect(Array.isArray(cat.children)).toBe(true);
       }
     });
@@ -808,20 +840,14 @@ describe('CopilotMoneyTools', () => {
       expect(result.view).toBe('search');
       const data = result.data as {
         query: string;
-        categories: { name: string; display_name: string }[];
+        categories: { category_id: string; category_name: string }[];
       };
       expect(data.query).toBe('groceries');
       expect(data.categories).toBeDefined();
       expect(Array.isArray(data.categories)).toBe(true);
-      expect(data.categories.length).toBeGreaterThan(0);
-
-      // At least one result should contain 'groceries'
-      const hasGroceries = data.categories.some(
-        (cat) =>
-          cat.name.toLowerCase().includes('groceries') ||
-          cat.display_name.toLowerCase().includes('groceries')
-      );
-      expect(hasGroceries).toBe(true);
+      expect(data.categories.length).toBe(1);
+      expect(data.categories[0].category_id).toBe('groceries');
+      expect(data.categories[0].category_name).toBe('Groceries');
     });
 
     test('returns subcategories view when parent_id provided', async () => {
@@ -831,12 +857,16 @@ describe('CopilotMoneyTools', () => {
       const data = result.data as {
         parent_id: string;
         parent_name: string;
-        subcategories: { id: string; name: string }[];
+        subcategories: { category_id: string; category_name: string }[];
       };
       expect(data.parent_id).toBe('food_and_drink');
       expect(data.parent_name).toBe('Food & Drink');
       expect(Array.isArray(data.subcategories)).toBe(true);
-      expect(data.subcategories.length).toBeGreaterThan(0);
+      expect(data.subcategories.length).toBe(2);
+      expect(data.subcategories.map((s) => s.category_name).sort()).toEqual([
+        'Groceries',
+        'Restaurants',
+      ]);
     });
   });
 

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -789,7 +789,7 @@ describe('CopilotMoneyTools', () => {
         result.data as {
           categories: {
             category_id: string;
-            parent_id: string | null;
+            parent_category_id: string | null;
             parent_name: string | null;
           }[];
         }
@@ -798,14 +798,14 @@ describe('CopilotMoneyTools', () => {
       // Find a subcategory that should have a parent
       const restaurants = categories.find((c) => c.category_id === 'restaurants');
       if (restaurants) {
-        expect(restaurants.parent_id).toBe('food_and_drink');
+        expect(restaurants.parent_category_id).toBe('food_and_drink');
         expect(restaurants.parent_name).toBe('Food & Drink');
       }
 
       // Root categories should have null parent
       const foodDrink = categories.find((c) => c.category_id === 'food_and_drink');
       if (foodDrink) {
-        expect(foodDrink.parent_id).toBeNull();
+        expect(foodDrink.parent_category_id).toBeNull();
         expect(foodDrink.parent_name).toBeNull();
       }
     });


### PR DESCRIPTION
## Summary

Fixes #238 — `get_categories` was built around the Plaid taxonomy (~120 static categories) as the primary system, but the Copilot Money app only uses user-created categories.

**Before:** list view returned 144 categories (120+ Plaid noise + ~24 user categories), search only found Plaid IDs (unusable with write tools), and ~6 real user categories were invisible (Education & Coaching, Sports, Automobile, etc.)

**After:** all views use user categories from LevelDB exclusively.

- **list**: shows all user categories (even $0 spent), includes emoji
- **search**: searches user categories by name
- **tree**: builds hierarchy from `parent_category_id` relationships
- **subcategories**: uses user category parent/child relationships
- Removed `type` filter (Plaid-specific concept)
- Removed unused Plaid taxonomy imports (`getRootCategories`, `getCategoryChildren`, etc.)

## Test plan

- [x] All 1576 tests pass (0 fail, 26 skip)
- [x] `bun run check` passes (typecheck + lint + format + tests)
- [x] Verify `get_categories(view: "search", query: "education")` now finds "Education & Coaching"
- [x] Verify `get_categories(view: "list")` returns 34 user categories (not 144)
- [x] Verify `get_categories(view: "tree")` shows parent/child hierarchy (Food > Restaurants/Groceries/Coffee, Automobile > Car/Gas/Parking, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)