### PR TITLE
chore(release): 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-04-16
+
+### Added
+
+- **Optimistic in-memory cache patching after writes.** Every successful GraphQL write now patches the corresponding entity in `CopilotDatabase`'s in-memory cache, so a subsequent read returns the new value without needing `refresh_database` + re-decode from LevelDB. Removes the stale-after-write UX for agents that write-then-read.
+- **Local-only `pack:mcpb:write` build script.** Produces a `copilot-money-mcp-write.mcpb` bundle advertising all 30 tools (17 read + 13 write) with `--write` baked into `mcp_config.args`, for self-installing the writes-enabled CLI in Claude Desktop. The committed `manifest.json` (read-only, 17 tools) is never touched.
+
+### Fixed
+
+- **`get_budgets` now reads the current month's value** ([#278](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/278)): Copilot's macOS app stopped writing to the top-level `amount` field ~2 years ago — fresh values live in `amounts[YYYY-MM]`. Our view was reading the legacy field and showing stale numbers. Also drops tombstoned entries (those without a live current-month value).
+- **`--write` flag now actually enables write tools** ([#282](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/282)): `cli.ts` parsed `--write` but forwarded a hardcoded `false` to `runServer`, so the flag had no effect. Also drops a stale "temporarily unavailable" banner that contradicted the restored-via-GraphQL writes from 2.0.0.
+- **`set_recurring_state` no longer fails on amount-only rules** ([#288](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/288)): `RecurringRule.nameContains` is non-nullable in Copilot's schema but the server returns `null` on recurrings matched by amount-only rules, causing every `setRecurringState` / `editRecurring` response to error. Trimmed the mutation response to only the fields we actually consume.
+- **Tool description drift** on four write/read tools corrected after an audit pass.
+
+### Changed
+
+- `GEMINI.md` now symlinks to `CLAUDE.md` so Gemini CLI users pick up the same project instructions.
+- CI: unit and E2E tests merged into a single job for accurate coverage reporting; README picks up a live CI status badge and Codecov badge.
+
 ## [2.0.0] - 2026-04-15
 
 Write tools are back — rewritten onto Copilot Money's official GraphQL API (`https://app.copilot.money/api/graphql`) after direct Firestore writes were blocked by Copilot's server-side type-check deploy. Opt-in via `--write` (unchanged). 13 write tools (down from 18) across transactions, tags, categories, budgets, and recurrings.

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "copilot-money-mcp",
   "display_name": "Copilot Money MCP Server",
   "description": "Query your personal finances with AI using local Copilot Money data. 17 read-only tools for transactions, investments, budgets, goals, and more.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "icon": "icon.png",
   "author": {
     "name": "Ignacio Hermosilla",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-money-mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-money-mcp",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-money-mcp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "MCP server for Copilot Money — query personal finances locally (17 read tools) and manage them via Copilot's GraphQL API (13 write tools, opt-in with --write)",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary

Patch release bundling post-2.0.0 fixes and two small features. No breaking changes.

### Added
- **Optimistic in-memory cache patching after writes** (cc85f40) — writes patch `CopilotDatabase`'s cache so a subsequent read returns the new value without `refresh_database`.
- **Local-only `pack:mcpb:write` build** (8935e41) — produces a writes-enabled `.mcpb` for self-install; committed `manifest.json` stays read-only.

### Fixed
- `get_budgets` reads from `amounts[current_month]` instead of the legacy top-level `amount` field ([#278](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/278))
- `--write` is actually plumbed through to `runServer`; stale "temporarily unavailable" banner dropped ([#282](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/282))
- `setRecurringState` / `editRecurring` no longer fail on amount-only rules with `nameContains = null` ([#288](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/288))
- Tool description drift corrected on 4 write/read tools

### Changed
- `GEMINI.md` → `CLAUDE.md` symlink for Gemini CLI users
- CI: unit + E2E merged into a single job for accurate coverage

## Test plan
- [x] `bun run check` (typecheck + lint + format + 1424 tests) passes
- [x] `sync-manifest` reports no drift
- [x] `pack:mcpb` produces `copilot-money-mcp-2.0.1.mcpb` cleanly
- [ ] Verify CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)