### PR TITLE
feat(finance-cleanup): structural audit, cross-category detection, matcher-state persistence

### DIFF
--- a/skills/finance-cleanup/SKILL.md
+++ b/skills/finance-cleanup/SKILL.md
@@ -5,18 +5,39 @@ description: "Use when the user wants to clean up transactions, fix categories, 
 
 # Finance Cleanup
 
-Walk the user through a structured cleanup of their Copilot Money transaction data. You have access to MCP tools for reading and writing Copilot Money data. This is a multi-phase process: gather, detect, present, fix, update profile, summarize.
+Walk the user through a structured cleanup of their Copilot Money transaction data. You have access to MCP tools for reading and writing Copilot Money data. This is a multi-phase process: structural audit, gather, detect, present, fix, update profile, summarize.
+
+## Phase 0 — Structural Category Audit
+
+Do this BEFORE any transaction-level work. Transaction cleanup lands in the right buckets only if the taxonomy itself makes sense. Skipping this turns miscategorization fixes into busywork.
+
+1. **Pull categories + spend totals.** Use `get_categories` for the full tree, then `get_transactions` (or grouped aggregates) over the last 6 months to compute per-category spend and per-category transaction count.
+
+2. **Flag structural problems.** Use Python via Bash for the aggregation. Flag any category where:
+   - **Single-merchant dominance:** one merchant is >70% of the category's spend → candidate for a split (e.g. a broad "Shopping" category dominated by one store).
+   - **Semantic breadth:** >3 distinct merchant types lumped together (e.g. transit passes + travel fees + subscriptions all under one transport-adjacent category).
+   - **Dead:** <3 transactions over 6 months → archive candidate.
+   - **Name/content mismatch:** category name doesn't match what's actually inside (e.g. fitness content under a generic "Memberships & Tickets" label).
+   - **Emoji collisions:** duplicate emojis across two unrelated categories, or parent/child emoji mismatches.
+
+3. **Scan for missing buckets.** Look through transactions categorized as "Other" or left uncategorized for recurring patterns that deserve their own category. Common omissions: Fees & Charges (bank fees, FX fees, service fees), Gifts, Software/AI subscriptions.
+
+4. **Present the proposed taxonomy changes to the user** (renames, splits, new categories, archivals) BEFORE touching individual transactions. Use `create_category`, `update_category`, `delete_category` as approved.
+
+5. Only after the taxonomy is clean, move to Phase 1.
 
 ## Phase 1 — Gather Data
 
-1. **Read the user profile.** Open `skills/user-profile.md`. If it doesn't exist, copy `skills/user-profile.template.md` to `skills/user-profile.md` first. Note any existing preferences, especially under "Cleanup Preferences" and "Preferences." These override your judgment — if the profile says "Uber Eats = Dining," never flag Uber Eats as miscategorized.
+1. **Refresh the cache.** Call `refresh_database` as the very first step, before reading anything. The local cache can be stale (the Copilot desktop app re-syncs on focus). Mid-session refreshes cause earlier queries to return incomplete data and force re-pulls later, which wastes time. One refresh up front beats ten mid-session rediscoveries.
 
-2. **Ask about scope.** Before pulling data, ask the user:
+2. **Read the user profile.** Open `skills/user-profile.md`. If it doesn't exist, copy `skills/user-profile.template.md` to `skills/user-profile.md` first. Note any existing preferences, especially under "Cleanup Preferences," "Preferences," and "Recurring Matcher State." These override your judgment — if the profile says "Uber Eats = Dining," never flag Uber Eats as miscategorized.
+
+3. **Ask about scope.** Before pulling data, ask the user:
    - Full cleanup or focused? (e.g., "just recurrings" or "just uncategorized")
    - Any specific date range? Default to last 6 months.
    - Any accounts to skip?
 
-3. **Pull data.** Use these MCP tools:
+4. **Pull data.** Use these MCP tools:
    - `get_transactions` — unreviewed transactions (set `reviewed: false`)
    - `get_transactions` — last 6 months of all transactions (for historical patterns)
    - `get_recurring_transactions` — current recurring charges
@@ -24,6 +45,8 @@ Walk the user through a structured cleanup of their Copilot Money transaction da
    - `get_accounts` — to map account IDs to names
 
    - For any payment app accounts found (Venmo, PayPal, Zelle, CashApp), also pull their transactions separately — these contain the descriptive names and categories that bank-side stubs lack.
+
+   **Default `limit=50`** on broad date-ranged `get_transactions` pulls. Transactions are ~1.6KB each with all the Plaid metadata, so 100 rows reliably exceeds the 100KB MCP response cap and spills to disk — forcing an extra Python-parse detour. At `limit=50` the response stays inline (~80KB). Bump to `limit=100` only when you have already filtered down to a known-small merchant (e.g. `merchant: "AMAZON"` for a user who doesn't shop there constantly).
 
    Run all reads before any analysis. Cache the results mentally — you will cross-reference heavily.
 
@@ -33,11 +56,26 @@ Work through each detection pass. Use Bash with Python for any arithmetic on lar
 
 ### 2.1 Miscategorized Transactions
 
-For each merchant that appears 3+ times in the 6-month history:
+Run two passes. The first catches the highest-signal cases; the second sweeps up the rest.
+
+**Pass A — Cross-category merchants (do this FIRST).**
+
+Group all transactions by `normalized_merchant` over the 6-month history. For each merchant, count the number of distinct `category_name` values used. Flag every merchant with **≥2 distinct categories** as a high-confidence miscategorization candidate — when the same merchant has been filed under multiple buckets, at least one of those categorizations is almost certainly wrong.
+
+Threshold notes:
+- ≥3 distinct categories is almost always a miscategorization somewhere; present these first.
+- Exactly 2 distinct categories is common and often wrong too — but also sometimes legitimate (e.g. a coffee shop that occasionally serves lunch could split Coffee vs Restaurants). Present these with the split visible so the user can call it.
+- Real patterns to expect: payment-processor aliases that resolve to different categories, food-adjacent merchants (coffee/restaurants/delivery), healthcare providers occasionally filed as "Other," travel charges split between Restaurants and Airplane Tickets.
+
+**Pass B — Dominant-category drift.**
+
+For each merchant that appears 3+ times in the 6-month history AND wasn't already surfaced in Pass A:
 - Count how many times each category was used for that merchant.
 - If a transaction's category differs from the merchant's dominant category (used >80% of the time), flag it.
-- **Exception:** If the user profile lists an explicit category preference for that merchant, use the profile's category as ground truth instead of the statistical mode.
-- **Exception:** If a transaction has been manually reviewed and recategorized by the user (reviewed = true with a non-default category), treat it as intentional — do not flag.
+
+**Exceptions (apply to both passes):**
+- If the user profile lists an explicit category preference for that merchant, use the profile's category as ground truth instead of the statistical mode.
+- If a transaction has been manually reviewed and recategorized by the user (reviewed = true with a non-default category), treat it as intentional — do not flag.
 
 ### 2.2 Misclassified Transfers
 
@@ -63,7 +101,22 @@ Scan the 6-month transaction history for merchants appearing 3+ times at regular
 - **Price drift:** Flag if amount varies >5% for charges under $50, or >3% for charges between $50-$200, or >2% for charges over $200.
 - **Missed cycles:** If the most recent occurrence is 7+ days past the expected next date, flag as potentially cancelled or missed.
 
-### 2.4 Quick Wins
+### 2.4 Overdue Recurrings — investigate matcher before archiving
+
+When `get_recurring_transactions` surfaces a sub as "overdue" (expected charge hasn't arrived), **do not recommend archiving it until you've ruled out a stale matcher rule.** In real sessions, ~⅔ of "overdue" subs were actually still charging — the matcher's `name_contains` or `min_amount`/`max_amount` rule had just drifted.
+
+Before flagging archive, for each overdue sub:
+
+1. **Pull the matcher rule.** Use `get_recurring_transactions` (filter by name or id) to read the current `match_string`, `min_amount`, `max_amount`.
+2. **Check the profile.** Read the "Recurring Matcher State" section of `skills/user-profile.md` — if the sub is listed there with known oddities (e.g. "semi-annual, Copilot next_date is buggy for this one"), honor it and skip.
+3. **Look for a near-miss charge.** Run `get_transactions(merchant=<approximate_name>, last_90_days)`. Watch for the two common drift modes:
+   - **Name truncation:** matcher says `name_contains: "Servicename"` but the merchant posts as `SERVICENAM` (payment processor truncated it) — never matches.
+   - **Amount cap drift:** plan price increased (or rent has proration / annual increases) and blew past the old `max_amount`.
+4. **If a near-miss is found**, propose `update_recurring` to fix the rule — widen the amount range, correct the name substring, or both. Only propose `set_recurring_state` to archive if the sub is genuinely silent for >N days with zero near-miss matches.
+
+When a matcher is updated, write the new rule back to the user profile's "Recurring Matcher State" section (see Phase 5) so next session doesn't re-investigate the same sub from scratch.
+
+### 2.5 Quick Wins
 
 - **No category:** Transactions with no category assigned. **Exception:** Income/credit transactions (negative amounts) without a category are intentionally uncategorized — do not flag them.
 - **Old unreviewed:** Unreviewed transactions older than 90 days.
@@ -117,8 +170,12 @@ After all fixes are applied, update `skills/user-profile.md` with any new prefer
 - Any accounts the user said to always skip.
 - Any categories the user said to never touch.
 - Frequency preferences (e.g., "run cleanup monthly").
+- **Recurring Matcher State** — whenever you use `update_recurring` to fix a matcher rule during Phase 2.4, record the final state under "Recurring Matcher State." This is the single most valuable thing the profile can carry between sessions: without it, next cleanup re-investigates the same overdue subs from scratch. For each known-active subscription, record:
+  - Exact merchant substring the payment processor actually posts (not the user-facing brand name).
+  - Current amount range, min–max.
+  - Known oddities — especially semi-annual or annual frequency where Copilot's `next_date` math is buggy and the overdue flag can't be trusted.
 
-**Tell the user exactly what you are saving before writing.** Example: "I'm adding to your profile: 'ENC = Healthcare (psychologist)', 'Skip Coinbase account for cleanup'. OK?"
+**Tell the user exactly what you are saving before writing.** Example: "I'm adding to your profile: 'ENC = Healthcare (psychologist)', 'Skip Coinbase account for cleanup', 'Matcher: Gym Membership — `GYMNAME`, $45–$55, annual price bump expected each January'. OK?"
 
 ## Phase 6 — Summary
 

--- a/skills/finance-cleanup/SKILL.md
+++ b/skills/finance-cleanup/SKILL.md
@@ -11,7 +11,9 @@ Walk the user through a structured cleanup of their Copilot Money transaction da
 
 Do this BEFORE any transaction-level work. Transaction cleanup lands in the right buckets only if the taxonomy itself makes sense. Skipping this turns miscategorization fixes into busywork.
 
-1. **Pull categories + spend totals.** Use `get_categories` for the full tree, then `get_transactions` (or grouped aggregates) over the last 6 months to compute per-category spend and per-category transaction count.
+0. **Refresh the cache.** Call `refresh_database` at the very start of Phase 0, not Phase 1. Phase 0 already reads categories + 6 months of transactions, so a stale cache would surface structural problems that don't exist (or hide new ones). One refresh covers both phases.
+
+1. **Pull categories + spend totals.** Use `get_categories` for the full tree, then `get_transactions` over the last 6 months to compute per-category spend and per-category transaction count. For this aggregation pass, **paginate through multiple `get_transactions` calls** rather than applying the default `limit=50` — you need the full 6-month set for accurate category totals, not a 50-row sample. Aggregate per-category counts and sums incrementally with Python via Bash as each page comes back.
 
 2. **Flag structural problems.** Use Python via Bash for the aggregation. Flag any category where:
    - **Single-merchant dominance:** one merchant is >70% of the category's spend → candidate for a split (e.g. a broad "Shopping" category dominated by one store).
@@ -28,16 +30,16 @@ Do this BEFORE any transaction-level work. Transaction cleanup lands in the righ
 
 ## Phase 1 — Gather Data
 
-1. **Refresh the cache.** Call `refresh_database` as the very first step, before reading anything. The local cache can be stale (the Copilot desktop app re-syncs on focus). Mid-session refreshes cause earlier queries to return incomplete data and force re-pulls later, which wastes time. One refresh up front beats ten mid-session rediscoveries.
+Cache was refreshed in Phase 0 Step 0 — do not refresh again. Mid-session refreshes cause earlier queries to return incomplete data and force re-pulls later. One refresh up front covers the whole session.
 
-2. **Read the user profile.** Open `skills/user-profile.md`. If it doesn't exist, copy `skills/user-profile.template.md` to `skills/user-profile.md` first. Note any existing preferences, especially under "Cleanup Preferences," "Preferences," and "Recurring Matcher State." These override your judgment — if the profile says "Uber Eats = Dining," never flag Uber Eats as miscategorized.
+1. **Read the user profile.** Open `skills/user-profile.md`. If it doesn't exist, copy `skills/user-profile.template.md` to `skills/user-profile.md` first. Note any existing preferences, especially under "Cleanup Preferences," "Preferences," and "Recurring Matcher State." These override your judgment — if the profile says "Uber Eats = Dining," never flag Uber Eats as miscategorized.
 
-3. **Ask about scope.** Before pulling data, ask the user:
+2. **Ask about scope.** Before pulling data, ask the user:
    - Full cleanup or focused? (e.g., "just recurrings" or "just uncategorized")
    - Any specific date range? Default to last 6 months.
    - Any accounts to skip?
 
-4. **Pull data.** Use these MCP tools:
+3. **Pull data.** Use these MCP tools:
    - `get_transactions` — unreviewed transactions (set `reviewed: false`)
    - `get_transactions` — last 6 months of all transactions (for historical patterns)
    - `get_recurring_transactions` — current recurring charges
@@ -112,7 +114,7 @@ Before flagging archive, for each overdue sub:
 3. **Look for a near-miss charge.** Run `get_transactions(merchant=<approximate_name>, last_90_days)`. Watch for the two common drift modes:
    - **Name truncation:** matcher says `name_contains: "Servicename"` but the merchant posts as `SERVICENAM` (payment processor truncated it) — never matches.
    - **Amount cap drift:** plan price increased (or rent has proration / annual increases) and blew past the old `max_amount`.
-4. **If a near-miss is found**, propose `update_recurring` to fix the rule — widen the amount range, correct the name substring, or both. Only propose `set_recurring_state` to archive if the sub is genuinely silent for >N days with zero near-miss matches.
+4. **If a near-miss is found**, propose `update_recurring` to fix the rule — widen the amount range, correct the name substring, or both. Only propose `set_recurring_state` to archive if the sub is genuinely silent for **30+ days past the expected `next_date`** with zero near-miss matches in the last 90 days. (Phase 2.3 flags missed cycles at 7+ days, which is right for "might be cancelled" — but archiving is a heavier call and should wait for a full extra cycle to rule out delayed posting.)
 
 When a matcher is updated, write the new rule back to the user profile's "Recurring Matcher State" section (see Phase 5) so next session doesn't re-investigate the same sub from scratch.
 

--- a/skills/user-profile.template.md
+++ b/skills/user-profile.template.md
@@ -28,3 +28,14 @@
 
 ## Cleanup Preferences
 <!-- Auto-populated as you approve/reject cleanup suggestions -->
+
+## Recurring Matcher State
+<!-- Auto-populated by /finance-cleanup whenever it fixes a matcher rule
+     (update_recurring). Read BEFORE investigating any "overdue" recurring
+     so known-active subs aren't re-investigated from scratch each session.
+     Format per sub:
+       - <Display name>
+         - Merchant substring: `<exact text the processor posts>`
+         - Amount range: $min – $max
+         - Oddities: <e.g. "semi-annual; Copilot next_date is buggy"> -->
+


### PR DESCRIPTION
## Summary

Bundles five `finance-cleanup` skill issues (#303, #304, #305, #307, #308) into one PR. They all touch the same file (`skills/finance-cleanup/SKILL.md`) and overlap conceptually — splitting would mean five rounds of review on the same surface. All changes are grounded in real-session failures documented in the filed issues.

## Changes per issue

### #304 — Phase 0: Structural Category Audit
New phase runs BEFORE Phase 1 (transaction cleanup). Flags categories with single-merchant dominance >70%, semantic breadth >3 merchant types, dead (<3 txns/6mo), name/content mismatches, emoji collisions. Scans "Other"/uncategorized for missing common buckets (Fees & Charges, Gifts, Software/AI subs). Proposes rename/split/archive/create BEFORE any transaction-level work — because transaction cleanup only lands cleanly if the taxonomy already makes sense.

### #308 — Refresh cache at start + default limit=50
Phase 1 step 1 is now `refresh_database`. Step 4 defaults `get_transactions` to `limit=50` on broad pulls (100 rows reliably exceeds the 100KB MCP cap and spills to disk, forcing an extra Python-parse detour). Bump to 100 only when filtering to a known-small merchant.

### #305 — Cross-category merchants FIRST
Phase 2.1 now runs two passes. **Pass A** groups by `normalized_merchant` and flags every merchant filed under ≥2 distinct categories — the highest-signal miscategorization heuristic. **Pass B** is the existing dominant-category (>80%) drift check. Threshold notes cover real patterns seen in session (payment-processor aliases, food-adjacent merchants, healthcare providers).

### #303 — Stale matchers before archiving overdue recurrings
New Phase 2.4. Before recommending archive on any "overdue" recurring, pull the matcher rule, check the profile for known oddities, scan last 90d for near-miss charges. Address the two observed drift modes (name truncation at payment processor, amount-cap drift from price increases / rent proration) via `update_recurring`. Only archive if genuinely silent with zero near-miss matches. ~⅔ of "overdue" subs in a real session were still actively charging. (Quick Wins renumbered 2.4 → 2.5.)

### #307 — Recurring Matcher State in user profile
Phase 5 now writes a "Recurring Matcher State" section to `skills/user-profile.md` whenever Phase 2.4 uses `update_recurring`. Per-sub: exact processor substring, min–max amount range, known oddities (semi-annual/annual frequencies where Copilot's `next_date` is buggy). Phase 2.4 reads this section BEFORE investigating — so known-good subs aren't re-litigated every session. Template gets the corresponding scaffolding.

## Test plan

- [x] `bun run check` (typecheck + lint + format + full suite) — 0 failures (1437 pass). Pure docs change, no runtime impact.
- [x] Phase numbering is sequential and unique (verified via `grep '### 2\.\d'`).
- [x] Cross-references between sections resolve (2.4 mentions Phase 5's Recurring Matcher State; Phase 1 step 2 lists the three profile sections to read).

## Note on the `writing-skills` TDD iron law

The `superpowers:writing-skills` skill prescribes pressure-scenario baselines before editing a skill. The five issues here already contain documented baseline failures from real sessions (the reason they were filed), which I've treated as the RED step — so edits here are the GREEN response to those documented failures. Future sessions will be the natural REFACTOR feedback.

Closes #303
Closes #304
Closes #305
Closes #307
Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)