### PR TITLE
docs(site): clarify unofficial status and third-party AI disclaimer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -78,10 +78,19 @@
     }
     .hero .badge {
       display: inline-block; padding: 6px 16px;
-      background: var(--accent-glow); border: 1px solid rgba(108,99,255,0.3);
-      border-radius: 20px; font-size: 0.8rem; color: var(--accent);
-      font-weight: 600; margin-bottom: 24px;
+      background: rgba(251, 146, 60, 0.12); border: 1px solid rgba(251, 146, 60, 0.4);
+      border-radius: 20px; font-size: 0.8rem; color: var(--orange);
+      font-weight: 600; margin: 16px 0 20px;
     }
+    .hero .disclaimer {
+      max-width: 640px; margin: 0 auto 32px;
+      padding: 12px 18px; border-radius: 10px;
+      background: rgba(251, 146, 60, 0.08);
+      border: 1px solid rgba(251, 146, 60, 0.25);
+      font-size: 0.9rem; color: var(--text-muted);
+      text-align: left;
+    }
+    .hero .disclaimer strong { color: var(--orange); }
     .hero h1 {
       font-size: clamp(2.2rem, 5vw, 3.5rem); font-weight: 800;
       line-height: 1.15; max-width: 750px; margin: 0 auto 20px;
@@ -346,9 +355,12 @@
 
 <!-- Hero -->
 <div class="hero">
-  <div class="badge">Open Source &middot; MIT License</div>
   <h1>Ask AI about <span class="gradient">your finances</span></h1>
-  <p>Connect your Copilot Money data to Claude, Cursor, Codex CLI, and more. Local-first and privacy-first — no third-party servers, no analytics.</p>
+  <div class="badge">&#9888; Unofficial &middot; Not affiliated with Copilot Money</div>
+  <p>Connect your Copilot Money data to Claude, Cursor, Codex CLI, and more. This project is an independent, open-source integration — it is not built, endorsed, or supported by Copilot Money.</p>
+  <div class="disclaimer">
+    <strong>Heads up:</strong> when you use this with an AI client (Claude, Cursor, Codex CLI, etc.), your Copilot Money data — transactions, balances, accounts — is sent to that AI provider so the model can answer your questions. This project has no servers and collects nothing, but the AI provider you choose is a third party that will see your financial data. Review their privacy policy before connecting.
+  </div>
   <div class="hero-buttons">
     <a href="https://github.com/ignaciohermosillacornejo/copilot-money-mcp/releases" class="btn btn-primary">
       <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
@@ -750,7 +762,7 @@ args = ["--write"]</div>
     <div class="feature-card">
       <div class="feature-icon orange">&#128274;</div>
       <h3>Privacy First</h3>
-      <p>Reads stay local — zero network. Writes sync via Copilot's own Firestore backend. No data collection, no analytics, no third parties.</p>
+      <p>Reads stay local — zero network. Writes sync via Copilot's own Firestore backend. This project has no servers, no analytics, and collects nothing. (Your chosen AI client still sees the data you query.)</p>
     </div>
   </div>
 </section>
@@ -758,8 +770,8 @@ args = ["--write"]</div>
 <!-- Privacy Banner -->
 <section>
   <div class="privacy-banner">
-    <h2>Local-first, no third parties</h2>
-    <p>Reads go straight to your locally cached Copilot Money database — zero network. Writes sync to your own Copilot account via the same Google Firestore backend the app already uses. Nothing is ever sent to us or any third party.</p>
+    <h2>Local-first, no project servers</h2>
+    <p>Reads go straight to your locally cached Copilot Money database — zero network. Writes sync to your own Copilot account via the same Google Firestore backend the app already uses. Nothing is ever sent to us. Note: the AI client you connect (Claude, Cursor, Codex CLI, etc.) is a third party and will see the finance data you query — check its privacy policy.</p>
     <p style="font-size: 0.85rem; margin-top: 12px;"><strong>Write defaults:</strong> the Claude Desktop <code>.mcpb</code> bundle enables all 35 tools (disable individual write tools from Settings &rarr; Extensions). Every other client's config is read-only by default — add <code>--write</code> to enable.</p>
     <div class="privacy-checks">
       <div class="privacy-check"><span class="check">&#10003;</span> No data collection</div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -790,7 +790,7 @@ args = ["--write"]</div>
     <div class="privacy-checks">
       <div class="privacy-check"><span class="check">&#10003;</span> No data collection</div>
       <div class="privacy-check"><span class="check">&#10003;</span> No analytics or telemetry</div>
-      <div class="privacy-check"><span class="check">&#10003;</span> No third-party servers</div>
+      <div class="privacy-check"><span class="check">&#10003;</span> No project servers</div>
       <div class="privacy-check"><span class="check">&#10003;</span> Write tools toggleable per-tool</div>
       <div class="privacy-check"><span class="check">&#10003;</span> Open source</div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -76,11 +76,22 @@
       padding: 140px 24px 80px; text-align: center;
       background: radial-gradient(ellipse at 50% 0%, var(--accent-glow) 0%, transparent 60%);
     }
+    .hero .badges {
+      display: flex; gap: 10px; justify-content: center;
+      flex-wrap: wrap; margin: 16px 0 20px;
+    }
     .hero .badge {
       display: inline-block; padding: 6px 16px;
+      border-radius: 20px; font-size: 0.8rem;
+      font-weight: 600;
+    }
+    .hero .badge.license {
+      background: var(--accent-glow); border: 1px solid rgba(108,99,255,0.3);
+      color: var(--accent);
+    }
+    .hero .badge.unofficial {
       background: rgba(251, 146, 60, 0.12); border: 1px solid rgba(251, 146, 60, 0.4);
-      border-radius: 20px; font-size: 0.8rem; color: var(--orange);
-      font-weight: 600; margin: 16px 0 20px;
+      color: var(--orange);
     }
     .hero .disclaimer {
       max-width: 640px; margin: 0 auto 32px;
@@ -356,8 +367,11 @@
 <!-- Hero -->
 <div class="hero">
   <h1>Ask AI about <span class="gradient">your finances</span></h1>
-  <div class="badge">&#9888; Unofficial &middot; Not affiliated with Copilot Money</div>
-  <p>Connect your Copilot Money data to Claude, Cursor, Codex CLI, and more. This project is an independent, open-source (MIT-licensed) integration — it is not built, endorsed, or supported by Copilot Money.</p>
+  <div class="badges">
+    <div class="badge license">Open Source &middot; MIT License</div>
+    <div class="badge unofficial">&#9888; Unofficial &middot; Not affiliated with Copilot Money</div>
+  </div>
+  <p>Connect your Copilot Money data to Claude, Cursor, Codex CLI, and more. This project is an independent integration — it is not built, endorsed, or supported by Copilot Money.</p>
   <div class="disclaimer">
     <strong>Heads up:</strong> when you use this with an AI client (Claude, Cursor, Codex CLI, etc.), your Copilot Money data — transactions, balances, accounts — is sent to that AI provider so the model can answer your questions. This project has no servers and collects nothing, but the AI provider you choose is a third party that will see your financial data. Review their privacy policy before connecting.
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -357,7 +357,7 @@
 <div class="hero">
   <h1>Ask AI about <span class="gradient">your finances</span></h1>
   <div class="badge">&#9888; Unofficial &middot; Not affiliated with Copilot Money</div>
-  <p>Connect your Copilot Money data to Claude, Cursor, Codex CLI, and more. This project is an independent, open-source integration — it is not built, endorsed, or supported by Copilot Money.</p>
+  <p>Connect your Copilot Money data to Claude, Cursor, Codex CLI, and more. This project is an independent, open-source (MIT-licensed) integration — it is not built, endorsed, or supported by Copilot Money.</p>
   <div class="disclaimer">
     <strong>Heads up:</strong> when you use this with an AI client (Claude, Cursor, Codex CLI, etc.), your Copilot Money data — transactions, balances, accounts — is sent to that AI provider so the model can answer your questions. This project has no servers and collects nothing, but the AI provider you choose is a third party that will see your financial data. Review their privacy policy before connecting.
   </div>
@@ -762,7 +762,7 @@ args = ["--write"]</div>
     <div class="feature-card">
       <div class="feature-icon orange">&#128274;</div>
       <h3>Privacy First</h3>
-      <p>Reads stay local — zero network. Writes sync via Copilot's own Firestore backend. This project has no servers, no analytics, and collects nothing. (Your chosen AI client still sees the data you query.)</p>
+      <p>Reads stay local — zero network. Writes sync via Copilot's own Firestore backend. No servers, no analytics, no data collection. Data you query is shared with your AI provider.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Move the "Not affiliated with Copilot Money" disclaimer into a prominent orange badge directly under the hero title, so visitors see it immediately.
- Add an in-hero disclaimer box explaining that the AI client the user connects (Claude, Cursor, Codex CLI, etc.) is a third party that will see the finance data being queried.
- Soften the "no third parties" claim in the privacy banner — we don't run servers, but the AI provider does see queried data.

## Test plan
- [ ] Open \`docs/index.html\` locally and confirm the badge sits under the h1 with the orange warning styling.
- [ ] Confirm the disclaimer box under the hero copy reads clearly and is legible in dark mode.
- [ ] Confirm the privacy banner ("Local-first, no project servers") reads accurately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)