### PR TITLE
docs: add Glama MCP server score badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue.svg)](https://www.typescriptlang.org/)
 [![Tests](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/ignaciohermosillacornejo/copilot-money-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/ignaciohermosillacornejo/copilot-money-mcp)
+[![copilot-money-mcp MCP server](https://glama.ai/mcp/servers/ignaciohermosillacornejo/copilot-money-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ignaciohermosillacornejo/copilot-money-mcp)
 
 ## Disclaimer
 


### PR DESCRIPTION
## Summary
- Add [Glama MCP server score badge](https://glama.ai/mcp/servers/ignaciohermosillacornejo/copilot-money-mcp) to the README, below the existing codecov badge.

## Test plan
- [x] Badge renders and links to the correct Glama page

🤖 Generated with [Claude Code](https://claude.com/claude-code)