### PR TITLE
ci: license-checker gate for production deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,24 @@ jobs:
       - name: Check formatting
         run: bun run format:check
 
+      - name: License check (production deps)
+        # Stages package.json only (NOT package-lock.json) and runs
+        # npm install --omit=dev to mirror scripts/pack-mcpb.ts exactly, so
+        # the gate measures the same graph that ships in the .mcpb bundle.
+        # The nested quotes in --excludePackages are intentional: inside $(...)
+        # bash opens a fresh shell-quoting scope, so the inner "..." is its own
+        # context and does not conflict with the outer quoting.
+        run: |
+          mkdir -p .license-check
+          cp package.json .license-check/
+          (cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
+          npx --yes license-checker@latest \
+            --start .license-check \
+            --production \
+            --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \
+            --excludePackages "copilot-money-mcp@$(node -p "require('./package.json').version")" \
+            --summary
+
   unit-tests:
     name: Unit Tests
     needs: [quality]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,11 +37,17 @@ jobs:
         # The nested quotes in --excludePackages are intentional: inside $(...)
         # bash opens a fresh shell-quoting scope, so the inner "..." is its own
         # context and does not conflict with the outer quoting.
+        # license-checker is pinned (not @latest) for supply-chain determinism;
+        # bump deliberately when SPDX database updates are needed.
+        # --onlyAllow matches flat SPDX IDs only. A dep declaring a composite
+        # expression like "(MIT OR Apache-2.0)" will fail the gate even when
+        # compatible; fix by adding it to --excludePackages with a comment, or
+        # switch to license-checker-rseidelsohn which parses expressions.
         run: |
           mkdir -p .license-check
           cp package.json .license-check/
           (cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
-          npx --yes license-checker@latest \
+          npx --yes license-checker@25.0.1 \
             --start .license-check \
             --production \
             --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ tests/fixtures/demo_database/
 scripts/*
 !scripts/graphql-capture/
 !scripts/launcher.sh
+# License-check scratch directory (created by CI license gate)
+.license-check/
 # Generated test fixtures
 tests/fixtures/mixed-files-db/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,30 @@ Tests mirror the `src/` structure in `tests/`. Synthetic fixtures in `tests/fixt
 - Write tool tests need a mock `FirestoreClient` (see existing write tool tests)
 - Run `bun run check` before submitting to catch typecheck, lint, and format issues
 
+### License check
+
+Production-tree licenses are gated in CI against the allowlist
+`MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0`. To run the same
+check locally before pushing:
+
+```bash
+mkdir -p .license-check
+cp package.json .license-check/
+(cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
+npx --yes license-checker@latest \
+  --start .license-check \
+  --production \
+  --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \
+  --excludePackages "copilot-money-mcp@$(node -p "require('./package.json').version")" \
+  --summary
+rm -rf .license-check
+```
+
+Expect exit 0. If a disallowed license surfaces, either swap the
+offending dep, pin to an earlier version, or — if the SPDX
+declaration is clearly wrong — add an explicit `--excludePackages`
+entry with a comment.
+
 ## Code Style
 
 - TypeScript strict mode

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ check locally before pushing:
 mkdir -p .license-check
 cp package.json .license-check/
 (cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
-npx --yes license-checker@latest \
+npx --yes license-checker@25.0.1 \
   --start .license-check \
   --production \
   --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \

--- a/docs/superpowers/plans/2026-04-14-license-hygiene.md
+++ b/docs/superpowers/plans/2026-04-14-license-hygiene.md
@@ -4,9 +4,9 @@
 
 **Goal:** Add a `license-checker` CI step to the `quality` job in `.github/workflows/test.yml` that fails when any production dependency's license falls outside `MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0`.
 
-**Architecture:** A single ~10-line `run:` step, appended after `Check formatting` in the existing `quality` job. The step creates a scratch directory, runs `npm ci --omit=dev --ignore-scripts` to produce the same production tree that `scripts/pack-mcpb.ts` ships, then invokes `license-checker` via `npx --yes license-checker@latest --onlyAllow ...`. No `package.json` change, no new workflow file, no bundle change. Local repro instructions are added to `CONTRIBUTING.md` so developers can run the same check before pushing.
+**Architecture:** A single ~10-line `run:` step, appended after `Check formatting` in the existing `quality` job. The step creates a scratch directory, runs `npm install --omit=dev --ignore-scripts` against a staged `package.json` (no lockfile) to produce the same production tree that `scripts/pack-mcpb.ts` ships, then invokes `license-checker` via `npx --yes license-checker@latest --onlyAllow ...`. No `package.json` change, no new workflow file, no bundle change. Local repro instructions are added to `CONTRIBUTING.md` so developers can run the same check before pushing.
 
-**Tech Stack:** GitHub Actions (ubuntu-latest), `license-checker` (invoked via npx, no devDep), `npm ci`. Nothing new on the project's core stack.
+**Tech Stack:** GitHub Actions (ubuntu-latest), `license-checker` (invoked via npx, no devDep), `npm install` (mirroring `pack-mcpb.ts`). Nothing new on the project's core stack.
 
 **Reference spec:** `docs/superpowers/specs/2026-04-14-license-hygiene-design.md`
 
@@ -50,8 +50,8 @@ Edit `.github/workflows/test.yml`. Insert after the existing `Check formatting` 
       - name: License check (production deps)
         run: |
           mkdir -p .license-check
-          cp package.json package-lock.json .license-check/
-          (cd .license-check && npm ci --omit=dev --ignore-scripts --no-audit --no-fund)
+          cp package.json .license-check/
+          (cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
           npx --yes license-checker@latest \
             --start .license-check \
             --production \
@@ -77,8 +77,8 @@ Run (from the repo root):
 ```bash
 rm -rf .license-check
 mkdir -p .license-check
-cp package.json package-lock.json .license-check/
-(cd .license-check && npm ci --omit=dev --ignore-scripts --no-audit --no-fund)
+cp package.json .license-check/
+(cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
 npx --yes license-checker@latest \
   --start .license-check \
   --production \
@@ -170,8 +170,8 @@ check locally before pushing:
 
 ```bash
 mkdir -p .license-check
-cp package.json package-lock.json .license-check/
-(cd .license-check && npm ci --omit=dev --ignore-scripts --no-audit --no-fund)
+cp package.json .license-check/
+(cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
 npx --yes license-checker@latest \
   --start .license-check \
   --production \
@@ -269,7 +269,7 @@ gh pr create --title "ci: license-checker gate for production deps" --body "$(ca
 ## Summary
 
 - Adds a `license-checker` step to the `quality` job in `test.yml` that fails CI on any production dep (direct or transitive) outside the allowlist `MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0`.
-- Scans an isolated `npm ci --omit=dev --ignore-scripts` tree so the check mirrors the `.mcpb` bundle's graph exactly.
+- Scans an isolated `npm install --omit=dev --ignore-scripts` tree (package.json only, no lockfile) so the check mirrors the `.mcpb` bundle's graph exactly.
 - Uses `npx --yes license-checker@latest` — no devDep added.
 - Documents local repro in `CONTRIBUTING.md`.
 

--- a/docs/superpowers/plans/2026-04-14-license-hygiene.md
+++ b/docs/superpowers/plans/2026-04-14-license-hygiene.md
@@ -1,0 +1,321 @@
+# License hygiene — CI gate implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `license-checker` CI step to the `quality` job in `.github/workflows/test.yml` that fails when any production dependency's license falls outside `MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0`.
+
+**Architecture:** A single ~10-line `run:` step, appended after `Check formatting` in the existing `quality` job. The step creates a scratch directory, runs `npm ci --omit=dev --ignore-scripts` to produce the same production tree that `scripts/pack-mcpb.ts` ships, then invokes `license-checker` via `npx --yes license-checker@latest --onlyAllow ...`. No `package.json` change, no new workflow file, no bundle change. Local repro instructions are added to `CONTRIBUTING.md` so developers can run the same check before pushing.
+
+**Tech Stack:** GitHub Actions (ubuntu-latest), `license-checker` (invoked via npx, no devDep), `npm ci`. Nothing new on the project's core stack.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-14-license-hygiene-design.md`
+
+---
+
+## File Structure
+
+**Modified:**
+- `.github/workflows/test.yml` — add one step to the `quality` job.
+- `CONTRIBUTING.md` — add a short "License check" subsection under the existing contributing guidance so developers can run the gate locally.
+
+**Not touched:** `package.json`, `bun.lock`, `scripts/pack-mcpb.ts`, `.github/workflows/build-mcpb.yml`, `.github/workflows/auto-release.yml`, `.github/workflows/npm-publish.yml`, any test file, any source file, the bundle.
+
+---
+
+## Task 1: Add the CI license-check step
+
+**Files:**
+- Modify: `.github/workflows/test.yml` (append one step to the `quality` job, after `Check formatting`)
+
+**Context:** The existing `quality` job ends with:
+
+```yaml
+      - name: Check formatting
+        run: bun run format:check
+```
+
+Followed by the `unit-tests` job at line 33. The new step must land *before* the `unit-tests` job starts and *inside* the `quality` job, i.e., between lines 31 and 33 of the current file.
+
+- [ ] **Step 1: Read the existing workflow to confirm line layout**
+
+Run: `cat .github/workflows/test.yml | head -35`
+
+Expected output shows the `quality` job ending with the `Check formatting` step, followed by a blank line, then `unit-tests:` at the top of the next job. Confirm the structure matches before editing.
+
+- [ ] **Step 2: Append the license-check step to the `quality` job**
+
+Edit `.github/workflows/test.yml`. Insert after the existing `Check formatting` step (currently lines 30-31) and before the blank line that separates the `quality` job from the `unit-tests` job:
+
+```yaml
+      - name: License check (production deps)
+        run: |
+          mkdir -p .license-check
+          cp package.json package-lock.json .license-check/
+          (cd .license-check && npm ci --omit=dev --ignore-scripts --no-audit --no-fund)
+          npx --yes license-checker@latest \
+            --start .license-check \
+            --production \
+            --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \
+            --excludePackages "copilot-money-mcp@$(node -p "require('./package.json').version")" \
+            --summary
+```
+
+Indentation must use spaces (not tabs) and match the other steps in the job — 6 spaces for the `- name:` line, 8 for `run:`, 10 for the heredoc body. After the edit, the `quality` job contains six steps: `checkout`, `Setup Bun`, `Install dependencies`, `Run type checking`, `Run linting`, `Check formatting`, `License check (production deps)`.
+
+- [ ] **Step 3: Verify the YAML parses cleanly**
+
+Run: `bunx --yes actionlint-cli .github/workflows/test.yml`
+
+(If `actionlint-cli` isn't available, substitute: `bunx --yes js-yaml .github/workflows/test.yml >/dev/null && echo OK`.)
+
+Expected: no output, or "OK". Any parse error means the indentation is wrong.
+
+- [ ] **Step 4: Run the license check locally to verify it passes against the current tree**
+
+Run (from the repo root):
+
+```bash
+rm -rf .license-check
+mkdir -p .license-check
+cp package.json package-lock.json .license-check/
+(cd .license-check && npm ci --omit=dev --ignore-scripts --no-audit --no-fund)
+npx --yes license-checker@latest \
+  --start .license-check \
+  --production \
+  --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \
+  --excludePackages "copilot-money-mcp@$(node -p "require('./package.json').version")" \
+  --summary
+rm -rf .license-check
+```
+
+Expected output (final two lines):
+
+```
+├─ MIT: 95
+├─ BSD-3-Clause: 14
+├─ ISC: 7
+├─ BSD-2-Clause: 1
+└─ Apache-2.0: 1
+```
+
+Exit code `$?` must be `0`. If any disallowed license is reported, STOP and report — the current tree was expected to be clean and the audit was run on 2026-04-14.
+
+Note: exact counts may drift over time as transitive deps update. What matters for this step is: (a) exit 0, (b) all reported licenses are in the allowlist. Numeric counts can differ from the reference above.
+
+- [ ] **Step 5: Ensure `.license-check/` is not tracked by git**
+
+Run: `git check-ignore -v .license-check/ || echo "not ignored"`
+
+If the output is "not ignored", add `.license-check/` to `.gitignore`. Check: `grep -F '.license-check' .gitignore`. If not present, append the entry:
+
+```bash
+echo '.license-check/' >> .gitignore
+```
+
+(This is the only reason `.gitignore` might need a change. Most repos already ignore it via generic patterns; the repo's current `.gitignore` does not, so this addition is likely required. Run `git status` after the CI step change to confirm no `.license-check/` leaked in.)
+
+- [ ] **Step 6: Confirm no stray files remain**
+
+Run: `git status`
+
+Expected: only `.github/workflows/test.yml` listed as modified, plus `.gitignore` if Step 5 touched it. Nothing else. If the staging `.license-check/` directory shows up as untracked, Step 5 was skipped or failed — go back.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .github/workflows/test.yml
+# Only add .gitignore if Step 5 modified it:
+git diff --cached --quiet .gitignore 2>/dev/null || git add .gitignore
+git commit -m "$(cat <<'EOF'
+ci: add license-checker gate for production deps (#260)
+
+Adds a license-check step to the quality job in test.yml. Fails CI
+when any production dep (direct or transitive) declares a license
+outside MIT/ISC/BSD-2/BSD-3/Apache-2.0. Uses npx license-checker
+against an isolated npm --omit=dev tree so the check matches the
+.mcpb bundle's graph exactly.
+
+See docs/superpowers/specs/2026-04-14-license-hygiene-design.md.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Document local repro in `CONTRIBUTING.md`
+
+**Files:**
+- Modify: `CONTRIBUTING.md` (add a short subsection)
+
+**Context:** Developers should be able to run the same license check locally before pushing to avoid a CI round-trip. The spec mentions this explicitly as part of the rollout plan.
+
+- [ ] **Step 1: Find the right insertion point**
+
+Run: `grep -n '^## ' CONTRIBUTING.md`
+
+The file has section headings like `## Getting Started`, `## Testing`, etc. Pick the section that most closely matches "running checks locally." If there's a `## Testing` or `## Development` section, insert after it. If none obviously fits, append a new `## License Checks` section at the end of the file, above any trailing `## License` / `## Contact` sections.
+
+- [ ] **Step 2: Add a "License check" subsection**
+
+Insert this block at the chosen location (either as a new `### License check` under an existing section, or as a standalone `## License checks` section):
+
+```markdown
+### License check
+
+Production-tree licenses are gated in CI against the allowlist
+`MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0`. To run the same
+check locally before pushing:
+
+```bash
+mkdir -p .license-check
+cp package.json package-lock.json .license-check/
+(cd .license-check && npm ci --omit=dev --ignore-scripts --no-audit --no-fund)
+npx --yes license-checker@latest \
+  --start .license-check \
+  --production \
+  --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \
+  --excludePackages "copilot-money-mcp@$(node -p "require('./package.json').version")" \
+  --summary
+rm -rf .license-check
+```
+
+Expect exit 0. If a disallowed license surfaces, either swap the
+offending dep, pin to an earlier version, or — if the SPDX
+declaration is clearly wrong — add an explicit `--excludePackages`
+entry with a comment.
+```
+
+Use the triple-backtick rendering exactly as shown; markdown renderers handle nested fences with language tags. If your editor struggles with the nested fences, use four backticks on the outer fence in the actual file.
+
+- [ ] **Step 3: Preview the rendered markdown**
+
+Run: `bunx --yes markdown-it CONTRIBUTING.md > /tmp/contributing-preview.html && echo OK`
+
+(If `markdown-it` isn't installed, skip — it's only a sanity check.)
+Expected: "OK". Open `/tmp/contributing-preview.html` to eyeball the rendering if tooling is available; otherwise proceed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -m "$(cat <<'EOF'
+docs: document local license-check repro in CONTRIBUTING (#260)
+
+Mirrors the CI gate added in the previous commit so contributors
+can validate production-tree licenses before pushing.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Full-suite verification
+
+**Files:** none modified; verification only.
+
+- [ ] **Step 1: Run the repo's full check suite**
+
+Run: `bun run check`
+
+Expected: all four sub-commands (`typecheck`, `lint`, `format:check`, `test --bail`) pass with exit 0. This matches what the pre-push hook runs.
+
+If anything fails, STOP and investigate. Nothing in this plan touches runtime code, so failures here should be pre-existing and unrelated — but fix them or surface them before proceeding.
+
+- [ ] **Step 2: Confirm branch state**
+
+Run: `git log --oneline origin/main..HEAD`
+
+Expected: three commits on the branch:
+
+1. `docs: spec CI license hygiene (#260)` — already on branch before this plan executes.
+2. `ci: add license-checker gate for production deps (#260)` — from Task 1.
+3. `docs: document local license-check repro in CONTRIBUTING (#260)` — from Task 2.
+
+Any other commits indicate drift; investigate.
+
+- [ ] **Step 3: Rebase onto origin/main**
+
+Before pushing, re-verify the branch is up to date with `main`:
+
+```bash
+git fetch origin main
+git rebase origin/main
+```
+
+Expected: either "Current branch ci/license-hygiene is up to date" or a clean rebase with no conflicts. If conflicts surface, STOP — this plan touches a single CI file plus CONTRIBUTING, and conflicts mean something unexpected landed on main. Do not force-resolve.
+
+---
+
+## Task 4: Push and open PR
+
+**Files:** none modified; git operations only.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin ci/license-hygiene
+```
+
+Pre-push hook will run `bun run check` again. Expected: exit 0. Do NOT use `--no-verify`.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "ci: license-checker gate for production deps" --body "$(cat <<'EOF'
+## Summary
+
+- Adds a `license-checker` step to the `quality` job in `test.yml` that fails CI on any production dep (direct or transitive) outside the allowlist `MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0`.
+- Scans an isolated `npm ci --omit=dev --ignore-scripts` tree so the check mirrors the `.mcpb` bundle's graph exactly.
+- Uses `npx --yes license-checker@latest` — no devDep added.
+- Documents local repro in `CONTRIBUTING.md`.
+
+Implements issue #260 item C (the CI-gate portion only). Aggregated `THIRD_PARTY_LICENSES` and CycloneDX SBOM are explicitly deferred — see the linked spec for the rationale.
+
+Spec: `docs/superpowers/specs/2026-04-14-license-hygiene-design.md`
+Plan: `docs/superpowers/plans/2026-04-14-license-hygiene.md`
+
+## Test plan
+
+- [ ] CI `quality` job passes on this PR, including the new License check step
+- [ ] License check reports the expected ~118 packages under MIT/BSD/ISC/Apache licenses with exit 0
+- [ ] No unexpected files or `.license-check/` artifacts are committed
+- [ ] Existing `unit-tests` and `e2e-tests` jobs remain green
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: `gh` prints a PR URL. Record it.
+
+- [ ] **Step 3: Wait for CI and review**
+
+Per the user's workflow preferences: wait 3-5 minutes for CI checks and automated review comments. Then:
+
+```bash
+gh pr checks
+gh pr view --comments
+gh api "repos/:owner/:repo/pulls/$(gh pr view --json number -q .number)/comments"
+```
+
+Expected: all checks green; no blocking review comments. Address every comment — including nits — before considering the work done.
+
+- [ ] **Step 4: Address review feedback (if any)**
+
+For each comment: make the change locally, commit with a conventional-commit prefix (`fix:`, `ci:`, `docs:` as appropriate), push. Re-check CI. Repeat until no outstanding comments.
+
+- [ ] **Step 5: Mark task complete**
+
+Work is done when: all CI green, all review comments addressed or resolved, PR approved (if reviewer required) or ready to merge.
+
+---
+
+## Self-review checklist (for the writer, already run)
+
+- **Spec coverage:** Every in-scope item in the spec maps to a task — the CI step (Task 1), local repro docs (Task 2), verification (Task 3), rollout (Task 4). Out-of-scope items (`THIRD_PARTY_LICENSES`, SBOM, modclean docs) are correctly absent.
+- **Placeholder scan:** No TBDs, TODOs, or "similar to Task N" references. Every code block is complete and verbatim.
+- **Type consistency:** The `--excludePackages` version-extraction expression is identical in the workflow step, the local repro, and the CONTRIBUTING snippet. Allowlist is spelled identically across all four appearances (spec Context, workflow step, CONTRIBUTING, PR body).

--- a/docs/superpowers/plans/2026-04-14-license-hygiene.md
+++ b/docs/superpowers/plans/2026-04-14-license-hygiene.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add a `license-checker` CI step to the `quality` job in `.github/workflows/test.yml` that fails when any production dependency's license falls outside `MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0`.
 
-**Architecture:** A single ~10-line `run:` step, appended after `Check formatting` in the existing `quality` job. The step creates a scratch directory, runs `npm install --omit=dev --ignore-scripts` against a staged `package.json` (no lockfile) to produce the same production tree that `scripts/pack-mcpb.ts` ships, then invokes `license-checker` via `npx --yes license-checker@latest --onlyAllow ...`. No `package.json` change, no new workflow file, no bundle change. Local repro instructions are added to `CONTRIBUTING.md` so developers can run the same check before pushing.
+**Architecture:** A single ~10-line `run:` step, appended after `Check formatting` in the existing `quality` job. The step creates a scratch directory, runs `npm install --omit=dev --ignore-scripts` against a staged `package.json` (no lockfile) to produce the same production tree that `scripts/pack-mcpb.ts` ships, then invokes `license-checker` via `npx --yes license-checker@25.0.1 --onlyAllow ...`. No `package.json` change, no new workflow file, no bundle change. Local repro instructions are added to `CONTRIBUTING.md` so developers can run the same check before pushing.
 
 **Tech Stack:** GitHub Actions (ubuntu-latest), `license-checker` (invoked via npx, no devDep), `npm install` (mirroring `pack-mcpb.ts`). Nothing new on the project's core stack.
 
@@ -52,7 +52,7 @@ Edit `.github/workflows/test.yml`. Insert after the existing `Check formatting` 
           mkdir -p .license-check
           cp package.json .license-check/
           (cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
-          npx --yes license-checker@latest \
+          npx --yes license-checker@25.0.1 \
             --start .license-check \
             --production \
             --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \
@@ -79,7 +79,7 @@ rm -rf .license-check
 mkdir -p .license-check
 cp package.json .license-check/
 (cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
-npx --yes license-checker@latest \
+npx --yes license-checker@25.0.1 \
   --start .license-check \
   --production \
   --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \
@@ -172,7 +172,7 @@ check locally before pushing:
 mkdir -p .license-check
 cp package.json .license-check/
 (cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
-npx --yes license-checker@latest \
+npx --yes license-checker@25.0.1 \
   --start .license-check \
   --production \
   --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \
@@ -270,7 +270,7 @@ gh pr create --title "ci: license-checker gate for production deps" --body "$(ca
 
 - Adds a `license-checker` step to the `quality` job in `test.yml` that fails CI on any production dep (direct or transitive) outside the allowlist `MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0`.
 - Scans an isolated `npm install --omit=dev --ignore-scripts` tree (package.json only, no lockfile) so the check mirrors the `.mcpb` bundle's graph exactly.
-- Uses `npx --yes license-checker@latest` — no devDep added.
+- Uses `npx --yes license-checker@25.0.1` — no devDep added.
 - Documents local repro in `CONTRIBUTING.md`.
 
 Implements issue #260 item C (the CI-gate portion only). Aggregated `THIRD_PARTY_LICENSES` and CycloneDX SBOM are explicitly deferred — see the linked spec for the rationale.

--- a/docs/superpowers/specs/2026-04-14-license-hygiene-design.md
+++ b/docs/superpowers/specs/2026-04-14-license-hygiene-design.md
@@ -19,7 +19,7 @@ Tracking: issue #260, item C ("License and supply chain"). This spec implements 
 **In scope:**
 
 - Add a `License check (production deps)` step to the existing `quality` job in `.github/workflows/test.yml`.
-- Use `license-checker` via `npx --yes license-checker@latest` — no devDep added to `package.json`.
+- Use `license-checker` via `npx --yes license-checker@25.0.1` — no devDep added to `package.json`.
 - Run the check against an isolated `npm install --omit=dev --ignore-scripts` tree that mirrors what `scripts/pack-mcpb.ts` ships (package.json only, no lockfile), not against bun's workspace layout.
 - Allowlist: `MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0` (verbatim from issue #260 item C).
 - Document a local repro command for developers who want to run the same check before pushing.
@@ -61,7 +61,7 @@ One new step at the end of the `quality` job in `.github/workflows/test.yml`, af
     mkdir -p .license-check
     cp package.json .license-check/
     (cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
-    npx --yes license-checker@latest \
+    npx --yes license-checker@25.0.1 \
       --start .license-check \
       --production \
       --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \
@@ -74,8 +74,8 @@ One new step at the end of the `quality` job in `.github/workflows/test.yml`, af
 **`npm install` in a scratch directory with `package.json` only (no lockfile), not `bun install`'s workspace tree.**
 The `.mcpb` bundle's dep graph is produced by `npm install --omit=dev --ignore-scripts` inside `scripts/pack-mcpb.ts`, which copies `package.json` into the staging directory but NOT `package-lock.json`. Scanning under the same semantics ensures the CI check sees the same set of packages the bundle ships. Copying the lockfile and switching to `npm ci` was considered and rejected: with the lockfile present npm walks the full resolved tree (including devDep entries) during peer-dep validation, and the project's `typescript@^6` conflicts with `typescript-eslint@8`'s `typescript@">=4.8.4 <6.0.0"` peer constraint. Forcing past that with `--legacy-peer-deps` would pass the check but silence a real signal, and — more importantly — would no longer mirror the bundle's actual install path. Bun's `node_modules/` layout can differ subtly (hoisting, peer-dep resolution) — catching a violation against a tree that is NOT what we ship would be a bug.
 
-**`npx license-checker@latest` rather than adding a devDep.**
-`license-checker` pulls ~30 transitive deps that are only relevant to CI. Adding it to `package.json` pollutes the dev graph (lockfile churn, `bun install` time). `npx --yes ... @latest` keeps it ephemeral. `@latest` is acceptable because the tool is low-churn and any breaking-change fallout surfaces as a visible CI failure, not a silent one. If the tool ever ships a regression, we pin a version in the step.
+**`npx license-checker@25.0.1` rather than adding a devDep.**
+`license-checker` pulls ~30 transitive deps that are only relevant to CI. Adding it to `package.json` pollutes the dev graph (lockfile churn, `bun install` time). `npx --yes ... @<version>` keeps it ephemeral. The version is pinned (not `@latest`) for supply-chain determinism — an `@latest` tag could pull a future release with a silent regression or a compromised publish. Bumps are deliberate and visible in git history; when the SPDX database needs to refresh or a bug fix is required, update the pin in one line.
 
 **`--production` + `--onlyAllow`.**
 `--production` restricts to the `dependencies` tree — matching what the bundle ships. `--onlyAllow` causes the tool to exit nonzero if any package's license is outside the list. Exit status is what fails the job.
@@ -104,7 +104,7 @@ No other files are touched.
 mkdir -p .license-check
 cp package.json .license-check/
 (cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
-npx --yes license-checker@latest \
+npx --yes license-checker@25.0.1 \
   --start .license-check \
   --production \
   --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \
@@ -134,7 +134,7 @@ The change is a single step in one workflow file. Revert the commit if anything 
 
 - **Adding `THIRD_PARTY_LICENSES` to the bundle.** Individual `LICENSE` files already ride along inside each `node_modules/<pkg>/` directory in the bundle, so MIT/BSD/ISC/Apache-2.0 notice-preservation obligations are already discharged. An aggregated file is auditor-convenience, not legal requirement.
 - **Adding a CycloneDX SBOM.** Deferred as low-ROI at this project's scale. Revisit if a downstream consumer requests one.
-- **Pinning `license-checker` to an exact version via devDeps.** Rejected in favor of `npx @latest` to keep the dev dep graph clean. Trade-off: we trust the tool not to break silently. Revisit if it ever does.
+- **Pinning `license-checker` as a devDep.** Rejected in favor of a version-pinned `npx --yes license-checker@<version>` invocation — gets the supply-chain determinism of a pin without polluting the dev dep graph. Bump the pin deliberately when needed.
 - **Running the gate inside `build-mcpb.yml` or `pack-mcpb.ts`.** Release-path gating is redundant with PR gating (main can only advance through green PRs). Adding the check to the pack script would duplicate work and slow bundle builds for no incremental safety.
 - **Broadening the allowlist to include BlueOak-1.0.0, CC0-1.0, Unlicense, 0BSD.** None currently appear in the tree. Expanding pre-emptively loosens the gate without benefit. Add when a real dep forces the decision.
 - **Blocking on main with `on: push` as well as PRs.** Redundant: `test.yml` already runs on main pushes for the existing jobs, and main only advances through PRs that have already run the gate.

--- a/docs/superpowers/specs/2026-04-14-license-hygiene-design.md
+++ b/docs/superpowers/specs/2026-04-14-license-hygiene-design.md
@@ -20,7 +20,7 @@ Tracking: issue #260, item C ("License and supply chain"). This spec implements 
 
 - Add a `License check (production deps)` step to the existing `quality` job in `.github/workflows/test.yml`.
 - Use `license-checker` via `npx --yes license-checker@latest` — no devDep added to `package.json`.
-- Run the check against an isolated `npm ci --omit=dev --ignore-scripts` tree that mirrors what `scripts/pack-mcpb.ts` ships, not against bun's workspace layout.
+- Run the check against an isolated `npm install --omit=dev --ignore-scripts` tree that mirrors what `scripts/pack-mcpb.ts` ships (package.json only, no lockfile), not against bun's workspace layout.
 - Allowlist: `MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0` (verbatim from issue #260 item C).
 - Document a local repro command for developers who want to run the same check before pushing.
 
@@ -59,8 +59,8 @@ One new step at the end of the `quality` job in `.github/workflows/test.yml`, af
 - name: License check (production deps)
   run: |
     mkdir -p .license-check
-    cp package.json package-lock.json .license-check/
-    (cd .license-check && npm ci --omit=dev --ignore-scripts --no-audit --no-fund)
+    cp package.json .license-check/
+    (cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
     npx --yes license-checker@latest \
       --start .license-check \
       --production \
@@ -71,8 +71,8 @@ One new step at the end of the `quality` job in `.github/workflows/test.yml`, af
 
 ### Design decisions and rationale
 
-**`npm ci` in a scratch directory (not `bun install`'s workspace tree).**
-The `.mcpb` bundle's dep graph is produced by `npm install --omit=dev --ignore-scripts` inside `scripts/pack-mcpb.ts`. Scanning an isolated npm-installed tree ensures the CI check sees the same set of packages the bundle ships. Bun's `node_modules/` layout can differ subtly (hoisting, peer-dep resolution) — catching a violation against a tree that is NOT what we ship would be a bug.
+**`npm install` in a scratch directory with `package.json` only (no lockfile), not `bun install`'s workspace tree.**
+The `.mcpb` bundle's dep graph is produced by `npm install --omit=dev --ignore-scripts` inside `scripts/pack-mcpb.ts`, which copies `package.json` into the staging directory but NOT `package-lock.json`. Scanning under the same semantics ensures the CI check sees the same set of packages the bundle ships. Copying the lockfile and switching to `npm ci` was considered and rejected: with the lockfile present npm walks the full resolved tree (including devDep entries) during peer-dep validation, and the project's `typescript@^6` conflicts with `typescript-eslint@8`'s `typescript@">=4.8.4 <6.0.0"` peer constraint. Forcing past that with `--legacy-peer-deps` would pass the check but silence a real signal, and — more importantly — would no longer mirror the bundle's actual install path. Bun's `node_modules/` layout can differ subtly (hoisting, peer-dep resolution) — catching a violation against a tree that is NOT what we ship would be a bug.
 
 **`npx license-checker@latest` rather than adding a devDep.**
 `license-checker` pulls ~30 transitive deps that are only relevant to CI. Adding it to `package.json` pollutes the dev graph (lockfile churn, `bun install` time). `npx --yes ... @latest` keeps it ephemeral. `@latest` is acceptable because the tool is low-churn and any breaking-change fallout surfaces as a visible CI failure, not a silent one. If the tool ever ships a regression, we pin a version in the step.
@@ -92,6 +92,7 @@ Blocking on PRs at the same level as `typecheck`, `lint`, and `format:check`. A 
 ### Files changed
 
 - `.github/workflows/test.yml` — one new step in the `quality` job, ~10 lines.
+- `.gitignore` — add `.license-check/` so the scratch directory created by the CI step is never accidentally committed.
 
 No other files are touched.
 
@@ -101,8 +102,8 @@ No other files are touched.
 
 ```bash
 mkdir -p .license-check
-cp package.json package-lock.json .license-check/
-(cd .license-check && npm ci --omit=dev --ignore-scripts --no-audit --no-fund)
+cp package.json .license-check/
+(cd .license-check && npm install --omit=dev --ignore-scripts --no-audit --no-fund)
 npx --yes license-checker@latest \
   --start .license-check \
   --production \
@@ -116,7 +117,7 @@ Expect exit 0 against the current tree.
 
 **Gate negative-path verification (manual, local only — not committed):**
 
-Temporarily add a known-GPL package (e.g. `readline-sync` which is under WTFPL) to `package.json`, run `npm ci` in the scratch dir, rerun the license-checker command, expect exit 1 with that package's name in the output. Revert the change. This verifies the gate actually rejects disallowed licenses; do not land this as a committed negative test.
+Temporarily add a known-GPL package (e.g. `readline-sync` which is under WTFPL) to `package.json`, run the `npm install` step in the scratch dir, rerun the license-checker command, expect exit 1 with that package's name in the output. Revert the change. This verifies the gate actually rejects disallowed licenses; do not land this as a committed negative test.
 
 **CI verification (in-PR):**
 The new step runs as part of the `quality` job on every PR. The PR that introduces the step exercises the step itself — expect the `quality` job to pass.

--- a/docs/superpowers/specs/2026-04-14-license-hygiene-design.md
+++ b/docs/superpowers/specs/2026-04-14-license-hygiene-design.md
@@ -1,0 +1,139 @@
+# License hygiene — CI gate for production-dep licenses
+
+**Status:** Design approved (2026-04-14)
+**Author:** nach
+**Scope:** Add a `license-checker` CI gate to `.github/workflows/test.yml` that fails the `quality` job when any production dependency (direct or transitive) uses a license outside an explicit allowlist. No runtime behavior change; no bundle-content change.
+
+## Motivation
+
+The `.mcpb` bundle distributed via GitHub Releases embeds `node_modules/` with roughly 118 production dependencies. When the project distributes that bundle, it becomes a redistributor under each dep's license. Today all transitive prod licenses are MIT/BSD/ISC/Apache-2.0, and the individual `LICENSE` files ship inside each `node_modules/<pkg>/` directory — so MIT/BSD/ISC/Apache-2.0 notice preservation is already satisfied by the existing bundle.
+
+The remaining risk is **future drift**: a transitive-dep bump could silently pull in a package with a problematic license (GPL/AGPL is rare in npm but not unheard of — ~1% of public packages). Catching that in code review by eyeballing a lockfile diff is not realistic.
+
+A ~10-line CI step that runs `license-checker` against the production tree and fails on anything outside an explicit allowlist is cheap insurance against that drift.
+
+Tracking: issue #260, item C ("License and supply chain"). This spec implements only the CI-gate part of item C. The other sub-items (aggregated `THIRD_PARTY_LICENSES`, CycloneDX SBOM) are explicitly deferred — see **Non-goals** below.
+
+## Scope
+
+**In scope:**
+
+- Add a `License check (production deps)` step to the existing `quality` job in `.github/workflows/test.yml`.
+- Use `license-checker` via `npx --yes license-checker@latest` — no devDep added to `package.json`.
+- Run the check against an isolated `npm ci --omit=dev --ignore-scripts` tree that mirrors what `scripts/pack-mcpb.ts` ships, not against bun's workspace layout.
+- Allowlist: `MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0` (verbatim from issue #260 item C).
+- Document a local repro command for developers who want to run the same check before pushing.
+
+**Out of scope (explicitly deferred):**
+
+- Aggregated `THIRD_PARTY_LICENSES` file. Individual `LICENSE` files already ship inside each `node_modules/<pkg>/` in the bundle, so license-notice preservation obligations are already satisfied. The aggregation is convenience for auditors, not a compliance gap for this project's scale.
+- CycloneDX SBOM. Low ROI for a personal-scale MCP; defer to a follow-up if/when compliance or vuln-scanning consumers ask for one.
+- Modclean preservation documentation. Will be specified as part of issue #260 item D (the modclean pass itself), not pre-emptively here.
+- Dev-dep license scanning. Dev deps do not ship in the bundle; no redistribution concern.
+- Any change to `build-mcpb.yml`, `auto-release.yml`, `npm-publish.yml`, `scripts/pack-mcpb.ts`, or `package.json`.
+
+## Context: current production-tree audit
+
+Run against the working tree on 2026-04-14 via `npx license-checker --production --summary`:
+
+| License     | Count |
+|-------------|------:|
+| MIT         | 95 |
+| BSD-3-Clause | 14 |
+| ISC         | 7 |
+| BSD-2-Clause | 1 |
+| Apache-2.0  | 1 |
+| **Total**   | **118** |
+
+All 118 prod-tree packages are covered by the proposed allowlist. No expansion needed today.
+
+The four direct prod deps are `@modelcontextprotocol/sdk`, `classic-level`, `protobufjs`, and `zod` — all MIT. All license diversity comes from the transitive tree.
+
+## Design
+
+### Where the step lands
+
+One new step at the end of the `quality` job in `.github/workflows/test.yml`, after `Check formatting`:
+
+```yaml
+- name: License check (production deps)
+  run: |
+    mkdir -p .license-check
+    cp package.json package-lock.json .license-check/
+    (cd .license-check && npm ci --omit=dev --ignore-scripts --no-audit --no-fund)
+    npx --yes license-checker@latest \
+      --start .license-check \
+      --production \
+      --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \
+      --excludePackages "copilot-money-mcp@$(node -p "require('./package.json').version")" \
+      --summary
+```
+
+### Design decisions and rationale
+
+**`npm ci` in a scratch directory (not `bun install`'s workspace tree).**
+The `.mcpb` bundle's dep graph is produced by `npm install --omit=dev --ignore-scripts` inside `scripts/pack-mcpb.ts`. Scanning an isolated npm-installed tree ensures the CI check sees the same set of packages the bundle ships. Bun's `node_modules/` layout can differ subtly (hoisting, peer-dep resolution) — catching a violation against a tree that is NOT what we ship would be a bug.
+
+**`npx license-checker@latest` rather than adding a devDep.**
+`license-checker` pulls ~30 transitive deps that are only relevant to CI. Adding it to `package.json` pollutes the dev graph (lockfile churn, `bun install` time). `npx --yes ... @latest` keeps it ephemeral. `@latest` is acceptable because the tool is low-churn and any breaking-change fallout surfaces as a visible CI failure, not a silent one. If the tool ever ships a regression, we pin a version in the step.
+
+**`--production` + `--onlyAllow`.**
+`--production` restricts to the `dependencies` tree — matching what the bundle ships. `--onlyAllow` causes the tool to exit nonzero if any package's license is outside the list. Exit status is what fails the job.
+
+**`--excludePackages "copilot-money-mcp@<version>"`.**
+The repo's own package appears in the scanned tree. Its license (MIT) is already in the allowlist, but excluding it avoids including the project itself in the checked set. The version is read dynamically via `node -p` so the step does not need to be kept in sync with `package.json`.
+
+**Allowlist handling of composite SPDX expressions.**
+`--onlyAllow` matches flat SPDX IDs only; a dep that declares e.g. `(MIT OR Apache-2.0)` reports the raw expression and does not match either half. No current prod dep uses a composite expression. If one surfaces in the future, the fix is to either switch to `license-checker-rseidelsohn` (which supports `--onlyAllow` with expression parsing) or add that specific package to `--excludePackages`. We'll decide when it actually happens.
+
+**Gating semantics.**
+Blocking on PRs at the same level as `typecheck`, `lint`, and `format:check`. A disallowed license is treated exactly like a failed type-check: fix the dep, push again. Release-time gating falls out for free because `auto-release.yml` only runs against main, which only gets updated via PR merges that are green.
+
+### Files changed
+
+- `.github/workflows/test.yml` — one new step in the `quality` job, ~10 lines.
+
+No other files are touched.
+
+## Testing and rollout
+
+**Pre-merge verification (developer-local):**
+
+```bash
+mkdir -p .license-check
+cp package.json package-lock.json .license-check/
+(cd .license-check && npm ci --omit=dev --ignore-scripts --no-audit --no-fund)
+npx --yes license-checker@latest \
+  --start .license-check \
+  --production \
+  --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0' \
+  --excludePackages "copilot-money-mcp@$(node -p "require('./package.json').version")" \
+  --summary
+rm -rf .license-check
+```
+
+Expect exit 0 against the current tree.
+
+**Gate negative-path verification (manual, local only — not committed):**
+
+Temporarily add a known-GPL package (e.g. `readline-sync` which is under WTFPL) to `package.json`, run `npm ci` in the scratch dir, rerun the license-checker command, expect exit 1 with that package's name in the output. Revert the change. This verifies the gate actually rejects disallowed licenses; do not land this as a committed negative test.
+
+**CI verification (in-PR):**
+The new step runs as part of the `quality` job on every PR. The PR that introduces the step exercises the step itself — expect the `quality` job to pass.
+
+**Failure mode and recovery:**
+If a future PR introduces a dep with a disallowed license, `license-checker` prints the offending package name, version, and license on stderr and exits nonzero. `quality` fails. The PR author either swaps the dep, pins to an earlier version, or — if the reporting is wrong (e.g. misdeclared SPDX) — adds the package to `--excludePackages` with a comment explaining why.
+
+**Rollback:**
+The change is a single step in one workflow file. Revert the commit if anything misbehaves post-merge. No state needs unwinding; the step does not produce artifacts.
+
+**Line-count delta:** `.github/workflows/test.yml` grows by ~10 lines.
+
+## Non-goals / things we explicitly did NOT consider
+
+- **Adding `THIRD_PARTY_LICENSES` to the bundle.** Individual `LICENSE` files already ride along inside each `node_modules/<pkg>/` directory in the bundle, so MIT/BSD/ISC/Apache-2.0 notice-preservation obligations are already discharged. An aggregated file is auditor-convenience, not legal requirement.
+- **Adding a CycloneDX SBOM.** Deferred as low-ROI at this project's scale. Revisit if a downstream consumer requests one.
+- **Pinning `license-checker` to an exact version via devDeps.** Rejected in favor of `npx @latest` to keep the dev dep graph clean. Trade-off: we trust the tool not to break silently. Revisit if it ever does.
+- **Running the gate inside `build-mcpb.yml` or `pack-mcpb.ts`.** Release-path gating is redundant with PR gating (main can only advance through green PRs). Adding the check to the pack script would duplicate work and slow bundle builds for no incremental safety.
+- **Broadening the allowlist to include BlueOak-1.0.0, CC0-1.0, Unlicense, 0BSD.** None currently appear in the tree. Expanding pre-emptively loosens the gate without benefit. Add when a real dep forces the decision.
+- **Blocking on main with `on: push` as well as PRs.** Redundant: `test.yml` already runs on main pushes for the existing jobs, and main only advances through PRs that have already run the gate.


### PR DESCRIPTION
## Summary

- Adds a `License check (production deps)` step to the `quality` job in `.github/workflows/test.yml` that fails CI on any production dep (direct or transitive) outside the allowlist `MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0`.
- Scans an isolated `npm install --omit=dev --ignore-scripts` tree (`package.json` only, no lockfile) so the check mirrors `scripts/pack-mcpb.ts` exactly — same graph the `.mcpb` bundle ships.
- Uses `npx --yes license-checker@latest`; no devDep added.
- Adds `.license-check/` to `.gitignore` so the scratch directory is never accidentally committed.
- Documents local repro in `CONTRIBUTING.md`.

Implements issue #260 item C (the CI-gate portion only). Aggregated `THIRD_PARTY_LICENSES` and CycloneDX SBOM are explicitly deferred — the rationale is in the spec. Individual `LICENSE` files already ship inside each `node_modules/<pkg>/` in the bundle, so MIT/BSD/ISC/Apache-2.0 notice-preservation obligations are already satisfied; the aggregated file is convenience for auditors, not a compliance gap at this project's scale.

## Design notes

A quirk worth flagging: the first attempt staged `package-lock.json` and used `npm ci`, which surfaced a real peer-dep conflict (`typescript@^6` vs `typescript-eslint@8`'s `typescript@">=4.8.4 <6.0.0"` peer constraint). The workaround would have been `--legacy-peer-deps`, but that silences a real signal and diverges from the bundle's actual install path. `pack-mcpb.ts` sidesteps the conflict by staging `package.json` only and letting `npm install` re-resolve fresh — the final CI step matches that pattern exactly.

Spec: `docs/superpowers/specs/2026-04-14-license-hygiene-design.md`
Plan: `docs/superpowers/plans/2026-04-14-license-hygiene.md`

## Test plan

- [ ] CI `quality` job passes on this PR, including the new License check step
- [ ] License check reports the expected ~118 prod packages under MIT/BSD/ISC/Apache and exits 0
- [ ] No `.license-check/` scratch directory is committed
- [ ] `unit-tests` and `e2e-tests` jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)