### PR TITLE
fix(mcpb): bundle production deps and attach .mcpb to auto-release

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"c741f9a6-7437-46f1-99d7-6974fbbef55f","pid":28002,"acquiredAt":1776141300043}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"c741f9a6-7437-46f1-99d7-6974fbbef55f","pid":28002,"acquiredAt":1776141300043}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -94,17 +94,6 @@ jobs:
           # Write to file to avoid escaping issues
           echo "$NOTES" > /tmp/release-notes.md
 
-      - name: Create release
-        if: steps.version.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          VERSION="${{ steps.version.outputs.current }}"
-          gh release create "v$VERSION" \
-            --title "v$VERSION" \
-            --notes-file /tmp/release-notes.md \
-            --target "${{ github.sha }}"
-
       - name: Setup Bun
         if: steps.version.outputs.changed == 'true'
         uses: oven-sh/setup-bun@v2
@@ -115,13 +104,21 @@ jobs:
         if: steps.version.outputs.changed == 'true'
         run: bun install
 
-      - name: Build and attach .mcpb bundle
+      - name: Build .mcpb bundle
+        if: steps.version.outputs.changed == 'true'
+        run: bun run pack:mcpb
+
+      - name: Create release with bundle
         if: steps.version.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          bun run pack:mcpb
-          gh release upload "v${{ steps.version.outputs.current }}" copilot-money-mcp.mcpb
+          VERSION="${{ steps.version.outputs.current }}"
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --notes-file /tmp/release-notes.md \
+            --target "${{ github.sha }}" \
+            copilot-money-mcp.mcpb
 
   # Publishing is chained directly via workflow_call rather than relying on the
   # release event, because releases created with the default GITHUB_TOKEN do not

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -105,6 +105,24 @@ jobs:
             --notes-file /tmp/release-notes.md \
             --target "${{ github.sha }}"
 
+      - name: Setup Bun
+        if: steps.version.outputs.changed == 'true'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        if: steps.version.outputs.changed == 'true'
+        run: bun install
+
+      - name: Build and attach .mcpb bundle
+        if: steps.version.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bun run pack:mcpb
+          gh release upload "v${{ steps.version.outputs.current }}" copilot-money-mcp.mcpb
+
   # Publishing is chained directly via workflow_call rather than relying on the
   # release event, because releases created with the default GITHUB_TOKEN do not
   # trigger downstream `release: published` workflows.

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ bun.lock
 # Build output
 dist/
 *.mcpb
+.mcpb-staging/
 
 # TypeScript
 *.tsbuildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ dist/
 *.mcpb
 .mcpb-staging/
 
+# Claude Code local state
+.claude/scheduled_tasks.lock
+.claude/settings.local.json
+
 # TypeScript
 *.tsbuildinfo
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "audit-reviews:dry": "bun run scripts/audit-pr-reviews.ts --dry-run",
     "fix": "bun run lint:fix && bun run format",
     "clean": "rm -rf dist coverage .bun-build",
-    "pack:mcpb": "bun run build:bundle && bun run build && bunx @anthropic-ai/mcpb pack",
+    "pack:mcpb": "bun run scripts/pack-mcpb.ts",
     "prepublishOnly": "bun run clean && bun run build && bun test",
     "prepare": "husky"
   },

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
   "scripts": {
     "dev": "bun run src/server.ts",
     "dev:debug": "bun --inspect run src/server.ts",
-    "build": "bun build src/cli.ts --outdir dist --target node --format esm --external classic-level && bun build src/core/decode-worker.ts --outdir dist --target node --format esm --external classic-level && chmod +x dist/cli.js",
-    "build:bundle": "bun build src/server.ts --outdir dist --target node --format esm --external classic-level && bun build src/core/decode-worker.ts --outdir dist --target node --format esm --external classic-level",
+    "build": "bun build src/cli.ts src/server.ts --outdir dist --target node --format esm --external classic-level && bun build src/core/decode-worker.ts --outdir dist --target node --format esm --external classic-level && chmod +x dist/cli.js",
     "test": "bun test",
     "test:e2e": "bun test tests/e2e/",
     "test:unit": "bun test tests/tools/ tests/core/ tests/models/ tests/utils/",

--- a/scripts/pack-mcpb.ts
+++ b/scripts/pack-mcpb.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env bun
+/**
+ * Pack the project into a self-contained .mcpb bundle.
+ *
+ * Usage: bun run scripts/pack-mcpb.ts
+ *
+ * The output bundle embeds production `node_modules/` so that native
+ * dependencies (classic-level ships prebuilds for every supported platform)
+ * resolve when Claude Desktop extracts and runs the bundle with its built-in
+ * Node runtime. Dev dependencies are left out by installing with `npm --omit=dev`
+ * in an isolated staging directory; the dev workspace is untouched.
+ */
+
+import { execSync } from 'node:child_process';
+import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const stagingDir = join(repoRoot, '.mcpb-staging');
+const outputPath = join(repoRoot, 'copilot-money-mcp.mcpb');
+
+const STAGED_FILES = [
+  'CHANGELOG.md',
+  'LICENSE',
+  'PRIVACY.md',
+  'README.md',
+  'SECURITY.md',
+  'dist',
+  'docs/EXAMPLE_QUERIES.md',
+  'icon.png',
+  'manifest.json',
+  'package.json',
+  'skills',
+];
+
+function run(cmd: string, cwd: string): void {
+  execSync(cmd, { stdio: 'inherit', cwd });
+}
+
+function copyInto(src: string, dest: string): void {
+  const srcPath = join(repoRoot, src);
+  if (!existsSync(srcPath)) {
+    throw new Error(`Expected source path missing: ${src}`);
+  }
+  const destPath = join(dest, src);
+  mkdirSync(dirname(destPath), { recursive: true });
+  cpSync(srcPath, destPath, { recursive: true });
+}
+
+if (existsSync(outputPath)) rmSync(outputPath);
+if (existsSync(stagingDir)) rmSync(stagingDir, { recursive: true, force: true });
+
+run('bun run build:bundle', repoRoot);
+run('bun run build', repoRoot);
+
+mkdirSync(stagingDir, { recursive: true });
+for (const path of STAGED_FILES) copyInto(path, stagingDir);
+
+// Install production deps into the staging dir. --ignore-scripts skips lifecycle
+// hooks (husky, etc.) that we don't need; classic-level's native build is not
+// required because node-gyp-build picks an appropriate prebuilt binary at load
+// time from node_modules/classic-level/prebuilds/.
+run('npm install --omit=dev --ignore-scripts --no-audit --no-fund', stagingDir);
+
+run(`bunx @anthropic-ai/mcpb pack . ${JSON.stringify(outputPath)}`, stagingDir);
+
+rmSync(stagingDir, { recursive: true, force: true });
+
+if (!existsSync(outputPath)) {
+  console.error(`Expected bundle at ${outputPath} but it was not created`);
+  process.exit(1);
+}
+console.log(`\nBundle: ${outputPath}`);

--- a/scripts/pack-mcpb.ts
+++ b/scripts/pack-mcpb.ts
@@ -52,21 +52,22 @@ function copyInto(src: string, dest: string): void {
 if (existsSync(outputPath)) rmSync(outputPath);
 if (existsSync(stagingDir)) rmSync(stagingDir, { recursive: true, force: true });
 
-run('bun run build:bundle', repoRoot);
 run('bun run build', repoRoot);
 
 mkdirSync(stagingDir, { recursive: true });
-for (const path of STAGED_FILES) copyInto(path, stagingDir);
+try {
+  for (const path of STAGED_FILES) copyInto(path, stagingDir);
 
-// Install production deps into the staging dir. --ignore-scripts skips lifecycle
-// hooks (husky, etc.) that we don't need; classic-level's native build is not
-// required because node-gyp-build picks an appropriate prebuilt binary at load
-// time from node_modules/classic-level/prebuilds/.
-run('npm install --omit=dev --ignore-scripts --no-audit --no-fund', stagingDir);
+  // Install production deps into the staging dir. --ignore-scripts skips lifecycle
+  // hooks (husky, etc.) that we don't need; classic-level's native build is not
+  // required because node-gyp-build picks an appropriate prebuilt binary at load
+  // time from node_modules/classic-level/prebuilds/.
+  run('npm install --omit=dev --ignore-scripts --no-audit --no-fund', stagingDir);
 
-run(`bunx @anthropic-ai/mcpb pack . ${JSON.stringify(outputPath)}`, stagingDir);
-
-rmSync(stagingDir, { recursive: true, force: true });
+  run(`bunx @anthropic-ai/mcpb pack . ${JSON.stringify(outputPath)}`, stagingDir);
+} finally {
+  rmSync(stagingDir, { recursive: true, force: true });
+}
 
 if (!existsSync(outputPath)) {
   console.error(`Expected bundle at ${outputPath} but it was not created`);

--- a/tests/integration/mcpb-bundle.test.ts
+++ b/tests/integration/mcpb-bundle.test.ts
@@ -94,11 +94,41 @@ function send(proc: ChildProcessWithoutNullStreams, msg: object): void {
   proc.stdin.write(JSON.stringify(msg) + '\n');
 }
 
+async function startAndInitialize(
+  extractDir: string
+): Promise<{ proc: ChildProcessWithoutNullStreams; initializeResult: JsonRpcResponse }> {
+  const proc = spawn('node', [join(extractDir, 'dist/cli.js'), '--write'], {
+    cwd: extractDir,
+    env: { ...process.env, NODE_PATH: '' },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  send(proc, {
+    jsonrpc: '2.0',
+    id: 0,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2025-11-25',
+      capabilities: {},
+      clientInfo: { name: 'mcpb-regression-test', version: '0.0.0' },
+    },
+  });
+  const initializeResult = await readResponse(proc, 0, 10_000);
+  return { proc, initializeResult };
+}
+
 describe('mcpb bundle', () => {
   let extractDir: string;
   let bundledVersion: string;
 
   beforeAll(() => {
+    // `unzip` is used to extract the bundle the way Claude Desktop does.
+    // Pre-flight so the failure is clear on minimal images (e.g. Alpine).
+    try {
+      execSync('unzip -v', { stdio: 'ignore' });
+    } catch {
+      throw new Error('unzip binary is required to run this test');
+    }
+
     execSync('bun run pack:mcpb', { cwd: repoRoot, stdio: 'inherit' });
     if (!existsSync(bundlePath)) {
       throw new Error(`pack:mcpb did not produce a bundle at ${bundlePath}`);
@@ -119,28 +149,10 @@ describe('mcpb bundle', () => {
   });
 
   test('server starts and responds to initialize with matching version', async () => {
-    const proc = spawn('node', [join(extractDir, 'dist/cli.js'), '--write'], {
-      cwd: extractDir,
-      env: { ...process.env, NODE_PATH: '' },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
+    const { proc, initializeResult } = await startAndInitialize(extractDir);
     try {
-      send(proc, {
-        jsonrpc: '2.0',
-        id: 0,
-        method: 'initialize',
-        params: {
-          protocolVersion: '2025-11-25',
-          capabilities: {},
-          clientInfo: { name: 'mcpb-regression-test', version: '0.0.0' },
-        },
-      });
-
-      const response = await readResponse(proc, 0, 10_000);
-      expect(response.error).toBeUndefined();
-      expect(response.result).toBeDefined();
-      const result = response.result as { serverInfo: { name: string; version: string } };
+      expect(initializeResult.error).toBeUndefined();
+      const result = initializeResult.result as { serverInfo: { name: string; version: string } };
       expect(result.serverInfo.name).toBe('copilot-money-mcp');
       expect(result.serverInfo.version).toBe(bundledVersion);
     } finally {
@@ -149,27 +161,10 @@ describe('mcpb bundle', () => {
   }, 20_000);
 
   test('server advertises the expected number of tools', async () => {
-    const proc = spawn('node', [join(extractDir, 'dist/cli.js'), '--write'], {
-      cwd: extractDir,
-      env: { ...process.env, NODE_PATH: '' },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-
+    const { proc } = await startAndInitialize(extractDir);
     try {
-      send(proc, {
-        jsonrpc: '2.0',
-        id: 0,
-        method: 'initialize',
-        params: {
-          protocolVersion: '2025-11-25',
-          capabilities: {},
-          clientInfo: { name: 'mcpb-regression-test', version: '0.0.0' },
-        },
-      });
-      await readResponse(proc, 0, 10_000);
       send(proc, { jsonrpc: '2.0', method: 'notifications/initialized' });
       send(proc, { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
-
       const response = await readResponse(proc, 1, 10_000);
       const tools = (response.result as { tools: unknown[] }).tools;
       expect(Array.isArray(tools)).toBe(true);

--- a/tests/integration/mcpb-bundle.test.ts
+++ b/tests/integration/mcpb-bundle.test.ts
@@ -102,18 +102,24 @@ async function startAndInitialize(
     env: { ...process.env, NODE_PATH: '' },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
-  send(proc, {
-    jsonrpc: '2.0',
-    id: 0,
-    method: 'initialize',
-    params: {
-      protocolVersion: '2025-11-25',
-      capabilities: {},
-      clientInfo: { name: 'mcpb-regression-test', version: '0.0.0' },
-    },
-  });
-  const initializeResult = await readResponse(proc, 0, 10_000);
-  return { proc, initializeResult };
+  try {
+    send(proc, {
+      jsonrpc: '2.0',
+      id: 0,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-11-25',
+        capabilities: {},
+        clientInfo: { name: 'mcpb-regression-test', version: '0.0.0' },
+      },
+    });
+    const initializeResult = await readResponse(proc, 0, 10_000);
+    return { proc, initializeResult };
+  } catch (err) {
+    // The caller never receives `proc`, so kill it here instead of leaking it.
+    proc.kill('SIGTERM');
+    throw err;
+  }
 }
 
 describe('mcpb bundle', () => {

--- a/tests/integration/mcpb-bundle.test.ts
+++ b/tests/integration/mcpb-bundle.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Regression test for the .mcpb bundle shipped to end users.
+ *
+ * The bundle is executed by Claude Desktop's built-in Node runtime after being
+ * extracted to an arbitrary directory. It must start and respond to the MCP
+ * `initialize` RPC without relying on anything outside the extracted directory
+ * — in particular, the repository's own `node_modules` is not visible there.
+ *
+ * The v1.6.0 and v1.6.1 bundles shipped broken because `classic-level` was
+ * marked `--external` at build time but `node_modules/` was excluded from the
+ * bundle via `.mcpbignore`. This test runs the packed bundle under the same
+ * constraints Claude Desktop does (extracted, isolated from the repo) so that
+ * kind of regression is caught before release.
+ */
+
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { spawn, execSync, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..');
+const bundlePath = join(repoRoot, 'copilot-money-mcp.mcpb');
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+function readResponse(
+  proc: ChildProcessWithoutNullStreams,
+  id: number,
+  timeoutMs = 5000
+): Promise<JsonRpcResponse> {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    let stderr = '';
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      let newlineIdx = buffer.indexOf('\n');
+      while (newlineIdx !== -1) {
+        const line = buffer.slice(0, newlineIdx).trim();
+        buffer = buffer.slice(newlineIdx + 1);
+        if (line) {
+          try {
+            const msg = JSON.parse(line) as JsonRpcResponse;
+            if (msg.id === id) {
+              cleanup();
+              resolve(msg);
+              return;
+            }
+          } catch {
+            // ignore non-JSON lines
+          }
+        }
+        newlineIdx = buffer.indexOf('\n');
+      }
+    };
+    const onStderr = (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    };
+    const onExit = (code: number | null) => {
+      cleanup();
+      reject(
+        new Error(
+          `Server exited with code ${code} before responding to id=${id}\n` +
+            `stdout buffer: ${buffer}\nstderr: ${stderr}`
+        )
+      );
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(`Timeout waiting for response id=${id}\nstdout: ${buffer}\nstderr: ${stderr}`)
+      );
+    }, timeoutMs);
+    const cleanup = () => {
+      clearTimeout(timer);
+      proc.stdout.off('data', onData);
+      proc.stderr.off('data', onStderr);
+      proc.off('exit', onExit);
+    };
+    proc.stdout.on('data', onData);
+    proc.stderr.on('data', onStderr);
+    proc.once('exit', onExit);
+  });
+}
+
+function send(proc: ChildProcessWithoutNullStreams, msg: object): void {
+  proc.stdin.write(JSON.stringify(msg) + '\n');
+}
+
+describe('mcpb bundle', () => {
+  let extractDir: string;
+  let bundledVersion: string;
+
+  beforeAll(() => {
+    execSync('bun run pack:mcpb', { cwd: repoRoot, stdio: 'inherit' });
+    if (!existsSync(bundlePath)) {
+      throw new Error(`pack:mcpb did not produce a bundle at ${bundlePath}`);
+    }
+    extractDir = mkdtempSync(join(tmpdir(), 'copilot-mcpb-test-'));
+    execSync(`unzip -q ${JSON.stringify(bundlePath)} -d ${JSON.stringify(extractDir)}`);
+    bundledVersion = JSON.parse(readFileSync(join(extractDir, 'package.json'), 'utf8')).version;
+  }, 120_000);
+
+  afterAll(() => {
+    if (extractDir) {
+      rmSync(extractDir, { recursive: true, force: true });
+    }
+  });
+
+  test('extracted bundle has a dist/cli.js entry point', () => {
+    expect(existsSync(join(extractDir, 'dist/cli.js'))).toBe(true);
+  });
+
+  test('server starts and responds to initialize with matching version', async () => {
+    const proc = spawn('node', [join(extractDir, 'dist/cli.js'), '--write'], {
+      cwd: extractDir,
+      env: { ...process.env, NODE_PATH: '' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    try {
+      send(proc, {
+        jsonrpc: '2.0',
+        id: 0,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-11-25',
+          capabilities: {},
+          clientInfo: { name: 'mcpb-regression-test', version: '0.0.0' },
+        },
+      });
+
+      const response = await readResponse(proc, 0, 10_000);
+      expect(response.error).toBeUndefined();
+      expect(response.result).toBeDefined();
+      const result = response.result as { serverInfo: { name: string; version: string } };
+      expect(result.serverInfo.name).toBe('copilot-money-mcp');
+      expect(result.serverInfo.version).toBe(bundledVersion);
+    } finally {
+      proc.kill('SIGTERM');
+    }
+  }, 20_000);
+
+  test('server advertises the expected number of tools', async () => {
+    const proc = spawn('node', [join(extractDir, 'dist/cli.js'), '--write'], {
+      cwd: extractDir,
+      env: { ...process.env, NODE_PATH: '' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    try {
+      send(proc, {
+        jsonrpc: '2.0',
+        id: 0,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-11-25',
+          capabilities: {},
+          clientInfo: { name: 'mcpb-regression-test', version: '0.0.0' },
+        },
+      });
+      await readResponse(proc, 0, 10_000);
+      send(proc, { jsonrpc: '2.0', method: 'notifications/initialized' });
+      send(proc, { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+      const response = await readResponse(proc, 1, 10_000);
+      const tools = (response.result as { tools: unknown[] }).tools;
+      expect(Array.isArray(tools)).toBe(true);
+      expect(tools.length).toBeGreaterThanOrEqual(35);
+    } finally {
+      proc.kill('SIGTERM');
+    }
+  }, 20_000);
+});


### PR DESCRIPTION
## Summary

- **Root cause**: Since commit `fa25f12` (Jan 21, 2026), `bun build` marks `classic-level` as `--external`, but `.mcpbignore` excludes `node_modules/`. Claude Desktop's extracted runtime couldn't resolve `classic-level` and exited with `ERR_MODULE_NOT_FOUND` before responding to `initialize`. v1.6.0 and v1.6.1 both shipped this way.
- **Fix**: Rewrote `pack:mcpb` as a staging script that installs production deps with `npm --omit=dev --ignore-scripts` into `.mcpb-staging/` and packs from there. `classic-level` ships prebuilds for every platform, so `--ignore-scripts` is safe and the resulting bundle is cross-platform. Dev `node_modules/` is untouched.
- **Regression test**: `tests/integration/mcpb-bundle.test.ts` runs `pack:mcpb`, extracts the bundle to `/tmp` (outside the repo so Node can't walk into the repo's `node_modules`), spawns `node dist/cli.js --write`, and asserts the server responds to `initialize` and advertises ≥35 tools. This reproduces exactly the runtime condition Claude Desktop enforces. Runs in ~4s and ships with the E2E test job on every PR.
- **CI**: `auto-release.yml` now builds and attaches `copilot-money-mcp.mcpb` inline. Previously this was expected to happen via `build-mcpb.yml`'s `push: tags: v*` trigger, which never fires for tags created by `GITHUB_TOKEN` — same reason `npm-publish` had to be chained via `workflow_call`.

v1.6.1's missing asset was already re-uploaded manually; this PR prevents v1.6.2+ from regressing.

## Test plan

- [x] `bun test tests/integration/mcpb-bundle.test.ts` passes (3/3)
- [x] `bun run check` passes locally (1578 pass, 0 fail)
- [x] Pre-push hook green
- [ ] Verify CI: E2E job includes the new integration test
- [ ] Verify after merge: next `chore: bump version to X.Y.Z` commit creates a release with `copilot-money-mcp.mcpb` attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)