### PR TITLE
test: rename misleading *-coverage test files

### DIFF
--- a/tests/models/budget.test.ts
+++ b/tests/models/budget.test.ts
@@ -1,8 +1,3 @@
-/**
- * Tests for budget.ts to improve coverage.
- * Specifically tests the getBudgetDisplayName helper function.
- */
-
 import { describe, expect, it } from 'bun:test';
 import { getBudgetDisplayName, type Budget } from '../../src/models/budget';
 

--- a/tests/utils/categories.test.ts
+++ b/tests/utils/categories.test.ts
@@ -1,11 +1,3 @@
-/**
- * Additional coverage tests for src/utils/categories.ts
- *
- * This file specifically tests uncovered branches:
- * - Line 925: lowercase category ID matching
- * - Lines 931-934: snake_case to Title Case conversion for unknown categories
- */
-
 import { describe, expect, test } from 'bun:test';
 import {
   getCategoryName,


### PR DESCRIPTION
## Summary

Two test files were named `*-coverage.test.ts` as if they were supplementary coverage tests for a primary test file, but they are in fact the **only** test file for their module. Rename to reflect their real role.

- `tests/utils/categories-coverage.test.ts` → `tests/utils/categories.test.ts`
- `tests/models/budget-coverage.test.ts` → `tests/models/budget.test.ts`

Also strip the "covers uncovered lines X, Y-Z" header comments — they cite specific source line numbers that rot as the source evolves.

No content changes beyond the comment removal. The tests themselves are substantive (case-insensitive category matching, snake_case title-casing, budget display-name fallback).

This is item #6 of 6 in the follow-up plan from PR #254 (test audit cleanup). All six items are small/independent enough to land as separate PRs.

## Test plan

- [x] `bun run check` (typecheck + lint + format + test): 1575 pass / 21 skip / 0 fail
- [x] No references to the old filenames anywhere in the repo (verified by `grep`)
- [x] Git history preserved via `git mv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)