### PR TITLE
ci: merge unit+e2e into single test job for accurate coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,8 @@ jobs:
             --excludePackages "copilot-money-mcp@$(node -p "require('./package.json').version")" \
             --summary
 
-  unit-tests:
-    name: Unit Tests
+  tests:
+    name: Tests
     needs: [quality]
     runs-on: ubuntu-latest
     steps:
@@ -69,41 +69,13 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Run unit tests with coverage
-        run: bun test --coverage --coverage-reporter=lcov tests/unit tests/models tests/core tests/utils
+      - name: Run all tests with coverage
+        run: bun test --coverage --coverage-reporter=lcov
 
-      - name: Upload unit test coverage to Codecov
+      - name: Upload coverage to Codecov
         if: (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push') && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v6
         with:
           files: coverage/lcov.info
-          flags: unit
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-
-  e2e-tests:
-    name: E2E Tests
-    needs: [quality]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Run E2E tests with coverage
-        run: bun test --coverage --coverage-reporter=lcov tests/e2e tests/tools tests/integration
-
-      - name: Upload E2E test coverage to Codecov
-        if: (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push') && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@v6
-        with:
-          files: coverage/lcov.info
-          flags: e2e
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,26 +4,9 @@ coverage:
       default:
         target: 95%
         threshold: 1%
-      unit:
-        target: 95%
-        threshold: 1%
-        flags:
-          - unit
-      e2e:
-        target: 70%
-        threshold: 1%
-        flags:
-          - e2e
     patch:
       default:
         target: 80%
 
-flags:
-  unit:
-    paths:
-      - src/
-    carryforward: true
-  e2e:
-    paths:
-      - src/
-    carryforward: true
+ignore:
+  - tests/


### PR DESCRIPTION
## Summary

- Codecov badge showed **84%** while local `bun test --coverage` reports **~96%**. Root cause: CI split tests into `unit-tests` + `e2e-tests` jobs; each saw only a partial slice of `src/`, and Bun's LCOV reports different line totals per run for the same file — breaking Codecov's union merge across the two flag uploads.
- Collapse into one `Tests` job running the full suite. Tests take ~10s total, so the split wasn't buying meaningful parallelism.
- Drop flag scoping in `codecov.yml`; add `ignore: tests/` so `tests/helpers/` doesn't count against the number.

Branch protection on `main` was updated to require the new `Tests` check instead of `Unit Tests` / `E2E Tests`.

## Test plan

- [ ] `Quality Checks` passes
- [ ] `Tests` job passes (runs full suite, uploads single LCOV)
- [ ] Codecov PR comment reports coverage close to 96% (expect jump from 84%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)