### PR TITLE
fix(account): allow null vested_quantity and vested_value in holdings

### DIFF
--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -21,8 +21,8 @@ const AccountHoldingSchema = z
     institution_value: z.number().optional(),
     quantity: z.number().optional(),
     iso_currency_code: z.string().optional(),
-    vested_quantity: z.number().optional(),
-    vested_value: z.number().optional(),
+    vested_quantity: z.number().nullable().optional(),
+    vested_value: z.number().nullable().optional(),
   })
   .passthrough();
 

--- a/tests/models/account.test.ts
+++ b/tests/models/account.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Schema tests for AccountSchema, focused on holdings field nullability.
+ *
+ * Regression: brokerage / IRA / Roth / CMA accounts cache holdings where
+ * `vested_quantity` and `vested_value` come through as literal null (only
+ * stock-plan accounts populate these with numbers). Before the fix, those
+ * nulls tripped Zod validation and the entire account was silently dropped
+ * by `processAccount` in the decoder, so `get_accounts` underreported.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { AccountSchema } from '../../src/models/account.js';
+
+describe('AccountSchema', () => {
+  test('accepts holding with null vested_quantity and vested_value', () => {
+    const result = AccountSchema.safeParse({
+      account_id: 'acc1',
+      current_balance: 100,
+      name: 'Individual Brokerage',
+      holdings: [
+        {
+          security_id: 'sec1',
+          account_id: 'acc1',
+          institution_price: 42.5,
+          institution_value: 425,
+          quantity: 10,
+          cost_basis: null,
+          vested_quantity: null,
+          vested_value: null,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts holding with numeric vested_quantity and vested_value', () => {
+    const result = AccountSchema.safeParse({
+      account_id: 'acc1',
+      current_balance: 100,
+      name: 'Stock Plan',
+      holdings: [
+        {
+          security_id: 'sec1',
+          quantity: 10,
+          vested_quantity: 7,
+          vested_value: 297.5,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('accepts holding when vested fields are omitted', () => {
+    const result = AccountSchema.safeParse({
+      account_id: 'acc1',
+      current_balance: 100,
+      holdings: [{ security_id: 'sec1', quantity: 10 }],
+    });
+
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`AccountHoldingSchema` declares `vested_quantity` and `vested_value` as `z.number().optional()`, which rejects `null`. Firestore stores these fields as literal `null` on investment accounts that aren't stock-plan accounts (plain brokerage, IRA, Roth, cash-management, etc.). Zod throws on parse, `processAccount`'s `catch` silently returns `null`, and those accounts are dropped entirely from `get_accounts` output.

Switched both fields to `.nullable().optional()` to match the existing `cost_basis` pattern in the same schema.

## Repro

Build a holding with `vested_quantity: null` (what Copilot actually writes for non-stock-plan accounts):

```ts
AccountHoldingSchema.parse({
  security_id: 'x',
  quantity: 1,
  institution_price: 1,
  institution_value: 1,
  cost_basis: null,
  vested_quantity: null,   // <-- throws before this patch
  vested_value: null,      // <-- throws before this patch
});
```

Before: `ZodError: Invalid input: expected number, received null` at `holdings[*].vested_quantity` / `vested_value`, account silently omitted from `get_accounts`.
After: parses, account appears in results.

## Changes

- `src/models/account.ts`: `vested_quantity` and `vested_value` → `.nullable().optional()`
- `tests/models/account.test.ts`: regression tests covering null, numeric, and missing cases

## Test plan

- [x] `bun test tests/models/account.test.ts` — 3/3 pass
- [x] `bun run check` (typecheck + lint + format + full suite) — 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)