### PR TITLE
Update tool count from 41 to 35 in documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Copilot Money MCP Server — AI-Powered Personal Finance</title>
-  <meta name="description" content="Query and manage your personal finances with AI. 41 tools for transactions, investments, budgets, goals, and more. Local-first, privacy-first.">
+  <meta name="description" content="Query and manage your personal finances with AI. 35 tools for transactions, investments, budgets, goals, and more. Local-first, privacy-first.">
   <link rel="icon" type="image/png" href="icon.png">
   <link rel="apple-touch-icon" href="icon.png">
   <meta property="og:title" content="Copilot Money MCP Server">
@@ -360,9 +360,9 @@
 
 <!-- Stats -->
 <div class="stats">
-  <div class="stat"><div class="num">41</div><div class="label">AI Tools</div></div>
+  <div class="stat"><div class="num">35</div><div class="label">AI Tools</div></div>
   <div class="stat"><div class="num">17</div><div class="label">Read Tools</div></div>
-  <div class="stat"><div class="num">24</div><div class="label">Write Tools</div></div>
+  <div class="stat"><div class="num">18</div><div class="label">Write Tools</div></div>
   <div class="stat"><div class="num">100%</div><div class="label">Open Source</div></div>
 </div>
 
@@ -401,7 +401,7 @@
         <span class="step-num">3</span>
         <span class="step-title">Restart Claude Desktop and start asking!</span>
         <p>"How much did I spend on food this month?" — Claude will use your Copilot Money data to answer.</p>
-        <p class="write-note">All 41 tools (read + write) are enabled by default. To run read-only, open Claude Desktop &rarr; Settings &rarr; Extensions &rarr; Copilot Money MCP and toggle off the write tools you don't want.</p>
+        <p class="write-note">All 35 tools (read + write) are enabled by default. To run read-only, open Claude Desktop &rarr; Settings &rarr; Extensions &rarr; Copilot Money MCP and toggle off the write tools you don't want.</p>
       </div>
     </div>
 
@@ -719,7 +719,7 @@ args = ["--write"]</div>
 <section id="features">
   <div class="section-label">Features</div>
   <h2>Everything you need</h2>
-  <p class="subtitle">41 tools covering every aspect of your personal finances.</p>
+  <p class="subtitle">35 tools covering every aspect of your personal finances.</p>
 
   <div class="features">
     <div class="feature-card">
@@ -760,7 +760,7 @@ args = ["--write"]</div>
   <div class="privacy-banner">
     <h2>Local-first, no third parties</h2>
     <p>Reads go straight to your locally cached Copilot Money database — zero network. Writes sync to your own Copilot account via the same Google Firestore backend the app already uses. Nothing is ever sent to us or any third party.</p>
-    <p style="font-size: 0.85rem; margin-top: 12px;"><strong>Write defaults:</strong> the Claude Desktop <code>.mcpb</code> bundle enables all 41 tools (disable individual write tools from Settings &rarr; Extensions). Every other client's config is read-only by default — add <code>--write</code> to enable.</p>
+    <p style="font-size: 0.85rem; margin-top: 12px;"><strong>Write defaults:</strong> the Claude Desktop <code>.mcpb</code> bundle enables all 35 tools (disable individual write tools from Settings &rarr; Extensions). Every other client's config is read-only by default — add <code>--write</code> to enable.</p>
     <div class="privacy-checks">
       <div class="privacy-check"><span class="check">&#10003;</span> No data collection</div>
       <div class="privacy-check"><span class="check">&#10003;</span> No analytics or telemetry</div>


### PR DESCRIPTION
## Summary
Updates all references to the total number of AI tools in the documentation from 41 to 35, along with adjusting the write tools count from 24 to 18 to reflect the current state of the project.

## Changes Made
- Updated meta description tag to reflect 35 tools instead of 41
- Updated stats section displaying AI tool counts (41 → 35 total, 24 → 18 write tools)
- Updated installation instructions note referencing tool count
- Updated features section subtitle to reference 35 tools
- Updated privacy banner documentation to reference 35 tools

## Details
This appears to be a documentation maintenance update to align the marketing materials and user-facing documentation with the actual number of tools currently available in the Copilot Money MCP Server. The changes are consistent across all documentation sections that reference tool counts.

https://claude.ai/code/session_019ZrtW7yJSUNqmxUPhGf9Rj