### PR TITLE
docs: remove stale 1.7.0 "writes temporarily unavailable" claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Copilot Money MCP Server
 
-MCP (Model Context Protocol) server that enables AI-powered queries and management of Copilot Money personal finance data by reading locally cached Firestore data (LevelDB + Protocol Buffers). 35 tools (17 read + 18 write). Read-only by default, write tools opt-in via `--write` flag.
+MCP (Model Context Protocol) server that enables AI-powered queries and management of Copilot Money personal finance data. Reads come from the locally cached Firestore database (LevelDB + Protocol Buffers); writes go through Copilot's GraphQL API at `app.copilot.money/api/graphql`. 30 tools (17 read + 13 write). Read-only by default, write tools opt-in via `--write` flag.
 
 ## Quick Reference
 
@@ -29,9 +29,8 @@ src/
 ├── core/
 │   ├── database.ts          # CopilotDatabase - cached data access layer
 │   ├── decoder.ts           # LevelDB binary decoder for Firestore protobufs
-│   ├── firestore-client.ts  # Firestore REST API client (write operations)
-│   ├── auth/                # Firebase authentication for writes
-│   └── format/              # Firestore field serialization
+│   ├── graphql/             # GraphQL client + per-domain write modules
+│   └── auth/                # Firebase authentication for writes
 ├── models/
 │   ├── transaction.ts  # Transaction Zod schema
 │   ├── account.ts      # Account Zod schema
@@ -40,7 +39,7 @@ src/
 │   ├── category.ts     # Category mappings (Plaid taxonomy)
 │   └── ...             # Other entity schemas (30+ models)
 ├── tools/
-│   └── tools.ts        # All MCP tool implementations (35 tools)
+│   └── tools.ts        # All MCP tool implementations (30 tools)
 ├── utils/
 │   ├── date.ts         # Date period parsing (this_month, last_30_days, etc.)
 │   └── categories.ts   # Category name resolution
@@ -50,7 +49,7 @@ src/
 
 ## Key Files
 
-- **`src/tools/tools.ts`** - All 35 MCP tools (17 read + 18 write) are implemented here as async methods in the `CopilotMoneyTools` class. Read schemas in `createToolSchemas()`, write schemas in `createWriteToolSchemas()`.
+- **`src/tools/tools.ts`** - All 30 MCP tools (17 read + 13 write) are implemented here as async methods in the `CopilotMoneyTools` class. Read schemas in `createToolSchemas()`, write schemas in `createWriteToolSchemas()`.
 - **`src/core/database.ts`** - `CopilotDatabase` class with methods like `getTransactions()`, `getAccounts()`, `getIncome()`, etc.
 - **`src/core/decoder.ts`** - Binary decoder that reads LevelDB files and parses Firestore Protocol Buffers.
 - **`manifest.json`** - MCP bundle metadata for .mcpb packaging.
@@ -80,7 +79,7 @@ Each MCP tool follows this pattern:
 
 ## Important Notes
 
-- **Privacy First**: Reads are 100% local with zero network requests. Opt-in writes (`--write`) send authenticated requests directly to Copilot Money's own Firebase/Firestore backend via `src/core/firestore-client.ts` — no third-party services, no project-operated servers.
+- **Privacy First**: Reads are 100% local with zero network requests. Opt-in writes (`--write`) send authenticated GraphQL requests directly to Copilot Money's own backend at `app.copilot.money/api/graphql` via `src/core/graphql/` — no third-party services, no project-operated servers.
 - **Read-Only by Default**: Write tools require `--write` flag
 - **Database Location**: `~/Library/Containers/com.copilot.production/Data/Library/Application Support/firestore/__FIRAPP_DEFAULT/copilot-production-22904/main`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,9 +45,9 @@ bun run sync-manifest  # Verify manifest.json matches code
 1. Copilot Money stores data in a local LevelDB/Firestore cache on macOS
 2. `src/core/decoder.ts` reads `.ldb` files and parses Firestore Protocol Buffers
 3. `src/core/database.ts` provides cached, filtered access to all collections
-4. `src/tools/tools.ts` implements 35 MCP tools (17 read + 18 write)
+4. `src/tools/tools.ts` implements 30 MCP tools (17 read + 13 write)
 5. `src/server.ts` handles MCP protocol communication and tool routing
-6. Write tools use `src/core/firestore-client.ts` to modify data via the Firestore REST API
+6. Write tools use `src/core/graphql/` to call Copilot's GraphQL API at `app.copilot.money/api/graphql`
 
 ### Project Structure
 
@@ -56,11 +56,10 @@ src/
 ├── core/
 │   ├── database.ts          # CopilotDatabase — cached data access layer
 │   ├── decoder.ts           # LevelDB binary decoder for Firestore protobufs
-│   ├── firestore-client.ts  # Firestore REST API client (write operations)
 │   ├── leveldb-reader.ts    # Low-level LevelDB iteration
 │   ├── protobuf-parser.ts   # Protocol Buffer wire format parser
-│   ├── auth/                # Firebase authentication for writes
-│   └── format/              # Firestore field serialization
+│   ├── graphql/             # GraphQL client + per-domain write modules
+│   └── auth/                # Firebase authentication for writes
 ├── models/                  # Zod schemas for all Firestore collections
 │   ├── transaction.ts       # Transaction schema
 │   ├── account.ts           # Account schema
@@ -82,7 +81,7 @@ src/
 
 ### Key Files
 
-- **`src/tools/tools.ts`** — All 35 tools as async methods in `CopilotMoneyTools`. Read tool schemas in `createToolSchemas()`, write tool schemas in `createWriteToolSchemas()`.
+- **`src/tools/tools.ts`** — All 30 tools as async methods in `CopilotMoneyTools`. Read tool schemas in `createToolSchemas()`, write tool schemas in `createWriteToolSchemas()`.
 - **`src/core/database.ts`** — `CopilotDatabase` class with 5-minute cache TTL, batch loading via `decodeAllCollectionsIsolated()` (worker thread), and filtered accessors.
 - **`src/core/decoder.ts`** — Binary decoder that reads LevelDB and parses Firestore Protocol Buffers. Decodes 30+ collection paths.
 - **`src/server.ts`** — MCP server with tool routing switch. `WRITE_TOOLS` set gates write operations behind the `--write` flag.
@@ -117,10 +116,10 @@ Same as read tools, plus:
 
 1. Schema goes in `createWriteToolSchemas()` (not `createToolSchemas()`)
 2. Add tool name to the `WRITE_TOOLS` set in `src/server.ts`
-3. Use `this.getFirestoreClient()` then `client.updateDocument()` or `client.createDocument()`
-4. Clear cache after writes: `this.db.clearCache()`
-5. Use validation helpers: `validateDocId()`, `validateDate()`, `validateMonth()`, `validateHexColor()`
-6. Follow the `updateGoal()` pattern for partial updates with dynamic `updateMask`
+3. Add a per-domain function in `src/core/graphql/` (see `setBudget` in `graphql/budgets.ts` or `editTransaction` in `graphql/transactions.ts` for the pattern)
+4. If the mutation isn't in `operations.generated.ts` yet, capture it under `docs/graphql-capture/` and run `bun run generate:graphql`
+5. Wrap GraphQL errors at the tool boundary with `graphQLErrorToMcpError(e)` so user-facing messages stay stable
+6. Use validation helpers: `validateDocId()`, `validateDate()`, `validateMonth()`, `validateHexColor()`
 
 ## Testing
 
@@ -136,7 +135,7 @@ Tests mirror the `src/` structure in `tests/`. Synthetic fixtures in `tests/fixt
 ### Writing Tests
 
 - Use `(db as any)._fieldName = [...]` to inject mock data in `beforeEach`
-- Write tool tests need a mock `FirestoreClient` (see existing write tool tests)
+- Write tool tests need a mock `GraphQLClient` — use `createMockGraphQLClient` from `tests/helpers/mock-graphql.ts`
 - Run `bun run check` before submitting to catch typecheck, lint, and format issues
 
 ### License check

--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@
 
 **This is an independent, community-driven project and is not affiliated with, endorsed by, or associated with Copilot Money or its parent company in any way.** This tool was created by an independent developer to enable AI-powered queries of locally cached data. "Copilot Money" is a trademark of its respective owner.
 
-> [!NOTE]
-> **Write tools are temporarily unavailable.** Copilot Money has restricted direct Firestore writes from third-party clients. The 18 write tools in this repo still exist as source, but the published CLI runs read-only. A replacement write path is being evaluated. Reads are unaffected.
-
 ## Overview
 
 An [MCP](https://modelcontextprotocol.io/) server that gives AI assistants access to your Copilot Money personal finance data. It reads from the locally cached Firestore database (LevelDB + Protocol Buffers) on your Mac. **Reads are 100% local with zero network requests.**
@@ -160,12 +157,6 @@ Uses `get_recurring_transactions`.
 | `get_connection_status` | Bank sync health for linked institutions, including last sync timestamps and errors. |
 | `get_cache_info` | Local cache metadata — date range, transaction count, cache age. |
 | `refresh_database` | Reload data from disk. Cache auto-refreshes every 5 minutes. |
-
-### Write Tools — temporarily unavailable
-
-Copilot Money has restricted direct Firestore writes from third-party clients, so the 18 write tools (`update_transaction`, `create_budget`, `create_goal`, `update_recurring`, etc.) no longer succeed against the live backend. The code still lives in `src/` and the tool schemas are preserved for reference and future work, but the published `copilot-money-mcp` CLI runs in read-only mode. Passing `--write` prints a notice and still starts read-only.
-
-A replacement write path (via Copilot Money's GraphQL web API) is being evaluated; progress will be tracked in the repo issues.
 
 ## Configuration
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Copilot Money MCP Server — AI-Powered Personal Finance</title>
-  <meta name="description" content="Query your personal finances with AI. 17 read-only tools for transactions, investments, budgets, goals, and more. Local-first, privacy-first.">
+  <meta name="description" content="Query your personal finances with AI. 17 tools for transactions, investments, budgets, goals, and more. Local-first, privacy-first.">
   <link rel="icon" type="image/png" href="icon.png">
   <link rel="apple-touch-icon" href="icon.png">
   <meta property="og:title" content="Copilot Money MCP Server">
@@ -597,7 +597,7 @@ command = "copilot-money-mcp"</div>
 <section id="features">
   <div class="section-label">Features</div>
   <h2>Everything you need</h2>
-  <p class="subtitle">17 read-only tools covering every aspect of your personal finances.</p>
+  <p class="subtitle">17 tools covering every aspect of your personal finances.</p>
 
   <div class="features">
     <div class="feature-card">


### PR DESCRIPTION
## Summary

2.0.0 restored writes via Copilot's GraphQL API (opt-in behind \`--write\`), but several docs still carried 1.7.0-era framing that writes are blocked. Cleans up the drift.

## Changes

- **README.md** — drop the top-of-fold "Write tools are temporarily unavailable" NOTE block and the entire "Write Tools — temporarily unavailable" section. Write tools aren't advertised in the README; the surface is deliberately kept low-key. The published \`.mcpb\` bundle remains intentionally read-only so one-click installs don't expose non-technical users to the write path. Anyone who wants writes will find them in source.
- **docs/index.html** — drop "read-only" from the meta description and the Features subtitle. The landing page now says "17 tools" without implying the project is exclusively read-only.
- **CONTRIBUTING.md** — update tool count (35 → 30), replace \`src/core/firestore-client.ts\` (deleted in 2.0.0) with \`src/core/graphql/\`, rewrite "Adding a New Write Tool" for the GraphQL pattern, switch testing note from mock \`FirestoreClient\` to \`createMockGraphQLClient\`.
- **CLAUDE.md** — parallel updates for developer context.

**Kept as-is:** \`manifest.json\` description stays "17 read-only tools" — that matches the intentionally read-only \`.mcpb\` bundle shipped to Claude Desktop.

## Not in scope

- Tool description recap across all 30 tools — separate follow-up.
- Local \`bun run pack:mcpb:write\` script for a writes-enabled bundle — separate follow-up.

## Test plan

- [x] \`bun run check\` green — 1381 pass / 0 fail
- [x] Branch based on latest \`origin/main\` (1a1a1c1)
- [x] Grep confirmed no remaining \`firestore-client\` / "35 tool" / "18 write" / "temporarily unavailable" refs in the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)