### PR TITLE
ci: delegate .mcpb build/release to reusable workflow (#260)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,20 +6,18 @@ on:
     paths:
       - 'package.json'
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  release:
-    name: Create release on version bump
+  detect-version:
+    name: Detect version bump
     runs-on: ubuntu-latest
-    # Only the repo owner can trigger releases
     if: github.actor == 'ignaciohermosillacornejo'
-    concurrency:
-      group: release-${{ github.ref }}
-      cancel-in-progress: false
-    permissions:
-      contents: write
     outputs:
       changed: ${{ steps.version.outputs.changed }}
-      version: ${{ steps.version.outputs.current }}
+      current: ${{ steps.version.outputs.current }}
 
     steps:
       - name: Checkout repository
@@ -68,68 +66,31 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Extract changelog
-        if: steps.version.outputs.changed == 'true'
-        id: changelog
-        env:
-          COMMIT_MSG: ${{ github.event.head_commit.message }}
-        run: |
-          VERSION="${{ steps.version.outputs.current }}"
-          # Extract the section for this version from CHANGELOG.md
-          # Matches from "## [x.y.z]" until the next "## [" or end of file
-          NOTES=$(awk -v ver="$VERSION" '
-            /^## \[/ {
-              if (found) exit
-              if (index($0, "[" ver "]")) found=1
-              next
-            }
-            found { print }
-          ' CHANGELOG.md)
-
-          if [ -z "$NOTES" ]; then
-            echo "No changelog entry found for $VERSION, using commit message"
-            NOTES="$COMMIT_MSG"
-          fi
-
-          # Write to file to avoid escaping issues
-          echo "$NOTES" > /tmp/release-notes.md
-
-      - name: Setup Bun
-        if: steps.version.outputs.changed == 'true'
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        if: steps.version.outputs.changed == 'true'
-        run: bun install
-
-      - name: Build .mcpb bundle
-        if: steps.version.outputs.changed == 'true'
-        run: bun run pack:mcpb
-
-      - name: Create release with bundle
-        if: steps.version.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          VERSION="${{ steps.version.outputs.current }}"
-          gh release create "v$VERSION" \
-            --title "v$VERSION" \
-            --notes-file /tmp/release-notes.md \
-            --target "${{ github.sha }}" \
-            copilot-money-mcp.mcpb
+  # Build the .mcpb and create the GitHub release atomically. Chained via
+  # workflow_call rather than relying on a tag-push trigger, because tags
+  # created with the default GITHUB_TOKEN do not fire `push: tags: v*`.
+  release:
+    name: Build and release .mcpb
+    needs: detect-version
+    if: needs.detect-version.outputs.changed == 'true' && github.actor == 'ignaciohermosillacornejo'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/build-mcpb.yml
+    with:
+      version: ${{ needs.detect-version.outputs.current }}
+      target_sha: ${{ github.sha }}
+      dry_run: false
 
   # Publishing is chained directly via workflow_call rather than relying on the
   # release event, because releases created with the default GITHUB_TOKEN do not
   # trigger downstream `release: published` workflows.
   publish:
     name: Publish to npm
-    needs: release
-    if: needs.release.outputs.changed == 'true' && github.actor == 'ignaciohermosillacornejo'
+    needs: [detect-version, release]
+    if: needs.detect-version.outputs.changed == 'true' && github.actor == 'ignaciohermosillacornejo'
     permissions:
       contents: read
-      id-token: write  # Required for npm OIDC trusted publishing
+      id-token: write
     uses: ./.github/workflows/npm-publish.yml
     with:
       dry_run: false

--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -1,112 +1,97 @@
-name: build release
+name: Build & Release .mcpb
 
 on:
-  push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      create_release:
-        description: 'Create a release'
-        required: true
-        type: boolean
-        default: true
       version:
-        description: 'Version tag for the release (e.g., v1.0.0)'
+        description: Release version without the `v` prefix (e.g. "1.6.2")
         required: true
         type: string
-
-env:
-  BUN_VERSION: '1.1.38'
+      target_sha:
+        description: Commit SHA to check out, build, and tag at
+        required: true
+        type: string
+      dry_run:
+        description: Build only; upload the bundle as an artifact and skip release creation
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version without the `v` prefix (e.g. "1.6.2")
+        required: true
+        type: string
+      target_sha:
+        description: Commit SHA to check out. Defaults to the selected branch's HEAD.
+        required: false
+        type: string
+      dry_run:
+        description: Build only; upload the bundle as an artifact and skip release creation
+        required: false
+        type: boolean
+        default: false
 
 jobs:
-  build:
-    name: Build .mcpb Bundle
+  build-and-release:
+    name: Build and release .mcpb
     runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Run type checking
-        run: bun run typecheck
-
-      - name: Run linting
-        run: bun run lint
-
-      - name: Check formatting
-        run: bun run format:check
-
-      - name: Run tests
-        run: bun test
-
-      - name: Build .mcpb bundle
-        run: bun run pack:mcpb
-
-      - name: Verify .mcpb file exists
-        run: |
-          if [ ! -f copilot-money-mcp.mcpb ]; then
-            echo "Error: .mcpb file not found"
-            exit 1
-          fi
-          ls -la copilot-money-mcp.mcpb
-
-      - name: Upload .mcpb artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: copilot-money-mcp-bundle
-          path: copilot-money-mcp.mcpb
-          retention-days: 30
-
-  release:
-    name: Create Release
-    needs: build
-    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.create_release)
-    runs-on: ubuntu-latest
-
     permissions:
       contents: write
 
     steps:
-      - name: Download .mcpb artifact
-        uses: actions/download-artifact@v8
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build .mcpb bundle
+        run: bun run pack:mcpb
+
+      - name: Extract changelog notes
+        if: ${{ !inputs.dry_run }}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          NOTES=$(awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) found=1
+              next
+            }
+            found { print }
+          ' CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            echo "No changelog entry for v$VERSION, using default message"
+            NOTES="Release v$VERSION"
+          fi
+          echo "$NOTES" > /tmp/release-notes.md
+
+      - name: Create release with bundle
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          TARGET: ${{ inputs.target_sha || github.sha }}
+        run: |
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --notes-file /tmp/release-notes.md \
+            --target "$TARGET" \
+            copilot-money-mcp.mcpb
+
+      - name: Upload artifact (dry run)
+        if: ${{ inputs.dry_run }}
+        uses: actions/upload-artifact@v7
         with:
           name: copilot-money-mcp-bundle
-
-      - name: Verify .mcpb file exists
-        run: |
-          if [ ! -f copilot-money-mcp.mcpb ]; then
-            echo "Error: .mcpb file not found"
-            exit 1
-          fi
-          ls -la copilot-money-mcp.mcpb
-
-      - name: Determine if prerelease
-        id: prerelease
-        run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            TAG="${{ inputs.version }}"
-          else
-            TAG="${GITHUB_REF#refs/tags/}"
-          fi
-          if [[ "$TAG" =~ (alpha|beta|rc|preview|dev) ]]; then
-            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.version || github.ref_name }}
-          files: copilot-money-mcp.mcpb
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}
+          path: copilot-money-mcp.mcpb
+          retention-days: 7

--- a/docs/superpowers/plans/2026-04-14-ci-workflow-call-refactor.md
+++ b/docs/superpowers/plans/2026-04-14-ci-workflow-call-refactor.md
@@ -1,0 +1,432 @@
+# CI workflow_call refactor — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the `.mcpb` build + GitHub release creation from inline steps in `auto-release.yml` into `build-mcpb.yml` as a reusable `workflow_call` target. No user-visible behavior change.
+
+**Architecture:** `auto-release.yml` becomes a thin orchestrator with three jobs (`detect-version` → `release` via `workflow_call` → `publish` via `workflow_call`). `build-mcpb.yml` owns the full build-and-release-atomically story and keeps `workflow_dispatch` for manual releases. The dead `push: tags: v*` trigger is removed.
+
+**Tech Stack:** GitHub Actions (YAML), `actionlint` (CI YAML validator), `@anthropic-ai/mcpb`, `bun`, `gh` CLI.
+
+**Spec:** `docs/superpowers/specs/2026-04-14-ci-workflow-call-refactor-design.md`
+
+---
+
+## File Structure
+
+- **Modify:** `.github/workflows/build-mcpb.yml` — rewrite entirely as a reusable workflow with `workflow_call` + `workflow_dispatch` triggers, single `build-and-release` job.
+- **Modify:** `.github/workflows/auto-release.yml` — split into three jobs (`detect-version`, `release`, `publish`); release job delegates to `build-mcpb.yml` via `workflow_call`; hoist `concurrency` to workflow level.
+
+No new files. No source code changes. No test changes.
+
+---
+
+## Task 1: Set up `actionlint` locally
+
+We need a way to statically validate the YAML before pushing to CI. `actionlint` checks GitHub Actions syntax, `workflow_call` input wiring, and expression references.
+
+**Files:** none (tool install only).
+
+- [ ] **Step 1: Install `actionlint` via Homebrew**
+
+Run: `brew install actionlint`
+Expected: installs the `actionlint` binary.
+
+- [ ] **Step 2: Baseline — lint the workflows at their current state**
+
+Run: `actionlint .github/workflows/*.yml`
+Expected: either silent exit (clean) or a list of issues. Record the output — any issues present now are not caused by this refactor.
+
+If the output lists issues, that's the baseline; subsequent runs must not add to it.
+
+- [ ] **Step 3: Commit (nothing to commit yet — skip)**
+
+No file changes in this task.
+
+---
+
+## Task 2: Rewrite `build-mcpb.yml` as a reusable workflow
+
+Replace the existing content entirely. The new workflow has two triggers (`workflow_call`, `workflow_dispatch`), identical input shapes on both, and a single `build-and-release` job that either creates a release or uploads an artifact based on the `dry_run` input.
+
+**Files:**
+- Modify: `.github/workflows/build-mcpb.yml` — full replacement.
+
+- [ ] **Step 1: Replace the file contents**
+
+Open `.github/workflows/build-mcpb.yml` and replace the entire file with:
+
+```yaml
+name: Build & Release .mcpb
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Release version without the `v` prefix (e.g. "1.6.2")
+        required: true
+        type: string
+      target_sha:
+        description: Commit SHA to check out, build, and tag at
+        required: true
+        type: string
+      dry_run:
+        description: Build only; upload the bundle as an artifact and skip release creation
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version without the `v` prefix (e.g. "1.6.2")
+        required: true
+        type: string
+      target_sha:
+        description: Commit SHA to check out. Defaults to the selected branch's HEAD.
+        required: false
+        type: string
+      dry_run:
+        description: Build only; upload the bundle as an artifact and skip release creation
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  build-and-release:
+    name: Build and release .mcpb
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.target_sha || github.sha }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build .mcpb bundle
+        run: bun run pack:mcpb
+
+      - name: Extract changelog notes
+        if: ${{ !inputs.dry_run }}
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          NOTES=$(awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) found=1
+              next
+            }
+            found { print }
+          ' CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            echo "No changelog entry for v$VERSION, using default message"
+            NOTES="Release v$VERSION"
+          fi
+          echo "$NOTES" > /tmp/release-notes.md
+
+      - name: Create release with bundle
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          TARGET: ${{ inputs.target_sha || github.sha }}
+        run: |
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --notes-file /tmp/release-notes.md \
+            --target "$TARGET" \
+            copilot-money-mcp.mcpb
+
+      - name: Upload artifact (dry run)
+        if: ${{ inputs.dry_run }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: copilot-money-mcp-bundle
+          path: copilot-money-mcp.mcpb
+          retention-days: 7
+```
+
+- [ ] **Step 2: Lint the rewritten workflow**
+
+Run: `actionlint .github/workflows/build-mcpb.yml`
+Expected: exits silently (0 issues for this file). If issues appear, fix them inline — common causes:
+- Missing `type:` on an input
+- Expression inside `if:` without `${{ }}` wrapping (actionlint is picky about boolean coercion on `inputs.dry_run`)
+- `uses:` action version that no longer resolves
+
+Re-run until clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/build-mcpb.yml
+git commit -m "ci: make build-mcpb.yml a reusable workflow_call target
+
+Replace the tag-push-triggered workflow with a workflow_call +
+workflow_dispatch reusable workflow. Inputs: version, target_sha,
+dry_run. Single build-and-release job — either creates a GitHub
+release with the .mcpb attached (normal path) or uploads the bundle
+as an artifact (dry_run). Drops the dead push: tags: v* trigger
+and the QA steps that duplicate test.yml."
+```
+
+---
+
+## Task 3: Manually validate the rewritten `build-mcpb.yml`
+
+Before wiring up the caller, prove the reusable workflow actually runs end-to-end. `workflow_dispatch` lets us pick any branch from the GitHub UI.
+
+**Files:** none (manual verification via GitHub UI).
+
+- [ ] **Step 1: Push the branch to the remote**
+
+```bash
+git push -u origin ci/workflow-call-refactor
+```
+
+- [ ] **Step 2: Trigger the workflow manually via the GitHub UI**
+
+1. Open https://github.com/ignaciohermosillacornejo/copilot-money-mcp/actions
+2. Pick "Build & Release .mcpb" in the left sidebar.
+3. Click **Run workflow** (top right).
+4. Select branch: `ci/workflow-call-refactor`.
+5. Fill inputs:
+   - `version`: `0.0.0-test`
+   - `target_sha`: leave blank (defaults to branch HEAD)
+   - `dry_run`: `true` (check the box)
+6. Click **Run workflow**.
+
+Expected outcome:
+- The run succeeds.
+- A `copilot-money-mcp-bundle` artifact appears on the run's summary page.
+- **No GitHub release is created for `v0.0.0-test`** (confirm at `/releases`).
+
+If the run fails or a release gets created, stop and diagnose. Do NOT proceed to Task 4 — the next step depends on this one working.
+
+- [ ] **Step 3: Commit (nothing to commit — manual step)**
+
+No file changes.
+
+---
+
+## Task 4: Rewrite `auto-release.yml` as an orchestrator
+
+Split the workflow into three jobs. `detect-version` is unchanged logic, just lifted into its own job. `release` delegates to `build-mcpb.yml` via `workflow_call`. `publish` stays the same. Concurrency moves to workflow level.
+
+**Files:**
+- Modify: `.github/workflows/auto-release.yml` — full replacement.
+
+- [ ] **Step 1: Replace the file contents**
+
+Open `.github/workflows/auto-release.yml` and replace the entire file with:
+
+```yaml
+name: Auto Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  detect-version:
+    name: Detect version bump
+    runs-on: ubuntu-latest
+    if: github.actor == 'ignaciohermosillacornejo'
+    outputs:
+      changed: ${{ steps.version.outputs.changed }}
+      current: ${{ steps.version.outputs.current }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Fetch pre-push state for version comparison
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          # Fetch the commit that was HEAD before this push, so we can compare
+          # package.json across the entire push (not just HEAD vs HEAD~1).
+          if [ "$BEFORE" != "0000000000000000000000000000000000000000" ] && [ -n "$BEFORE" ]; then
+            git fetch --depth=1 origin "$BEFORE" || true
+          fi
+
+      - name: Check for version bump
+        id: version
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "current=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+
+          # Check if tag already exists (fetch tags first)
+          git fetch --tags --quiet
+          if git rev-parse "v$CURRENT_VERSION" >/dev/null 2>&1; then
+            echo "Tag v$CURRENT_VERSION already exists, skipping"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Compare against the state before this push (handles multi-commit pushes)
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ] || [ -z "$BEFORE" ]; then
+            echo "Initial push, treating as version change"
+            OLD_VERSION=""
+          else
+            git show "$BEFORE":package.json > /tmp/old-package.json 2>/dev/null || true
+            OLD_VERSION=$(node -p "try { require('/tmp/old-package.json').version } catch { '' }")
+          fi
+
+          if [ "$CURRENT_VERSION" != "$OLD_VERSION" ]; then
+            echo "Version changed: $OLD_VERSION -> $CURRENT_VERSION"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version unchanged ($CURRENT_VERSION), skipping"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Build the .mcpb and create the GitHub release atomically. Chained via
+  # workflow_call rather than relying on a tag-push trigger, because tags
+  # created with the default GITHUB_TOKEN do not fire `push: tags: v*`.
+  release:
+    name: Build and release .mcpb
+    needs: detect-version
+    if: needs.detect-version.outputs.changed == 'true' && github.actor == 'ignaciohermosillacornejo'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/build-mcpb.yml
+    with:
+      version: ${{ needs.detect-version.outputs.current }}
+      target_sha: ${{ github.sha }}
+      dry_run: false
+
+  # Publishing is chained directly via workflow_call rather than relying on the
+  # release event, because releases created with the default GITHUB_TOKEN do not
+  # trigger downstream `release: published` workflows.
+  publish:
+    name: Publish to npm
+    needs: [detect-version, release]
+    if: needs.detect-version.outputs.changed == 'true' && github.actor == 'ignaciohermosillacornejo'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      dry_run: false
+    secrets: inherit
+```
+
+- [ ] **Step 2: Lint the rewritten workflow**
+
+Run: `actionlint .github/workflows/auto-release.yml`
+Expected: exits silently. Common issues and fixes:
+- `needs.detect-version.outputs.current` used but job didn't declare the output → check the `outputs:` block on `detect-version`.
+- `uses: ./.github/workflows/build-mcpb.yml` path wrong → path must be relative to the repo root and start with `./`.
+- `secrets: inherit` missing on the `publish` job → keep it; removing it breaks npm-publish's OIDC plumbing.
+
+Re-run until clean.
+
+- [ ] **Step 3: Lint ALL workflows together to catch cross-file issues**
+
+Run: `actionlint .github/workflows/*.yml`
+Expected: no new issues compared to the Task 1 baseline. If `actionlint` reports issues in files we didn't touch, they existed before this refactor — leave them alone.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/auto-release.yml
+git commit -m "ci: shrink auto-release.yml to an orchestrator
+
+Split into three jobs: detect-version → release (via workflow_call
+to build-mcpb.yml) → publish (via workflow_call to npm-publish.yml).
+Move concurrency key to workflow level so it serializes the full
+run, not just a single job. Drops all inline bun setup / install /
+pack / changelog / gh release create steps — those now live in
+build-mcpb.yml behind a reusable interface.
+
+No user-visible behavior change. Refs #260."
+```
+
+---
+
+## Task 5: Push and open the PR
+
+**Files:** none (git + gh only).
+
+- [ ] **Step 1: Push the updated branch**
+
+```bash
+git push
+```
+
+- [ ] **Step 2: Rebase onto origin/main if it has moved**
+
+```bash
+git fetch origin main
+git log HEAD..origin/main --oneline
+```
+
+If there are new commits on main, rebase:
+
+```bash
+git rebase origin/main
+git push --force-with-lease
+```
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --title "ci: delegate .mcpb build/release to reusable workflow (#260)" --body "$(cat <<'EOF'
+## Summary
+
+- Shrinks `auto-release.yml` from ~125 lines to ~85 by moving the inline bun setup / install / pack / changelog / `gh release create` steps into `build-mcpb.yml` behind a `workflow_call` interface.
+- Mirrors the existing `npm-publish.yml` `workflow_call` pattern.
+- Hoists \`concurrency\` to workflow level in \`auto-release.yml\` so it serializes the whole run, not just one job.
+- Removes the dead \`push: tags: v*\` trigger from \`build-mcpb.yml\` (never fires for GITHUB_TOKEN-created tags).
+- Drops QA steps (typecheck/lint/format:check/test) from \`build-mcpb.yml\` — \`test.yml\` already guards every commit on main via PR CI.
+
+No user-visible behavior change. No new secrets; still uses only \`github.token\`.
+
+Spec: \`docs/superpowers/specs/2026-04-14-ci-workflow-call-refactor-design.md\`
+Tracks: #260
+
+## Test plan
+
+- [x] \`actionlint .github/workflows/*.yml\` clean locally
+- [x] Manual \`workflow_dispatch\` of \`build-mcpb.yml\` on this branch with \`dry_run=true\` → bundle uploaded as artifact, no release created
+- [ ] Post-merge: next \`chore: bump version\` commit creates a GitHub release with \`copilot-money-mcp.mcpb\` attached and publishes to npm
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Wait for CI + automated review**
+
+After the PR is open, CI (`test.yml`) runs. An automated review usually arrives in 2–5 minutes. Read it and address any feedback before considering the task complete.
+
+---
+
+## Self-review checklist (run before handing off)
+
+Before marking the plan ready, verify:
+
+- [ ] Every spec requirement has a task (spec coverage).
+- [ ] No TBD/TODO/placeholder text in any step.
+- [ ] Every workflow input referenced later is defined earlier (input consistency across `build-mcpb.yml` and `auto-release.yml`).
+- [ ] Every code block for YAML is complete and valid (no ellipses, no "…same as above").
+- [ ] Every commit message matches the conventional-commit prefix style the repo uses (`ci:`, `fix:`, `docs:`, etc.).

--- a/docs/superpowers/specs/2026-04-14-ci-workflow-call-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-14-ci-workflow-call-refactor-design.md
@@ -111,7 +111,7 @@ push main (package.json changed)
 2. **`release`** — `needs: detect-version`, `if: needs.detect-version.outputs.changed == 'true' && github.actor == 'ignaciohermosillacornejo'`, `permissions: contents: write`. A `uses: ./.github/workflows/build-mcpb.yml` call with:
    ```yaml
    with:
-     version:    ${{ needs.detect-version.outputs.version }}
+     version:    ${{ needs.detect-version.outputs.current }}
      target_sha: ${{ github.sha }}
      dry_run:    false
    ```

--- a/docs/superpowers/specs/2026-04-14-ci-workflow-call-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-14-ci-workflow-call-refactor-design.md
@@ -1,0 +1,156 @@
+# CI workflow_call refactor — delegate .mcpb build/release from auto-release
+
+**Status:** Design approved (2026-04-14)
+**Author:** nach
+**Scope:** CI restructuring — move .mcpb build + GitHub release creation from inline steps in `auto-release.yml` into a reusable `workflow_call` target in `build-mcpb.yml`. No user-visible behavior change.
+
+## Motivation
+
+PR #251 fixed the regression where the .mcpb bundle shipped broken in v1.6.0 and v1.6.1. That fix added the bundle build + release creation as inline steps inside `auto-release.yml`:
+
+```yaml
+- name: Setup Bun
+- name: Install dependencies
+- name: Build .mcpb bundle
+- name: Create release with bundle
+```
+
+This works, but it mixes two responsibilities in one workflow:
+
+1. **Version-bump detection** — scan `package.json`, compare against the pre-push state, decide whether this commit is a release.
+2. **Bundle build + release publishing** — checkout, install, pack, `gh release create` with the asset.
+
+We already have a precedent for splitting responsibilities via reusable workflows: `npm-publish.yml` was refactored into a `workflow_call` target (commit `1656219`) for exactly the same reason — GITHUB_TOKEN-created tags don't trigger downstream `push: tags: v*` or `release: published` handlers, so chaining had to happen at the workflow level.
+
+`build-mcpb.yml` currently has a dead `push: tags: v*` trigger (for the same GITHUB_TOKEN reason) and a `workflow_dispatch` trigger. Turning it into a reusable workflow consolidates the bundle-release story in one file and shrinks `auto-release.yml` to a thin orchestrator.
+
+Tracking: issue #260, item "CI simplification".
+
+## Scope
+
+**In scope:**
+
+- Restructure `build-mcpb.yml` to be reusable via `workflow_call` (plus keep `workflow_dispatch` for manual releases).
+- Remove the dead `push: tags: v*` trigger from `build-mcpb.yml`.
+- Rewrite `auto-release.yml` to delegate the build + release to `build-mcpb.yml` via `workflow_call`.
+- Hoist the `concurrency` key in `auto-release.yml` from the `release` job to the workflow level.
+- Drop the redundant QA steps (typecheck, lint, format:check, test) from `build-mcpb.yml` — `test.yml` already guards every main commit through PR CI.
+
+**Out of scope:**
+
+- Any change to `npm-publish.yml`.
+- Any change to `test.yml`.
+- Any change to the bundle contents, `pack-mcpb.ts`, or the regression test.
+- Other items from issue #260 (license hygiene, platform-specific variants, modclean, SBOM, Node ABI pinning).
+
+## Architecture
+
+```
+push main (package.json changed)
+         │
+         ▼
+┌────────────────────┐
+│ auto-release.yml   │  Orchestrator
+│  • detect version  │  (no secrets, no build)
+│  • call mcpb       │
+│  • call npm        │
+└─────────┬──────────┘
+          │ workflow_call
+          ├───────────────────────────┐
+          ▼                           ▼
+┌────────────────────┐      ┌────────────────────┐
+│ build-mcpb.yml     │      │ npm-publish.yml    │
+│  (reusable)        │      │  (already reusable)│
+│  • pack            │      │                    │
+│  • create release  │      │                    │
+│  • attach .mcpb    │      │                    │
+└────────────────────┘      └────────────────────┘
+```
+
+## `build-mcpb.yml` (reusable)
+
+**Triggers:**
+
+- `workflow_call` — new; used by `auto-release.yml`.
+- `workflow_dispatch` — kept; for manual releases.
+- `push: tags: v*` — **removed**. Dead code under the GITHUB_TOKEN model; manual tag pushes can use `workflow_dispatch` instead.
+
+**Inputs (identical shape for both triggers):**
+
+| Name         | Type    | Required | Default | Notes                                           |
+|--------------|---------|----------|---------|-------------------------------------------------|
+| `version`    | string  | yes      | —       | Release version, without `v` prefix. E.g. `1.6.2`. |
+| `target_sha` | string  | yes      | —       | Commit SHA to check out, build, and tag at.     |
+| `dry_run`    | boolean | no       | `false` | Build only; upload as artifact, no release.     |
+
+**Permissions:** `contents: write` (for `gh release create`).
+**Auth:** `GH_TOKEN: ${{ github.token }}` — default token, no secrets.
+
+**Single job `build-and-release`:**
+
+1. `actions/checkout@v6` at `${{ inputs.target_sha }}`.
+2. `oven-sh/setup-bun@v2`.
+3. `bun install`.
+4. `bun run pack:mcpb` — produces `copilot-money-mcp.mcpb` at repo root.
+5. If `!inputs.dry_run`: extract the `## [<version>]` section from `CHANGELOG.md` into `/tmp/release-notes.md`. Fall back to `"Release v<version>"` when the section is missing.
+6. If `!inputs.dry_run`: `gh release create "v<version>" --title "v<version>" --notes-file /tmp/release-notes.md --target "<target_sha>" copilot-money-mcp.mcpb`. Atomic — the release and the asset land together.
+7. If `inputs.dry_run`: `actions/upload-artifact@v7` with `name: copilot-money-mcp-bundle`, `path: copilot-money-mcp.mcpb`, `retention-days: 7`.
+
+**Why one job instead of the current two:** the current file has a separate `release` job only because its release creation was gated on the trigger. With the gate now expressed inline as `if: !inputs.dry_run`, the artifact-handoff dance (`upload-artifact` then `download-artifact`) becomes ceremony with no benefit.
+
+## `auto-release.yml` (orchestrator)
+
+**Trigger:** unchanged — `push: branches: [main], paths: ['package.json']`.
+
+**Workflow-level concurrency** (hoisted from job level): `group: release-${{ github.ref }}, cancel-in-progress: false`. With three jobs in the workflow, job-level concurrency doesn't serialize the whole run; workflow-level does.
+
+**Three jobs:**
+
+1. **`detect-version`** — runs on `ubuntu-latest`, gated on `github.actor == 'ignaciohermosillacornejo'`. Same steps as today's version-detection logic (checkout, fetch pre-push state, compare `package.json` versions, emit `changed` and `current` outputs).
+
+2. **`release`** — `needs: detect-version`, `if: needs.detect-version.outputs.changed == 'true' && github.actor == 'ignaciohermosillacornejo'`, `permissions: contents: write`. A `uses: ./.github/workflows/build-mcpb.yml` call with:
+   ```yaml
+   with:
+     version:    ${{ needs.detect-version.outputs.version }}
+     target_sha: ${{ github.sha }}
+     dry_run:    false
+   ```
+
+3. **`publish`** — unchanged. `needs: [detect-version, release]`, same actor check, same `uses: ./.github/workflows/npm-publish.yml` with `dry_run: false` and `secrets: inherit`.
+
+**Line-count delta:** `auto-release.yml` drops from ~125 to ~70 lines. All Bun setup, install, pack, changelog extraction, and `gh release create` steps move to `build-mcpb.yml`.
+
+## Behavior delta
+
+None that is user-visible:
+
+- Same trigger for auto-release.
+- Same actor gate.
+- Same atomic release creation (tag + release + asset in one step).
+- Same npm publish chain with OIDC.
+- No new secrets; no environment references.
+
+## Testing and rollout
+
+**Pre-merge verification:**
+
+- `actionlint .github/workflows/*.yml` locally. Catches YAML shape errors, unused inputs, bad expression references, and missing `workflow_call` input bindings. Cheap (~1s).
+- From the PR branch, GitHub UI → Actions → `build-mcpb` → Run workflow with `version: <anything>`, `target_sha: <PR head>`, `dry_run: true`. Exercises the full build path end-to-end, uploads an artifact, creates no release. Proves: inputs wiring, checkout-at-SHA, `bun run pack:mcpb`, artifact upload step.
+
+**What can't be tested pre-merge:**
+
+- The `workflow_call` edge from `auto-release.yml` → `build-mcpb.yml`. It only resolves when `auto-release.yml` runs against `main`, which requires a real version bump in `package.json`. The first post-merge release exercises it.
+
+**Failure modes and recovery:**
+
+- `build-mcpb` fails after the version bump lands → no release is created, `publish` is skipped. To retry: either push a trivial commit (auto-release no-ops because version is unchanged) and manually `workflow_dispatch build-mcpb.yml` with the stuck version, or bump the patch again.
+- Tag already exists → `gh release create` errors out explicitly; not silent.
+- Npm publish fails after release succeeds → release + asset are already on GitHub. Same as today; the `publish` job can be re-run from the Actions UI.
+
+**Rollback:** the two workflow files are self-contained. Revert the commit if anything misbehaves post-merge.
+
+## Non-goals / things we explicitly did NOT consider
+
+- **Storing a PAT to chain via `release: published`.** Explicitly avoided; `workflow_call` exists for exactly this reason without secrets.
+- **A separate `mcpb-release.yml` file.** Renaming `build-mcpb.yml` would break the Actions UI history continuity for no benefit.
+- **Passing release notes as a workflow input.** GitHub Actions string inputs technically support multi-line values, but re-extracting the changelog inside the reusable workflow is simpler and keeps the orchestrator free of CHANGELOG knowledge.


### PR DESCRIPTION
## Summary

- Shrinks `auto-release.yml` from ~125 lines to 97 by moving the inline bun setup / install / pack / changelog / `gh release create` steps into `build-mcpb.yml` behind a `workflow_call` interface.
- Mirrors the existing `npm-publish.yml` `workflow_call` pattern.
- Hoists `concurrency` to workflow level in `auto-release.yml` so it serializes the whole run, not just one job.
- Removes the dead `push: tags: v*` trigger from `build-mcpb.yml` (never fires for GITHUB_TOKEN-created tags — same reason `npm-publish` had to be chained via `workflow_call`).
- Drops QA steps (typecheck/lint/format:check/test) from `build-mcpb.yml` — `test.yml` already guards every commit on main via PR CI.

No user-visible behavior change. No new secrets; still uses only `github.token`.

Spec: `docs/superpowers/specs/2026-04-14-ci-workflow-call-refactor-design.md`
Plan: `docs/superpowers/plans/2026-04-14-ci-workflow-call-refactor.md`
Tracks: #260

## Test plan

- [x] `actionlint .github/workflows/*.yml` — no new issues (only pre-existing `audit-reviews.yml:78` info)
- [x] Manual `workflow_dispatch` of `build-mcpb.yml` on this branch with `dry_run=true` → bundle uploaded as artifact (6.8 MB), no release created. Run: https://github.com/ignaciohermosillacornejo/copilot-money-mcp/actions/runs/24420501508
- [ ] Post-merge: next `chore: bump version` commit creates a GitHub release with `copilot-money-mcp.mcpb` attached and publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)