### PR TITLE
fix(#282): plumb --write flag to runServer and drop stale banner

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,6 +52,7 @@ Usage:
 Options:
   --db-path <path>    Path to LevelDB database (default: Copilot Money's default location)
   --timeout <ms>      Decode timeout in milliseconds (default: 90000 = 90 seconds)
+  --write             Enable write tools (sends authenticated requests to Copilot Money's GraphQL API)
   --verbose, -v       Enable verbose logging
   --help, -h          Show this help message
 
@@ -95,18 +96,7 @@ function configureLogging(verbose: boolean): void {
 async function main(): Promise<void> {
   const { dbPath, verbose, timeoutMs, writeFlagSeen } = parseArgs();
 
-  // Configure logging first so the --write notice (and any later stderr) picks
-  // up the [ERROR] timestamp prefix in verbose mode.
   configureLogging(verbose);
-
-  if (writeFlagSeen) {
-    console.error(
-      '[copilot-money-mcp] --write is temporarily unavailable: Copilot Money ' +
-        'has restricted direct Firestore writes from third-party clients. ' +
-        'Starting in read-only mode. Status: ' +
-        'https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues'
-    );
-  }
 
   try {
     if (verbose) {
@@ -117,12 +107,13 @@ async function main(): Promise<void> {
       } else {
         console.log('Using default Copilot Money database location');
       }
+      if (writeFlagSeen) {
+        console.log('Write tools enabled (--write)');
+      }
       /* eslint-enable no-console */
     }
 
-    // Run the server in read-only mode. Write tools are temporarily disabled
-    // in the published CLI while the backend is reworked; see --write handling above.
-    await runServer(dbPath, timeoutMs, false);
+    await runServer(dbPath, timeoutMs, writeFlagSeen);
   } catch (error) {
     console.error('Server error:', error);
     process.exit(1);

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -129,10 +129,16 @@ describe('CLI entry point', () => {
       expect(stderr).not.toContain('Invalid');
     });
 
-    test('--write prints a temporarily-unavailable notice', async () => {
+    test('--write does not print a "temporarily unavailable" notice', async () => {
       const { stderr } = await runCli(['--write']);
 
-      expect(stderr).toContain('--write is temporarily unavailable');
+      expect(stderr).not.toContain('temporarily unavailable');
+    });
+
+    test('--write + --verbose logs that write tools are enabled', async () => {
+      const { stderr } = await runCli(['--write', '-v']);
+
+      expect(stderr).toContain('Write tools enabled');
     });
   });
 


### PR DESCRIPTION
## Summary
- `cli.ts` parsed `--write` but always passed a hardcoded `false` to `runServer()`, so the flag was a no-op for end users
- Also printed a stale "temporarily unavailable" notice that contradicts current `CHANGELOG`, `PRIVACY`, and `SECURITY` docs (writes were restored via GraphQL in 2.0.0)
- Forward `writeFlagSeen` to `runServer`, log it under `--verbose`, surface `--write` in `--help` text
- Update the cli unit test that asserted the stale banner

Closes #282.

## Test plan
- [x] `bun test tests/unit/cli.test.ts` — 14/14 pass
- [x] `bun run check` — typecheck + lint + format + 1420 tests pass
- [ ] Manual: `bun run src/cli.ts --write -v` shows "Write tools enabled (--write)" in stderr and does **not** show "temporarily unavailable"
- [ ] Manual: `bun run src/cli.ts --help` shows `--write` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)