### PR TITLE
fix(plaid-account): allow null vested_quantity and vested_value

### DIFF
--- a/src/models/plaid-account.ts
+++ b/src/models/plaid-account.ts
@@ -16,8 +16,8 @@ const HoldingSchema = z
     institution_value: z.number().optional(),
     quantity: z.number().optional(),
     iso_currency_code: z.string().optional(),
-    vested_quantity: z.number().optional(),
-    vested_value: z.number().optional(),
+    vested_quantity: z.number().nullable().optional(),
+    vested_value: z.number().nullable().optional(),
   })
   .passthrough();
 

--- a/tests/models/plaid-account.test.ts
+++ b/tests/models/plaid-account.test.ts
@@ -103,4 +103,60 @@ describe('PlaidAccountSchema', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  /**
+   * Regression: brokerage / IRA / Roth / CMA plaid accounts cache holdings
+   * where `vested_quantity` and `vested_value` come through as literal null
+   * (only stock-plan accounts populate these with numbers). Before the fix,
+   * those nulls tripped Zod validation and the entire plaid account was
+   * silently dropped by `processPlaidAccount` in the decoder.
+   *
+   * Parallel to PR #302, which fixed the same pattern in AccountHoldingSchema.
+   */
+  describe('holdings vested field nullability (parallel to #302)', () => {
+    test('accepts holding with null vested_quantity and vested_value', () => {
+      const result = PlaidAccountSchema.safeParse({
+        plaid_account_id: 'plaid-acc-nullable',
+        holdings: [
+          {
+            security_id: 'sec1',
+            account_id: 'acc1',
+            institution_price: 42.5,
+            institution_value: 425,
+            quantity: 10,
+            cost_basis: null,
+            vested_quantity: null,
+            vested_value: null,
+          },
+        ],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    test('accepts holding with numeric vested_quantity and vested_value', () => {
+      const result = PlaidAccountSchema.safeParse({
+        plaid_account_id: 'plaid-acc-numeric',
+        holdings: [
+          {
+            security_id: 'sec1',
+            quantity: 10,
+            vested_quantity: 7,
+            vested_value: 297.5,
+          },
+        ],
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    test('accepts holding when vested fields are omitted', () => {
+      const result = PlaidAccountSchema.safeParse({
+        plaid_account_id: 'plaid-acc-omitted',
+        holdings: [{ security_id: 'sec1', quantity: 10 }],
+      });
+
+      expect(result.success).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Parallel to PR #302 but for the sibling schema. `PlaidAccountSchema` in `src/models/plaid-account.ts` declared `vested_quantity` and `vested_value` as `z.number().optional()`, which rejects `null`. Copilot Money writes literal `null` for non-stock-plan plaid-level accounts (plain brokerage, IRA, Roth, CMA, etc.). Zod throws on parse, `processPlaidAccount`'s `safeParse` returns `null` (`src/core/decoder.ts:1817`), and the entire plaid account is silently dropped from the decoded cache.

Switched both fields to `.nullable().optional()` to match the existing `cost_basis` pattern in the same schema.

This is latent on some caches today (no plaid-path holdings currently have null vested_* for me), but will fire as soon as Copilot writes holdings under `items/*/accounts/*` for any account that isn't a stock-plan account.

## Changes

- `src/models/plaid-account.ts`: `vested_quantity` and `vested_value` → `.nullable().optional()`
- `tests/models/plaid-account.test.ts`: 3 regression tests (null / numeric / omitted) mirroring the #302 pattern

## Test plan

- [x] `bun test tests/models/plaid-account.test.ts` — 8/8 pass
- [x] `bun run check` (typecheck + lint + format + full suite) — 0 failures (1430 pass)

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)