### PR TITLE
docs: symlink GEMINI.md to CLAUDE.md for Gemini CLI users

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Summary

- Gemini CLI reads `GEMINI.md` by default ([docs](https://geminicli.com/docs/cli/gemini-md/)) — same hierarchical walk as Claude Code's `CLAUDE.md`.
- Add a `GEMINI.md -> CLAUDE.md` symlink so Gemini users get project context with zero config, mirroring what we already do for `AGENTS.md`.

Inspired by patterns seen across forks (notably mstupp1's playground fork) where contributors were adding Gemini support manually.

## Test plan

- [x] `ls -la` shows GEMINI.md as a symlink to CLAUDE.md
- [x] Pre-push hook (`bun run check`) passes: typecheck + lint + format + 1440 tests
- [ ] CI green