### PR TITLE
docs(tools): audit pass — fix description drift on 4 tools

### DIFF
--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3679,10 +3679,12 @@ export function createToolSchemas(): ToolSchema[] {
     {
       name: 'get_balance_history',
       description:
-        'Get daily balance snapshots for accounts over time. Returns current_balance, ' +
-        'available_balance, and limit per day. Requires a granularity parameter (daily, weekly, ' +
-        'or monthly) to control response size. Weekly and monthly modes downsample by keeping ' +
-        'the last data point per period. Filter by account_id and date range.',
+        'Get daily balance snapshots for accounts over time. Each entry returns current_balance, ' +
+        'available_balance, limit, account_id, and account_name. The response also includes an ' +
+        '`accounts` array listing the distinct account IDs in the paginated page. Requires a ' +
+        'granularity parameter (daily, weekly, or monthly) to control response size. Weekly and ' +
+        'monthly modes downsample by keeping the last data point per period. Filter by ' +
+        'account_id and date range.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -3912,7 +3914,10 @@ export function createWriteToolSchemas(): ToolSchema[] {
       name: 'review_transactions',
       description:
         'Mark one or more transactions as reviewed (or unreviewed). ' +
-        'Accepts an array of transaction_ids. Writes directly to Copilot Money via GraphQL.',
+        'Accepts an array of transaction_ids. Writes are issued via GraphQL in parallel with ' +
+        'a cap of 5 in flight at a time. On the first GraphQL error, new writes stop, in-flight ' +
+        'writes settle, and the error is thrown with a `reviewed_count` reflecting how many ' +
+        'succeeded before the failure (partial success is possible).',
       inputSchema: {
         type: 'object',
         properties: {
@@ -3949,11 +3954,9 @@ export function createWriteToolSchemas(): ToolSchema[] {
           },
           color_name: {
             type: 'string',
-            description: 'Optional color name (e.g. "blue", "red")',
-          },
-          hex_color: {
-            type: 'string',
-            description: 'Optional hex color code (e.g. "#FF5733")',
+            description:
+              'Optional palette token from Copilot (e.g. "PURPLE2", "OLIVE1", "RED1"). ' +
+              'Defaults to "PURPLE2" when omitted. See existing tags for valid values.',
           },
         },
         required: ['name'],
@@ -4176,8 +4179,8 @@ export function createWriteToolSchemas(): ToolSchema[] {
     {
       name: 'update_tag',
       description:
-        'Update an existing tag. Provide tag_id (required) and at least one of name, ' +
-        'color_name, or hex_color. Only the specified fields are updated. ' +
+        'Update an existing tag. Provide tag_id (required) and at least one of name or ' +
+        'color_name. Only the specified fields are updated. ' +
         'Writes directly to Copilot Money via GraphQL.',
       inputSchema: {
         type: 'object',
@@ -4192,11 +4195,9 @@ export function createWriteToolSchemas(): ToolSchema[] {
           },
           color_name: {
             type: 'string',
-            description: 'New color name (e.g. "blue", "red")',
-          },
-          hex_color: {
-            type: 'string',
-            description: 'New hex color code (e.g. "#FF5733")',
+            description:
+              'New palette token from Copilot (e.g. "PURPLE2", "OLIVE1", "RED1"). ' +
+              'See existing tags for valid values.',
           },
         },
         required: ['tag_id'],

--- a/tests/unit/write-tool-schemas.test.ts
+++ b/tests/unit/write-tool-schemas.test.ts
@@ -20,13 +20,16 @@ describe('createWriteToolSchemas', () => {
     expect(updateTxn!.inputSchema.additionalProperties).toBe(false);
   });
 
-  test('create_tag schema requires name and exposes color fields', () => {
+  test('create_tag schema requires name and exposes color_name only (no hex_color)', () => {
+    // The implementation only reads color_name — hex_color was previously
+    // advertised in the schema but silently ignored by createTag, so it was
+    // removed during the 2.0.1 tool-description audit.
     const createTag = createWriteToolSchemas().find((s) => s.name === 'create_tag');
     expect(createTag).toBeDefined();
     expect(createTag!.inputSchema.required).toEqual(['name']);
     expect(createTag!.inputSchema.properties).toHaveProperty('name');
     expect(createTag!.inputSchema.properties).toHaveProperty('color_name');
-    expect(createTag!.inputSchema.properties).toHaveProperty('hex_color');
+    expect(createTag!.inputSchema.properties).not.toHaveProperty('hex_color');
   });
 
   test('delete_tag schema requires tag_id', () => {


### PR DESCRIPTION
## Summary

Walked all 30 tool schemas in \`createToolSchemas()\` + \`createWriteToolSchemas()\` and cross-referenced each against its implementation. Four real drifts fixed.

## Fixed

### 1. \`create_tag\` / \`update_tag\` — \`hex_color\` advertised but silently ignored

The input schemas advertised a \`hex_color\` parameter, but:

- \`createTag()\` (tools.ts:2526) only reads \`args.color_name\`.
- \`updateTag()\` (tools.ts:2725) doesn't even have \`hex_color\` in its TypeScript signature.

The underlying GraphQL \`CreateTag\` / \`EditTag\` mutations accept \`colorName\` only (palette token like \`"PURPLE2"\`), not a hex string. Removed \`hex_color\` from both schemas. Also fixed the \`color_name\` description, which previously said "blue"/"red" — those aren't valid. Correct values are palette tokens like \`"PURPLE2"\`, \`"OLIVE1"\`, \`"RED1"\`.

Updated \`tests/unit/write-tool-schemas.test.ts\` to assert \`hex_color\` is NOT present so this drift can't reappear silently.

### 2. \`get_balance_history\` — response fields undocumented

The implementation returns an \`accounts: string[]\` array (distinct account IDs in the page) and an \`account_name\` on each entry. Both were missing from the schema description. Added them.

### 3. \`review_transactions\` — concurrency + partial-failure semantics

The implementation caps concurrent writes at 5 and returns a \`reviewed_count\` that reflects partial success when a GraphQL error interrupts the batch. Callers need to know this so they can reconcile which IDs actually got through. Documented.

## Verified but not touched

- \`delete_tag\` / \`delete_category\` \`idempotentHint: true\` was flagged by the auditing agent since deletion of a non-existent ID throws. Kept as-is: "idempotent" refers to the operation's effect (entity ends up not existing either way), which matches the MCP spec's intent.
- \`get_recurring_transactions\` already documents the \`copilot_subscriptions\` array via the \`include_copilot_subscriptions\` param description. No change.
- All write-tool references to GraphQL are already current — no stale Firestore references remained in the tool docs after 2.0.0.

## Test plan

- [x] \`bun run check\` green — 1381 pass / 0 fail
- [x] \`bun run sync-manifest\` clean (no drift between manifest and schemas)
- [x] Branch based on latest \`origin/main\` (a626027)

🤖 Generated with [Claude Code](https://claude.com/claude-code)