### PR TITLE
feat(cache): optimistic in-memory patching after writes

### DIFF
--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -386,6 +386,126 @@ export class CopilotDatabase {
   }
 
   /**
+   * Patch the in-memory budget for a category after a successful set_budget
+   * write. Mirrors what Copilot's app writes to LevelDB: the value lands in
+   * `amounts[YYYY-MM]` keyed by the current month (or an explicit month when
+   * `month` is provided). See issue #278 for the investigation — the top-level
+   * `amount` field is a frozen legacy artifact the Copilot app stopped
+   * writing to ~2 years ago, so the only way to observe a fresh budget write
+   * is via the amounts map.
+   *
+   * If no budget exists yet for the category, a new entry is pushed so the
+   * setBudget-then-getBudgets round trip still reflects the write.
+   *
+   * @returns true if the cache was populated and the patch applied, false if
+   *   the cache had not been loaded yet (next load picks up real state).
+   */
+  patchCachedBudget(categoryId: string, amount: number, month?: string): boolean {
+    if (!this._budgets) return false;
+    const monthKey =
+      month ??
+      (() => {
+        const d = new Date();
+        return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+      })();
+
+    const existing = this._budgets.find((b) => b.category_id === categoryId);
+    if (existing) {
+      existing.amounts = { ...(existing.amounts ?? {}), [monthKey]: amount };
+    } else {
+      this._budgets.push({
+        budget_id: `patched-${categoryId}`,
+        category_id: categoryId,
+        amounts: { [monthKey]: amount },
+      });
+    }
+    return true;
+  }
+
+  /**
+   * Insert or merge a tag in the in-memory cache. If a tag with the same
+   * `tag_id` exists, incoming fields are merged on top (missing fields are
+   * preserved). Otherwise the tag is appended.
+   *
+   * No-op if the cache has not been loaded yet.
+   */
+  patchCachedTagUpsert(tag: Tag): void {
+    if (!this._tags) return;
+    const idx = this._tags.findIndex((t) => t.tag_id === tag.tag_id);
+    if (idx >= 0) {
+      Object.assign(this._tags[idx]!, tag);
+    } else {
+      this._tags.push(tag);
+    }
+  }
+
+  /**
+   * Remove a tag from the in-memory cache by id. No-op (returns false) if
+   * the cache isn't loaded or the tag isn't found.
+   */
+  patchCachedTagDelete(tagId: string): boolean {
+    if (!this._tags) return false;
+    const before = this._tags.length;
+    this._tags = this._tags.filter((t) => t.tag_id !== tagId);
+    return this._tags.length < before;
+  }
+
+  /**
+   * Insert or merge a category in the in-memory cache. Invalidates the
+   * derived `_categoryNameMap` so the next read rebuilds it. No-op if the
+   * cache has not been loaded yet.
+   */
+  patchCachedCategoryUpsert(category: Category): void {
+    if (!this._userCategories) return;
+    const idx = this._userCategories.findIndex((c) => c.category_id === category.category_id);
+    if (idx >= 0) {
+      Object.assign(this._userCategories[idx]!, category);
+    } else {
+      this._userCategories.push(category);
+    }
+    this._categoryNameMap = null;
+  }
+
+  /**
+   * Remove a category from the in-memory cache. Invalidates the derived
+   * name map. Returns false if the cache isn't loaded or the id isn't found.
+   */
+  patchCachedCategoryDelete(categoryId: string): boolean {
+    if (!this._userCategories) return false;
+    const before = this._userCategories.length;
+    this._userCategories = this._userCategories.filter((c) => c.category_id !== categoryId);
+    if (this._userCategories.length < before) {
+      this._categoryNameMap = null;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Insert or merge a recurring item. No-op if cache isn't loaded.
+   */
+  patchCachedRecurringUpsert(recurring: Recurring): void {
+    if (!this._recurring) return;
+    const idx = this._recurring.findIndex((r) => r.recurring_id === recurring.recurring_id);
+    if (idx >= 0) {
+      Object.assign(this._recurring[idx]!, recurring);
+    } else {
+      this._recurring.push(recurring);
+    }
+  }
+
+  /**
+   * Remove a recurring item by id. Returns false if cache isn't loaded or
+   * the id isn't found.
+   */
+  patchCachedRecurringDelete(recurringId: string): boolean {
+    if (!this._recurring) return false;
+    const before = this._recurring.length;
+    this._recurring = this._recurring.filter((r) => r.recurring_id !== recurringId);
+    return this._recurring.length < before;
+  }
+
+  /**
    * Get the timestamp when cache was last loaded.
    *
    * @returns Unix timestamp in milliseconds, or null if not loaded

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -32,7 +32,14 @@ import {
   isIncomeCategory,
   isKnownPlaidCategory,
 } from '../utils/categories.js';
-import type { Transaction, Account, InvestmentPrice, InvestmentSplit } from '../models/index.js';
+import type {
+  Transaction,
+  Account,
+  InvestmentPrice,
+  InvestmentSplit,
+  Tag,
+  Recurring,
+} from '../models/index.js';
 import { getTransactionDisplayName, getRecurringDisplayName } from '../models/index.js';
 import type { InvestmentPerformance, TwrHolding } from '../models/investment-performance.js';
 import type { Security } from '../models/security.js';
@@ -2291,6 +2298,13 @@ export class CopilotMoneyTools {
           isExcluded: args.is_excluded ?? false,
         },
       });
+      this.db.patchCachedCategoryUpsert({
+        category_id: result.id,
+        name: result.name,
+        color: result.colorName,
+        emoji: args.emoji,
+        excluded: args.is_excluded ?? false,
+      });
       return {
         success: true,
         category_id: result.id,
@@ -2405,6 +2419,16 @@ export class CopilotMoneyTools {
         isReviewed: 'reviewed',
       };
       const updated = Object.keys(result.changed).map((k) => graphqlToApiName[k] ?? k);
+
+      // Optimistic cache patch: writes to the in-memory cache so a subsequent
+      // read returns the new value without needing refresh_database + re-decode.
+      const patch: Partial<Transaction> = {};
+      if ('category_id' in args && args.category_id !== undefined)
+        patch.category_id = args.category_id;
+      if ('note' in args && args.note !== undefined) patch.user_note = args.note;
+      if ('tag_ids' in args && args.tag_ids !== undefined) patch.tag_ids = args.tag_ids;
+      if (Object.keys(patch).length > 0) this.db.patchCachedTransaction(transaction_id, patch);
+
       return {
         success: true,
         transaction_id: result.id,
@@ -2509,6 +2533,13 @@ export class CopilotMoneyTools {
       throw error;
     }
 
+    // Optimistic cache patch — only for ids that successfully completed.
+    // A partial-failure throw above would have bypassed this, so here we
+    // patch every id in the batch.
+    for (const id of transaction_ids) {
+      this.db.patchCachedTransaction(id, { user_reviewed: reviewed });
+    }
+
     return {
       success: true,
       reviewed_count,
@@ -2536,6 +2567,11 @@ export class CopilotMoneyTools {
       const result = await gqlCreateTag(client, {
         input: { name: args.name.trim(), colorName },
       });
+      this.db.patchCachedTagUpsert({
+        tag_id: result.id,
+        name: result.name,
+        color_name: result.colorName,
+      });
       return {
         success: true,
         tag_id: result.id,
@@ -2562,6 +2598,7 @@ export class CopilotMoneyTools {
     const client = this.getGraphQLClient();
     try {
       const result = await gqlDeleteTag(client, { id: args.tag_id });
+      this.db.patchCachedTagDelete(args.tag_id);
       return { success: true, tag_id: result.id, deleted: true };
     } catch (e) {
       if (e instanceof GraphQLError) throw new Error(graphQLErrorToMcpError(e), { cause: e });
@@ -2594,6 +2631,12 @@ export class CopilotMoneyTools {
 
     try {
       const result = await gqlEditCategory(client, { id: args.category_id, input });
+      const patch: Partial<Category> = { category_id: args.category_id };
+      if (args.name !== undefined) patch.name = args.name;
+      if (args.color_name !== undefined) patch.color = args.color_name;
+      if (args.emoji !== undefined) patch.emoji = args.emoji;
+      if (args.is_excluded !== undefined) patch.excluded = args.is_excluded;
+      this.db.patchCachedCategoryUpsert(patch as Category);
       return {
         success: true,
         category_id: result.id,
@@ -2616,6 +2659,7 @@ export class CopilotMoneyTools {
     const client = this.getGraphQLClient();
     try {
       const result = await gqlDeleteCategory(client, { id: args.category_id });
+      this.db.patchCachedCategoryDelete(args.category_id);
       return { success: true, category_id: result.id, deleted: true };
     } catch (e) {
       if (e instanceof GraphQLError) throw new Error(graphQLErrorToMcpError(e), { cause: e });
@@ -2656,6 +2700,7 @@ export class CopilotMoneyTools {
         amount: args.amount,
         month: args.month,
       });
+      this.db.patchCachedBudget(args.category_id, parseFloat(args.amount), args.month);
       return {
         success: true,
         category_id: result.categoryId,
@@ -2690,6 +2735,12 @@ export class CopilotMoneyTools {
         id: args.recurring_id,
         input: { state: args.state },
       });
+      // GraphQL returns uppercase state ("ACTIVE"); the LevelDB cache stores
+      // lowercase ("active"). Normalize to the cache's shape on patch.
+      this.db.patchCachedRecurringUpsert({
+        recurring_id: args.recurring_id,
+        state: args.state.toLowerCase() as 'active' | 'paused' | 'archived',
+      });
       return { success: true, recurring_id: result.id, state: args.state };
     } catch (e) {
       if (e instanceof GraphQLError) throw new Error(graphQLErrorToMcpError(e), { cause: e });
@@ -2708,6 +2759,7 @@ export class CopilotMoneyTools {
     const client = this.getGraphQLClient();
     try {
       const result = await gqlDeleteRecurring(client, { id: args.recurring_id });
+      this.db.patchCachedRecurringDelete(args.recurring_id);
       return { success: true, recurring_id: result.id, deleted: true };
     } catch (e) {
       if (e instanceof GraphQLError) throw new Error(graphQLErrorToMcpError(e), { cause: e });
@@ -2737,6 +2789,10 @@ export class CopilotMoneyTools {
 
     try {
       const result = await gqlEditTag(client, { id: args.tag_id, input });
+      const patch: Partial<Tag> = { tag_id: args.tag_id };
+      if (args.name !== undefined) patch.name = args.name;
+      if (args.color_name !== undefined) patch.color_name = args.color_name;
+      this.db.patchCachedTagUpsert(patch as Tag);
       return { success: true, tag_id: result.id, updated: Object.keys(result.changed) };
     } catch (e) {
       if (e instanceof GraphQLError) throw new Error(graphQLErrorToMcpError(e), { cause: e });
@@ -2785,6 +2841,12 @@ export class CopilotMoneyTools {
           },
         },
       });
+      this.db.patchCachedRecurringUpsert({
+        recurring_id: result.id,
+        name: result.name,
+        state: result.state.toLowerCase() as 'active' | 'paused' | 'archived',
+        frequency: result.frequency,
+      });
       return {
         success: true,
         recurring_id: result.id,
@@ -2832,6 +2894,14 @@ export class CopilotMoneyTools {
 
     try {
       const result = await gqlEditRecurring(client, { id: args.recurring_id, input });
+      const patch: Partial<Recurring> = { recurring_id: args.recurring_id };
+      if (args.state !== undefined) {
+        patch.state = args.state.toLowerCase() as 'active' | 'paused' | 'archived';
+      }
+      if (args.rule?.name_contains !== undefined) patch.match_string = args.rule.name_contains;
+      if (args.rule?.min_amount !== undefined) patch.min_amount = parseFloat(args.rule.min_amount);
+      if (args.rule?.max_amount !== undefined) patch.max_amount = parseFloat(args.rule.max_amount);
+      this.db.patchCachedRecurringUpsert(patch as Recurring);
       return { success: true, recurring_id: result.id, updated: Object.keys(result.changed) };
     } catch (e) {
       if (e instanceof GraphQLError) throw new Error(graphQLErrorToMcpError(e), { cause: e });

--- a/tests/core/database.test.ts
+++ b/tests/core/database.test.ts
@@ -318,6 +318,209 @@ describe('CopilotDatabase', () => {
     });
   });
 
+  describe('patchCachedBudget (issue #278 follow-up)', () => {
+    const currentMonth = (): string => {
+      const d = new Date();
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+    };
+
+    test('updates amounts[current_month] on an existing budget matched by category_id', () => {
+      (db as any)._budgets = [
+        { budget_id: 'b1', category_id: 'cat_food', amount: 0, amounts: {} },
+        { budget_id: 'b2', category_id: 'cat_rent', amount: 2000, amounts: {} },
+      ];
+      const month = currentMonth();
+
+      const result = db.patchCachedBudget('cat_food', 250);
+
+      expect(result).toBe(true);
+      const budgets = (db as any)._budgets as Array<{
+        category_id: string;
+        amounts: Record<string, number>;
+      }>;
+      expect(budgets.find((b) => b.category_id === 'cat_food')!.amounts[month]).toBe(250);
+      // Other budgets untouched
+      expect(budgets.find((b) => b.category_id === 'cat_rent')!.amounts).toEqual({});
+    });
+
+    test('uses explicit month when provided', () => {
+      (db as any)._budgets = [
+        { budget_id: 'b1', category_id: 'cat_food', amount: 0, amounts: { '2026-01': 100 } },
+      ];
+
+      db.patchCachedBudget('cat_food', 175, '2026-07');
+
+      const b = ((db as any)._budgets as Array<{ amounts: Record<string, number> }>)[0]!;
+      expect(b.amounts['2026-07']).toBe(175);
+      expect(b.amounts['2026-01']).toBe(100); // untouched
+    });
+
+    test('treats amount=0 as explicit clear (stored as 0, not skipped)', () => {
+      (db as any)._budgets = [
+        { budget_id: 'b1', category_id: 'cat_food', amount: 250, amounts: { '2026-04': 250 } },
+      ];
+
+      db.patchCachedBudget('cat_food', 0, '2026-04');
+
+      const b = ((db as any)._budgets as Array<{ amounts: Record<string, number> }>)[0]!;
+      expect(b.amounts['2026-04']).toBe(0);
+    });
+
+    test('initializes amounts map when the existing budget has no map', () => {
+      (db as any)._budgets = [{ budget_id: 'b1', category_id: 'cat_food', amount: 0 }]; // no amounts key
+      const month = currentMonth();
+
+      db.patchCachedBudget('cat_food', 300);
+
+      const b = ((db as any)._budgets as Array<{ amounts?: Record<string, number> }>)[0]!;
+      expect(b.amounts?.[month]).toBe(300);
+    });
+
+    test('creates a new budget entry when no budget exists for the category', () => {
+      (db as any)._budgets = [
+        { budget_id: 'b1', category_id: 'cat_rent', amount: 2000, amounts: {} },
+      ];
+      const month = currentMonth();
+
+      const result = db.patchCachedBudget('cat_new', 500);
+
+      expect(result).toBe(true);
+      const budgets = (db as any)._budgets as Array<{
+        category_id?: string;
+        amounts?: Record<string, number>;
+      }>;
+      expect(budgets).toHaveLength(2);
+      const created = budgets.find((b) => b.category_id === 'cat_new')!;
+      expect(created.amounts?.[month]).toBe(500);
+    });
+
+    test('returns false when budgets cache is not loaded', () => {
+      (db as any)._budgets = null;
+
+      const result = db.patchCachedBudget('cat_food', 250);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('patchCachedTagUpsert / patchCachedTagDelete', () => {
+    test('upsert adds a new tag when id does not exist', () => {
+      (db as any)._tags = [{ tag_id: 't1', name: 'Existing', color_name: 'RED1' }];
+
+      db.patchCachedTagUpsert({ tag_id: 't2', name: 'New Tag', color_name: 'OLIVE1' });
+
+      const tags = (db as any)._tags as Array<{ tag_id: string; name?: string }>;
+      expect(tags).toHaveLength(2);
+      expect(tags.find((t) => t.tag_id === 't2')?.name).toBe('New Tag');
+    });
+
+    test('upsert merges fields into an existing tag', () => {
+      (db as any)._tags = [{ tag_id: 't1', name: 'Old', color_name: 'RED1' }];
+
+      db.patchCachedTagUpsert({ tag_id: 't1', name: 'Updated' });
+
+      const tag = (
+        (db as any)._tags as Array<{ tag_id: string; name?: string; color_name?: string }>
+      )[0]!;
+      expect(tag.name).toBe('Updated');
+      expect(tag.color_name).toBe('RED1'); // preserved
+    });
+
+    test('delete removes the tag by id', () => {
+      (db as any)._tags = [
+        { tag_id: 't1', name: 'Keep' },
+        { tag_id: 't2', name: 'Remove' },
+      ];
+
+      const result = db.patchCachedTagDelete('t2');
+
+      expect(result).toBe(true);
+      expect((db as any)._tags).toHaveLength(1);
+      expect(((db as any)._tags as Array<{ tag_id: string }>)[0]!.tag_id).toBe('t1');
+    });
+
+    test('patchers are no-ops when cache is not loaded', () => {
+      (db as any)._tags = null;
+      expect(db.patchCachedTagDelete('t1')).toBe(false);
+      // upsert does nothing (no exception); cache stays null so next load is fresh
+      db.patchCachedTagUpsert({ tag_id: 't1', name: 'X' });
+      expect((db as any)._tags).toBeNull();
+    });
+  });
+
+  describe('patchCachedCategoryUpsert / patchCachedCategoryDelete', () => {
+    test('upsert adds a new category and invalidates category name map', () => {
+      (db as any)._userCategories = [{ category_id: 'c1', name: 'Existing' }];
+      (db as any)._categoryNameMap = new Map([['c1', 'Existing']]);
+
+      db.patchCachedCategoryUpsert({ category_id: 'c2', name: 'New Category' });
+
+      expect((db as any)._userCategories).toHaveLength(2);
+      expect((db as any)._categoryNameMap).toBeNull();
+    });
+
+    test('upsert updates an existing category by id', () => {
+      (db as any)._userCategories = [{ category_id: 'c1', name: 'Old', emoji: '🍕' }];
+      (db as any)._categoryNameMap = new Map([['c1', 'Old']]);
+
+      db.patchCachedCategoryUpsert({ category_id: 'c1', name: 'New' });
+
+      const cat = ((db as any)._userCategories as Array<{ name?: string; emoji?: string }>)[0]!;
+      expect(cat.name).toBe('New');
+      expect(cat.emoji).toBe('🍕'); // preserved
+      expect((db as any)._categoryNameMap).toBeNull();
+    });
+
+    test('delete removes the category and invalidates the name map', () => {
+      (db as any)._userCategories = [
+        { category_id: 'c1', name: 'Keep' },
+        { category_id: 'c2', name: 'Remove' },
+      ];
+      (db as any)._categoryNameMap = new Map([
+        ['c1', 'Keep'],
+        ['c2', 'Remove'],
+      ]);
+
+      const result = db.patchCachedCategoryDelete('c2');
+
+      expect(result).toBe(true);
+      expect((db as any)._userCategories).toHaveLength(1);
+      expect((db as any)._categoryNameMap).toBeNull();
+    });
+  });
+
+  describe('patchCachedRecurringUpsert / patchCachedRecurringDelete', () => {
+    test('upsert adds a new recurring', () => {
+      (db as any)._recurring = [{ recurring_id: 'r1', name: 'Spotify' }];
+
+      db.patchCachedRecurringUpsert({ recurring_id: 'r2', name: 'Netflix', state: 'active' });
+
+      expect((db as any)._recurring).toHaveLength(2);
+    });
+
+    test('upsert merges fields into existing recurring', () => {
+      (db as any)._recurring = [{ recurring_id: 'r1', name: 'Spotify', state: 'active' }];
+
+      db.patchCachedRecurringUpsert({ recurring_id: 'r1', state: 'paused' });
+
+      const rec = ((db as any)._recurring as Array<{ name?: string; state?: string }>)[0]!;
+      expect(rec.state).toBe('paused');
+      expect(rec.name).toBe('Spotify'); // preserved
+    });
+
+    test('delete removes the recurring by id', () => {
+      (db as any)._recurring = [
+        { recurring_id: 'r1', name: 'Keep' },
+        { recurring_id: 'r2', name: 'Remove' },
+      ];
+
+      const result = db.patchCachedRecurringDelete('r2');
+
+      expect(result).toBe(true);
+      expect((db as any)._recurring).toHaveLength(1);
+    });
+  });
+
   describe('Cache TTL configuration', () => {
     const originalEnv = process.env.COPILOT_CACHE_TTL_MINUTES;
 

--- a/tests/tools/optimistic-cache.test.ts
+++ b/tests/tools/optimistic-cache.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Integration tests for optimistic in-memory cache patching after writes.
+ *
+ * Each test: (1) inject cache fixture, (2) call the write tool against a mock
+ * GraphQL client, (3) call the corresponding read tool WITHOUT
+ * refresh_database, (4) assert the new value is visible. This proves the
+ * `patchCached*` wiring makes writes observable without re-decoding LevelDB.
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { CopilotMoneyTools } from '../../src/tools/tools.js';
+import { CopilotDatabase } from '../../src/core/database.js';
+import { createMockGraphQLClient } from '../helpers/mock-graphql.js';
+
+const currentMonth = (): string => {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+};
+
+describe('optimistic cache patching — transactions', () => {
+  let db: CopilotDatabase;
+  let tools: CopilotMoneyTools;
+
+  beforeEach(() => {
+    db = new CopilotDatabase('/fake');
+    (db as any)._allCollectionsLoaded = true;
+    (db as any)._cacheLoadedAt = Date.now();
+    (db as any)._transactions = [
+      {
+        transaction_id: 'txn1',
+        amount: 50,
+        date: '2026-04-01',
+        name: 'Coffee',
+        category_id: 'cat_food',
+        account_id: 'acc1',
+        item_id: 'item1',
+        user_note: 'old note',
+        user_reviewed: false,
+      },
+    ];
+    (db as any)._userCategories = [{ category_id: 'cat_new', name: 'Dining' }];
+    (db as any)._tags = [];
+  });
+
+  test('update_transaction — read reflects new note without refresh', async () => {
+    const client = createMockGraphQLClient({
+      EditTransaction: {
+        editTransaction: {
+          transaction: {
+            id: 'txn1',
+            categoryId: 'cat_food',
+            userNotes: 'new note',
+            isReviewed: false,
+            tags: [],
+          },
+        },
+      },
+    });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.updateTransaction({ transaction_id: 'txn1', note: 'new note' });
+    const after = await db.getAllTransactions();
+    const t = after.find((x) => x.transaction_id === 'txn1');
+
+    expect(t?.user_note).toBe('new note');
+  });
+
+  test('review_transactions — every id in batch is marked reviewed in cache', async () => {
+    (db as any)._transactions = [
+      {
+        transaction_id: 't1',
+        amount: 10,
+        date: '2026-04-01',
+        account_id: 'a',
+        item_id: 'i',
+        user_reviewed: false,
+      },
+      {
+        transaction_id: 't2',
+        amount: 20,
+        date: '2026-04-02',
+        account_id: 'a',
+        item_id: 'i',
+        user_reviewed: false,
+      },
+    ];
+    const client = createMockGraphQLClient({
+      EditTransaction: {
+        editTransaction: {
+          transaction: { id: 't1', categoryId: '', userNotes: null, isReviewed: true, tags: [] },
+        },
+      },
+    });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.reviewTransactions({ transaction_ids: ['t1', 't2'], reviewed: true });
+    const after = await db.getAllTransactions();
+
+    expect(after.find((t) => t.transaction_id === 't1')?.user_reviewed).toBe(true);
+    expect(after.find((t) => t.transaction_id === 't2')?.user_reviewed).toBe(true);
+  });
+});
+
+describe('optimistic cache patching — tags', () => {
+  let db: CopilotDatabase;
+  let tools: CopilotMoneyTools;
+
+  beforeEach(() => {
+    db = new CopilotDatabase('/fake');
+    (db as any)._allCollectionsLoaded = true;
+    (db as any)._cacheLoadedAt = Date.now();
+    (db as any)._tags = [{ tag_id: 'existing', name: 'Existing', color_name: 'RED1' }];
+  });
+
+  test('create_tag — new tag appears in getTags', async () => {
+    const client = createMockGraphQLClient({
+      CreateTag: {
+        createTag: { id: 'new_tag', name: 'New', colorName: 'OLIVE1' },
+      },
+    });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.createTag({ name: 'New', color_name: 'OLIVE1' });
+    const tags = await db.getTags();
+
+    expect(tags.find((t) => t.tag_id === 'new_tag')?.name).toBe('New');
+  });
+
+  test('update_tag — cached tag reflects new color', async () => {
+    const client = createMockGraphQLClient({
+      EditTag: {
+        editTag: { id: 'existing', name: 'Existing', colorName: 'BLUE1' },
+      },
+    });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.updateTag({ tag_id: 'existing', color_name: 'BLUE1' });
+    const tags = await db.getTags();
+
+    expect(tags.find((t) => t.tag_id === 'existing')?.color_name).toBe('BLUE1');
+  });
+
+  test('delete_tag — tag no longer in getTags', async () => {
+    const client = createMockGraphQLClient({ DeleteTag: { deleteTag: true } });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.deleteTag({ tag_id: 'existing' });
+    const tags = await db.getTags();
+
+    expect(tags.find((t) => t.tag_id === 'existing')).toBeUndefined();
+  });
+});
+
+describe('optimistic cache patching — categories', () => {
+  let db: CopilotDatabase;
+  let tools: CopilotMoneyTools;
+
+  beforeEach(() => {
+    db = new CopilotDatabase('/fake');
+    (db as any)._allCollectionsLoaded = true;
+    (db as any)._cacheLoadedAt = Date.now();
+    (db as any)._userCategories = [{ category_id: 'cat1', name: 'Old Name', excluded: false }];
+    (db as any)._categoryNameMap = new Map([['cat1', 'Old Name']]);
+  });
+
+  test('update_category — rename visible without refresh, name map invalidated', async () => {
+    const client = createMockGraphQLClient({
+      EditCategory: {
+        editCategory: {
+          category: { id: 'cat1', name: 'New Name', colorName: 'RED1' },
+        },
+      },
+    });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.updateCategory({ category_id: 'cat1', name: 'New Name' });
+    const cats = await db.getUserCategories();
+    const cat = cats.find((c) => c.category_id === 'cat1');
+
+    expect(cat?.name).toBe('New Name');
+    // The cached name-map is eagerly rebuilt on next access; check the new
+    // name comes through resolveCategoryName-style lookups.
+    const map = await db.getCategoryNameMap();
+    expect(map.get('cat1')).toBe('New Name');
+  });
+
+  test('delete_category — removed from cache', async () => {
+    const client = createMockGraphQLClient({ DeleteCategory: { deleteCategory: true } });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.deleteCategory({ category_id: 'cat1' });
+    const cats = await db.getUserCategories();
+
+    expect(cats.find((c) => c.category_id === 'cat1')).toBeUndefined();
+  });
+});
+
+describe('optimistic cache patching — budgets (primary motivation for issue #278)', () => {
+  let db: CopilotDatabase;
+  let tools: CopilotMoneyTools;
+
+  beforeEach(() => {
+    db = new CopilotDatabase('/fake');
+    (db as any)._allCollectionsLoaded = true;
+    (db as any)._cacheLoadedAt = Date.now();
+    (db as any)._userCategories = [{ category_id: 'cat_food', name: 'Food' }];
+    (db as any)._budgets = [
+      {
+        budget_id: 'b1',
+        category_id: 'cat_food',
+        amount: 0, // the frozen legacy field
+        amounts: {},
+      },
+    ];
+  });
+
+  test('set_budget without month — get_budgets reflects amount for current month', async () => {
+    const client = createMockGraphQLClient({
+      EditBudget: { editCategoryBudget: true },
+    });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.setBudget({ category_id: 'cat_food', amount: '275.50' });
+    const result = await tools.getBudgets({});
+    const b = result.budgets.find((x) => x.category_id === 'cat_food')!;
+
+    expect(b.amount).toBe(275.5);
+    expect(b.amounts?.[currentMonth()]).toBe(275.5);
+  });
+
+  test('set_budget with explicit future month — value lands in amounts map', async () => {
+    const client = createMockGraphQLClient({
+      EditBudgetMonthly: { editCategoryBudgetMonthly: true },
+    });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.setBudget({ category_id: 'cat_food', amount: '400.00', month: '2026-12' });
+    const result = await tools.getBudgets({});
+    const b = result.budgets.find((x) => x.category_id === 'cat_food')!;
+
+    expect(b.amounts?.['2026-12']).toBe(400);
+  });
+
+  test('set_budget on a category with no prior budget creates a new entry', async () => {
+    (db as any)._userCategories = [{ category_id: 'cat_food', name: 'Food' }];
+    (db as any)._budgets = []; // no existing budget
+    const client = createMockGraphQLClient({
+      EditBudget: { editCategoryBudget: true },
+    });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.setBudget({ category_id: 'cat_food', amount: '100.00' });
+    const result = await tools.getBudgets({});
+
+    expect(result.budgets.find((x) => x.category_id === 'cat_food')?.amount).toBe(100);
+  });
+});
+
+describe('optimistic cache patching — recurrings', () => {
+  let db: CopilotDatabase;
+  let tools: CopilotMoneyTools;
+
+  beforeEach(() => {
+    db = new CopilotDatabase('/fake');
+    (db as any)._allCollectionsLoaded = true;
+    (db as any)._cacheLoadedAt = Date.now();
+    (db as any)._transactions = [
+      {
+        transaction_id: 'seed_txn',
+        amount: 9.99,
+        date: '2026-04-01',
+        name: 'Spotify',
+        account_id: 'acc1',
+        item_id: 'item1',
+      },
+    ];
+    (db as any)._recurring = [
+      { recurring_id: 'r1', name: 'Netflix', state: 'active', frequency: 'MONTHLY' },
+    ];
+  });
+
+  test('set_recurring_state — state change visible in cache (normalized to lowercase)', async () => {
+    const client = createMockGraphQLClient({
+      EditRecurring: {
+        editRecurring: {
+          recurring: {
+            id: 'r1',
+            name: 'Netflix',
+            state: 'PAUSED',
+            frequency: 'MONTHLY',
+            categoryId: '',
+          },
+        },
+      },
+    });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.setRecurringState({ recurring_id: 'r1', state: 'PAUSED' });
+    const recs = (db as any)._recurring as Array<{ recurring_id: string; state?: string }>;
+
+    expect(recs.find((r) => r.recurring_id === 'r1')?.state).toBe('paused');
+  });
+
+  test('create_recurring — new recurring appears in cache', async () => {
+    const client = createMockGraphQLClient({
+      CreateRecurring: {
+        createRecurring: {
+          id: 'new_rec',
+          name: 'Spotify',
+          state: 'ACTIVE',
+          frequency: 'MONTHLY',
+          categoryId: '',
+        },
+      },
+    });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.createRecurring({ transaction_id: 'seed_txn', frequency: 'MONTHLY' });
+    const recs = (db as any)._recurring as Array<{ recurring_id: string }>;
+
+    expect(recs.find((r) => r.recurring_id === 'new_rec')).toBeDefined();
+  });
+
+  test('delete_recurring — removed from cache', async () => {
+    const client = createMockGraphQLClient({ DeleteRecurring: { deleteRecurring: true } });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.deleteRecurring({ recurring_id: 'r1' });
+    const recs = (db as any)._recurring as Array<{ recurring_id: string }>;
+
+    expect(recs.find((r) => r.recurring_id === 'r1')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

After every successful GraphQL write the MCP tool layer now patches the corresponding entity in \`CopilotDatabase\`'s in-memory cache, so a subsequent read returns the new value **without** needing \`refresh_database\` + re-decode from LevelDB. This removes the stale-after-write UX for every write tool and — since no read path has to re-open LevelDB just to observe a write we already know succeeded — eliminates the \`.ldb\` temp-copy + worker-thread decode that used to follow every write.

For **budgets specifically**, this is the only way MCP-initiated writes become observable: Copilot's macOS app stopped persisting the top-level \`amount\` field to LevelDB ~2 years ago (issue #278), so the LevelDB path is stale regardless of how often we refresh. The patch writes into \`amounts[YYYY-MM]\` to mirror what the Copilot app itself writes.

## New patchers on \`CopilotDatabase\`

- \`patchCachedBudget(categoryId, amount, month?)\` — writes \`amounts[month ?? current_month]\`. If no budget exists for the category, pushes a new entry so \`setBudget → getBudgets\` still round-trips.
- \`patchCachedTagUpsert(tag)\` / \`patchCachedTagDelete(id)\`
- \`patchCachedCategoryUpsert(cat)\` / \`patchCachedCategoryDelete(id)\` — also invalidate the derived \`_categoryNameMap\` so rename/delete propagates to \`resolveCategoryName\` and any tool that enriches by name.
- \`patchCachedRecurringUpsert(rec)\` / \`patchCachedRecurringDelete(id)\`

All patchers no-op when the cache hasn't been loaded yet — next load picks up the real state (which for budgets is still stale, but for every other entity is fresh).

## Wired into all 13 write tools

- \`update_transaction\` — patches \`{category_id?, user_note?, tag_ids?}\` on the cached transaction.
- \`review_transactions\` — patches \`user_reviewed\` on every successfully completed id. Partial-failure semantics preserved: a batch that throws mid-flight patches nothing; a fully successful batch patches all of them.
- \`create_tag\` / \`update_tag\` / \`delete_tag\`
- \`create_category\` / \`update_category\` / \`delete_category\`
- \`set_budget\` (no month → current month; with month → that month)
- \`set_recurring_state\` — normalizes GraphQL's uppercase state ("PAUSED") to the cache's lowercase form ("paused") to match how the decoder stores it.
- \`create_recurring\` / \`update_recurring\` / \`delete_recurring\`

## Not in scope

- Temp-DB-cache invalidation on \`refresh_database\` — that's a separate concern (picks up external edits made in the Copilot app itself, not MCP-initiated writes) and has different edge cases.
- New API surface — everything stays backward compatible.

## Tests

- \`tests/core/database.test.ts\` — 16 new unit tests covering every patcher: no-op when cache not loaded, explicit-zero preservation for budget clears, id-not-found returns, upsert vs. create semantics, name-map invalidation on category patches.
- \`tests/tools/optimistic-cache.test.ts\` — 13 new integration tests. Each test injects a fixture cache, runs the write against a mock GraphQL client, runs the corresponding read tool **without** \`refresh_database\`, and asserts the new value is present. This is the behavior-level proof that the wiring actually eliminates the post-write refresh.

Full suite: **1419 pass / 0 fail / 21 skip**.

## Test plan

- [x] \`bun run check\` green
- [x] Branch based on latest \`origin/main\` (e5e14b6)
- [x] No changes to \`manifest.json\` / release pipeline — this is a behavior-only improvement inside the CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)