### PR TITLE
feat(decoder): wire warnUnreadFields across all remaining processors

### DIFF
--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -1036,6 +1036,34 @@ function processAccount(fields: Map<string, FirestoreValue>, docId: string): Acc
     return null;
   }
 
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [
+        'account_id',
+        'id',
+        'current_balance',
+        'original_current_balance',
+        'available_balance',
+        'limit',
+        'type',
+        'account_type',
+        'subtype',
+        'original_type',
+        'original_subtype',
+        'verification_status',
+        'latest_balance_update',
+        'holdings',
+        'metadata',
+        'merged',
+        ...stringFields,
+        ...booleanFields,
+      ],
+      ignored: [],
+    },
+    { collection: 'accounts', docId }
+  );
+
   return validateOrWarn(AccountSchema, accData, {
     collection: 'accounts',
     docId,
@@ -1142,6 +1170,34 @@ function processRecurring(fields: Map<string, FirestoreValue>, docId: string): R
   // field name, but our schema exposes last_date for readability. Both kept for consumers.
   if (latestDate) recData.latest_date = latestDate;
 
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [
+        'recurring_id',
+        'id',
+        'state',
+        'is_active',
+        'amount',
+        'min_amount',
+        'max_amount',
+        'days_filter',
+        'latest_date',
+        'next_date',
+        'last_date',
+        'transaction_ids',
+        'excluded_transaction_ids',
+        'included_transaction_ids',
+        'skip_filter_update',
+        'identification_method',
+        '_origin',
+        ...stringFields,
+      ],
+      ignored: [],
+    },
+    { collection: 'recurring', docId }
+  );
+
   return validateOrWarn(RecurringSchema, recData, {
     collection: 'recurring',
     docId,
@@ -1199,6 +1255,15 @@ function processBudget(fields: Map<string, FirestoreValue>, docId: string): Budg
   // ID field
   const id = getString(fields, 'id');
   if (id) budgetData.id = id;
+
+  warnUnreadFields(
+    fields,
+    {
+      consumed: ['budget_id', 'amount', 'is_active', 'amounts', 'id', ...stringFields],
+      ignored: [],
+    },
+    { collection: 'budgets', docId }
+  );
 
   return validateOrWarn(BudgetSchema, budgetData, {
     collection: 'budgets',
@@ -1284,6 +1349,22 @@ function processGoal(fields: Map<string, FirestoreValue>, docId: string): Goal |
     }
   }
 
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [
+        'goal_id',
+        'emoji',
+        'associated_accounts',
+        'savings',
+        ...stringFields,
+        ...boolFields,
+      ],
+      ignored: [],
+    },
+    { collection: 'goals', docId }
+  );
+
   return validateOrWarn(GoalSchema, goalData, {
     collection: 'goals',
     docId,
@@ -1360,6 +1441,22 @@ function processGoalHistory(
       historyData.current_amount = latestBalance;
     }
   }
+
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [
+        'goal_id',
+        'current_amount',
+        'target_amount',
+        'total_contribution',
+        'daily_data',
+        ...stringFields,
+      ],
+      ignored: [],
+    },
+    { collection: 'goal_history', docId }
+  );
 
   return validateOrWarn(GoalHistorySchema, historyData, {
     collection: 'goal_history',

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -1505,6 +1505,23 @@ function processInvestmentPrice(
     if (value) priceData[field] = value;
   }
 
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [
+        'investment_id',
+        'ticker_symbol',
+        'date',
+        'month',
+        ...priceFields,
+        ...ohlcvFields,
+        ...metaFields,
+      ],
+      ignored: [],
+    },
+    { collection: 'investment_prices', docId }
+  );
+
   return validateOrWarn(InvestmentPriceSchema, priceData, {
     collection: 'investment_prices',
     docId,
@@ -1560,6 +1577,15 @@ function processInvestmentSplit(
   if (Object.keys(adjustments).length > 0) {
     splitData.adjustments = adjustments;
   }
+
+  warnUnreadFields(
+    fields,
+    {
+      consumed: ['split_id', ...stringFields, ...numericFields, ...Object.keys(adjustments)],
+      ignored: [],
+    },
+    { collection: 'investment_splits', docId }
+  );
 
   return validateOrWarn(InvestmentSplitSchema, splitData, {
     collection: 'investment_splits',
@@ -1649,6 +1675,22 @@ function processItem(fields: Map<string, FirestoreValue>, docId: string): Item |
   const fetchDataMap = getMap(fields, 'fetch_data');
   if (fetchDataMap) itemData.fetch_data = toPlainObject(fetchDataMap);
 
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [
+        'item_id',
+        'products',
+        'fetch_data',
+        ...stringFields,
+        ...timestampFields,
+        ...boolFields,
+      ],
+      ignored: [],
+    },
+    { collection: 'items', docId }
+  );
+
   return validateOrWarn(ItemSchema, itemData, {
     collection: 'items',
     docId,
@@ -1704,6 +1746,23 @@ function processCategory(fields: Map<string, FirestoreValue>, docId: string): Ca
     if (value) categoryData[field] = value;
   }
 
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [
+        'category_id',
+        'name',
+        'order',
+        ...stringFields,
+        ...booleanFields,
+        ...arrayFields,
+        ...additionalStringFields,
+      ],
+      ignored: [],
+    },
+    { collection: 'categories', docId }
+  );
+
   return validateOrWarn(CategorySchema, categoryData, {
     collection: 'categories',
     docId,
@@ -1738,6 +1797,15 @@ function processUserAccount(
 
   const order = getNumber(fields, 'order');
   if (order !== undefined) userAccountData.order = order;
+
+  warnUnreadFields(
+    fields,
+    {
+      consumed: ['account_id', 'name', 'hidden', 'order'],
+      ignored: [],
+    },
+    { collection: 'user_accounts', docId }
+  );
 
   return userAccountData;
 }

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -2198,6 +2198,14 @@ function processHoldingsHistoryMeta(
     }
   }
 
+  warnUnreadFields(
+    fields,
+    // All raw fields are passed through by the generic loop above, so every
+    // key is consumed by design.
+    { consumed: Array.from(fields.keys()), ignored: [] },
+    { collection: 'holdings_history_meta', docId }
+  );
+
   return validateOrWarn(HoldingsHistoryMetaSchema, data, {
     collection: 'holdings_history_meta',
     docId,
@@ -2266,6 +2274,14 @@ function processHoldingsHistory(
     }
   }
 
+  warnUnreadFields(
+    fields,
+    // 'history' is explicitly handled above; everything else is passed through
+    // by the generic loop — so every raw field is consumed by design.
+    { consumed: Array.from(fields.keys()), ignored: [] },
+    { collection: 'holdings_history', docId }
+  );
+
   return validateOrWarn(HoldingsHistorySchema, data, {
     collection: 'holdings_history',
     docId,
@@ -2283,6 +2299,12 @@ function processChange(fields: Map<string, FirestoreValue>, docId: string): Chan
       if (extracted !== undefined) data[key] = extracted;
     }
   }
+  warnUnreadFields(
+    fields,
+    // Generic pass-through reads every raw key.
+    { consumed: Array.from(fields.keys()), ignored: [] },
+    { collection: 'changes', docId }
+  );
   return validateOrWarn(ChangeSchema, data, {
     collection: 'changes',
     docId,
@@ -2315,11 +2337,26 @@ function processSubChange<T>(
   // Copilot ever adds a new suffix, we fall through to 'change_sub' and
   // embed the raw collection path in docId so the warn is still diagnosable.
   if (collection.endsWith('/t')) {
+    warnUnreadFields(
+      fields,
+      { consumed: Array.from(fields.keys()), ignored: [] },
+      { collection: 'transaction_changes', docId }
+    );
     return validateOrWarn(schema, data, { collection: 'transaction_changes', docId });
   }
   if (collection.endsWith('/a')) {
+    warnUnreadFields(
+      fields,
+      { consumed: Array.from(fields.keys()), ignored: [] },
+      { collection: 'account_changes', docId }
+    );
     return validateOrWarn(schema, data, { collection: 'account_changes', docId });
   }
+  warnUnreadFields(
+    fields,
+    { consumed: Array.from(fields.keys()), ignored: [] },
+    { collection: 'change_sub', docId: `${docId} (unknown collection: ${collection})` }
+  );
   return validateOrWarn(schema, data, {
     collection: 'change_sub',
     docId: `${docId} (unknown collection: ${collection})`,
@@ -2386,6 +2423,22 @@ function processSecurity(fields: Map<string, FirestoreValue>, docId: string): Se
   // info map
   const infoMap = getMap(fields, 'info');
   if (infoMap) data.info = toPlainObject(infoMap);
+
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [
+        'security_id',
+        'option_contract',
+        'info',
+        ...stringFields,
+        ...numericFields,
+        ...booleanFields,
+      ],
+      ignored: [],
+    },
+    { collection: 'securities', docId }
+  );
 
   return validateOrWarn(SecuritySchema, data, {
     collection: 'securities',

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -1842,6 +1842,25 @@ function processInvestmentPerformance(
   const access = getStringArray(fields, 'access');
   if (access) data.access = access;
 
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [
+        'security_id',
+        'securityId',
+        'type',
+        'user_id',
+        'userId',
+        'last_update',
+        'lastUpdate',
+        'position',
+        'access',
+      ],
+      ignored: [],
+    },
+    { collection: 'investment_performance', docId }
+  );
+
   return validateOrWarn(InvestmentPerformanceSchema, data, {
     collection: 'investment_performance',
     docId,
@@ -1892,6 +1911,15 @@ function processTwrHolding(
     }
     if (Object.keys(history).length > 0) data.history = history;
   }
+
+  warnUnreadFields(
+    fields,
+    {
+      consumed: ['security_id', 'securityId', 'history'],
+      ignored: [],
+    },
+    { collection: 'twr_holdings', docId }
+  );
 
   return validateOrWarn(TwrHoldingSchema, data, {
     collection: 'twr_holdings',
@@ -2018,6 +2046,24 @@ function processPlaidAccount(
     }
   }
 
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [
+        'verification_status',
+        'latest_balance_update',
+        'holdings',
+        ...stringFields,
+        ...numberFields,
+        'limit',
+        ...booleanFields,
+        ...mapFieldNames,
+      ],
+      ignored: [],
+    },
+    { collection: 'plaid_accounts', docId }
+  );
+
   return validateOrWarn(PlaidAccountSchema, data, {
     collection: 'plaid_accounts',
     docId,
@@ -2038,6 +2084,15 @@ function processTag(fields: Map<string, FirestoreValue>, docId: string): Tag | n
     const value = getString(fields, field);
     if (value !== undefined) data[field] = value;
   }
+
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [...stringFields],
+      ignored: [],
+    },
+    { collection: 'tags', docId }
+  );
 
   return validateOrWarn(TagSchema, data, {
     collection: 'tags',
@@ -2094,6 +2149,15 @@ function processBalanceHistory(
 
   const origin = getString(fields, '_origin');
   if (origin !== undefined) data._origin = origin;
+
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [...numericFields, '_origin'],
+      ignored: [],
+    },
+    { collection: 'balance_history', docId }
+  );
 
   return validateOrWarn(BalanceHistorySchema, data, {
     collection: 'balance_history',

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -2528,6 +2528,24 @@ function processUserProfile(
   const origin = getString(fields, '_origin');
   if (origin !== undefined) data._origin = origin;
 
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [
+        'fcm_tokens',
+        'latest_spending_trigger',
+        'rollovers_starte_date',
+        '_origin',
+        ...stringFields,
+        ...numericFields,
+        ...booleanFields,
+        ...mapFields,
+      ],
+      ignored: [],
+    },
+    { collection: 'user_profile', docId }
+  );
+
   return validateOrWarn(UserProfileSchema, data, {
     collection: 'user_profile',
     docId,
@@ -2548,6 +2566,13 @@ function processAmazonIntegration(
     const extracted = extractValue(value);
     if (extracted !== undefined) data[key] = extracted;
   }
+
+  warnUnreadFields(
+    fields,
+    // Generic pass-through reads every raw key.
+    { consumed: Array.from(fields.keys()), ignored: [] },
+    { collection: 'amazon_integrations', docId }
+  );
 
   return validateOrWarn(AmazonIntegrationSchema, data, {
     collection: 'amazon_integrations',
@@ -2600,6 +2625,23 @@ function processAmazonOrder(
   const transactions = getStringArray(fields, 'transactions');
   if (transactions) data.transactions = transactions;
 
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [
+        'date',
+        'account_id',
+        'match_state',
+        'items',
+        'details',
+        'payment',
+        'transactions',
+      ],
+      ignored: [],
+    },
+    { collection: 'amazon_orders', docId }
+  );
+
   return validateOrWarn(AmazonOrderSchema, data, {
     collection: 'amazon_orders',
     docId,
@@ -2646,6 +2688,13 @@ function processSubscription(
     }
   }
 
+  warnUnreadFields(
+    fields,
+    // Explicit fields + generic pass-through below — every raw key is consumed.
+    { consumed: Array.from(fields.keys()), ignored: [] },
+    { collection: 'subscriptions', docId }
+  );
+
   return validateOrWarn(SubscriptionSchema, data, {
     collection: 'subscriptions',
     docId,
@@ -2678,6 +2727,13 @@ function processInvite(fields: Map<string, FirestoreValue>, docId: string): Invi
     }
   }
 
+  warnUnreadFields(
+    fields,
+    // Explicit fields + generic pass-through below — every raw key is consumed.
+    { consumed: Array.from(fields.keys()), ignored: [] },
+    { collection: 'invites', docId }
+  );
+
   return validateOrWarn(InviteSchema, data, {
     collection: 'invites',
     docId,
@@ -2699,6 +2755,12 @@ function processUserItems(fields: Map<string, FirestoreValue>, docId: string): U
       if (extracted !== undefined) data[key] = extracted;
     }
   }
+
+  warnUnreadFields(
+    fields,
+    { consumed: Array.from(fields.keys()), ignored: [] },
+    { collection: 'user_items', docId }
+  );
 
   return validateOrWarn(UserItemsSchema, data, {
     collection: 'user_items',
@@ -2725,6 +2787,12 @@ function processFeatureTracking(
     }
   }
 
+  warnUnreadFields(
+    fields,
+    { consumed: Array.from(fields.keys()), ignored: [] },
+    { collection: 'feature_tracking', docId }
+  );
+
   return validateOrWarn(FeatureTrackingSchema, data, {
     collection: 'feature_tracking',
     docId,
@@ -2746,6 +2814,12 @@ function processSupport(fields: Map<string, FirestoreValue>, docId: string): Sup
       if (extracted !== undefined) data[key] = extracted;
     }
   }
+
+  warnUnreadFields(
+    fields,
+    { consumed: Array.from(fields.keys()), ignored: [] },
+    { collection: 'support', docId }
+  );
 
   return validateOrWarn(SupportSchema, data, {
     collection: 'support',

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -11,7 +11,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { iterateDocuments } from './leveldb-reader.js';
 import { type FirestoreValue, toPlainObject } from './protobuf-parser.js';
-import { validateOrWarn } from './schema-warn.js';
+import { validateOrWarn, warnUnreadFields } from './schema-warn.js';
 
 // Re-export for potential use by other modules
 export { toPlainObject } from './protobuf-parser.js';
@@ -858,6 +858,36 @@ function processTransaction(
   if (copilotType === 'internal_transfer') {
     txnData.internal_transfer = true;
   }
+
+  warnUnreadFields(
+    fields,
+    {
+      consumed: [
+        // scalar fields handled at the top
+        'transaction_id',
+        'amount',
+        'date',
+        'type',
+        ...stringFields,
+        ...booleanFields,
+        ...numericFields,
+        'created_timestamp',
+        ...stringArrayFields,
+        ...mapFields,
+      ],
+      ignored: [
+        // Nested objects. We read the flat equivalents separately (city,
+        // region, lat, lon, payment_method, ppd_id, etc.), so the nested
+        // parent is deliberately skipped rather than round-tripped.
+        'location',
+        'payment_meta',
+        // Numeric array of ML confidence scores paired with
+        // intelligence_suggested_category_ids. No downstream consumer.
+        'intelligence_category_scores',
+      ],
+    },
+    { collection: 'transactions', docId }
+  );
 
   return validateOrWarn(TransactionSchema, txnData, {
     collection: 'transactions',

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -2299,12 +2299,14 @@ function processChange(fields: Map<string, FirestoreValue>, docId: string): Chan
       if (extracted !== undefined) data[key] = extracted;
     }
   }
+
   warnUnreadFields(
     fields,
     // Generic pass-through reads every raw key.
     { consumed: Array.from(fields.keys()), ignored: [] },
     { collection: 'changes', docId }
   );
+
   return validateOrWarn(ChangeSchema, data, {
     collection: 'changes',
     docId,
@@ -2690,7 +2692,7 @@ function processSubscription(
 
   warnUnreadFields(
     fields,
-    // Explicit fields + generic pass-through below — every raw key is consumed.
+    // Explicit fields + generic pass-through above — every raw key is consumed.
     { consumed: Array.from(fields.keys()), ignored: [] },
     { collection: 'subscriptions', docId }
   );
@@ -2729,7 +2731,7 @@ function processInvite(fields: Map<string, FirestoreValue>, docId: string): Invi
 
   warnUnreadFields(
     fields,
-    // Explicit fields + generic pass-through below — every raw key is consumed.
+    // Explicit fields + generic pass-through above — every raw key is consumed.
     { consumed: Array.from(fields.keys()), ignored: [] },
     { collection: 'invites', docId }
   );

--- a/src/core/schema-warn.ts
+++ b/src/core/schema-warn.ts
@@ -2,9 +2,16 @@
  * Shared helper for the LevelDB decoder. Returns null on Zod failure
  * (preserving caller contract) but emits a structured `console.warn` to
  * stderr so schema drops become auditable instead of silent.
+ *
+ * Also exports `warnUnreadFields` which catches a different, equally silent
+ * class of drops: fields present in the raw Firestore doc that no processor
+ * reads (e.g. a new field Copilot adds upstream). Schema-drop logging can't
+ * catch those because they never reach Zod — the decoder's allow-list filters
+ * them out first.
  */
 
 import type { ZodType } from 'zod';
+import type { FirestoreValue } from './protobuf-parser.js';
 
 export type DecodeContext = {
   collection: string;
@@ -18,6 +25,11 @@ export type DecodeContext = {
 // same issue are silently dropped. If you need every offending docId, grep
 // the cache with the logged path/code.
 const warnedKeys = new Set<string>();
+
+// Dedupe set for warnUnreadFields — separate namespace from schema-drop keys
+// so a `validateOrWarn(collection=X, path=Y)` and an unread-field warn on the
+// same `(X, Y)` don't collide. Reset by __resetWarnedKeys.
+const warnedUnreadKeys = new Set<string>();
 
 export function validateOrWarn<T>(schema: ZodType<T>, data: unknown, ctx: DecodeContext): T | null {
   const result = schema.safeParse(data);
@@ -43,7 +55,43 @@ export function validateOrWarn<T>(schema: ZodType<T>, data: unknown, ctx: Decode
   return null;
 }
 
+/**
+ * Warn once per `(collection, fieldName)` when a raw Firestore doc contains a
+ * field that is neither consumed nor explicitly ignored by the processor.
+ *
+ * Why this exists: `validateOrWarn` protects the Zod boundary. It fires when
+ * a value we attempted to read fails validation. But the allow-list in every
+ * `process*` function drops unknown fields before Zod ever sees them — if
+ * Copilot ships a new field, we'd never know. This helper closes that gap.
+ *
+ * Rules:
+ *   - `consumed`: fields the processor actively reads (e.g. `stringFields`).
+ *   - `ignored`: fields we know about but deliberately drop (e.g. denormalized
+ *     nested objects where we read the flat equivalents, or noisy intelligence
+ *     scores). Entries here document intent.
+ *   - Any raw key not in either set emits one `console.warn` per process.
+ *   - Consumed and ignored may overlap freely (e.g. if a field is read in
+ *     some branches and ignored in others).
+ */
+export function warnUnreadFields(
+  fields: Map<string, FirestoreValue>,
+  options: { consumed: readonly string[]; ignored: readonly string[] },
+  ctx: DecodeContext
+): void {
+  const known = new Set<string>([...options.consumed, ...options.ignored]);
+  for (const key of fields.keys()) {
+    if (known.has(key)) continue;
+    const dedupeKey = `unread::${ctx.collection}::${key}`;
+    if (warnedUnreadKeys.has(dedupeKey)) continue;
+    warnedUnreadKeys.add(dedupeKey);
+    console.warn(
+      `[copilot-money-mcp] unread field: collection=${ctx.collection} docId=${ctx.docId} field=${key}`
+    );
+  }
+}
+
 // Exposed for tests only.
 export function __resetWarnedKeys(): void {
   warnedKeys.clear();
+  warnedUnreadKeys.clear();
 }

--- a/tests/core/decoder-leveldb.test.ts
+++ b/tests/core/decoder-leveldb.test.ts
@@ -187,9 +187,14 @@ describe('LevelDB Decoder', () => {
         expect(result.length).toBe(1);
         expect(result[0]?.transaction_id).toBe('txn_good');
         expect(warnSpy).toHaveBeenCalled();
-        const message = warnSpy.mock.calls[0]?.[0] as string;
-        expect(message).toContain('collection=transactions');
-        expect(message).toContain('path=date');
+        // The same fixture may also trigger unread-field warns (helper fields
+        // like is_transfer/note/tags are not part of the Copilot schema), so
+        // find the schema-drop entry rather than indexing calls[0].
+        const messages = warnSpy.mock.calls.map((c) => c[0] as string);
+        const schemaDrop = messages.find((m) => m.includes('schema drop'));
+        expect(schemaDrop).toBeDefined();
+        expect(schemaDrop).toContain('collection=transactions');
+        expect(schemaDrop).toContain('path=date');
       } finally {
         warnSpy.mockRestore();
       }

--- a/tests/core/schema-warn.test.ts
+++ b/tests/core/schema-warn.test.ts
@@ -11,7 +11,8 @@
 
 import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { z } from 'zod';
-import { validateOrWarn, __resetWarnedKeys } from '../../src/core/schema-warn.js';
+import { validateOrWarn, warnUnreadFields, __resetWarnedKeys } from '../../src/core/schema-warn.js';
+import type { FirestoreValue } from '../../src/core/protobuf-parser.js';
 
 const Schema = z.object({
   id: z.string(),
@@ -127,7 +128,7 @@ describe('validateOrWarn', () => {
     expect(warnSpy).toHaveBeenCalledTimes(2);
   });
 
-  test('__resetWarnedKeys clears state between runs', () => {
+  test('__resetWarnedKeys clears state between runs (schema-drop path)', () => {
     validateOrWarn(
       Schema,
       { id: 'x', amount: 'bad' },
@@ -147,6 +148,131 @@ describe('validateOrWarn', () => {
         collection: 'accounts',
         docId: 'doc2',
       }
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('warnUnreadFields', () => {
+  let warnSpy: ReturnType<typeof spyOn>;
+
+  // Small factory for FirestoreValue-shaped test fixtures — we only care about
+  // the .keys() of the Map, not the values, so `type: 'string'` is fine.
+  function fakeFields(keys: string[]): Map<string, FirestoreValue> {
+    return new Map(keys.map((k) => [k, { type: 'string', value: '' } as FirestoreValue]));
+  }
+
+  beforeEach(() => {
+    __resetWarnedKeys();
+    warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test('emits no warns when every raw field is consumed', () => {
+    warnUnreadFields(
+      fakeFields(['a', 'b']),
+      {
+        consumed: ['a', 'b'],
+        ignored: [],
+      },
+      { collection: 'transactions', docId: 'doc1' }
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('emits no warns when every raw field is explicitly ignored', () => {
+    warnUnreadFields(
+      fakeFields(['legacy1', 'legacy2']),
+      {
+        consumed: [],
+        ignored: ['legacy1', 'legacy2'],
+      },
+      { collection: 'accounts', docId: 'doc1' }
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('warns once per unknown field with collection+docId+field in message', () => {
+    warnUnreadFields(
+      fakeFields(['known', 'mystery_field']),
+      {
+        consumed: ['known'],
+        ignored: [],
+      },
+      { collection: 'transactions', docId: 'doc42' }
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = warnSpy.mock.calls[0][0] as string;
+    expect(msg).toContain('copilot-money-mcp');
+    expect(msg).toContain('unread field');
+    expect(msg).toContain('collection=transactions');
+    expect(msg).toContain('docId=doc42');
+    expect(msg).toContain('field=mystery_field');
+  });
+
+  test('dedupes the same (collection, field) across calls', () => {
+    warnUnreadFields(
+      fakeFields(['new_thing']),
+      { consumed: [], ignored: [] },
+      { collection: 'transactions', docId: 'doc1' }
+    );
+    warnUnreadFields(
+      fakeFields(['new_thing']),
+      { consumed: [], ignored: [] },
+      { collection: 'transactions', docId: 'doc2' }
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('same field across different collections emits separate warns', () => {
+    warnUnreadFields(
+      fakeFields(['shared']),
+      { consumed: [], ignored: [] },
+      { collection: 'transactions', docId: 'doc1' }
+    );
+    warnUnreadFields(
+      fakeFields(['shared']),
+      { consumed: [], ignored: [] },
+      { collection: 'accounts', docId: 'doc2' }
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('multiple unknown fields in one call emit one warn each', () => {
+    warnUnreadFields(
+      fakeFields(['known', 'mystery_a', 'mystery_b']),
+      { consumed: ['known'], ignored: [] },
+      { collection: 'transactions', docId: 'doc1' }
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('consumed and ignored entries can overlap without crashing', () => {
+    warnUnreadFields(
+      fakeFields(['a']),
+      { consumed: ['a'], ignored: ['a'] },
+      { collection: 'transactions', docId: 'doc1' }
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test('__resetWarnedKeys clears unread-field dedupe state too', () => {
+    warnUnreadFields(
+      fakeFields(['x']),
+      { consumed: [], ignored: [] },
+      { collection: 'transactions', docId: 'doc1' }
+    );
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    __resetWarnedKeys();
+
+    warnUnreadFields(
+      fakeFields(['x']),
+      { consumed: [], ignored: [] },
+      { collection: 'transactions', docId: 'doc2' }
     );
     expect(warnSpy).toHaveBeenCalledTimes(2);
   });


### PR DESCRIPTION
## Summary
- Wires `warnUnreadFields` (introduced in 8e72f97) into all 28 remaining `process*` functions in `src/core/decoder.ts` — every processor now emits a one-time `console.warn` when a raw Firestore doc carries a field neither consumed nor explicitly ignored by its allow-list.
- Each `consumed` list is derived from what the processor actually reads (the in-function `stringFields`/`booleanFields`/`numericFields`/`stringArrayFields`/`mapFields` arrays plus direct `getString`/`getMap`/... calls). `ignored` starts empty on all new call sites — a real-DB probe will populate it in a follow-up.
- Processors that use a generic `for (const [key, value] of fields)` pass-through (holdings_history, changes, amazon_integrations, subscriptions, invites, user_items, feature_tracking, support) spread `Array.from(fields.keys())` into `consumed`; the call is effectively a no-op today but keeps coverage symmetric so the site is ready when one of them gets a specific allow-list.
- `processSubChange` logs under three distinct collection strings (`transaction_changes`, `account_changes`, `change_sub`) mirroring its existing `validateOrWarn` branches.
- `processUserAccount` has no `validateOrWarn` call (it returns a plain object); its warn is logged under collection=`user_accounts` to keep telemetry distinct from the main `accounts` collection.

## Judgment calls
- **`processPlaidAccount` already surfaced `field=type` as unread** against the existing test fixture. `processPlaidAccount` reads `account_type` but not `type`, where `processAccount` reads both. Left as-is — the warn fires exactly as designed, and the fix belongs in a follow-up PR along with other real-DB findings.
- The schema-drop ordering test in `tests/core/decoder-leveldb.test.ts` was updated to scan all `warnSpy` calls for the schema-drop message rather than indexing `calls[0]`, because fixture helper fields (`is_transfer`, `note`, `tags`) correctly trigger unread-field warns ahead of the schema-drop warn being asserted.

## Follow-up
- Run the decoder against the real local Copilot Firestore cache, capture the set of `unread field:` warnings emitted, and decide per field whether to (a) add it to the processor's `consumed` list (and read it into the output), or (b) add it to `ignored` with a comment explaining why it is deliberately dropped.

## Test plan
- [x] `bun test tests/core/decoder-coverage.test.ts tests/core/schema-warn.test.ts` passes (135 tests).
- [x] `bun run check` passes end-to-end (1449 pass, 21 skip, 0 fail across 64 files).
- [ ] Real-DB probe (follow-up PR) to populate `ignored` lists per collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)