### PR TITLE
chore(release): 2.0.0 — GraphQL write tools, breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-04-15
+
+Write tools are back — rewritten onto Copilot Money's official GraphQL API (`https://app.copilot.money/api/graphql`) after direct Firestore writes were blocked by Copilot's server-side type-check deploy. Opt-in via `--write` (unchanged). 13 write tools (down from 18) across transactions, tags, categories, budgets, and recurrings.
+
+### Breaking Changes
+
+- **Budget write tools consolidated.** `create_budget` / `update_budget` / `delete_budget` → single **`set_budget`**. The Copilot API only exposes `EditBudget(categoryId, {amount})`, so budgets are addressed by category rather than by budget document ID. `amount="0"` clears the budget. Pass `month="YYYY-MM"` for a single-month override (via `EditBudgetMonthly`); omit for the all-months default.
+- **`create_recurring` signature changed.** Now takes `{transaction_id, frequency}` — the API requires seeding a recurring from an existing transaction, so the tool derives `accountId` / `itemId` from the local DB. Previous `{name, amount, category_id, ...}` shape is gone.
+- **Goal write tools removed.** `create_goal` / `update_goal` / `delete_goal` have no web GraphQL equivalent (the app's goal mutations are mobile-only). Goal read tools (`get_goals`, `get_goal_history`) are unchanged.
+- **`update_transaction` field set trimmed.** No longer accepts `excluded`, `name`, `internal_transfer`, or `goal_id` — these are not writable through the public GraphQL mutations. Remaining writable fields: `category_id`, `note`, `tag_ids`.
+- **Error message wording changed.** The old "budgeting disabled" message is gone. When budgeting or rollovers are disabled in Copilot → Settings → General, writes succeed on the server and return a `USER_ACTION_REQUIRED` error with an "enable manually in Copilot settings" hint. The value will not appear in the Copilot UI until those toggles are re-enabled — see the `set_budget` tool description for the full caveat.
+
+### Added
+
+- `src/core/graphql/client.ts` — typed `GraphQLClient` and `GraphQLError` with discriminated `code: 'AUTH_FAILED' | 'SCHEMA_ERROR' | 'USER_ACTION_REQUIRED' | 'NETWORK' | 'UNKNOWN'`. Every thrown error logs operation name + code + HTTP status to stderr; response bodies are never logged (PII).
+- Six per-domain GraphQL modules (`transactions`, `categories`, `tags`, `recurrings`, `budgets`, `accounts`) — thin pure functions over the client, typed args in and compact `{id, changed}` out.
+- `scripts/generate-graphql-operations.ts` — build-time generator that reads captured mutation docs and emits `operations.generated.ts` with `__typename`-transformed query strings matching Apollo's `documentTransform` wire shape.
+- `scripts/smoke-graphql.ts` — opt-in, not in CI, runs against the developer's real account with create-edit-delete round-trips for each domain (`--skip-destructive` for read-only steps).
+
+### Removed
+
+- `src/core/firestore-client.ts`, `src/core/format/`, and their tests. The direct-Firestore write backend is gone. Field-mapping knowledge preserved in `docs/reference/firestore-write-schema.md` so future readers can recover it.
+
+### Known issues
+
+- **`set_budget` sync lag**: Writes succeed on the server but may take minutes to appear via `get_budgets` — budget docs appear to sync through Copilot's native app on a slower cadence than transactions/tags/categories/recurrings (which sync in seconds). Tool descriptions for `set_budget` and `get_budgets` document the caveat. Tracked in [#278](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/278).
+- Per-month overrides written via `set_budget(month=...)` are not surfaced in `get_budgets` — only the all-months default `amount` is shown.
+- **Upstream bugs surfaced during smoke testing** (reported to Copilot; no workaround on our side):
+  - `EditTransaction` silently accepts invalid `categoryId` values — the server returns success but the category isn't actually changed.
+  - Error messages occasionally leak the user's Firebase UID in the composite document ID when a mutation fails.
+
 ## [1.7.1] - 2026-04-15
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "copilot-money-mcp",
   "display_name": "Copilot Money MCP Server",
   "description": "Query your personal finances with AI using local Copilot Money data. 17 read-only tools for transactions, investments, budgets, goals, and more.",
-  "version": "1.7.1",
+  "version": "2.0.0",
   "icon": "icon.png",
   "author": {
     "name": "Ignacio Hermosilla",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-money-mcp",
-  "version": "1.7.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-money-mcp",
-      "version": "1.7.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "copilot-money-mcp",
-  "version": "1.7.1",
-  "description": "MCP server for Copilot Money - query personal finances with AI using local data (17 read-only tools)",
+  "version": "2.0.0",
+  "description": "MCP server for Copilot Money — query personal finances locally (17 read tools) and manage them via Copilot's GraphQL API (13 write tools, opt-in with --write)",
   "keywords": [
     "mcp",
     "copilot-money",

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3514,7 +3514,13 @@ export function createToolSchemas(): ToolSchema[] {
         "Get budgets from Copilot's native budget tracking. " +
         'Retrieves user-defined spending limits and budget rules stored in the app. ' +
         'Returns budget details including amounts, periods (monthly/yearly/weekly), ' +
-        'category associations, and active status. Calculates total budgeted amount as monthly equivalent.',
+        'category associations, and active status. Calculates total budgeted amount as monthly equivalent. ' +
+        'Sync note: after `set_budget` writes, budget changes can take significantly longer ' +
+        'to reflect in this read than other collections (transactions/tags/categories/recurrings ' +
+        'sync in seconds; budgets may take minutes). Do not assume a fresh `set_budget` is ' +
+        'immediately observable here — poll with `refresh_database` or verify directly in the ' +
+        'Copilot app. Per-month overrides written via `set_budget(month=...)` are not surfaced ' +
+        'in this view; only the all-months default `amount` is returned.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -4068,7 +4074,10 @@ export function createWriteToolSchemas(): ToolSchema[] {
         'Copilot → Settings → General, the budget write still succeeds on the server, but ' +
         'the value will not appear in the Copilot UI until those toggles are re-enabled. ' +
         'Rollover behavior also depends on the "Rollover categories" selection in the same ' +
-        'settings pane, which is not writable through this tool.',
+        'settings pane, which is not writable through this tool. ' +
+        'Sync delay: successful writes may not be visible via `get_budgets` for minutes — ' +
+        'budget docs sync on a slower cadence than other collections. Do not retry the write ' +
+        'just because the read does not reflect it yet.',
       inputSchema: {
         type: 'object' as const,
         properties: {


### PR DESCRIPTION
## Summary

Cuts the 2.0.0 release after PR #275 landed the GraphQL write-tool rewrite. Major-version bump is justified — the write tool surface is breaking for any 1.7.x user the moment they pass `--write`.

- Bumps `package.json` / `package-lock.json` / `manifest.json` from 1.7.1 → 2.0.0.
- Updates `package.json` description to reflect 17 read + 13 write tools (was "17 read-only tools" after 1.7.0 disabled writes).
- Adds a 2.0.0 CHANGELOG entry enumerating every breaking change a 1.7.x user hits, plus known issues surfaced during smoke testing.
- Documents the `set_budget` → `get_budgets` sync lag directly in both tool descriptions so LLM callers don't retry the write when the read doesn't reflect it yet. Tracked separately in #278.

## Breaking changes (from #275)

- `set_budget` replaces `create_budget` / `update_budget` / `delete_budget` (API is keyed by `categoryId`, not budget ID; `amount="0"` clears; `month="YYYY-MM"` for single-month override).
- `create_recurring` now takes `{transaction_id, frequency}` — the API requires seeding from an existing transaction.
- `create_goal` / `update_goal` / `delete_goal` removed — no web GraphQL equivalent.
- `update_transaction` no longer accepts `excluded` / `name` / `internal_transfer` / `goal_id`.
- Error wording: `"budgeting disabled"` is gone; replaced by `USER_ACTION_REQUIRED` with an "enable manually in Copilot settings" hint.

## Known issues called out in release notes

- `set_budget` writes take minutes to appear in `get_budgets` (tracked in #278; documented in tool descriptions; not a code-level fix we can ship without reproduction).
- `set_budget(month=...)` monthly overrides land in the budget doc's `amounts` map but aren't surfaced by `get_budgets` — called out in tool descriptions.
- Upstream Copilot bugs (already reported, no workaround on our side):
  - `EditTransaction` silently accepts invalid `categoryId`.
  - Error messages occasionally leak Firebase UID in composite IDs.

## Test plan

- [x] `bun run check` — 1372 pass / 0 fail / 21 skip
- [x] `bun run pack:mcpb` — produces valid 6.9MB bundle with `version: 2.0.0`
- [x] Branch based on latest `origin/main` (6a5fdee)
- [ ] Merge and tag `2.0.0`, publish GitHub release with CHANGELOG body as notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)