### PR TITLE
Clarify data sharing with AI providers in privacy docs

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -67,7 +67,7 @@ This database contains:
 ## Data Usage
 
 Data read from your local database is used exclusively to:
-1. Respond to queries from Claude Desktop via the Model Context Protocol (MCP)
+1. Respond to queries from an AI client (Claude Desktop, ChatGPT, Cursor, etc.) via the Model Context Protocol (MCP)
 2. Perform local calculations (e.g., spending aggregations, category summaries)
 3. Filter and search transactions based on your requests
 
@@ -101,8 +101,8 @@ In opt-in write mode, requested changes are sent directly from your machine to G
 ### Your Control
 
 You maintain full control over your data:
-- The server only runs when you explicitly start it via Claude Desktop
-- You can stop the server at any time by closing Claude Desktop
+- The server only runs when you explicitly start it via your MCP client
+- You can stop the server at any time by closing your MCP client
 - You can uninstall the server at any time
 - Your Copilot Money data remains in its original location
 - **Write mode is strictly opt-in:** Write tools are unavailable unless you explicitly start the server with `--write`. Without this flag, the server cannot modify your Copilot Money data even if instructed to do so
@@ -143,7 +143,7 @@ When integrated with an AI client such as Claude Desktop, ChatGPT, Cursor, or Ge
 ## Third-Party Services
 
 This server does not integrate with any third-party services beyond:
-- **Your MCP client's AI provider** (optional but required for AI-powered queries) — e.g., Anthropic (Claude Desktop), OpenAI (ChatGPT, Cursor with GPT), Google (Gemini). Your Copilot Money data is shared with this provider as part of normal MCP tool-call responses. See [Data Shared With AI Providers](#important-data-shared-with-ai-providers).
+- **Your MCP client's AI provider** (required only if you use the server for AI-powered queries; optional if you call tools programmatically) — e.g., Anthropic (Claude Desktop), OpenAI (ChatGPT, Cursor with GPT), Google (Gemini). Your Copilot Money data is shared with this provider as part of normal MCP tool-call responses. See [Data Shared With AI Providers](#important-data-shared-with-ai-providers).
 - **Copilot Money** (reads the local database created by the app)
 - **Google Firebase / Firestore** (only in opt-in write mode; this is Copilot Money's own backend, accessed directly with your own Copilot Money credentials)
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -14,6 +14,21 @@ The server operates in two modes:
 - **Read-only mode (default):** Reads data exclusively from your local Copilot Money database cache. No network requests are made.
 - **Write mode (opt-in, `--write` flag):** Adds the ability to modify your Copilot Money data. Because Copilot Money is backed by Google Firebase/Firestore, write operations require authenticated network requests to Firebase/Firestore on your behalf. See the [Write Mode and Network Access](#write-mode-and-network-access) section below.
 
+## Important: Data Shared With AI Providers
+
+**The MCP server itself is local, but the AI assistant you connect it to is not.** When you use this server with a hosted AI model (Claude Desktop, ChatGPT, Gemini, Cursor, or any other MCP-compatible client that relies on a cloud-hosted model), the tool responses containing your Copilot Money data — transactions, balances, account names, merchants, categories, holdings, and so on — are sent to that AI provider so the model can answer your question.
+
+**That means your financial data will leave your machine and be transmitted to a third-party AI provider**, such as:
+
+- **Anthropic** (if you use Claude Desktop or any Claude-powered client)
+- **OpenAI** (if you use ChatGPT, GPT-based tools, or Cursor with GPT models)
+- **Google** (if you use Gemini or any Google-hosted model)
+- **Any other AI provider** whose model your MCP client connects to
+
+Each provider has its own privacy policy, data retention, and training-data practices, which apply to this data once it is transmitted. This project has no control over how those providers handle your data.
+
+**By using this MCP server with a hosted AI model, you are knowingly and voluntarily sharing your financial data with the provider of that model. You must be comfortable with that trade-off.** If you are not, do not use this tool — consider waiting for an official Copilot Money integration, or running a fully local model that does not transmit data off your machine.
+
 ## Data Collection
 
 **We do not collect, store, or transmit any of your data to our servers or any third party.** The server has no backend, no analytics, and no telemetry.
@@ -63,12 +78,12 @@ All processing happens in memory on your local machine. No data is persisted out
 
 ## Data Sharing
 
-**We do not share your data with anyone.**
+**This project does not collect or share your data with anyone.** However, please read the section above on [Data Shared With AI Providers](#important-data-shared-with-ai-providers) — the AI model you connect this server to will receive your financial data as part of normal MCP tool-call responses.
 
 - No data is sent to our servers (we don't have servers)
-- No data is sent to third parties for analytics, advertising, or tracking
-- No data is sent to Anthropic (beyond what Claude Desktop processes locally)
-- No analytics or crash reports are transmitted
+- No data is sent to third parties for analytics, advertising, or tracking by this project
+- No analytics or crash reports are transmitted by this project
+- **Your AI provider (Anthropic, OpenAI, Google, or whichever model you use) will receive your Copilot Money data** as part of answering your queries — governed by that provider's privacy policy, not this project's
 
 In opt-in write mode, requested changes are sent directly from your machine to Google Firebase/Firestore using your own Copilot Money credentials. This is the same backend Copilot Money itself uses to persist your data — no intermediary server operated by this project is involved. This traffic is governed by Google's and Copilot Money's own privacy policies.
 
@@ -116,18 +131,19 @@ Network traffic in write mode is subject to:
 - [Google's Privacy Policy](https://policies.google.com/privacy) (as Firebase/Firestore is operated by Google)
 - Copilot Money's own terms and privacy policy (as you are modifying data on their backend)
 
-## Claude Desktop Integration
+## AI Client Integration
 
-When integrated with Claude Desktop:
-- Queries are processed by Claude via MCP protocol
-- Claude may temporarily process your financial data to answer questions
-- This processing happens according to [Anthropic's Privacy Policy](https://www.anthropic.com/privacy)
-- You control what queries are sent to Claude
+When integrated with an AI client such as Claude Desktop, ChatGPT, Cursor, or Gemini:
+- Your queries and the tool responses produced by this server are processed by the underlying AI model
+- To answer your questions, the AI model will see the Copilot Money data returned by tool calls (transactions, balances, merchants, categories, holdings, etc.)
+- This data is transmitted to and processed by the AI provider (Anthropic, OpenAI, Google, or another third party, depending on which model you use) according to **that provider's** privacy policy and data retention terms — not this project's
+- Relevant policies include [Anthropic's Privacy Policy](https://www.anthropic.com/privacy), [OpenAI's Privacy Policy](https://openai.com/policies/privacy-policy), and [Google's Privacy Policy](https://policies.google.com/privacy)
+- You control what queries you send and which AI client you connect to this server
 
 ## Third-Party Services
 
 This server does not integrate with any third-party services beyond:
-- **Claude Desktop** (optional, required for AI-powered queries)
+- **Your MCP client's AI provider** (optional but required for AI-powered queries) — e.g., Anthropic (Claude Desktop), OpenAI (ChatGPT, Cursor with GPT), Google (Gemini). Your Copilot Money data is shared with this provider as part of normal MCP tool-call responses. See [Data Shared With AI Providers](#important-data-shared-with-ai-providers).
 - **Copilot Money** (reads the local database created by the app)
 - **Google Firebase / Firestore** (only in opt-in write mode; this is Copilot Money's own backend, accessed directly with your own Copilot Money credentials)
 
@@ -155,4 +171,8 @@ For privacy-related questions or concerns:
 
 ## Summary
 
-**In short:** This server is a local-first tool that reads your Copilot Money data to enable AI-powered queries via Claude Desktop. In its default read-only mode, your data never leaves your machine. If you explicitly opt in to write mode with the `--write` flag, the server can additionally apply your requested changes by talking directly to Copilot Money's own Firebase/Firestore backend using your own credentials. We never collect, store, or transmit your financial information to servers operated by this project — we don't have any.
+**In short:** This server is a local-first tool that reads your Copilot Money data to enable AI-powered queries via an MCP client such as Claude Desktop, ChatGPT, Cursor, or Gemini. This project never collects, stores, or transmits your financial information to servers operated by this project — we don't have any.
+
+**However, the AI assistant you connect this server to will see your Copilot Money data** in order to answer your questions, and that data will be transmitted to the corresponding AI provider (Anthropic, OpenAI, Google, or another third party) according to that provider's privacy policy. By using this MCP server with a hosted AI model, you knowingly accept sharing your financial data with that provider. If you are not comfortable with that, do not use this tool.
+
+If you explicitly opt in to write mode with the `--write` flag, the server can additionally apply your requested changes by talking directly to Copilot Money's own Firebase/Firestore backend using your own credentials.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ We never collect, store, or transmit your data to any server operated by this pr
 - In opt-in write mode, requests go directly from your machine to Copilot Money's own Firebase/Firestore backend using your own credentials — never through any third-party service
 - Open source — verify the code yourself
 
+> [!IMPORTANT]
+> **Heads up about AI providers.** While this server itself runs locally and never sends your data to any server operated by this project, **the AI assistant you connect it to (Claude, ChatGPT, Gemini, etc.) will see your Copilot Money data** as part of answering your questions. That means your financial data will be transmitted to and processed by the provider of whichever model you choose — **Anthropic, OpenAI, Google, or another third party** — subject to that provider's own privacy policy and data retention terms.
+>
+> **By using this MCP server with a hosted AI model, you are knowingly sharing your financial data with that AI provider.** Only use this tool if you are comfortable with that trade-off. If you are not, consider waiting for an official Copilot Money integration or using a fully local model.
+
 ## Quick Start
 
 ### Prerequisites


### PR DESCRIPTION
## Summary

This PR updates the PRIVACY.md and README.md documentation to clearly communicate that while the MCP server itself is local and never transmits data to servers operated by this project, **the AI assistant you connect it to will receive your financial data** as part of normal tool-call responses. This is a critical privacy distinction that users must understand before using the tool.

## Key Changes

- **Added prominent "Data Shared With AI Providers" section** in PRIVACY.md explaining that hosted AI models (Claude, ChatGPT, Gemini, etc.) will receive Copilot Money data and are subject to each provider's own privacy policies
- **Updated "Data Sharing" section** to clarify that while this project doesn't collect or share data, the connected AI provider will receive financial data as part of answering queries
- **Renamed "Claude Desktop Integration" to "AI Client Integration"** to reflect support for multiple AI providers (Anthropic, OpenAI, Google, etc.), not just Claude
- **Updated "Third-Party Services" section** to explicitly note that AI provider data sharing occurs as part of normal MCP tool-call responses
- **Revised summary** to emphasize the distinction between local-first operation and AI provider data transmission
- **Added prominent warning box in README.md** with important notice about AI provider data sharing

## Notable Details

- Maintains accurate distinction: this project has no backend/servers, but the AI model you use does
- Clarifies that users must actively choose to accept this trade-off
- Provides guidance that users uncomfortable with sharing should not use the tool or should wait for official integrations
- Links to relevant privacy policies for major AI providers (Anthropic, OpenAI, Google)

https://claude.ai/code/session_01Y6WCw7QfCuemUMaoYxF8Tr