### PR TITLE
feat(decoder): close all real-DB field coverage gaps

### DIFF
--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -23,7 +23,7 @@ import { Goal, GoalSchema } from '../models/goal.js';
 import { GoalHistory, GoalHistorySchema, DailySnapshot } from '../models/goal-history.js';
 import { InvestmentPrice, InvestmentPriceSchema } from '../models/investment-price.js';
 import { InvestmentSplit, InvestmentSplitSchema } from '../models/investment-split.js';
-import { Item, ItemSchema } from '../models/item.js';
+import { Item, ItemSchema, IGNORED_ITEM_FIELDS } from '../models/item.js';
 import { Category, CategorySchema } from '../models/category.js';
 import {
   InvestmentPerformance,
@@ -815,6 +815,9 @@ function processTransaction(
     'skip_balance_adjust',
     'user_deleted',
     'intelligence_powered',
+    // Some docs store internal_transfer directly as a boolean in addition to
+    // (or instead of) the string `type === "internal_transfer"` pattern.
+    'internal_transfer',
   ];
 
   for (const field of booleanFields) {
@@ -839,6 +842,8 @@ function processTransaction(
     'intelligence_suggested_category_ids',
     'tag_ids',
     'children_transaction_ids',
+    // Legacy/alternative name for intelligence_suggested_category_ids.
+    'suggestion_ids',
   ];
 
   for (const field of stringArrayFields) {
@@ -927,6 +932,9 @@ function processAccount(fields: Map<string, FirestoreValue>, docId: string): Acc
     '_origin',
     'nickname',
     'group_id',
+    'user_id',
+    // Stable account ID that survives provider re-auth; safer join key than item/id.
+    'persistent_account_id',
   ];
 
   for (const field of stringFields) {
@@ -963,6 +971,16 @@ function processAccount(fields: Map<string, FirestoreValue>, docId: string): Acc
   if (availableBalance !== undefined) {
     accData.available_balance = Math.round(availableBalance * 100) / 100;
   }
+
+  // Last auto-sync balance snapshot — used when live fetches aren't available.
+  const lastAutoBalance = getNumber(fields, 'last_auto_current_balance');
+  if (lastAutoBalance !== undefined) {
+    accData.last_auto_current_balance = Math.round(lastAutoBalance * 100) / 100;
+  }
+
+  // IDs of financial_goals this account funds (emergency fund, vacation, etc.).
+  const financialGoalIds = getStringArray(fields, 'financial_goal_ids');
+  if (financialGoalIds) accData.financial_goal_ids = financialGoalIds;
 
   // Check for null limit (credit cards) vs numeric limit
   const limitField = fields.get('limit');
@@ -1056,6 +1074,8 @@ function processAccount(fields: Map<string, FirestoreValue>, docId: string): Acc
         'holdings',
         'metadata',
         'merged',
+        'last_auto_current_balance',
+        'financial_goal_ids',
         ...stringFields,
         ...booleanFields,
       ],
@@ -1505,6 +1525,11 @@ function processInvestmentPrice(
     if (value) priceData[field] = value;
   }
 
+  // The actual price payload — keyed by day-of-month on daily docs and by
+  // intraday timestamp on hf docs. Values carry numeric prices plus metadata.
+  const pricesMap = getMap(fields, 'prices');
+  if (pricesMap) priceData.prices = toPlainObject(pricesMap);
+
   warnUnreadFields(
     fields,
     {
@@ -1513,6 +1538,7 @@ function processInvestmentPrice(
         'ticker_symbol',
         'date',
         'month',
+        'prices',
         ...priceFields,
         ...ohlcvFields,
         ...metaFields,
@@ -1675,6 +1701,14 @@ function processItem(fields: Map<string, FirestoreValue>, docId: string): Item |
   const fetchDataMap = getMap(fields, 'fetch_data');
   if (fetchDataMap) itemData.fetch_data = toPlainObject(fetchDataMap);
 
+  // Plaid error payload — richer than the flat error_code/error_message fields.
+  const errorMap = getMap(fields, 'error');
+  if (errorMap) itemData.error = toPlainObject(errorMap);
+
+  // OAuth flow metadata for institutions that use OAuth auth.
+  const oauthMap = getMap(fields, 'oauth');
+  if (oauthMap) itemData.oauth = toPlainObject(oauthMap);
+
   warnUnreadFields(
     fields,
     {
@@ -1682,11 +1716,13 @@ function processItem(fields: Map<string, FirestoreValue>, docId: string): Item |
         'item_id',
         'products',
         'fetch_data',
+        'error',
+        'oauth',
         ...stringFields,
         ...timestampFields,
         ...boolFields,
       ],
-      ignored: [],
+      ignored: IGNORED_ITEM_FIELDS,
     },
     { collection: 'items', docId }
   );
@@ -1721,7 +1757,14 @@ function processCategory(fields: Map<string, FirestoreValue>, docId: string): Ca
   const order = getNumber(fields, 'order');
   if (order !== undefined) categoryData.order = order;
 
-  const booleanFields = ['excluded', 'is_other', 'auto_budget_lock', 'auto_delete_lock'];
+  const booleanFields = [
+    'excluded',
+    'is_other',
+    'auto_budget_lock',
+    'auto_delete_lock',
+    // Per-category budget rollover toggle.
+    'rollover_disabled',
+  ];
   for (const field of booleanFields) {
     const value = getBoolean(fields, field);
     if (value !== undefined) categoryData[field] = value;
@@ -2599,8 +2642,9 @@ function processAmazonOrder(
     data.amazon_user_id = parts[amazonIdx + 1];
   }
 
-  // String fields
-  for (const field of ['date', 'account_id', 'match_state']) {
+  // String fields. `id` parallels order_id (Copilot stores both); copilot_tx is
+  // set once Copilot matches this order to a posted transaction.
+  for (const field of ['date', 'account_id', 'match_state', 'id', 'copilot_tx']) {
     const value = getString(fields, field) ?? getDateString(fields, field);
     if (value !== undefined) data[field] = value;
   }
@@ -2634,6 +2678,8 @@ function processAmazonOrder(
         'date',
         'account_id',
         'match_state',
+        'id',
+        'copilot_tx',
         'items',
         'details',
         'payment',

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -76,6 +76,16 @@ export const AccountSchema = z
     // Visibility - accounts marked as deleted by user or merged into other accounts
     user_deleted: z.boolean().optional(),
 
+    // Ownership & linkage
+    user_id: z.string().optional(),
+    // Stable account identifier that survives re-linking (the provider-side ID
+    // doesn't persist across reconnects; persistent_account_id does).
+    persistent_account_id: z.string().optional(),
+    // Last automated balance snapshot — used when a live fetch isn't available.
+    last_auto_current_balance: z.number().optional(),
+    // IDs of financial_goals linked to this account (funds toward emergency fund, etc.).
+    financial_goal_ids: z.array(z.string()).optional(),
+
     // Investment fields
     holdings: z.array(AccountHoldingSchema).optional(),
     holdings_initialized: z.boolean().optional(),

--- a/src/models/amazon.ts
+++ b/src/models/amazon.ts
@@ -29,6 +29,12 @@ const AmazonOrderItemSchema = z
 export const AmazonOrderSchema = z
   .object({
     order_id: z.string(),
+    // Copilot also stores the same ID under `id` on the order doc — preserved
+    // verbatim so downstream consumers that dereference the raw doc still work.
+    id: z.string().optional(),
+    // Copilot's linked transaction ID. Set once Copilot matches this Amazon
+    // order to a posted transaction; used to join item-level receipts to spend.
+    copilot_tx: z.string().optional(),
     amazon_user_id: z.string().optional(),
     date: z.string().optional(),
     account_id: z.string().optional(),

--- a/src/models/category.ts
+++ b/src/models/category.ts
@@ -37,6 +37,8 @@ export const CategorySchema = z
     is_other: z.boolean().optional(),
     auto_budget_lock: z.boolean().optional(),
     auto_delete_lock: z.boolean().optional(),
+    // Whether unused budget for this category carries forward to next month.
+    rollover_disabled: z.boolean().optional(),
 
     // Plaid mapping - links custom categories to standard Plaid categories
     plaid_category_ids: z.array(z.string()).optional(),

--- a/src/models/investment-price.ts
+++ b/src/models/investment-price.ts
@@ -54,6 +54,12 @@ export const InvestmentPriceSchema = z
     currency: z.string().optional(), // "USD", etc.
     source: z.string().optional(), // Data source identifier
     price_type: z.string().optional(), // "daily" or "hf"
+
+    // Nested price payload. For daily docs this is keyed by day-of-month (`01`–`31`);
+    // for hf docs it's keyed by intraday timestamp. Values carry the numeric price
+    // plus source metadata. The schema stays loose because the key space varies by
+    // price_type — consumers should inspect `prices` alongside `date`/`month`.
+    prices: z.record(z.string(), z.unknown()).optional(),
   })
   .passthrough(); // Allow additional fields we haven't discovered yet
 

--- a/src/models/item.ts
+++ b/src/models/item.ts
@@ -81,9 +81,9 @@ export const ItemSchema = z
     accounts: z.array(z.string()).optional(), // Array of account IDs linked to this item
     account_count: z.number().optional(), // Number of accounts
 
-    // Metadata
-    available_products: z.array(z.string()).optional(), // Available Plaid products
-    billed_products: z.array(z.string()).optional(), // Products billed for this item
+    // Metadata. Note: available_products / billed_products / optional_products
+    // are declared in IGNORED_ITEM_FIELDS and never populated by the decoder,
+    // so they intentionally don't appear here.
     created_at: z.string().optional(), // When item was created
     updated_at: z.string().optional(), // Last update timestamp
     webhook: z.string().optional(), // Webhook URL for updates

--- a/src/models/item.ts
+++ b/src/models/item.ts
@@ -72,6 +72,9 @@ export const ItemSchema = z
     error_code: z.string().optional(), // Plaid error code
     error_message: z.string().optional(), // Human-readable error message
     error_type: z.string().optional(), // Error type (e.g., "ITEM_ERROR")
+    // Full Plaid error payload — richer than the flat error_* fields.
+    // Contains { error_code, error_message, error_type, display_message, ... }.
+    error: z.record(z.string(), z.unknown()).optional(),
     needs_update: z.boolean().optional(), // Flag indicating re-authentication needed
 
     // Account linkage
@@ -102,6 +105,9 @@ export const ItemSchema = z
     disconnect_attempted: z.string().optional(),
     disconnect_attempted_error: z.string().optional(),
     fetch_data: z.record(z.string(), z.unknown()).optional(),
+    // OAuth flow metadata — present for institutions that use OAuth rather
+    // than direct-credential auth. Shape varies by provider.
+    oauth: z.record(z.string(), z.unknown()).optional(),
     id: z.string().optional(),
     latest_investments_refresh: z.string().optional(),
     status_last_webhook_code_sent: z.string().optional(),
@@ -110,6 +116,27 @@ export const ItemSchema = z
   .passthrough(); // Allow additional fields we haven't discovered yet
 
 export type Item = z.infer<typeof ItemSchema>;
+
+/**
+ * Fields Copilot stores on item docs that we deliberately drop at the decoder
+ * boundary. Keeping this list next to the schema documents *why* each field is
+ * withheld — especially the sensitive ones — and feeds the `ignored` option of
+ * `warnUnreadFields` so unseen-field warnings stay off for them.
+ *
+ * Treat access tokens as sensitive even when we're reading them off a local
+ * file: they're bearer credentials for the user's bank connection.
+ */
+export const IGNORED_ITEM_FIELDS = [
+  // Plaid bearer credentials — never surface to tool output.
+  'access_token',
+  'deleted_access_token',
+  // Non-Plaid aggregator (Akoya) metadata; no downstream consumer.
+  'akoya',
+  // Plaid product feature flags — useful to Copilot internally, not to the MCP's tools.
+  'available_products',
+  'billed_products',
+  'optional_products',
+] as const;
 
 /**
  * Get the display name for an item (institution name or fallback).

--- a/src/models/transaction.ts
+++ b/src/models/transaction.ts
@@ -89,6 +89,8 @@ export const TransactionSchema = z
     intelligence_suggested_category_ids: z.array(z.string()).optional(),
     intelligence_chosen_category_id: z.string().optional(),
     intelligence_powered: z.boolean().optional(),
+    // Alternative/legacy name some docs carry alongside intelligence_suggested_category_ids
+    suggestion_ids: z.array(z.string()).optional(),
 
     // Recurring references
     recurring_id: z.string().optional(),

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -1071,7 +1071,7 @@ export class CopilotMoneyTools {
         institution_name: getItemDisplayName(item),
         institution_id: item.institution_id,
         status,
-        products: item.billed_products ?? [],
+        products: item.products ?? [],
         last_transactions_update: item.status_transactions_last_successful_update ?? null,
         last_transactions_failed: item.status_transactions_last_failed_update ?? null,
         last_investments_update: item.status_investments_last_successful_update ?? null,

--- a/tests/core/decoder-coverage.test.ts
+++ b/tests/core/decoder-coverage.test.ts
@@ -2,7 +2,8 @@
  * Additional tests for decoder.ts to achieve 100% code coverage.
  */
 
-import { describe, test, expect, afterEach, beforeEach } from 'bun:test';
+import { describe, test, expect, afterEach, beforeEach, spyOn } from 'bun:test';
+import { __resetWarnedKeys } from '../../src/core/schema-warn.js';
 import {
   extractValue,
   decodeInvestmentPrices,
@@ -894,6 +895,138 @@ describe('decoder coverage', () => {
 
       const childB = txns.find((t) => t.transaction_id === 'child-b')!;
       expect(childB.parent_transaction_id).toBe('parent-1');
+    });
+
+    test('round-trips real-DB coverage fields (transactions/accounts/categories/items/investment_prices/amazon_orders)', async () => {
+      // Locks in the 12 fields added in the "close all real-DB coverage gaps"
+      // PR. Each block asserts the decoder surfaces the new field; collectively
+      // they guard against regressions that would make these fields silently
+      // drop again (the exact class of bug that motivated the whole coverage-
+      // warn effort).
+      const dbPath = path.join(FIXTURES_DIR, 'coverage-fields-db');
+      await createTestDatabase(dbPath, [
+        // transactions: internal_transfer (boolean direct) + suggestion_ids
+        {
+          collection: 'transactions',
+          id: 'txn-cov',
+          fields: {
+            transaction_id: 'txn-cov',
+            amount: 25,
+            date: '2026-04-20',
+            name: 'Test',
+            internal_transfer: true,
+            suggestion_ids: ['sug-a', 'sug-b'],
+          },
+        },
+        // accounts: financial_goal_ids + last_auto_current_balance + persistent_account_id + user_id
+        {
+          collection: 'accounts',
+          id: 'acc-cov',
+          fields: {
+            account_id: 'acc-cov',
+            name: 'Coverage Checking',
+            current_balance: 1000,
+            account_type: 'depository',
+            user_id: 'user-123',
+            persistent_account_id: 'persist-xyz',
+            last_auto_current_balance: 999.5,
+            financial_goal_ids: ['goal-a', 'goal-b'],
+          },
+        },
+        // categories: rollover_disabled
+        {
+          collection: 'categories',
+          id: 'cat-cov',
+          fields: {
+            category_id: 'cat-cov',
+            name: 'Test Category',
+            rollover_disabled: true,
+          },
+        },
+        // amazon_orders: copilot_tx + id
+        {
+          collection: 'amazon/u1/orders',
+          id: 'order-cov',
+          fields: {
+            date: '2026-04-20',
+            id: 'dup-order-id',
+            copilot_tx: 'linked-tx-123',
+          },
+        },
+        // items: error + oauth
+        {
+          collection: 'items',
+          id: 'item-cov',
+          fields: {
+            item_id: 'item-cov',
+            institution_name: 'Test Bank',
+            error: { error_code: 'ITEM_LOGIN_REQUIRED', display_message: 'Please re-authenticate' },
+            oauth: { state: 'connected', last_refresh: '2026-04-20' },
+          },
+        },
+      ]);
+
+      const { transactions, accounts, categories, items, amazonOrders } =
+        await decodeAllCollections(dbPath);
+
+      const txn = transactions.find((t) => t.transaction_id === 'txn-cov')!;
+      expect(txn.internal_transfer).toBe(true);
+      expect(txn.suggestion_ids).toEqual(['sug-a', 'sug-b']);
+
+      const acc = accounts.find((a) => a.account_id === 'acc-cov')!;
+      expect(acc.user_id).toBe('user-123');
+      expect(acc.persistent_account_id).toBe('persist-xyz');
+      expect(acc.last_auto_current_balance).toBe(999.5);
+      expect(acc.financial_goal_ids).toEqual(['goal-a', 'goal-b']);
+
+      const cat = categories.find((c) => c.category_id === 'cat-cov')!;
+      expect(cat.rollover_disabled).toBe(true);
+
+      const order = amazonOrders.find((o) => o.order_id === 'order-cov')!;
+      expect(order.id).toBe('dup-order-id');
+      expect(order.copilot_tx).toBe('linked-tx-123');
+
+      const item = items.find((i) => i.item_id === 'item-cov')!;
+      expect(item.error).toEqual({
+        error_code: 'ITEM_LOGIN_REQUIRED',
+        display_message: 'Please re-authenticate',
+      });
+      expect(item.oauth).toEqual({ state: 'connected', last_refresh: '2026-04-20' });
+    });
+
+    test('IGNORED_ITEM_FIELDS suppresses warns for sensitive + Plaid metadata fields', async () => {
+      // If the decoder ever stops passing IGNORED_ITEM_FIELDS to warnUnreadFields,
+      // this test's warn-spy assertion will flip to expect.toHaveBeenCalled() and
+      // fail — catching the regression at the source.
+      const dbPath = path.join(FIXTURES_DIR, 'ignored-item-fields-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'items',
+          id: 'item-ignored',
+          fields: {
+            item_id: 'item-ignored',
+            institution_name: 'Sensitive Bank',
+            access_token: 'access-sandbox-SENSITIVE',
+            deleted_access_token: 'access-sandbox-OLD',
+            akoya: 'akoya-metadata',
+            available_products: ['transactions', 'auth'],
+            billed_products: ['transactions'],
+            optional_products: ['investments'],
+          },
+        },
+      ]);
+
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        __resetWarnedKeys();
+        await decodeItems(dbPath);
+        const unreadItemWarns = warnSpy.mock.calls
+          .map((call) => String(call[0] ?? ''))
+          .filter((msg) => msg.includes('collection=items') && msg.includes('unread field'));
+        expect(unreadItemWarns).toEqual([]);
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 

--- a/tests/core/decoder-coverage.test.ts
+++ b/tests/core/decoder-coverage.test.ts
@@ -964,9 +964,24 @@ describe('decoder coverage', () => {
             oauth: { state: 'connected', last_refresh: '2026-04-20' },
           },
         },
+        // investment_prices: the `prices` payload map
+        {
+          collection: 'investment_prices',
+          id: 'inv-cov',
+          fields: {
+            investment_id: 'inv-cov',
+            ticker_symbol: 'COV',
+            date: '2026-04-20',
+            currency: 'USD',
+            prices: {
+              '2026-04-20': { price: 150.5, source: 'plaid' },
+              '2026-04-19': { price: 149.0, source: 'plaid' },
+            },
+          },
+        },
       ]);
 
-      const { transactions, accounts, categories, items, amazonOrders } =
+      const { transactions, accounts, categories, items, amazonOrders, investmentPrices } =
         await decodeAllCollections(dbPath);
 
       const txn = transactions.find((t) => t.transaction_id === 'txn-cov')!;
@@ -992,6 +1007,13 @@ describe('decoder coverage', () => {
         display_message: 'Please re-authenticate',
       });
       expect(item.oauth).toEqual({ state: 'connected', last_refresh: '2026-04-20' });
+
+      const price = investmentPrices.find((p) => p.investment_id === 'inv-cov')!;
+      expect(price).toBeDefined();
+      expect(price.prices).toEqual({
+        '2026-04-20': { price: 150.5, source: 'plaid' },
+        '2026-04-19': { price: 149.0, source: 'plaid' },
+      });
     });
 
     test('IGNORED_ITEM_FIELDS suppresses warns for sensitive + Plaid metadata fields', async () => {

--- a/tests/integration/tools.test.ts
+++ b/tests/integration/tools.test.ts
@@ -572,7 +572,10 @@ describe('CopilotMoneyTools Integration', () => {
             item_id: 'item1',
             institution_name: 'Chase',
             institution_id: 'ins_56',
-            billed_products: ['transactions'],
+            // getConnectionStatus now reads item.products (which the decoder
+            // actually populates) instead of item.billed_products (which was
+            // always undefined, so the field used to always return []).
+            products: ['transactions'],
             status_transactions_last_successful_update: '2026-03-08T06:14:29.057Z',
             latest_fetch: '2026-03-08T06:14:34.117Z',
             login_required: false,


### PR DESCRIPTION
## Summary

A full smoke run of `decodeAllCollections` against a real Copilot DB (via the `warnUnreadFields` infra that shipped in PR #316) surfaced **18 unique unread fields across 6 collections**. This PR triages every one of them so the next smoke run emits zero warnings.

## Triage

### Decoded + added to schema (12 fields)

| Collection | Field | Why |
|---|---|---|
| `accounts` | `financial_goal_ids` | Links account → goals |
| `accounts` | `last_auto_current_balance` | Last auto-sync balance snapshot |
| `accounts` | `persistent_account_id` | Stable ID that survives re-linking (better join key) |
| `accounts` | `user_id` | Owner ID |
| `categories` | `rollover_disabled` | Per-category budget rollover toggle |
| `investment_prices` | `prices` | The actual price payload — we decoded every metadata field but dropped the data itself |
| `amazon_orders` | `copilot_tx` | Links the Amazon order to Copilot's matched transaction |
| `amazon_orders` | `id` | Copilot stores order ID under both `order_id` and `id` |
| `items` | `error` | Full Plaid error payload — richer than the flat `error_code`/`error_message` |
| `items` | `oauth` | OAuth flow metadata for OAuth institutions |
| `transactions` | `internal_transfer` | Boolean on the doc directly, in addition to the `type === \"internal_transfer\"` pattern |
| `transactions` | `suggestion_ids` | Legacy/alternative name alongside `intelligence_suggested_category_ids` |

### Documented as intentionally ignored (6 fields)

Exported as `IGNORED_ITEM_FIELDS` from `src/models/item.ts` — colocated with the Zod schema so the domain knowledge about what's in an items doc lives with the schema, not inside `decoder.ts`:

- `access_token`, `deleted_access_token` — **Plaid bearer credentials.** Must never surface to tool output.
- `akoya` — non-Plaid aggregator metadata; no downstream consumer.
- `available_products`, `billed_products`, `optional_products` — Plaid feature flags; useful to Copilot internally, not to our tools.

## Verification

Before:
```
⚠️  18 unique unread field(s) across 6 collection(s)
```

After:
```
✅ No unread fields found across any collection.
```

(28 collections exercised. 2 collections — `changes`, `userAccounts` — have zero docs in the test DB so their processors weren't exercised; future user activity will eventually fire warnings for them if any gaps exist.)

## Test plan
- [x] `bun run check` — 1449 pass, 0 fail
- [x] Smoke run against real DB — 0 unread fields across all 28 exercised collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)