### PR TITLE
chore: audit-followup nits across 6 PRs

### DIFF
--- a/.github/workflows/audit-reviews.yml
+++ b/.github/workflows/audit-reviews.yml
@@ -27,7 +27,7 @@ jobs:
       PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -56,7 +56,7 @@ jobs:
 
       - name: Load secrets from 1Password
         if: steps.check.outputs.skip != 'true'
-        uses: 1password/load-secrets-action@v4
+        uses: 1password/load-secrets-action@2bfca7363ef8f96bb66d38dd50981bf948040c7e # v4
         with:
           export-env: true
         env:
@@ -65,7 +65,7 @@ jobs:
 
       - name: Audit PR reviews with Claude
         if: steps.check.outputs.skip != 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@e30d45253b1abcc29a121ab35b8bf156061582bd # v1
         with:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload audit artifact
         if: always() && steps.check.outputs.skip != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: audit-result-pr-${{ env.PR_NUMBER }}
           path: audit-result.json

--- a/scripts/verify-optimistic-consistency.ts
+++ b/scripts/verify-optimistic-consistency.ts
@@ -447,7 +447,9 @@ async function main(): Promise<void> {
     }
     // Capture the actual current state and uppercase it for the GraphQL enum
     // restore. The decoder yields lowercase ('active'), the API expects upper.
-    const originalState = (target.state ?? 'active').toUpperCase();
+    // `target.state` is non-undefined here (the .find above filtered on it),
+    // so no fallback is needed.
+    const originalState = target.state.toUpperCase();
     try {
       await tools.setRecurringState({ recurring_id: target.recurring_id, state: 'PAUSED' });
       console.log(`  paused recurring ${target.recurring_id} "${target.name}"`);

--- a/scripts/verify-optimistic-consistency.ts
+++ b/scripts/verify-optimistic-consistency.ts
@@ -46,8 +46,27 @@ function argVal(name: string): string | undefined {
   if (i >= 0 && i + 1 < argv.length) return argv[i + 1];
   return undefined;
 }
+const PHASE_NAMES = ['tags', 'categories', 'txn', 'budgets', 'recurrings'] as const;
+type PhaseName = (typeof PHASE_NAMES)[number];
+
 const skip = new Set((argVal('--skip') ?? '').split(',').filter(Boolean));
 const only = argVal('--only');
+
+if (only && !PHASE_NAMES.includes(only as PhaseName)) {
+  console.error(
+    `Unknown --only phase: "${only}". Valid phases: ${PHASE_NAMES.join(', ')}`
+  );
+  process.exit(1);
+}
+for (const s of skip) {
+  if (!PHASE_NAMES.includes(s as PhaseName)) {
+    console.error(
+      `Unknown --skip phase: "${s}". Valid phases: ${PHASE_NAMES.join(', ')}`
+    );
+    process.exit(1);
+  }
+}
+
 function enabled(name: string): boolean {
   if (only) return name === only;
   return !skip.has(name);
@@ -94,7 +113,7 @@ async function pollUntilFreshMatches<T>(
   intervalSec: number
 ): Promise<{ matched: boolean; elapsedSec: number; lastValue: T }> {
   const start = Date.now();
-  let lastValue: T;
+  let lastValue!: T;
   while (true) {
     await freshDecode(db);
     lastValue = await read();
@@ -173,6 +192,7 @@ async function main(): Promise<void> {
 
   // 1) TAGS: create a disposable tag, verify it shows up optimistically, then after fresh decode.
   if (enabled('tags')) {
+    await runPhase('tags.create', async () => {
     heading('tags — create then delete');
     const tagName = `opt-probe-${marker}`;
     let tagId: string | undefined;
@@ -219,10 +239,12 @@ async function main(): Promise<void> {
         }
       }
     }
+    });
   }
 
   // 2) CATEGORIES: create a disposable category, verify and delete.
   if (enabled('categories')) {
+    await runPhase('categories.create', async () => {
     heading('categories — create then delete');
     const catName = `opt-probe-${marker}`;
     let catId: string | undefined;
@@ -272,10 +294,12 @@ async function main(): Promise<void> {
         }
       }
     }
+    });
   }
 
   // 3) TRANSACTIONS: edit a note on a real transaction, then restore.
   if (enabled('txn')) {
+    await runPhase('transactions.update_note', async () => {
     heading('transactions — edit note then restore');
     const all = await db.getAllTransactions();
     const target = all.find((t) => t.account_id && t.item_id && !t.is_pending);
@@ -331,10 +355,12 @@ async function main(): Promise<void> {
         }
       }
     }
+    });
   }
 
   // 4) BUDGETS: set amount on a LEAF category (no children), then restore.
   if (enabled('budgets')) {
+    await runPhase('budgets.set_leaf', async () => {
     heading('budgets — setBudget on a leaf category, then restore');
     const cats = await db.getUserCategories();
     const userCatIds = new Set(cats.map((c) => c.category_id));
@@ -406,6 +432,7 @@ async function main(): Promise<void> {
         }
       }
     }
+    });
   }
 
   // 5) RECURRINGS: toggle state on an existing recurring and restore.
@@ -418,47 +445,47 @@ async function main(): Promise<void> {
       console.log('  (no active recurring found; skipping)');
       return;
     }
-    {
-      const originalState = 'ACTIVE';
+    // Capture the actual current state and uppercase it for the GraphQL enum
+    // restore. The decoder yields lowercase ('active'), the API expects upper.
+    const originalState = (target.state ?? 'active').toUpperCase();
+    try {
+      await tools.setRecurringState({ recurring_id: target.recurring_id, state: 'PAUSED' });
+      console.log(`  paused recurring ${target.recurring_id} "${target.name}"`);
+
+      const optAll = await db.getRecurring();
+      const opt = optAll.find((r) => r.recurring_id === target.recurring_id);
+      console.log(`  optimistic state=${opt?.state}`);
+
+      const synced = await pollUntilFreshMatches(
+        db,
+        () => db.getRecurring(),
+        (recs) =>
+          recs.find((r) => r.recurring_id === target.recurring_id)?.state === 'paused',
+        60,
+        5
+      );
+      const syncedR = synced.lastValue.find((r) => r.recurring_id === target.recurring_id);
+      console.log(
+        `  synced (${synced.elapsedSec.toFixed(1)}s) state=${syncedR?.state} ${synced.matched ? '✓' : '(timed out)'}`
+      );
+      results.push({
+        name: 'recurrings.set_state',
+        optimisticValue: { state: opt?.state },
+        syncedValue: { state: syncedR?.state },
+        matched: opt?.state === syncedR?.state,
+        syncSec: synced.matched ? synced.elapsedSec : null,
+      });
+    } finally {
       try {
-        await tools.setRecurringState({ recurring_id: target.recurring_id, state: 'PAUSED' });
-        console.log(`  paused recurring ${target.recurring_id} "${target.name}"`);
-
-        const optAll = await db.getRecurring();
-        const opt = optAll.find((r) => r.recurring_id === target.recurring_id);
-        console.log(`  optimistic state=${opt?.state}`);
-
-        const synced = await pollUntilFreshMatches(
-          db,
-          () => db.getRecurring(),
-          (recs) =>
-            recs.find((r) => r.recurring_id === target.recurring_id)?.state === 'paused',
-          60,
-          5
-        );
-        const syncedR = synced.lastValue.find((r) => r.recurring_id === target.recurring_id);
-        console.log(
-          `  synced (${synced.elapsedSec.toFixed(1)}s) state=${syncedR?.state} ${synced.matched ? '✓' : '(timed out)'}`
-        );
-        results.push({
-          name: 'recurrings.set_state',
-          optimisticValue: { state: opt?.state },
-          syncedValue: { state: syncedR?.state },
-          matched: opt?.state === syncedR?.state,
-          syncSec: synced.matched ? synced.elapsedSec : null,
+        await tools.setRecurringState({
+          recurring_id: target.recurring_id,
+          state: originalState,
         });
-      } finally {
-        try {
-          await tools.setRecurringState({
-            recurring_id: target.recurring_id,
-            state: originalState,
-          });
-          console.log(`  cleanup: restored state ✓`);
-        } catch (e) {
-          console.log(
-            `  cleanup: restore FAILED — manual: setRecurringState ${target.recurring_id} to ${originalState}: ${e}`
-          );
-        }
+        console.log(`  cleanup: restored state ✓`);
+      } catch (e) {
+        console.log(
+          `  cleanup: restore FAILED — manual: setRecurringState ${target.recurring_id} to ${originalState}: ${e}`
+        );
       }
     }
     });

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -5,6 +5,7 @@
  * proper error handling.
  */
 
+import { randomUUID } from 'crypto';
 import { existsSync, readdirSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
@@ -413,8 +414,12 @@ export class CopilotDatabase {
     if (existing) {
       existing.amounts = { ...(existing.amounts ?? {}), [monthKey]: amount };
     } else {
+      // Synthetic placeholder so set_budget → get_budgets reflects the write
+      // before Copilot syncs the real entry. Use a UUID rather than a
+      // deterministic prefix so the surface ID looks like a real Firestore id
+      // instead of advertising "this is fake" to clients.
       this._budgets.push({
-        budget_id: `patched-${categoryId}`,
+        budget_id: randomUUID(),
         category_id: categoryId,
         amounts: { [monthKey]: amount },
       });

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2490,6 +2490,10 @@ export class CopilotMoneyTools {
     // accurately reflects completed writes.
     const CONCURRENCY = 5;
     let reviewed_count = 0;
+    // The `null as {...} | null` cast is load-bearing under TS strict: a bare
+    // `= null` lets control-flow analysis narrow the variable to `null` and
+    // forget the annotated wider type, which then breaks the `if (firstError)`
+    // narrow + the `error instanceof GraphQLError` check below. Don't remove.
     let firstError: { id: string; error: unknown } | null = null as {
       id: string;
       error: unknown;
@@ -2557,7 +2561,6 @@ export class CopilotMoneyTools {
   async createTag(args: {
     name: string;
     color_name?: string;
-    hex_color?: string;
   }): Promise<{ success: true; tag_id: string; name: string; color_name: string }> {
     const client = this.getGraphQLClient();
     if (!args.name?.trim()) throw new Error('Tag name must not be empty');
@@ -3611,8 +3614,7 @@ export function createToolSchemas(): ToolSchema[] {
         '`amounts` map of per-month overrides for history lookups. For parent ' +
         'categories, the returned `amount` is the resolved total (children + ' +
         'rollovers) that Copilot displays in the Budgets view. Totals use the ' +
-        'current-month effective amount. ' +
-        'Refresh note: after `set_budget` writes, `refresh_database` then read.',
+        'current-month effective amount.',
       inputSchema: {
         type: 'object',
         properties: {

--- a/tests/core/graphql/recurrings.test.ts
+++ b/tests/core/graphql/recurrings.test.ts
@@ -67,13 +67,13 @@ describe('editRecurring', () => {
   });
 
   test('converts rule.minAmount/maxAmount string to Float on the wire', async () => {
+    // Server response shape: editRecurring.recurring no longer selects `rule`
+    // (see issue #288 — RecurringRule.nameContains is non-nullable in the
+    // schema but the server returns null for amount-only rules, which made
+    // every EditRecurring throw). The mock omits rule deliberately.
     const client = createMockClient({
       editRecurring: {
-        recurring: {
-          id: 'r1',
-          state: 'ACTIVE',
-          rule: { nameContains: 'x', minAmount: 5, maxAmount: 100, days: [1] },
-        },
+        recurring: { id: 'r1', state: 'ACTIVE' },
       },
     });
     await editRecurring(client, {
@@ -93,6 +93,39 @@ describe('editRecurring', () => {
     });
     expect(typeof call[2].input.rule.minAmount).toBe('number');
     expect(typeof call[2].input.rule.maxAmount).toBe('number');
+  });
+
+  test('changed.rule echoes the caller input as strings (not the wire Float values)', async () => {
+    const client = createMockClient({
+      editRecurring: { recurring: { id: 'r1', state: 'ACTIVE' } },
+    });
+    const out = await editRecurring(client, {
+      id: 'r1',
+      input: { rule: { nameContains: 'netflix', minAmount: '5.00', maxAmount: '100', days: [1] } },
+    });
+    expect(out).toEqual({
+      id: 'r1',
+      changed: {
+        rule: { nameContains: 'netflix', minAmount: '5.00', maxAmount: '100', days: [1] },
+      },
+    });
+  });
+
+  test('regression: server omits rule entirely → editRecurring still resolves', async () => {
+    // Pre-#288, editRecurring read rule.nameContains off the response. When
+    // the server returned null nameContains for amount-only rules the call
+    // threw. The fix stops reading the field; this test pins that behavior
+    // by giving the mock response no rule at all.
+    const client = createMockClient({
+      editRecurring: { recurring: { id: 'r1', state: 'PAUSED' } },
+    });
+    const out = await editRecurring(client, {
+      id: 'r1',
+      input: { state: 'PAUSED', rule: { minAmount: '10' } },
+    });
+    expect(out.id).toBe('r1');
+    expect(out.changed.state).toBe('PAUSED');
+    expect(out.changed.rule).toEqual({ minAmount: '10' });
   });
 
   test('throws for invalid amount string', async () => {

--- a/tests/tools/optimistic-cache.test.ts
+++ b/tests/tools/optimistic-cache.test.ts
@@ -163,6 +163,28 @@ describe('optimistic cache patching — categories', () => {
     (db as any)._categoryNameMap = new Map([['cat1', 'Old Name']]);
   });
 
+  test('create_category — new category appears in cache without refresh', async () => {
+    const client = createMockGraphQLClient({
+      CreateCategory: {
+        createCategory: { id: 'cat2', name: 'Travel', colorName: 'BLUE2' },
+      },
+    });
+    tools = new CopilotMoneyTools(db, client);
+
+    await tools.createCategory({
+      name: 'Travel',
+      color_name: 'BLUE2',
+      emoji: '✈️',
+      is_excluded: false,
+    });
+    const cats = await db.getUserCategories();
+
+    expect(cats.find((c) => c.category_id === 'cat2')?.name).toBe('Travel');
+    // Name-map invalidation: new category's name resolves through getCategoryNameMap.
+    const map = await db.getCategoryNameMap();
+    expect(map.get('cat2')).toBe('Travel');
+  });
+
   test('update_category — rename visible without refresh, name map invalidated', async () => {
     const client = createMockGraphQLClient({
       EditCategory: {

--- a/tests/unit/write-tool-schemas.test.ts
+++ b/tests/unit/write-tool-schemas.test.ts
@@ -39,6 +39,16 @@ describe('createWriteToolSchemas', () => {
     expect(deleteTag!.inputSchema.properties).toHaveProperty('tag_id');
   });
 
+  test('update_tag schema exposes color_name only (no hex_color)', () => {
+    // Symmetric guard with create_tag — updateTag also only reads color_name,
+    // and a schema edit could silently re-add hex_color without this assertion.
+    const updateTag = createWriteToolSchemas().find((s) => s.name === 'update_tag');
+    expect(updateTag).toBeDefined();
+    expect(updateTag!.inputSchema.required).toEqual(['tag_id']);
+    expect(updateTag!.inputSchema.properties).toHaveProperty('color_name');
+    expect(updateTag!.inputSchema.properties).not.toHaveProperty('hex_color');
+  });
+
   test('create_category schema requires name and is non-idempotent', () => {
     const createCat = createWriteToolSchemas().find((s) => s.name === 'create_category');
     expect(createCat).toBeDefined();


### PR DESCRIPTION
## Summary

Batches the LOW/MEDIUM follow-ups from the PR audit bot into a single cleanup PR. Each item below maps to one open audit issue.

| Issue | What changed |
|---|---|
| **#276** | SHA-pin all 4 actions in `audit-reviews.yml` (audit flagged 3; pinned the 4th for consistency) |
| **#277** | Audit suggested removing the `null as {…} \| null` cast on `firstError`; the cast is **load-bearing** — TS strict narrows the variable to `null` without it and breaks the `if (firstError)` + `instanceof` check below. Kept and documented; will close audit issue with rationale. |
| **#285** | Drop dead `hex_color?` from `createTag` TS signature; add symmetric `update_tag` schema test |
| **#287** | Drop stale "after `set_budget` writes, `refresh_database` then read" line from `get_budgets` description; replace `patched-${categoryId}` synthetic budget_id with `crypto.randomUUID()`; add missing `create_category` optimistic-cache test |
| **#290** | Wrap remaining 4 phases of `verify-optimistic-consistency.ts` in `runPhase()`; capture `originalState` from `target.state` (was hardcoded); drop dead inner `{}` block; add `!` definite-assignment assertion on `lastValue`; validate `--only` / `--skip` phase names |
| **#292** | Drop dead `rule:` mock from `recurrings.test.ts`; add `changed.rule` echo assertion; add regression test where server omits `rule` entirely (the #288 bug scenario) |

Closes #276, #285, #287, #290, #292. **#277 will be closed separately** with the technical rationale (cast is not redundant).

## Test plan
- [x] `bun run check` — typecheck + lint + format + 1423 tests pass (4 new)
- [x] All 6 audit issues' specific evidence lines re-verified — no longer reproduces

🤖 Generated with [Claude Code](https://claude.com/claude-code)