### PR TITLE
ci: chain npm-publish from auto-release via workflow_call

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,6 +17,9 @@ jobs:
       cancel-in-progress: false
     permissions:
       contents: write
+    outputs:
+      changed: ${{ steps.version.outputs.changed }}
+      version: ${{ steps.version.outputs.current }}
 
     steps:
       - name: Checkout repository
@@ -101,3 +104,16 @@ jobs:
             --title "v$VERSION" \
             --notes-file /tmp/release-notes.md \
             --target "${{ github.sha }}"
+
+  # Publishing is chained directly via workflow_call rather than relying on the
+  # release event, because releases created with the default GITHUB_TOKEN do not
+  # trigger downstream `release: published` workflows.
+  publish:
+    name: Publish to npm
+    needs: release
+    if: needs.release.outputs.changed == 'true'
+    permissions:
+      contents: read
+      id-token: write  # Required for npm OIDC trusted publishing
+    uses: ./.github/workflows/npm-publish.yml
+    secrets: inherit

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -111,9 +111,11 @@ jobs:
   publish:
     name: Publish to npm
     needs: release
-    if: needs.release.outputs.changed == 'true'
+    if: needs.release.outputs.changed == 'true' && github.actor == 'ignaciohermosillacornejo'
     permissions:
       contents: read
       id-token: write  # Required for npm OIDC trusted publishing
     uses: ./.github/workflows/npm-publish.yml
+    with:
+      dry_run: false
     secrets: inherit

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,13 @@ on:
         required: false
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      dry_run:
+        description: 'Perform a dry run (do not actually publish)'
+        required: false
+        type: boolean
+        default: false
 
 env:
   BUN_VERSION: 'latest'
@@ -24,10 +31,13 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
-    # Only run for releases created by trusted publishers, or manual dispatch by owner
+    # Only run for releases created by trusted publishers, or any other trigger
+    # (workflow_dispatch / workflow_call) initiated by the trusted actor. Note: in a
+    # workflow_call context, github.event_name reflects the calling workflow's event
+    # (e.g. 'push'), not 'workflow_call', so we gate on actor rather than event_name.
     if: |
       (github.event_name == 'release' && github.event.release.author.login == 'ignaciohermosillacornejo') ||
-      (github.event_name == 'workflow_dispatch' && github.actor == 'ignaciohermosillacornejo')
+      (github.event_name != 'release' && github.actor == 'ignaciohermosillacornejo')
 
     steps:
       - name: Verify publisher is trusted
@@ -98,9 +108,9 @@ jobs:
           echo "Version $PACKAGE_VERSION is available for publishing"
 
       - name: Publish to npm (dry run)
-        if: github.event.inputs.dry_run == 'true'
+        if: inputs.dry_run == true || github.event.inputs.dry_run == 'true'
         run: npm publish --dry-run --verbose
 
       - name: Publish to npm
-        if: github.event.inputs.dry_run != 'true'
+        if: inputs.dry_run != true && github.event.inputs.dry_run != 'true'
         run: npm publish --provenance --access public --verbose


### PR DESCRIPTION
## Summary

- Fixes the gap that left **v1.6.1 unpublished to npm** even though the GitHub release was created. Releases created with the default `GITHUB_TOKEN` don't trigger downstream `release: published` workflows (GitHub's anti-loop safeguard), so `npm-publish.yml` never fired.
- Promotes `npm-publish.yml` to a reusable workflow (`workflow_call`) and chains it directly from `auto-release.yml`. The full release → publish pipeline now runs in one push-triggered execution.
- v1.6.1 was published to npm separately via manual `workflow_dispatch` so users aren't blocked.

## Changes

- `npm-publish.yml`
  - Add `workflow_call` trigger with matching `dry_run` input
  - Relax the gate: trust `github.actor` for non-release events (in `workflow_call`, `github.event_name` reflects the **calling** workflow's event, not `'workflow_call'`)
  - Handle `dry_run` from both `inputs.*` (workflow_call) and `github.event.inputs.*` (workflow_dispatch) contexts
- `auto-release.yml`
  - Expose `changed` and `version` outputs from the release job
  - Add a `publish` job gated on `changed == 'true'` that calls `npm-publish.yml` with `secrets: inherit` and `id-token: write` for OIDC trusted publishing

## Test plan

- [ ] Workflow YAML lints clean (no syntax errors)
- [ ] On next version bump merge to `main`, verify Auto Release run shows two jobs (`release` then `publish`) and the publish job uploads to npm
- [ ] If something goes wrong, manual `gh workflow run npm-publish.yml` still works as a fallback (the workflow_dispatch trigger is preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)