### PR TITLE
docs(graphql): catalog hidden mutations + error-leak recon methodology

### DIFF
--- a/docs/graphql-capture/hidden-mutations.md
+++ b/docs/graphql-capture/hidden-mutations.md
@@ -1,0 +1,214 @@
+# Hidden Copilot Money Mutations
+
+Mutations discovered on Copilot's GraphQL endpoint (`https://app.copilot.money/api/graphql`) that the web-session capture never observed. Surfaced by error-leak recon (see [`introspection-recon.md`](./introspection-recon.md)).
+
+Signatures below reflect only what the server confirmed via validation errors. Optional input fields and non-required output fields may exist but are hidden by Apollo's error suppression — "unknowns" are called out per mutation.
+
+## Summary
+
+| Mutation | MCP tool yet? | Risk | Primary use |
+|---|---|---|---|
+| [`splitTransaction`](#splittransaction) | ❌ | medium (reversal via edit/delete) | Split one transaction into N children |
+| [`createTransaction`](#createtransaction) | ❌ | medium | Manual-account transactions |
+| [`deleteTransaction`](#deletetransaction) | ❌ | high (destructive) | Remove a transaction |
+| [`addTransactionToRecurring`](#addtransactiontorecurring) | ❌ | low | Attach one-off to existing recurring |
+| [`bulkEditTransactions`](#bulkedittransactions) | ❌ | **DO NOT PROBE** blindly | Edit many transactions at once |
+| [`bulkDeleteTransactions`](#bulkdeletetransactions) | ❌ | **high (destructive)** | Delete many transactions |
+| [`createAccount`](#createaccount) | ❌ | medium | Manual account creation |
+| [`deleteAccount`](#deleteaccount) | ❌ | high (cascades to all txns) | Remove a manual account |
+| [`deleteUser`](#deleteuser) | ❌ | **existential** | Delete the entire user account |
+
+No other hidden mutations surfaced across the ~460-candidate sweep (see `scripts/recon/probe-mutations-wide.ts`).
+
+## Budget mutations — finding
+
+**No hidden budget mutations exist.** Budget CRUD is entirely captured by `editBudget(categoryId, input)` and `editBudgetMonthly(categoryId, input)` — Copilot treats a budget as an *attribute of a category*, not a separate entity. No `createBudget`, `deleteBudget`, `resetBudget`, or `rolloverBudget` exist on the server. "Removing" a budget is done by calling `editBudget` with the appropriate zero/null amount.
+
+## Goal mutations — finding
+
+**No goal mutations exist on the GraphQL endpoint.** Probes for `createGoal`, `editGoal`, `deleteGoal`, `archiveGoal`, `contributeToGoal`, `transferToGoal` all returned "Cannot query field". Goals are read-only via this API — any changes go through a different channel (likely direct Firestore writes from the iOS app).
+
+---
+
+## splitTransaction
+
+Signature:
+
+```graphql
+mutation SplitTransaction(
+  $itemId:    ID!
+  $accountId: ID!
+  $id:        ID!                         # parent transaction's ID
+  $input:     [SplitTransactionInput!]!   # one entry per child split
+) {
+  splitTransaction(itemId: $itemId, accountId: $accountId, id: $id, input: $input) {
+    parentTransaction  { id }             # original, "hidden" after split
+    splitTransactions  { id }             # new child docs
+  }
+}
+
+input SplitTransactionInput {
+  name:       String!   # display name per split (e.g. "Rent", "Hotel")
+  date:       Date!     # typically matches parent.date
+  amount:     Float!    # children must sum to parent.amount (server enforces)
+  categoryId: ID!       # required per split
+}
+```
+
+**Return shape:** `SplitTransactionOutput!` has exactly two fields: `parentTransaction: Transaction!` and `splitTransactions: [Transaction!]!`.
+
+**Unknowns:** optional fields on `SplitTransactionInput` (tags, notes, isReviewed, etc. all rejected as "not defined" — the server really does only accept the four required fields at split time). Downstream edits require per-child `editTransaction` calls.
+
+**How splits manifest in Firestore (for the cache):** after success, the parent doc gets `children_transaction_ids: [...]` with the new child IDs and `category_id: ""` + `old_category_id: <original>`. Each child doc gets `parent_transaction_id: <parent>`. This is what the Phase 1 decoder work (PR #315) surfaces to MCP consumers.
+
+**Reversal:** no dedicated mutation. Probes for `unsplitTransaction`, `revertSplit`, `undoSplit` all "Cannot query field". To undo a split, callers would delete each child (via `deleteTransaction`) and then edit the parent to restore its category — but Copilot's UI also supports reverting via "edit split → remove all entries".
+
+---
+
+## createTransaction
+
+```graphql
+mutation CreateTransaction(
+  $itemId:    ID!
+  $accountId: ID!
+  $input:     CreateTransactionInput!
+) {
+  createTransaction(itemId: $itemId, accountId: $accountId, input: $input) {
+    id
+    # Transaction fields per existing TransactionFields fragment
+  }
+}
+
+input CreateTransactionInput {
+  name:       String!
+  date:       Date!
+  amount:     Float!
+  categoryId: ID!
+  type:       TransactionType!   # enum — values unknown, needs probe
+  # Optional fields unknown
+}
+```
+
+**Unknowns:**
+- `TransactionType` enum values — Copilot UI allows manual transactions to be "expense", "income", or "transfer" so those are likely candidates. Confirm by sending an invalid value and harvesting the "must be one of" list.
+- Optional input fields (notes, tags, isReviewed, etc.).
+
+**Intended use:** This is what Copilot uses when the user adds a manual transaction to a manual account. Plaid-connected accounts should not be written to this way — they'd be overwritten on the next sync.
+
+---
+
+## deleteTransaction
+
+```graphql
+mutation DeleteTransaction($itemId: ID!, $accountId: ID!, $id: ID!) {
+  deleteTransaction(itemId: $itemId, accountId: $accountId, id: $id)   # Boolean!
+}
+```
+
+Returns `Boolean!`. **Destructive — no soft-delete.** Firestore picks up the removal and Copilot's clients stop rendering it.
+
+**Caveat:** probably idempotent-safe on Plaid transactions (Plaid re-syncs and the transaction comes back on next refresh) but this hasn't been confirmed.
+
+---
+
+## addTransactionToRecurring
+
+```graphql
+mutation AddTransactionToRecurring(
+  $itemId:    ID!
+  $accountId: ID!
+  $id:        ID!                          # transaction ID to attach
+  $input:     AddTransactionToRecurringInput!
+) {
+  addTransactionToRecurring(itemId: $itemId, accountId: $accountId, id: $id, input: $input) {
+    # AddTransactionToRecurringOutput fields unknown
+  }
+}
+
+input AddTransactionToRecurringInput {
+  recurringId: ID!      # required
+  # Optional fields unknown
+}
+```
+
+**Use case:** manually link a one-off transaction to an existing recurring series that Copilot's auto-detection missed (e.g., a rent transaction that didn't match the existing rent recurring).
+
+---
+
+## bulkEditTransactions
+
+```graphql
+mutation BulkEditTransactions($input: BulkEditTransactionInput!) {
+  bulkEditTransactions(input: $input) {
+    # BulkEditTransactionsOutput fields unknown
+  }
+}
+```
+
+**⚠ Do not probe with empty input.** A probe with `input: {}` caused the server to execute a real SQL query (`select "item_id", "account_id", "transaction_id" from "transactions" where ...`) with ~48 placeholders before failing. The full input shape is unknown and reverse-engineering it via error leak is not safe against a live account.
+
+**Intended use:** batch apply the same change (category, tags, reviewed state) to many transactions in one call. Likely what Copilot's iOS "select many → edit" UI uses.
+
+**How to reverse-engineer safely:** iOS traffic capture, or set up a disposable test account and probe against it.
+
+---
+
+## bulkDeleteTransactions
+
+```graphql
+mutation BulkDeleteTransactions(/* args unknown */) {
+  bulkDeleteTransactions {
+    # BulkDeleteTransactionsOutput fields unknown
+  }
+}
+```
+
+Confirmed to exist (returns `BulkDeleteTransactionsOutput!`) but neither argument shape nor output fields are known. Given the risk profile, we didn't probe further.
+
+---
+
+## createAccount
+
+```graphql
+mutation CreateAccount(/* required args unknown */) {
+  createAccount {
+    # Returns Account!
+  }
+}
+```
+
+Confirmed to exist and return `Account!`. Intended for manual account creation (the "Add account → Manual" flow in Copilot's UI).
+
+---
+
+## deleteAccount
+
+```graphql
+mutation DeleteAccount($itemId: ID!, /* other args unknown */) {
+  deleteAccount(itemId: $itemId /* ... */)   # returns ID!
+}
+```
+
+Confirmed to exist, returns `ID!` (presumably the deleted account's ID). Only `itemId` is confirmed required.
+
+**Destructive:** deleting an account likely cascades to its transactions.
+
+---
+
+## deleteUser
+
+```graphql
+mutation DeleteUser($confirm: Boolean!) {
+  deleteUser(confirm: $confirm)   # Boolean!
+}
+```
+
+**⚠⚠ Existential — deletes the user's entire Copilot account.** Surfaced by the brute-force sweep; listed here for completeness and as a warning. The `confirm: Boolean!` guard is the only protection — do not expose this via any MCP tool without a multi-step confirmation gate.
+
+---
+
+## What the web-session capture already knows
+
+These are in `docs/graphql-capture/operations/mutations/` — confirmed by real traffic, not recon:
+
+`CreateCategory`, `CreateRecurring`, `CreateTag`, `DeleteCategory`, `DeleteRecurring`, `DeleteTag`, `EditAccount`, `EditBudget`, `EditBudgetMonthly`, `EditCategory`, `EditRecurring`, `EditTag`, `EditTransaction`, `EditUser`.

--- a/docs/graphql-capture/hidden-mutations.md
+++ b/docs/graphql-capture/hidden-mutations.md
@@ -18,7 +18,7 @@ Signatures below reflect only what the server confirmed via validation errors. O
 | [`deleteAccount`](#deleteaccount) | ❌ | high (cascades to all txns) | Remove a manual account |
 | [`deleteUser`](#deleteuser) | ❌ | **existential** | Delete the entire user account |
 
-No other hidden mutations surfaced across the ~460-candidate sweep (see `scripts/recon/probe-mutations-wide.ts`).
+No other hidden mutations surfaced across a brute-force sweep of ~460 verb × entity combinations. The probe script was a throwaway in `/tmp/` during investigation; see [`introspection-recon.md`](./introspection-recon.md) for the methodology to reconstruct it.
 
 ## Budget mutations — finding
 
@@ -26,7 +26,17 @@ No other hidden mutations surfaced across the ~460-candidate sweep (see `scripts
 
 ## Goal mutations — finding
 
-**No goal mutations exist on the GraphQL endpoint.** Probes for `createGoal`, `editGoal`, `deleteGoal`, `archiveGoal`, `contributeToGoal`, `transferToGoal` all returned "Cannot query field". Goals are read-only via this API — any changes go through a different channel (likely direct Firestore writes from the iOS app).
+**No goal mutations exist on the GraphQL endpoint.** A focused sweep of 277 candidate names returned zero hits. The sweep covered:
+
+- all verb × entity combinations for `Goal`, `Goals`, `FinancialGoal`, `FinancialGoals`, `SavingsGoal`, `SavingsGoals`, and `Savings` — across 33 verbs (`create`/`edit`/`delete`/`archive`/`pause`/`complete`/`contribute`/`fund`/`allocate`/`transfer`/…);
+- transaction-goal linking candidates: `setTransactionGoal`, `linkTransactionToGoal`, `attachTransactionToGoal`, `moveTransactionToGoal`, `assignGoalToTransaction`, etc.;
+- account-goal linking candidates: `linkAccountToGoal`, `setGoalAccount`, `setSavingsAccount`, `enableSavings`, etc.;
+- goal-category linking candidates: `linkCategoryToGoal`, `setGoalCategories`, etc.;
+- progress/contribution ops: `editGoalProgress`, `incrementGoal`, `contributeToGoal`, etc.
+
+Additionally, `editTransaction`'s `EditTransactionInput` does **not** accept any of `goal`, `goalId`, `financial_goal_id`, `financialGoalId`, `savingsGoalId` — all probed keys were rejected with "not defined by type EditTransactionInput". The `goal_id` field we decode from Firestore (see `src/models/transaction.ts`) is a Firestore-side attribute only; it has no GraphQL read or write path.
+
+**Conclusion:** goals are entirely client-side in Copilot. The iOS and desktop apps write goal changes directly to Firestore (bypassing the GraphQL layer that Copilot's own backend enforces for other entities). To support goal writes from the MCP, we'd need Firestore write access — a larger architectural change than adding another GraphQL tool.
 
 ---
 
@@ -107,7 +117,7 @@ mutation DeleteTransaction($itemId: ID!, $accountId: ID!, $id: ID!) {
 
 Returns `Boolean!`. **Destructive — no soft-delete.** Firestore picks up the removal and Copilot's clients stop rendering it.
 
-**Caveat:** probably idempotent-safe on Plaid transactions (Plaid re-syncs and the transaction comes back on next refresh) but this hasn't been confirmed.
+⚠ **Unverified behavior.** Plaid-connected transactions *may* re-appear on the next sync (Plaid is the source of truth), making delete appear idempotent — but this hasn't been tested. Even if the transaction reappears, any user-side metadata (category override, tags, notes, reviewed state, goal link, split children) is likely *not* preserved across the delete/re-sync round-trip. Treat `deleteTransaction` on Plaid transactions as destructive until verified otherwise.
 
 ---
 
@@ -157,13 +167,13 @@ mutation BulkEditTransactions($input: BulkEditTransactionInput!) {
 
 ```graphql
 mutation BulkDeleteTransactions(/* args unknown */) {
-  bulkDeleteTransactions {
+  bulkDeleteTransactions(/* required args not yet probed */) {
     # BulkDeleteTransactionsOutput fields unknown
   }
 }
 ```
 
-Confirmed to exist (returns `BulkDeleteTransactionsOutput!`) but neither argument shape nor output fields are known. Given the risk profile, we didn't probe further.
+Confirmed to exist (returns `BulkDeleteTransactionsOutput!`) but neither argument shape nor output fields are known. **Do not call without args** — it almost certainly requires a list of transaction IDs, but reading the error-enumeration path further could risk the same validation-bypass behavior as `bulkEditTransactions`. Given the risk profile, we didn't probe further.
 
 ---
 

--- a/docs/graphql-capture/introspection-recon.md
+++ b/docs/graphql-capture/introspection-recon.md
@@ -1,0 +1,133 @@
+# GraphQL Introspection Recon
+
+How we discover mutations and their signatures when the server has introspection disabled (as Copilot's production server does).
+
+## Why this matters
+
+The web-session capture (`docs/graphql-capture/flows/01-web-session.md`) shows only operations the web app actually fires. The iOS app and any admin/internal tooling use additional operations the web capture never sees. `splitTransaction` is one such operation: the web app doesn't expose splits, but the mutation exists on the server and is reachable with a normal user token.
+
+Closing this gap without iOS traffic capture requires **error-leak recon**: deliberate invalid queries whose error responses reveal real field and type names.
+
+## Rules of engagement (read-only by construction)
+
+- **Never send a syntactically complete mutation with real IDs.** Validation failures happen before execution; an invalid query mutates nothing.
+- **Always use fake IDs** (e.g. `__does_not_exist__`). If the mutation gets past argument validation and hits the data layer, a fake ID fails the ownership/existence check and rolls back before any write.
+- **One exception**: `bulkEditTransactions(input: {})` leaked a SQL error with ~48 parameter placeholders, suggesting it *does* hit the data layer with an unvalidated empty input. **Do not probe this mutation with any non-trivial input** without setting up an isolated test account.
+- Each probe is a standalone GraphQL request authenticated with the user's own Firebase token (same auth path the MCP already uses). No traffic to third parties; everything goes to `app.copilot.money/api/graphql`.
+
+## Technique 1 — "Did you mean" enumeration
+
+When you query a non-existent field on `Mutation`, Apollo responds with:
+
+```json
+{ "errors": [{
+  "message": "Cannot query field \"splitTransactions\" on type \"Mutation\". Did you mean \"splitTransaction\", \"editTransaction\", \"bulkEditTransactions\", \"deleteTransaction\", or \"createTransaction\"?"
+}]}
+```
+
+Each "Did you mean" list contains up to 5 real mutation names that are edit-distance-close to the query. Probe with a deliberately fake name and harvest the suggestions. Candidates that worked for us:
+
+| Probe | Leaked mutations |
+|---|---|
+| `splitTransactions` | `splitTransaction`, `editTransaction`, `bulkEditTransactions`, `deleteTransaction`, `createTransaction` |
+| `editTransactionSplit` | `editTransaction`, `bulkEditTransactions`, `splitTransaction`, `deleteTransaction` |
+| `addTransactionChild` | `addTransactionToRecurring` |
+| `createChildTransaction` | `createTransaction`, `deleteTransaction`, `editTransaction` |
+
+See `scripts/recon/probe-mutations-wide.ts` for the full sweep that brute-forces verb × entity combinations.
+
+## Technique 2 — required-arg enumeration
+
+If a mutation exists, the error for "no args" lists every required argument by name + type:
+
+```
+Field "splitTransaction" argument "itemId" of type "ID!" is required, but it was not provided.
+Field "splitTransaction" argument "accountId" of type "ID!" is required, but it was not provided.
+Field "splitTransaction" argument "id" of type "ID!" is required, but it was not provided.
+Field "splitTransaction" argument "input" of type "[SplitTransactionInput!]!" is required, but it was not provided.
+```
+
+Send `mutation Probe { candidateName }` — the response enumerates every required arg. Optional args are invisible this way (see Technique 4).
+
+## Technique 3 — input-type required fields
+
+Provide an empty input and the server enumerates the required input-type fields:
+
+```
+mutation Probe {
+  splitTransaction(itemId: "x", accountId: "x", id: "x", input: [{}])
+    { __typename }
+}
+```
+
+```
+Field "SplitTransactionInput.name" of required type "String!" was not provided.
+Field "SplitTransactionInput.date" of required type "Date!" was not provided.
+Field "SplitTransactionInput.amount" of required type "Float!" was not provided.
+Field "SplitTransactionInput.categoryId" of required type "ID!" was not provided.
+```
+
+## Technique 4 — "unknown field" enumeration
+
+If `Did you mean` doesn't fire for a suggestion on the input type, the error just confirms the field doesn't exist:
+
+```
+Field "tagIds" is not defined by type "SplitTransactionInput".
+```
+
+This means Apollo is configured to not leak optional field names. You can still brute-force candidates by trying common names one at a time — each returns "not defined" if absent, or "OK/typed-error" if present.
+
+## Technique 5 — output-type field discovery
+
+Apollo rejects unknown subfields:
+
+```
+Cannot query field "__nonexistent__" on type "SplitTransactionOutput".
+```
+
+but does **not** list valid ones. Output fields must be enumerated by probing one candidate at a time. Common shapes we tried for `SplitTransactionOutput`:
+
+| Candidate | Result |
+|---|---|
+| `transaction` / `transactions` | nonexistent |
+| `parentTransaction` | **exists** (object, needs subselection) |
+| `splitTransactions` | **exists** (list) |
+| `id` / `success` / `errors` / `edges` / `node` / `data` | nonexistent |
+
+`parentTransaction` and `splitTransactions` both require subselection, which means they're object types — safe to assume they're `Transaction` (confirmed via the existing `fragment TransactionFields`).
+
+## Remaining gaps
+
+Fields still unknown even after recon:
+
+1. **Optional input fields** on every discovered input type. Apollo doesn't leak them. Needs either iOS traffic capture or brute-force name guessing.
+2. **Arg signatures** for `createAccount` and `deleteAccount` (beyond the required ones) — we know they exist and what they return but haven't fully walked their inputs.
+3. **Full `BulkEditTransactionInput` shape** — we refuse to probe with empty input because that path does not short-circuit at validation (see the "Rules of engagement" caveat above). Need iOS traffic to reverse.
+4. **Full `CreateTransactionInput` optional fields** — required ones known (`name`, `date`, `amount`, `categoryId`, `type: TransactionType!`); optional unknown.
+5. **Queries**. This recon only covered `Mutation`. Copilot's server likely has unpublished queries too (e.g. admin/debug). Run the same sweep against `query Probe { ... }` instead of `mutation`.
+6. **Subscriptions**. GraphQL subscriptions for real-time updates may exist. Probe `subscription Probe { ... }` with candidate names.
+7. **The `TransactionType` enum**. Known to exist (required on `createTransaction`) but values unknown. Send invalid values and harvest from the "must be one of X, Y, Z" error.
+
+## How to re-run the recon
+
+The probe scripts live in `/tmp/` in the developer's machine during investigation — they're intentionally throwaway since the signatures change infrequently. Minimal reproducer:
+
+```ts
+import { FirebaseAuth } from 'src/core/auth/firebase-auth.ts';
+import { extractRefreshToken } from 'src/core/auth/browser-token.ts';
+
+const auth = new FirebaseAuth(() => extractRefreshToken());
+const idToken = await auth.getIdToken();
+
+const res = await fetch('https://app.copilot.money/api/graphql', {
+  method: 'POST',
+  headers: { Authorization: `Bearer ${idToken}`, 'Content-Type': 'application/json' },
+  body: JSON.stringify({
+    operationName: 'Probe',
+    query: `mutation Probe { theCandidateName }`,
+  }),
+});
+console.log(await res.text());
+```
+
+If the response contains `Cannot query field`, the mutation doesn't exist. Anything else — required-arg message, subfield-selection message, "Did you mean" — means it exists. Harvest the type names from the error and feed them back in to walk the schema.

--- a/docs/graphql-capture/introspection-recon.md
+++ b/docs/graphql-capture/introspection-recon.md
@@ -34,7 +34,7 @@ Each "Did you mean" list contains up to 5 real mutation names that are edit-dist
 | `addTransactionChild` | `addTransactionToRecurring` |
 | `createChildTransaction` | `createTransaction`, `deleteTransaction`, `editTransaction` |
 
-See `scripts/recon/probe-mutations-wide.ts` for the full sweep that brute-forces verb × entity combinations.
+The actual probe script lived in `/tmp/` during investigation and wasn't committed — see the "How to re-run the recon" section below for a minimal reproducer.
 
 ## Technique 2 — required-arg enumeration
 

--- a/docs/graphql-capture/schema/operations.md
+++ b/docs/graphql-capture/schema/operations.md
@@ -1,5 +1,7 @@
 # Operations Index
 
+Operations below are from the web-session capture (`flows/01-web-session.md`). Additional mutations that exist on the server but were **never observed in the web capture** — including `splitTransaction`, `createTransaction`, `deleteTransaction`, and others — are documented in [`../hidden-mutations.md`](../hidden-mutations.md). The recon methodology used to discover them is in [`../introspection-recon.md`](../introspection-recon.md).
+
 - [AccountLiveBalance](operations/queries/AccountLiveBalance.md) — query, 18 observation(s)
 - [Accounts](operations/queries/Accounts.md) — query, 2 observation(s)
 - [Announcement](operations/queries/Announcement.md) — query, 1 observation(s)

--- a/docs/graphql-capture/test-agents.md
+++ b/docs/graphql-capture/test-agents.md
@@ -81,14 +81,16 @@ The agents only probe — they never execute a real mutation. Every call uses a 
      createTransaction(
        itemId: "__does_not_exist__"
        accountId: "__does_not_exist__"
-       input: { name: "x", date: "2026-01-01", amount: 1.0, categoryId: "x", type: __BAD__ }
+       input: { name: "x", date: "2026-01-01", amount: 1.0, categoryId: "x", type: INVALID_PROBE_VALUE }
      ) { id }
    }
    ```
 
-2. Expected: Apollo returns "Value 'BAD' does not exist in 'TransactionType' enum. Did you mean X, Y, Z?" or "Expected type 'TransactionType'. Did you mean 'expense', 'income', 'transfer'?".
+   (Don't use a name starting with `__` — GraphQL reserves double-underscore for introspection types, and Apollo will reject the name itself before enum validation runs.)
 
-3. Report every enum value the error surfaces.
+2. Expected: a response whose error message names the real `TransactionType` enum values. Exact phrasing is not guaranteed — could be "Value 'INVALID_PROBE_VALUE' does not exist in 'TransactionType' enum", "Expected type 'TransactionType'", or similar, possibly with a "Did you mean …" suggesting valid values. If the error contains a quoted list of candidates, those are the real enum members.
+
+3. Report every enum value the error surfaces. Do **not** assume the values are `expense`/`income`/`transfer` or any other specific set — only trust what the server actually returns.
 
 4. For each value, send a follow-up probe using that value as `type` and `__does_not_exist__` for all IDs. Expected: "Account not found" or similar data-layer error (confirming the type was accepted). Report which values the server accepts.
 
@@ -103,6 +105,8 @@ The agents only probe — they never execute a real mutation. Every call uses a 
 **Scope:** read-only.
 
 **Task:**
+
+All probes in this agent run under the user's own Firebase token. Even if an admin/debug query exists, the server will enforce row-level authorization — the probe reveals the *shape* of the API surface, not privileged data. "Admin" names in the candidate list below are there because they're common GraphQL conventions, not because we expect them to return anything the user isn't already authorized to see.
 
 1. Run a 50-candidate brute force against `query Probe { <candidate> }` for names like `adminStats`, `healthCheck`, `debugUser`, `internalQueue`, `transactionCount`, `userActivity`, `auditLog`, etc. Harvest any that return "required argument" or "subfield selection" errors (meaning exists). Ignore ones with "Cannot query field" (don't exist).
 

--- a/docs/graphql-capture/test-agents.md
+++ b/docs/graphql-capture/test-agents.md
@@ -1,0 +1,123 @@
+# Test-agent prompts for recon verification
+
+Copy these into an Agent call when you want an independent verification that the signatures in [`hidden-mutations.md`](./hidden-mutations.md) still hold against the live endpoint. Each prompt is self-contained (no shared state), so multiple agents can run in parallel.
+
+The agents only probe — they never execute a real mutation. Every call uses a fake ID (`__does_not_exist__`) so validation stops the request before any write.
+
+---
+
+## Agent 1 — splitTransaction signature re-verification
+
+**Role:** verify that the `splitTransaction` mutation still accepts the signature documented in `docs/graphql-capture/hidden-mutations.md`.
+
+**Scope:** read-only probes via the Firebase-authenticated GraphQL client.
+
+**Task:**
+
+1. Use `src/core/auth/firebase-auth.ts` + `src/core/auth/browser-token.ts` to get an ID token. Do not write any new auth code — use what the MCP already uses.
+2. POST to `https://app.copilot.money/api/graphql` with these six probes (all with `operationName: "Probe"`):
+
+   a. `mutation Probe { splitTransaction }` — expect four "argument X of type Y is required" errors naming `itemId: ID!`, `accountId: ID!`, `id: ID!`, `input: [SplitTransactionInput!]!`.
+
+   b. `mutation Probe { splitTransaction(itemId: "x", accountId: "x", id: "x", input: [{}]) { __typename } }` — expect four required-field errors on `SplitTransactionInput`: `name: String!`, `date: Date!`, `amount: Float!`, `categoryId: ID!`.
+
+   c. `mutation Probe { splitTransaction(itemId: "x", accountId: "x", id: "x", input: [{name:"x", date:"2026-01-01", amount:1.0, categoryId:"x"}]) { parentTransaction { id } } }` — expect "Transaction not found" (i.e. args valid, server rejected at data-layer).
+
+   d. Same as (c) but with `splitTransactions { id }` instead — also expect "Transaction not found".
+
+   e. Same as (c) but with `__nonexistent__` subfield — expect "Cannot query field '\_\_nonexistent\_\_' on type 'SplitTransactionOutput'".
+
+   f. Try one optional input field that shouldn't exist: `splitTransaction(..., input: [{name:"x", date:"2026-01-01", amount:1.0, categoryId:"x", tagIds:["t"]}]) { __typename }` — expect "Field 'tagIds' is not defined by type 'SplitTransactionInput'".
+
+3. Report PASS/FAIL for each probe, with the actual first-error message from the server.
+
+**Constraints:**
+- No `edit*`, `create*`, `delete*` calls. Only `Probe` with fake IDs.
+- If an unexpected response appears (e.g. `id: "x"` actually matches a real ID), stop immediately and report the discrepancy.
+
+**Output:** markdown table with probe letter, expected, actual, and verdict.
+
+---
+
+## Agent 2 — mutation enumeration via "Did you mean"
+
+**Role:** confirm the list of mutations in `hidden-mutations.md` is still current, and surface any new ones that have appeared.
+
+**Scope:** read-only.
+
+**Task:**
+
+1. Send these 8 deliberately-misspelled mutation probes (each via `operationName: "Probe"`, body `mutation Probe { <name> }`):
+   - `splitTransactions` (plural of real one)
+   - `editTransactionSplit`
+   - `createTransactionSplit`
+   - `addTransactionChild`
+   - `createChildTransaction`
+   - `bulkEditTransaction` (singular of real bulk one)
+   - `partitionTransaction`
+   - `divideTransaction`
+
+2. From each "Did you mean X, Y, Z" response, collect the suggested names into a single deduped set.
+
+3. Compare against the known set (from `hidden-mutations.md` + `docs/graphql-capture/schema/operations.md`). Report any name that appears in the suggestions but is NOT in the known set — those are newly-discovered mutations to document.
+
+4. For each new name, send one follow-up probe (`mutation Probe { <newName> }`) and report its return type from the subfield-selection or required-arg error.
+
+**Output:** (a) union of known + newly-discovered names, (b) for each new name, the probe response verbatim.
+
+---
+
+## Agent 3 — TransactionType enum values
+
+**Role:** fill one of the documented gaps — the `TransactionType!` enum values required by `createTransaction`.
+
+**Scope:** read-only.
+
+**Task:**
+
+1. Send:
+   ```graphql
+   mutation Probe {
+     createTransaction(
+       itemId: "__does_not_exist__"
+       accountId: "__does_not_exist__"
+       input: { name: "x", date: "2026-01-01", amount: 1.0, categoryId: "x", type: __BAD__ }
+     ) { id }
+   }
+   ```
+
+2. Expected: Apollo returns "Value 'BAD' does not exist in 'TransactionType' enum. Did you mean X, Y, Z?" or "Expected type 'TransactionType'. Did you mean 'expense', 'income', 'transfer'?".
+
+3. Report every enum value the error surfaces.
+
+4. For each value, send a follow-up probe using that value as `type` and `__does_not_exist__` for all IDs. Expected: "Account not found" or similar data-layer error (confirming the type was accepted). Report which values the server accepts.
+
+**Output:** the full list of `TransactionType` enum values.
+
+---
+
+## Agent 4 — query + subscription recon
+
+**Role:** extend the methodology beyond mutations to `Query` and `Subscription` root types.
+
+**Scope:** read-only.
+
+**Task:**
+
+1. Run a 50-candidate brute force against `query Probe { <candidate> }` for names like `adminStats`, `healthCheck`, `debugUser`, `internalQueue`, `transactionCount`, `userActivity`, `auditLog`, etc. Harvest any that return "required argument" or "subfield selection" errors (meaning exists). Ignore ones with "Cannot query field" (don't exist).
+
+2. Do the same for `subscription Probe { <candidate> }`. Candidates: `transactionAdded`, `transactionUpdated`, `accountBalanceChanged`, `itemStatusChanged`, `notificationReceived`, `budgetAlert`, etc.
+
+3. Any hit on subscriptions is especially interesting — subscriptions imply real-time push channels we might use for MCP.
+
+**Output:** alphabetical list of (a) confirmed hidden queries and (b) confirmed subscriptions, each with the return-type name from the error message.
+
+---
+
+## Running agents in parallel
+
+In a Claude Code session, dispatch all four at once via multiple `Agent` tool calls in one message. They don't share state so there's no ordering requirement.
+
+After they finish, fold new findings back into `hidden-mutations.md` and update this file's "last verified" date.
+
+**Last verified:** 2026-04-22 (initial publish)


### PR DESCRIPTION
## Summary

Documents nine mutations on Copilot's GraphQL endpoint that the web-session capture never saw, plus the error-leak recon methodology used to discover them.

## Motivation

The web app has no split-transaction UI, so the existing capture flow (`docs/graphql-capture/flows/01-web-session.md`) never exercised a split mutation. But iOS does — and the server accepts the mutation from any authenticated user token, regardless of which client fires it. Probing the endpoint with deliberate validation failures turned up `splitTransaction` plus eight other hidden mutations, so the MCP can reach them without needing iOS traffic capture.

## What's in this PR

Three new docs under `docs/graphql-capture/` + an index cross-link:

- **`hidden-mutations.md`** — signatures for all nine discovered mutations: `splitTransaction`, `createTransaction`, `deleteTransaction`, `addTransactionToRecurring`, `bulkEditTransactions`, `bulkDeleteTransactions`, `createAccount`, `deleteAccount`, `deleteUser`. Each entry flags risk level, known/unknown fields, reversal paths, and intended use. Explicitly answers "are there hidden budget mutations?" (no — budgets are a category attribute, managed via `editBudget` / `editBudgetMonthly`) and "are there goal mutations?" (no — goals are read-only via GraphQL).
- **`introspection-recon.md`** — five-technique methodology: "Did you mean" enumeration, required-arg leaks, input-type field leaks, unknown-field probes, output-subfield probing. Safety rules (fake IDs only; `bulkEditTransactions` is off-limits because it short-circuits too late during validation). A "Remaining gaps" section lists seven things we still don't know and how to close each.
- **`test-agents.md`** — four self-contained Agent prompts for (1) re-verifying the `splitTransaction` signature, (2) enumerating mutations via "Did you mean" recon, (3) discovering the `TransactionType` enum values, (4) extending the sweep to `Query` and `Subscription` root types.

Updated `docs/graphql-capture/schema/operations.md` with a header cross-link pointing readers at the new hidden-mutations doc.

## Non-goals (follow-ups)

- **No code changes.** This PR is docs-only — the MCP isn't wired to any of the new mutations yet. A follow-up would add a `split_transaction` write tool and the others as appropriate.
- **No live verification.** The test-agent prompts can be run to re-verify against the live endpoint; that's intentionally a separate session (keeps this PR reviewable without network dependencies).

## Test plan
- [x] `grep -r "splitTransaction" docs/` surfaces the new doc entries
- [x] `docs/graphql-capture/schema/operations.md` still renders with the cross-link
- [x] Existing test suite untouched (`bun run check` would be a no-op since no code changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)