### PR TITLE
feat(transactions): surface split-transaction linkage + stop double-counting

### DIFF
--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -789,6 +789,7 @@ function processTransaction(
     'posted_transaction_id',
     'original_transaction_id',
     'old_category_id',
+    'parent_transaction_id',
   ];
 
   for (const field of stringFields) {
@@ -837,6 +838,7 @@ function processTransaction(
     'plaid_category_strings',
     'intelligence_suggested_category_ids',
     'tag_ids',
+    'children_transaction_ids',
   ];
 
   for (const field of stringArrayFields) {

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -98,9 +98,7 @@ export const TransactionSchema = z
     posted_transaction_id: z.string().optional(),
     original_transaction_id: z.string().optional(),
 
-    // Split-transaction linkage. When the user splits a transaction in Copilot,
-    // the original doc gains `children_transaction_ids` and each new child doc
-    // gets `parent_transaction_id`. Both fields are bidirectional pointers.
+    // Present only on split transactions: parent gains children IDs, children gain parent ID.
     parent_transaction_id: z.string().optional(),
     children_transaction_ids: z.array(z.string()).optional(),
 

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -98,6 +98,12 @@ export const TransactionSchema = z
     posted_transaction_id: z.string().optional(),
     original_transaction_id: z.string().optional(),
 
+    // Split-transaction linkage. When the user splits a transaction in Copilot,
+    // the original doc gains `children_transaction_ids` and each new child doc
+    // gets `parent_transaction_id`. Both fields are bidirectional pointers.
+    parent_transaction_id: z.string().optional(),
+    children_transaction_ids: z.array(z.string()).optional(),
+
     // Tags
     tag_ids: z.array(z.string()).optional(),
 

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -319,6 +319,17 @@ export interface HoldingEntry {
 }
 
 /**
+ * Drop split-transaction parents from a list. Each split parent's amount
+ * equals the sum of its children's amounts, so any aggregation (category
+ * totals, merchant grouping, recurring detection) double-counts if parents
+ * are included alongside their children. Copilot hides parents in its own
+ * UI for the same reason.
+ */
+function filterSplitParents<T extends { children_transaction_ids?: string[] }>(txns: T[]): T[] {
+  return txns.filter((t) => !t.children_transaction_ids || t.children_transaction_ids.length === 0);
+}
+
+/**
  * Collection of MCP tools for querying Copilot Money data.
  */
 export class CopilotMoneyTools {
@@ -1219,11 +1230,13 @@ export class CopilotMoneyTools {
       case 'list':
       default: {
         // Get transactions with date filtering if period/dates specified
-        const transactions = await this.db.getTransactions({
-          startDate: start_date,
-          endDate: end_date,
-          limit: 50000, // Get all for aggregation
-        });
+        const transactions = filterSplitParents(
+          await this.db.getTransactions({
+            startDate: start_date,
+            endDate: end_date,
+            limit: 50000, // Get all for aggregation
+          })
+        );
 
         // Count transactions and amounts per category
         const categoryStats = new Map<string, { count: number; totalAmount: number }>();
@@ -1410,12 +1423,16 @@ export class CopilotMoneyTools {
       [start_date, end_date] = parsePeriod(period);
     }
 
-    // Get all transactions in the period
-    const transactions = await this.db.getTransactions({
-      startDate: start_date,
-      endDate: end_date,
-      limit: 50000,
-    });
+    // Get all transactions in the period. Split parents share a merchant
+    // name with their children and would inflate occurrence counts, producing
+    // false-positive recurring matches.
+    const transactions = filterSplitParents(
+      await this.db.getTransactions({
+        startDate: start_date,
+        endDate: end_date,
+        limit: 50000,
+      })
+    );
 
     // Group by merchant name
     const merchantTransactions = new Map<

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -455,6 +455,7 @@ export class CopilotMoneyTools {
     exclude_transfers?: boolean;
     exclude_deleted?: boolean;
     exclude_excluded?: boolean;
+    exclude_split_parents?: boolean;
     pending?: boolean;
     region?: string;
     country?: string;
@@ -492,6 +493,7 @@ export class CopilotMoneyTools {
       exclude_transfers = true,
       exclude_deleted = true,
       exclude_excluded = true,
+      exclude_split_parents = true,
       pending,
       region,
       country,
@@ -623,6 +625,16 @@ export class CopilotMoneyTools {
       const excludedCategoryIds = await this.getExcludedCategoryIds();
       transactions = transactions.filter(
         (txn) => !txn.excluded && !(txn.category_id && excludedCategoryIds.has(txn.category_id))
+      );
+    }
+
+    // Filter out split parents. Copilot hides these from its own UI after a
+    // split — the children carry the real categorized amounts. Keeping the
+    // parent would double-count the same spend (parent.amount == sum of
+    // children.amount).
+    if (exclude_split_parents) {
+      transactions = transactions.filter(
+        (txn) => !txn.children_transaction_ids || txn.children_transaction_ids.length === 0
       );
     }
 
@@ -3368,6 +3380,14 @@ export function createToolSchemas(): ToolSchema[] {
           exclude_excluded: {
             type: 'boolean',
             description: 'Exclude user-excluded transactions (default: true)',
+            default: true,
+          },
+          exclude_split_parents: {
+            type: 'boolean',
+            description:
+              'Exclude split-transaction parents (docs with children_transaction_ids). ' +
+              'The children already carry the real categorized amounts — returning the ' +
+              'parent would double-count the spend. Default: true.',
             default: true,
           },
           pending: {

--- a/tests/core/decoder-coverage.test.ts
+++ b/tests/core/decoder-coverage.test.ts
@@ -880,6 +880,10 @@ describe('decoder coverage', () => {
 
       const parent = txns.find((t) => t.transaction_id === 'parent-1')!;
       expect(parent).toBeDefined();
+      // Order is load-bearing: Firestore array fields preserve insertion
+      // order and getStringArray walks them in-order, so the decoder round-
+      // trip must keep children_transaction_ids stable (some callers rely
+      // on display order).
       expect(parent.children_transaction_ids).toEqual(['child-a', 'child-b']);
       expect(parent.parent_transaction_id).toBeUndefined();
 

--- a/tests/core/decoder-coverage.test.ts
+++ b/tests/core/decoder-coverage.test.ts
@@ -829,6 +829,68 @@ describe('decoder coverage', () => {
       expect(investBool).toBeDefined();
       expect(investBool.from_investment).toBe(true);
     });
+
+    test('extracts split-transaction linkage fields', async () => {
+      // When the user splits a transaction in Copilot, the original doc gets
+      // `children_transaction_ids: string[]` and each new child doc gets
+      // `parent_transaction_id: string`. Both fields live on the Firestore
+      // doc but were previously dropped by the decoder allow-list.
+      const dbPath = path.join(FIXTURES_DIR, 'txn-split-linkage-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'transactions',
+          id: 'parent-1',
+          fields: {
+            transaction_id: 'parent-1',
+            amount: 4346.6,
+            date: '2026-04-01',
+            name: 'BILT RENT - AVENUE',
+            children_transaction_ids: ['child-a', 'child-b'],
+            old_category_id: 'rent-cat',
+          },
+        },
+        {
+          collection: 'transactions',
+          id: 'child-a',
+          fields: {
+            transaction_id: 'child-a',
+            amount: 2771.6,
+            date: '2026-04-01',
+            name: 'BILT RENT - AVENUE',
+            category_id: 'rent-cat',
+            parent_transaction_id: 'parent-1',
+          },
+        },
+        {
+          collection: 'transactions',
+          id: 'child-b',
+          fields: {
+            transaction_id: 'child-b',
+            amount: 1575.0,
+            date: '2026-04-01',
+            name: 'BILT RENT - AVENUE',
+            category_id: 'hotels-cat',
+            parent_transaction_id: 'parent-1',
+          },
+        },
+      ]);
+
+      const txns = await decodeTransactions(dbPath);
+      expect(txns.length).toBe(3);
+
+      const parent = txns.find((t) => t.transaction_id === 'parent-1')!;
+      expect(parent).toBeDefined();
+      expect(parent.children_transaction_ids).toEqual(['child-a', 'child-b']);
+      expect(parent.parent_transaction_id).toBeUndefined();
+
+      const childA = txns.find((t) => t.transaction_id === 'child-a')!;
+      expect(childA).toBeDefined();
+      expect(childA.parent_transaction_id).toBe('parent-1');
+      expect(childA.children_transaction_ids).toBeUndefined();
+
+      const childB = txns.find((t) => t.transaction_id === 'child-b')!;
+      expect(childB.parent_transaction_id).toBe('parent-1');
+    });
   });
 
   describe('decodeAllCollections', () => {

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -100,6 +100,36 @@ const mockTransactionsWithFilters: Transaction[] = [
     account_id: 'acc1',
     excluded: true,
   },
+  {
+    // Split parent: has children_transaction_ids, so its amount is already
+    // accounted for by the two child rows below. Double-counting this would
+    // inflate spend totals.
+    transaction_id: 'txn_split_parent',
+    amount: 4346.6,
+    date: '2024-03-01',
+    name: 'Bilt Rent Parent',
+    account_id: 'acc1',
+    children_transaction_ids: ['txn_split_child_a', 'txn_split_child_b'],
+    old_category_id: 'shopping',
+  },
+  {
+    transaction_id: 'txn_split_child_a',
+    amount: 2771.6,
+    date: '2024-03-01',
+    name: 'Bilt Rent Child A',
+    category_id: 'shopping',
+    account_id: 'acc1',
+    parent_transaction_id: 'txn_split_parent',
+  },
+  {
+    transaction_id: 'txn_split_child_b',
+    amount: 1575.0,
+    date: '2024-03-01',
+    name: 'Bilt Rent Child B',
+    category_id: 'shopping',
+    account_id: 'acc1',
+    parent_transaction_id: 'txn_split_parent',
+  },
 ];
 
 const mockAccountsWithHidden: Account[] = [
@@ -680,14 +710,14 @@ describe('CopilotMoneyTools', () => {
       (db as any)._transactions = [...mockTransactionsWithFilters];
     });
 
-    test('excludes transfers, deleted, and excluded transactions by default', async () => {
+    test('excludes transfers, deleted, excluded, and split parents by default', async () => {
       const result = await tools.getTransactions({
         start_date: '2024-03-01',
         end_date: '2024-03-31',
       });
-      // Only normal transaction should be returned
-      expect(result.count).toBe(1);
-      expect(result.transactions[0].transaction_id).toBe('txn_normal');
+      // Normal + two split children (they're real spend); parent is double-count.
+      const ids = result.transactions.map((t) => t.transaction_id).sort();
+      expect(ids).toEqual(['txn_normal', 'txn_split_child_a', 'txn_split_child_b']);
     });
 
     test('includes transfers when exclude_transfers is false', async () => {
@@ -696,8 +726,8 @@ describe('CopilotMoneyTools', () => {
         end_date: '2024-03-31',
         exclude_transfers: false,
       });
-      // Normal + transfer
-      expect(result.count).toBe(2);
+      // Normal + transfer + 2 split children
+      expect(result.count).toBe(4);
     });
 
     test('includes deleted transactions when exclude_deleted is false', async () => {
@@ -706,8 +736,8 @@ describe('CopilotMoneyTools', () => {
         end_date: '2024-03-31',
         exclude_deleted: false,
       });
-      // Normal + deleted
-      expect(result.count).toBe(2);
+      // Normal + deleted + 2 split children
+      expect(result.count).toBe(4);
     });
 
     test('includes excluded transactions when exclude_excluded is false', async () => {
@@ -716,8 +746,24 @@ describe('CopilotMoneyTools', () => {
         end_date: '2024-03-31',
         exclude_excluded: false,
       });
-      // Normal + excluded
-      expect(result.count).toBe(2);
+      // Normal + excluded + 2 split children
+      expect(result.count).toBe(4);
+    });
+
+    test('includes split parents when exclude_split_parents is false', async () => {
+      const result = await tools.getTransactions({
+        start_date: '2024-03-01',
+        end_date: '2024-03-31',
+        exclude_split_parents: false,
+      });
+      // Normal + parent + 2 children = 4
+      const ids = result.transactions.map((t) => t.transaction_id).sort();
+      expect(ids).toEqual([
+        'txn_normal',
+        'txn_split_child_a',
+        'txn_split_child_b',
+        'txn_split_parent',
+      ]);
     });
 
     test('includes all transactions when all filters are disabled', async () => {
@@ -727,9 +773,10 @@ describe('CopilotMoneyTools', () => {
         exclude_transfers: false,
         exclude_deleted: false,
         exclude_excluded: false,
+        exclude_split_parents: false,
       });
-      // All 4 transactions
-      expect(result.count).toBe(4);
+      // All 7 transactions
+      expect(result.count).toBe(7);
     });
   });
 

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -1583,34 +1583,36 @@ describe('CopilotMoneyTools - Recurring Transactions Detail View', () => {
   });
 
   test('does not count split parents as recurring occurrences', async () => {
-    // A single split across 3 months creates 1 parent + 2 children per month.
-    // Without filtering, pattern detection sees 9 occurrences of "Bilt Rent"
-    // and flags it as recurring even though it's really 3 monthly rents.
+    // Scenario: a monthly recurring charge ("Gym Fees") that the user splits
+    // 50/50 every month. Child amounts are identical so the merchant clears
+    // the recurring detector's 30% amount-variance filter. Each month leaves
+    // 1 parent + 2 children with the same merchant name; without filtering
+    // the detector sees 9 occurrences, with filtering it sees the true 6.
     const split = (suffix: string, month: string): Transaction[] => [
       {
         transaction_id: `parent-${suffix}`,
-        amount: 3000,
+        amount: 100,
         date: month,
-        name: 'Bilt Rent',
+        name: 'Gym Fees',
         account_id: 'acc1',
         children_transaction_ids: [`child-a-${suffix}`, `child-b-${suffix}`],
-        old_category_id: 'rent',
+        old_category_id: 'fitness',
       },
       {
         transaction_id: `child-a-${suffix}`,
-        amount: 2000,
+        amount: 50,
         date: month,
-        name: 'Bilt Rent',
-        category_id: 'rent',
+        name: 'Gym Fees',
+        category_id: 'fitness',
         account_id: 'acc1',
         parent_transaction_id: `parent-${suffix}`,
       },
       {
         transaction_id: `child-b-${suffix}`,
-        amount: 1000,
+        amount: 50,
         date: month,
-        name: 'Bilt Rent',
-        category_id: 'hotels',
+        name: 'Gym Fees',
+        category_id: 'personal_care',
         account_id: 'acc1',
         parent_transaction_id: `parent-${suffix}`,
       },
@@ -1629,10 +1631,9 @@ describe('CopilotMoneyTools - Recurring Transactions Detail View', () => {
 
     // Expect occurrences to reflect real splits (2 children × 3 months = 6),
     // not parents (3 more would bring us to 9).
-    const bilt = result.recurring.find((r) => r.merchant === 'Bilt Rent');
-    if (bilt) {
-      expect(bilt.occurrences).toBe(6);
-    }
+    const gym = result.recurring.find((r) => r.merchant === 'Gym Fees');
+    expect(gym).toBeDefined();
+    expect(gym!.occurrences).toBe(6);
   });
 
   test('returns copilot subscriptions with grouped items by state', async () => {

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -858,6 +858,50 @@ describe('CopilotMoneyTools', () => {
       }
     });
 
+    test('does not double-count split parents in category totals', async () => {
+      // parent $300 in groceries, two children $100 + $200 also in groceries.
+      // Correct total for groceries = $300, not $600.
+      (db as any)._transactions = [
+        {
+          transaction_id: 'split_parent',
+          amount: 300,
+          date: '2024-03-01',
+          name: 'Costco Split',
+          account_id: 'acc1',
+          children_transaction_ids: ['split_child_a', 'split_child_b'],
+          old_category_id: 'groceries',
+        },
+        {
+          transaction_id: 'split_child_a',
+          amount: 100,
+          date: '2024-03-01',
+          name: 'Costco Split',
+          category_id: 'groceries',
+          account_id: 'acc1',
+          parent_transaction_id: 'split_parent',
+        },
+        {
+          transaction_id: 'split_child_b',
+          amount: 200,
+          date: '2024-03-01',
+          name: 'Costco Split',
+          category_id: 'groceries',
+          account_id: 'acc1',
+          parent_transaction_id: 'split_parent',
+        },
+      ];
+
+      const result = await tools.getCategories({
+        start_date: '2024-03-01',
+        end_date: '2024-03-31',
+      });
+      const groceries = (
+        result.data as { categories: { category_id: string; total_amount: number }[] }
+      ).categories.find((c) => c.category_id === 'groceries');
+
+      expect(groceries?.total_amount).toBe(300);
+    });
+
     test('returns tree view with hierarchy', async () => {
       const result = await tools.getCategories({ view: 'tree' });
 
@@ -1536,6 +1580,59 @@ describe('CopilotMoneyTools - Recurring Transactions Detail View', () => {
     expect(planetFitness?.average_amount).toBe(50);
     expect(planetFitness?.transactions).toBeDefined();
     expect(planetFitness?.transactions?.length).toBeLessThanOrEqual(5);
+  });
+
+  test('does not count split parents as recurring occurrences', async () => {
+    // A single split across 3 months creates 1 parent + 2 children per month.
+    // Without filtering, pattern detection sees 9 occurrences of "Bilt Rent"
+    // and flags it as recurring even though it's really 3 monthly rents.
+    const split = (suffix: string, month: string): Transaction[] => [
+      {
+        transaction_id: `parent-${suffix}`,
+        amount: 3000,
+        date: month,
+        name: 'Bilt Rent',
+        account_id: 'acc1',
+        children_transaction_ids: [`child-a-${suffix}`, `child-b-${suffix}`],
+        old_category_id: 'rent',
+      },
+      {
+        transaction_id: `child-a-${suffix}`,
+        amount: 2000,
+        date: month,
+        name: 'Bilt Rent',
+        category_id: 'rent',
+        account_id: 'acc1',
+        parent_transaction_id: `parent-${suffix}`,
+      },
+      {
+        transaction_id: `child-b-${suffix}`,
+        amount: 1000,
+        date: month,
+        name: 'Bilt Rent',
+        category_id: 'hotels',
+        account_id: 'acc1',
+        parent_transaction_id: `parent-${suffix}`,
+      },
+    ];
+    (db as any)._recurring = [];
+    (db as any)._transactions = [
+      ...split('jan', '2024-01-01'),
+      ...split('feb', '2024-02-01'),
+      ...split('mar', '2024-03-01'),
+    ];
+
+    const result = await tools.getRecurringTransactions({
+      start_date: '2024-01-01',
+      end_date: '2024-04-01',
+    });
+
+    // Expect occurrences to reflect real splits (2 children × 3 months = 6),
+    // not parents (3 more would bring us to 9).
+    const bilt = result.recurring.find((r) => r.merchant === 'Bilt Rent');
+    if (bilt) {
+      expect(bilt.occurrences).toBe(6);
+    }
   });
 
   test('returns copilot subscriptions with grouped items by state', async () => {


### PR DESCRIPTION
## Summary
- Decodes `parent_transaction_id` and `children_transaction_ids` from the Firestore doc so split relationships are now visible via `get_transactions`.
- Adds `exclude_split_parents: boolean = true` to `get_transactions`; parents are hidden by default so spend totals match what Copilot shows in its own UI.

## Why
Splitting a transaction in Copilot creates N child docs plus keeps the original as a "parent" with `children_transaction_ids` pointing at the children. Each child carries `parent_transaction_id` pointing back. Both fields were present in the raw LevelDB doc but silently dropped by `processTransaction`'s hand-maintained allow-list, which meant:

1. Callers had no way to identify or link split transactions.
2. Every query that summed amounts (`/finance-pulse`, budgets, spend-by-category) would double-count the split — `parent.amount + child_a.amount + child_b.amount = 2 × actual_spend`.

Concretely I verified this on my own DB: a \$4346.60 Bilt Rent split showed up in `get_transactions` as three rows (one parent + two children) totalling \$8693.20 even though the UI only shows \$4346.60.

## What changed
- `src/models/transaction.ts` — added `parent_transaction_id?: string` and `children_transaction_ids?: string[]` to `TransactionSchema`.
- `src/core/decoder.ts` — added both field names to `processTransaction`'s string/string-array allow-lists.
- `src/tools/tools.ts` — added `exclude_split_parents` option + filter, wired into the MCP tool schema.
- Tests — one decoder-level round-trip test and one tool-level test covering the default-on exclusion + explicit opt-in.

## Follow-up (Phase 2)
The existing `validateOrWarn` logging catches schema-validation drops but not allow-list drops, which is why these fields slipped past for so long. A structural coverage warn (fire once when a raw doc contains a field no processor reads) is tracked as a follow-up.

## Test plan
- [x] `bun run check` passes locally (typecheck + lint + format + 1439 tests).
- [x] Verified on real DB: parent now has `children_transaction_ids`, children have `parent_transaction_id`, and default `get_transactions` no longer returns the parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)