### PR TITLE
feat(decoder): surface silent schema drops via validateOrWarn helper

### DIFF
--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -2050,12 +2050,19 @@ function processSubChange<T>(
       if (extracted !== undefined) data[key] = extracted;
     }
   }
-  const logicalCollection = collection.endsWith('/t')
-    ? 'transaction_changes'
-    : collection.endsWith('/a')
-      ? 'account_changes'
-      : 'change_sub';
-  return validateOrWarn(schema, data, { collection: logicalCollection, docId });
+  // Dedupe-friendly stable names for the two known sub-change types. If
+  // Copilot ever adds a new suffix, we fall through to 'change_sub' and
+  // embed the raw collection path in docId so the warn is still diagnosable.
+  if (collection.endsWith('/t')) {
+    return validateOrWarn(schema, data, { collection: 'transaction_changes', docId });
+  }
+  if (collection.endsWith('/a')) {
+    return validateOrWarn(schema, data, { collection: 'account_changes', docId });
+  }
+  return validateOrWarn(schema, data, {
+    collection: 'change_sub',
+    docId: `${docId} (unknown collection: ${collection})`,
+  });
 }
 
 /**

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -11,6 +11,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { iterateDocuments } from './leveldb-reader.js';
 import { type FirestoreValue, toPlainObject } from './protobuf-parser.js';
+import { validateOrWarn } from './schema-warn.js';
 
 // Re-export for potential use by other modules
 export { toPlainObject } from './protobuf-parser.js';
@@ -856,11 +857,10 @@ function processTransaction(
     txnData.internal_transfer = true;
   }
 
-  try {
-    return TransactionSchema.parse(txnData);
-  } catch {
-    return null;
-  }
+  return validateOrWarn(TransactionSchema, txnData, {
+    collection: 'transactions',
+    docId,
+  });
 }
 
 /**
@@ -1004,11 +1004,10 @@ function processAccount(fields: Map<string, FirestoreValue>, docId: string): Acc
     return null;
   }
 
-  try {
-    return AccountSchema.parse(accData);
-  } catch {
-    return null;
-  }
+  return validateOrWarn(AccountSchema, accData, {
+    collection: 'accounts',
+    docId,
+  });
 }
 
 /**
@@ -1111,11 +1110,10 @@ function processRecurring(fields: Map<string, FirestoreValue>, docId: string): R
   // field name, but our schema exposes last_date for readability. Both kept for consumers.
   if (latestDate) recData.latest_date = latestDate;
 
-  try {
-    return RecurringSchema.parse(recData);
-  } catch {
-    return null;
-  }
+  return validateOrWarn(RecurringSchema, recData, {
+    collection: 'recurring',
+    docId,
+  });
 }
 
 /**
@@ -1170,11 +1168,10 @@ function processBudget(fields: Map<string, FirestoreValue>, docId: string): Budg
   const id = getString(fields, 'id');
   if (id) budgetData.id = id;
 
-  try {
-    return BudgetSchema.parse(budgetData);
-  } catch {
-    return null;
-  }
+  return validateOrWarn(BudgetSchema, budgetData, {
+    collection: 'budgets',
+    docId,
+  });
 }
 
 /**
@@ -1255,11 +1252,10 @@ function processGoal(fields: Map<string, FirestoreValue>, docId: string): Goal |
     }
   }
 
-  try {
-    return GoalSchema.parse(goalData);
-  } catch {
-    return null;
-  }
+  return validateOrWarn(GoalSchema, goalData, {
+    collection: 'goals',
+    docId,
+  });
 }
 
 /**
@@ -1333,11 +1329,10 @@ function processGoalHistory(
     }
   }
 
-  try {
-    return GoalHistorySchema.parse(historyData);
-  } catch {
-    return null;
-  }
+  return validateOrWarn(GoalHistorySchema, historyData, {
+    collection: 'goal_history',
+    docId,
+  });
 }
 
 /**
@@ -1381,8 +1376,10 @@ function processInvestmentPrice(
     if (value) priceData[field] = value;
   }
 
-  const validated = InvestmentPriceSchema.safeParse(priceData);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(InvestmentPriceSchema, priceData, {
+    collection: 'investment_prices',
+    docId,
+  });
 }
 
 /**
@@ -1435,8 +1432,10 @@ function processInvestmentSplit(
     splitData.adjustments = adjustments;
   }
 
-  const validated = InvestmentSplitSchema.safeParse(splitData);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(InvestmentSplitSchema, splitData, {
+    collection: 'investment_splits',
+    docId,
+  });
 }
 
 /**
@@ -1521,8 +1520,10 @@ function processItem(fields: Map<string, FirestoreValue>, docId: string): Item |
   const fetchDataMap = getMap(fields, 'fetch_data');
   if (fetchDataMap) itemData.fetch_data = toPlainObject(fetchDataMap);
 
-  const validated = ItemSchema.safeParse(itemData);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(ItemSchema, itemData, {
+    collection: 'items',
+    docId,
+  });
 }
 
 /**
@@ -1574,8 +1575,10 @@ function processCategory(fields: Map<string, FirestoreValue>, docId: string): Ca
     if (value) categoryData[field] = value;
   }
 
-  const validated = CategorySchema.safeParse(categoryData);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(CategorySchema, categoryData, {
+    collection: 'categories',
+    docId,
+  });
 }
 
 /**
@@ -1642,8 +1645,10 @@ function processInvestmentPerformance(
   const access = getStringArray(fields, 'access');
   if (access) data.access = access;
 
-  const validated = InvestmentPerformanceSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(InvestmentPerformanceSchema, data, {
+    collection: 'investment_performance',
+    docId,
+  });
 }
 
 /**
@@ -1691,8 +1696,10 @@ function processTwrHolding(
     if (Object.keys(history).length > 0) data.history = history;
   }
 
-  const validated = TwrHoldingSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(TwrHoldingSchema, data, {
+    collection: 'twr_holdings',
+    docId,
+  });
 }
 
 /**
@@ -1814,8 +1821,10 @@ function processPlaidAccount(
     }
   }
 
-  const validated = PlaidAccountSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(PlaidAccountSchema, data, {
+    collection: 'plaid_accounts',
+    docId,
+  });
 }
 
 /**
@@ -1833,8 +1842,10 @@ function processTag(fields: Map<string, FirestoreValue>, docId: string): Tag | n
     if (value !== undefined) data[field] = value;
   }
 
-  const validated = TagSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(TagSchema, data, {
+    collection: 'tags',
+    docId,
+  });
 }
 
 /**
@@ -1887,8 +1898,10 @@ function processBalanceHistory(
   const origin = getString(fields, '_origin');
   if (origin !== undefined) data._origin = origin;
 
-  const validated = BalanceHistorySchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(BalanceHistorySchema, data, {
+    collection: 'balance_history',
+    docId,
+  });
 }
 
 /**
@@ -1924,8 +1937,10 @@ function processHoldingsHistoryMeta(
     }
   }
 
-  const validated = HoldingsHistoryMetaSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(HoldingsHistoryMetaSchema, data, {
+    collection: 'holdings_history_meta',
+    docId,
+  });
 }
 
 /**
@@ -1990,8 +2005,10 @@ function processHoldingsHistory(
     }
   }
 
-  const validated = HoldingsHistorySchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(HoldingsHistorySchema, data, {
+    collection: 'holdings_history',
+    docId,
+  });
 }
 
 /**
@@ -2005,8 +2022,10 @@ function processChange(fields: Map<string, FirestoreValue>, docId: string): Chan
       if (extracted !== undefined) data[key] = extracted;
     }
   }
-  const validated = ChangeSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(ChangeSchema, data, {
+    collection: 'changes',
+    docId,
+  });
 }
 
 /**
@@ -2031,8 +2050,12 @@ function processSubChange<T>(
       if (extracted !== undefined) data[key] = extracted;
     }
   }
-  const validated = schema.safeParse(data);
-  return validated.success ? validated.data : null;
+  const logicalCollection = collection.endsWith('/t')
+    ? 'transaction_changes'
+    : collection.endsWith('/a')
+      ? 'account_changes'
+      : 'change_sub';
+  return validateOrWarn(schema, data, { collection: logicalCollection, docId });
 }
 
 /**
@@ -2096,8 +2119,10 @@ function processSecurity(fields: Map<string, FirestoreValue>, docId: string): Se
   const infoMap = getMap(fields, 'info');
   if (infoMap) data.info = toPlainObject(infoMap);
 
-  const validated = SecuritySchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(SecuritySchema, data, {
+    collection: 'securities',
+    docId,
+  });
 }
 
 /**
@@ -2182,8 +2207,10 @@ function processUserProfile(
   const origin = getString(fields, '_origin');
   if (origin !== undefined) data._origin = origin;
 
-  const validated = UserProfileSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(UserProfileSchema, data, {
+    collection: 'user_profile',
+    docId,
+  });
 }
 
 /**
@@ -2201,8 +2228,10 @@ function processAmazonIntegration(
     if (extracted !== undefined) data[key] = extracted;
   }
 
-  const validated = AmazonIntegrationSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(AmazonIntegrationSchema, data, {
+    collection: 'amazon_integrations',
+    docId,
+  });
 }
 
 /**
@@ -2250,8 +2279,10 @@ function processAmazonOrder(
   const transactions = getStringArray(fields, 'transactions');
   if (transactions) data.transactions = transactions;
 
-  const validated = AmazonOrderSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(AmazonOrderSchema, data, {
+    collection: 'amazon_orders',
+    docId,
+  });
 }
 
 /**
@@ -2294,8 +2325,10 @@ function processSubscription(
     }
   }
 
-  const validated = SubscriptionSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(SubscriptionSchema, data, {
+    collection: 'subscriptions',
+    docId,
+  });
 }
 
 /**
@@ -2324,8 +2357,10 @@ function processInvite(fields: Map<string, FirestoreValue>, docId: string): Invi
     }
   }
 
-  const validated = InviteSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(InviteSchema, data, {
+    collection: 'invites',
+    docId,
+  });
 }
 
 /**
@@ -2344,8 +2379,10 @@ function processUserItems(fields: Map<string, FirestoreValue>, docId: string): U
     }
   }
 
-  const validated = UserItemsSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(UserItemsSchema, data, {
+    collection: 'user_items',
+    docId,
+  });
 }
 
 /**
@@ -2367,8 +2404,10 @@ function processFeatureTracking(
     }
   }
 
-  const validated = FeatureTrackingSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(FeatureTrackingSchema, data, {
+    collection: 'feature_tracking',
+    docId,
+  });
 }
 
 /**
@@ -2387,8 +2426,10 @@ function processSupport(fields: Map<string, FirestoreValue>, docId: string): Sup
     }
   }
 
-  const validated = SupportSchema.safeParse(data);
-  return validated.success ? validated.data : null;
+  return validateOrWarn(SupportSchema, data, {
+    collection: 'support',
+    docId,
+  });
 }
 
 /**

--- a/src/core/schema-warn.ts
+++ b/src/core/schema-warn.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared helper for the LevelDB decoder. Replaces silent
+ * `safeParse → return null` patterns with a version that still returns
+ * null on failure (preserving caller contract) but emits a structured
+ * `console.warn` to stderr so schema drops become auditable.
+ *
+ * Motivation: PR #302 / issue #306 were latent for months because
+ * `processAccount` silently dropped accounts on Zod failure, with zero
+ * signal anywhere. See issue #309 for the full background.
+ */
+
+import type { ZodType } from 'zod';
+
+export type DecodeContext = {
+  collection: string;
+  docId: string;
+};
+
+// Dedupe key = `${collection}::${firstIssue.path.join('.')}::${firstIssue.code}`.
+// One warn per unique key per process. Prevents log flood when Copilot ships
+// a new field shape that affects every doc in a collection.
+const warnedKeys = new Set<string>();
+
+export function validateOrWarn<T>(schema: ZodType<T>, data: unknown, ctx: DecodeContext): T | null {
+  const result = schema.safeParse(data);
+  if (result.success) return result.data;
+
+  const first = result.error.issues[0];
+  if (first) {
+    const pathStr = first.path.join('.');
+    const key = `${ctx.collection}::${pathStr}::${first.code}`;
+    if (!warnedKeys.has(key)) {
+      warnedKeys.add(key);
+      // console.warn writes to stderr in Node, safe for MCP stdio transport.
+      // console.log would corrupt the JSON-RPC protocol on stdout.
+      console.warn(
+        `[copilot-money-mcp] schema drop: collection=${ctx.collection} docId=${ctx.docId} path=${pathStr} code=${first.code} message="${first.message}"`
+      );
+    }
+  }
+  return null;
+}
+
+// Exposed for tests only.
+export function __resetWarnedKeys(): void {
+  warnedKeys.clear();
+}

--- a/src/core/schema-warn.ts
+++ b/src/core/schema-warn.ts
@@ -1,12 +1,7 @@
 /**
- * Shared helper for the LevelDB decoder. Replaces silent
- * `safeParse → return null` patterns with a version that still returns
- * null on failure (preserving caller contract) but emits a structured
- * `console.warn` to stderr so schema drops become auditable.
- *
- * Motivation: PR #302 / issue #306 were latent for months because
- * `processAccount` silently dropped accounts on Zod failure, with zero
- * signal anywhere. See issue #309 for the full background.
+ * Shared helper for the LevelDB decoder. Returns null on Zod failure
+ * (preserving caller contract) but emits a structured `console.warn` to
+ * stderr so schema drops become auditable instead of silent.
  */
 
 import type { ZodType } from 'zod';
@@ -18,13 +13,17 @@ export type DecodeContext = {
 
 // Dedupe key = `${collection}::${firstIssue.path.join('.')}::${firstIssue.code}`.
 // One warn per unique key per process. Prevents log flood when Copilot ships
-// a new field shape that affects every doc in a collection.
+// a new field shape that affects every doc in a collection. Note: only the
+// first docId that hits a given key is logged — all subsequent docs with the
+// same issue are silently dropped. If you need every offending docId, grep
+// the cache with the logged path/code.
 const warnedKeys = new Set<string>();
 
 export function validateOrWarn<T>(schema: ZodType<T>, data: unknown, ctx: DecodeContext): T | null {
   const result = schema.safeParse(data);
   if (result.success) return result.data;
 
+  // Zod always provides ≥1 issue on failure; guard is defensive only.
   const first = result.error.issues[0];
   if (first) {
     const pathStr = first.path.join('.');
@@ -33,6 +32,9 @@ export function validateOrWarn<T>(schema: ZodType<T>, data: unknown, ctx: Decode
       warnedKeys.add(key);
       // console.warn writes to stderr in Node, safe for MCP stdio transport.
       // console.log would corrupt the JSON-RPC protocol on stdout.
+      // `message` may include the received value for enum issues; current
+      // schemas only enum over system-controlled strings (account_type,
+      // frequency, etc.), and stderr stays local to the user's machine.
       console.warn(
         `[copilot-money-mcp] schema drop: collection=${ctx.collection} docId=${ctx.docId} path=${pathStr} code=${first.code} message="${first.message}"`
       );

--- a/tests/core/decoder-leveldb.test.ts
+++ b/tests/core/decoder-leveldb.test.ts
@@ -4,7 +4,7 @@
  * These tests verify that the decoder properly reads from LevelDB databases.
  */
 
-import { describe, test, expect, afterEach, beforeEach } from 'bun:test';
+import { describe, test, expect, afterEach, beforeEach, spyOn } from 'bun:test';
 import {
   decodeTransactions,
   decodeAccounts,
@@ -14,6 +14,7 @@ import {
   decodeGoalHistory,
   decodeCategories,
 } from '../../src/core/decoder.js';
+import { __resetWarnedKeys } from '../../src/core/schema-warn.js';
 import {
   createTransactionDb,
   createAccountDb,
@@ -155,6 +156,43 @@ describe('LevelDB Decoder', () => {
       // Only the complete transaction should be returned
       expect(result.length).toBe(1);
       expect(result[0]?.transaction_id).toBe('txn_003');
+    });
+
+    test('silent schema drop emits a stderr warn (issue #309)', async () => {
+      __resetWarnedKeys();
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const dbPath = path.join(FIXTURES_DIR, 'schema-warn-db');
+        // Malformed date: TransactionSchema requires /^\d{4}-\d{2}-\d{2}$/,
+        // so this doc is dropped by the decoder. Before #309 this was silent;
+        // now it must emit a structured warn to stderr.
+        const transactions: TestTransaction[] = [
+          {
+            transaction_id: 'txn_bad',
+            amount: 10.0,
+            date: 'not-a-date',
+            name: 'Bad Date',
+          },
+          {
+            transaction_id: 'txn_good',
+            amount: 20.0,
+            date: '2024-05-01',
+            name: 'Good',
+          },
+        ];
+
+        await createTransactionDb(dbPath, transactions);
+        const result = await decodeTransactions(dbPath);
+
+        expect(result.length).toBe(1);
+        expect(result[0]?.transaction_id).toBe('txn_good');
+        expect(warnSpy).toHaveBeenCalled();
+        const message = warnSpy.mock.calls[0]?.[0] as string;
+        expect(message).toContain('collection=transactions');
+        expect(message).toContain('path=date');
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     test('skips transactions with zero amount', async () => {

--- a/tests/core/schema-warn.test.ts
+++ b/tests/core/schema-warn.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for validateOrWarn — the shared helper that replaces silent
+ * `safeParse → return null` patterns in the decoder. On parse failure it
+ * returns null (preserving caller contract) but emits a structured
+ * `console.warn` to stderr so silent schema drops become auditable.
+ *
+ * Dedupe is per-process, keyed by (collection, first-issue path, issue code),
+ * to prevent log flood when Copilot ships a new field shape affecting every
+ * doc in a collection.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { z } from 'zod';
+import { validateOrWarn, __resetWarnedKeys } from '../../src/core/schema-warn.js';
+
+const Schema = z.object({
+  id: z.string(),
+  amount: z.number(),
+});
+
+describe('validateOrWarn', () => {
+  let warnSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    __resetWarnedKeys();
+    warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test('returns parsed data on success', () => {
+    const result = validateOrWarn(
+      Schema,
+      { id: 'x', amount: 1 },
+      {
+        collection: 'accounts',
+        docId: 'doc1',
+      }
+    );
+
+    expect(result).toEqual({ id: 'x', amount: 1 });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('returns null and warns on failure', () => {
+    const result = validateOrWarn(
+      Schema,
+      { id: 'x', amount: 'not-a-number' },
+      {
+        collection: 'accounts',
+        docId: 'doc1',
+      }
+    );
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0][0] as string;
+    expect(message).toContain('copilot-money-mcp');
+    expect(message).toContain('schema drop');
+    expect(message).toContain('collection=accounts');
+    expect(message).toContain('docId=doc1');
+    expect(message).toContain('path=amount');
+  });
+
+  test('dedupes identical failures (same collection + path + code)', () => {
+    validateOrWarn(
+      Schema,
+      { id: 'x', amount: 'bad' },
+      {
+        collection: 'accounts',
+        docId: 'doc1',
+      }
+    );
+    validateOrWarn(
+      Schema,
+      { id: 'y', amount: 'also-bad' },
+      {
+        collection: 'accounts',
+        docId: 'doc2',
+      }
+    );
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('different failure paths emit separate warns', () => {
+    validateOrWarn(
+      Schema,
+      { id: 'x', amount: 'bad' },
+      {
+        collection: 'accounts',
+        docId: 'doc1',
+      }
+    );
+    validateOrWarn(
+      Schema,
+      { id: 42, amount: 1 },
+      {
+        collection: 'accounts',
+        docId: 'doc2',
+      }
+    );
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('different collections emit separate warns for the same path', () => {
+    validateOrWarn(
+      Schema,
+      { id: 'x', amount: 'bad' },
+      {
+        collection: 'accounts',
+        docId: 'doc1',
+      }
+    );
+    validateOrWarn(
+      Schema,
+      { id: 'x', amount: 'bad' },
+      {
+        collection: 'transactions',
+        docId: 'doc2',
+      }
+    );
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('__resetWarnedKeys clears state between runs', () => {
+    validateOrWarn(
+      Schema,
+      { id: 'x', amount: 'bad' },
+      {
+        collection: 'accounts',
+        docId: 'doc1',
+      }
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    __resetWarnedKeys();
+
+    validateOrWarn(
+      Schema,
+      { id: 'x', amount: 'bad' },
+      {
+        collection: 'accounts',
+        docId: 'doc2',
+      }
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces every silent `safeParse → return null` (22 sites) and `try { parse } catch { return null }` (6 sites) pattern in `src/core/decoder.ts` with a shared `validateOrWarn` helper that preserves the null-on-failure contract but emits a structured `console.warn` to **stderr** so schema drops become auditable.

**Motivation:** PR #302 / issue #306 were latent for months because `processAccount` silently dropped accounts on Zod failure, with zero signal anywhere — no log, no counter, no error surfaced to the MCP client. This closes that gap across the whole decoder.

## Design

```ts
validateOrWarn(schema, data, { collection, docId }) → T | null
```

- Dedupe is per-process, keyed by `(collection, first-issue path, issue code)` — prevents log flood when Copilot ships a new field shape affecting every doc in a collection.
- `console.warn` lands on stderr (safe for MCP stdio transport — `console.log` would corrupt JSON-RPC on stdout).
- Format is `key=value` structured text (greppable from a terminal).
- `__resetWarnedKeys()` is exposed for tests only.

## Commits

1. **`feat(decoder): add validateOrWarn helper for schema drops`** — helper + 6 unit tests (success, failure, dedupe same, dedupe different path, dedupe different collection, `__resetWarnedKeys` works).
2. **`refactor(decoder): migrate 28 silent schema-drop sites to validateOrWarn`** — mechanical migration + one integration test in `decoder-leveldb.test.ts` that feeds a malformed-date transaction and asserts the stderr warn fires via the full decoder call path.

## Collection-name decisions

- Each `processFoo` hardcodes its logical collection (e.g., `'transactions'`, `'plaid_accounts'`). No caller-signature changes.
- `processPlaidAccount` already has an in-scope `collection` param, but it's the full Firestore path `items/{item_id}/accounts/{docId}` — that would defeat dedupe (one bucket per item_id). Hardcoded `'plaid_accounts'` instead.
- `processSubChange` is generic over `T`, so the logical name is derived from the path suffix (`/t` → `transaction_changes`, `/a` → `account_changes`).

## Test plan

- [x] `bun test tests/core/schema-warn.test.ts` — 6/6 pass
- [x] `bun test tests/core/decoder-leveldb.test.ts` — 14/14 pass (incl. new integration test)
- [x] `bun run check` (typecheck + lint + format + full suite) — 0 failures (1437 pass)
- [x] No new lint warnings introduced (existing 15 are in `tools.ts:2479-2514`)

## Acceptance criteria from #309

- [x] `validateOrWarn` helper implemented with per-process dedupe
- [x] All silent-drop sites in `src/core/decoder.ts` migrated (28 total: 22 `safeParse` + 6 `try/catch`)
- [x] Unit test file covering helper behavior (success, failure, dedupe, reset)
- [x] Integration test proving a real dropped doc produces a stderr warn during decode
- [x] `bun run check` passes

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)