### PR TITLE
docs: add organize transactions demo GIF to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ An [MCP](https://modelcontextprotocol.io/) server that gives AI assistants acces
 Organizing transactions with natural language — categorize, tag, and clean up your feed in one pass:
 
 <p align="center">
-  <img src="docs/demos/organize.gif" alt="Organizing transactions with natural language" width="720" />
+  <img src="https://github.com/user-attachments/assets/3d652c74-2431-4e76-b77c-165cf5b8c6a8" alt="Organizing transactions with natural language" width="720" />
 </p>
 
 ## Privacy First

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ An [MCP](https://modelcontextprotocol.io/) server that gives AI assistants acces
 
 **Read-only by default.** Write tools require explicitly starting the server with `--write` to enable.
 
+## Demo
+
+Organizing transactions with natural language — categorize, tag, and clean up your feed in one pass:
+
+<p align="center">
+  <img src="docs/demos/organize.gif" alt="Organizing transactions with natural language" width="720" />
+</p>
+
 ## Privacy First
 
 We never collect, store, or transmit your data to any server operated by this project — we don't have any. See our [Privacy Policy](PRIVACY.md) for details.

--- a/skills/finance-cleanup/SKILL.md
+++ b/skills/finance-cleanup/SKILL.md
@@ -41,7 +41,7 @@ For each merchant that appears 3+ times in the 6-month history:
 
 ### 2.2 Misclassified Transfers
 
-**Payment app accounts (Venmo, PayPal, etc.):** These create two-sided transactions — a generic stub on the bank/checking side (e.g., "VENMO" with no detail, marked as internal transfer) and a richly-described transaction on the payment app account side (e.g., "Bar Whistler to Fernando Alamos" with proper category). Before flagging bank-side payment app stubs as false transfers, check if the payment app account exists (`get_accounts`) and whether the real transaction lives there. If both sides exist, the bank-side stub is correctly marked as a transfer — leave it alone.
+**Payment app accounts (Venmo, PayPal, etc.):** These create two-sided transactions — a generic stub on the bank/checking side (e.g., "VENMO" with no detail, marked as internal transfer) and a richly-described transaction on the payment app account side (e.g., "Bar Whistler to Sam Rivera" with proper category). Before flagging bank-side payment app stubs as false transfers, check if the payment app account exists (`get_accounts`) and whether the real transaction lives there. If both sides exist, the bank-side stub is correctly marked as a transfer — leave it alone.
 
 Two directions to check:
 


### PR DESCRIPTION
## Summary
- Add a `## Demo` section to the README with an animated GIF showing the organize-transactions flow, so GitHub visitors get an immediate visual of what the write tools feel like without having to click through to the docs site.
- GIF was generated from `docs/demos/organize.mp4` with ffmpeg (720px wide, 24 fps, 1.2× playback speed, palette-optimized, ~5.1 MB).

## Test plan
- [ ] README renders on GitHub with the GIF autoplaying in the new Demo section
- [ ] GIF plays smoothly at 24 fps and feels appropriately paced (not sluggish, not frantic)
- [ ] Existing docs site (`docs/index.html`) still uses the `.mp4` sources and is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)