### PR TITLE
chore: release 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-04-15
+
+### Fixed
+- **Extension now installs on current Claude Desktop** (#249, upstream [mcpb#229](https://github.com/modelcontextprotocol/mcpb/issues/229)): Claude Desktop 1.2581+ runs Node MCPB extensions inside an Electron UtilityProcess that enforces macOS hardened-runtime library validation, which rejects ad-hoc-signed npm prebuilds (our `classic-level` binding). The process died in `dlopen` before any of our code ran, leaving users with a silent "Server disconnected" status. Routes the launch through `dist/launcher.sh` — an absolute path rather than the literal string `"node"` — so Claude Desktop's router falls through to plain `child_process` spawn where native deps load normally. The launcher tries `command -v node` first, then falls back through `~/.volta/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `/usr/bin` (GUI-launched macOS processes don't inherit shell PATH).
+
+### Changed
+- **Extension declared macOS-only** (`compatibility.platforms: ["darwin"]`): Copilot Money itself only ships for macOS, so the MCP server now tells Claude Desktop / the MCPB catalog to block install on Windows and Linux rather than letting users install something that would have nothing to read.
+
 ## [1.7.0] - 2026-04-14
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "copilot-money-mcp",
   "display_name": "Copilot Money MCP Server",
   "description": "Query your personal finances with AI using local Copilot Money data. 17 read-only tools for transactions, investments, budgets, goals, and more.",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "icon": "icon.png",
   "author": {
     "name": "Ignacio Hermosilla",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-money-mcp",
-  "version": "1.6.1",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-money-mcp",
-      "version": "1.6.1",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.2.0",
@@ -18,7 +18,7 @@
         "copilot-money-mcp": "dist/cli.js"
       },
       "devDependencies": {
-        "@anthropic-ai/mcpb": "*",
+        "@anthropic-ai/mcpb": "latest",
         "@eslint/js": "^10.0.1",
         "@types/bun": "^1.1.0",
         "@types/node": "^25.0.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-money-mcp",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "MCP server for Copilot Money - query personal finances with AI using local data (17 read-only tools)",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary
- Bumps to `1.7.1` to ship #270: fix for Claude Desktop 1.2581+ refusing to load the extension due to macOS hardened-runtime library validation rejecting `classic-level`'s ad-hoc-signed prebuild. Users on affected Claude Desktop versions currently see a silent "Server disconnected" status with no diagnostic output (process dies in `dlopen` before our JS runs).
- Includes the accompanying scope change from #270: `compatibility.platforms: ["darwin"]`, since Copilot Money itself only ships for macOS.
- Regenerates `package-lock.json` (version drift: lockfile was still on `1.6.1` — bumped to `1.7.1` in the same commit).

Triggers `.github/workflows/auto-release.yml` on merge (fires on `package.json` change under `main` + version diff). That workflow calls `build-mcpb.yml` via `workflow_call` to publish the `.mcpb` asset.

## Changes
- `package.json` / `package-lock.json` — `1.7.0` → `1.7.1`
- `manifest.json` — `1.7.0` → `1.7.1`
- `CHANGELOG.md` — new `## [1.7.1]` section under Keep-a-Changelog format, linking #249 (user report) and upstream [mcpb#229](https://github.com/modelcontextprotocol/mcpb/issues/229)

## Upstream
- User report: #249
- Root-cause + workaround write-up filed upstream: modelcontextprotocol/mcpb#229

## Test plan
- [x] `bun run check` passes (1509 pass, 0 fail)
- [x] Fresh `.mcpb` from `main` installed cleanly in Claude Desktop 1.2581.0, confirmed startup stderr banner now visible in logs and `tools/list` round-trips
- [ ] Auto-release workflow produces `.mcpb` asset on v1.7.1 tag (watches after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)