### PR TITLE
chore(lint): remove unnecessary type assertions for typescript-eslint 8.59

### DIFF
--- a/src/core/graphql/queries/accounts.ts
+++ b/src/core/graphql/queries/accounts.ts
@@ -52,7 +52,7 @@ export async function fetchAccounts(client: GraphQLClient): Promise<AccountNode[
   const data = await client.query<Record<string, never>, AccountsResponse>(
     'Accounts',
     ACCOUNTS,
-    {} as Record<string, never>
+    {}
   );
   return data.accounts;
 }

--- a/src/core/protobuf-parser.ts
+++ b/src/core/protobuf-parser.ts
@@ -173,7 +173,7 @@ export function encodeVarint(value: number): Buffer {
 export function parseTag(tag: number): { fieldNumber: number; wireType: WireType } {
   return {
     fieldNumber: tag >>> 3,
-    wireType: (tag & 0x07) as WireType,
+    wireType: tag & 0x07,
   };
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -262,9 +262,7 @@ export class CopilotMoneyServer {
           break;
 
         case 'get_accounts':
-          result = await this.tools.getAccounts(
-            typedArgs as Parameters<typeof this.tools.getAccounts>[0]
-          );
+          result = await this.tools.getAccounts(typedArgs);
           break;
 
         case 'get_connection_status':
@@ -272,45 +270,31 @@ export class CopilotMoneyServer {
           break;
 
         case 'get_categories':
-          result = await this.tools.getCategories(
-            (typedArgs as Parameters<typeof this.tools.getCategories>[0]) || {}
-          );
+          result = await this.tools.getCategories(typedArgs || {});
           break;
 
         case 'get_recurring_transactions':
-          result = await this.tools.getRecurringTransactions(
-            (typedArgs as Parameters<typeof this.tools.getRecurringTransactions>[0]) || {}
-          );
+          result = await this.tools.getRecurringTransactions(typedArgs || {});
           break;
 
         case 'get_budgets':
-          result = await this.tools.getBudgets(
-            (typedArgs as Parameters<typeof this.tools.getBudgets>[0]) || {}
-          );
+          result = await this.tools.getBudgets(typedArgs || {});
           break;
 
         case 'get_goals':
-          result = await this.tools.getGoals(
-            (typedArgs as Parameters<typeof this.tools.getGoals>[0]) || {}
-          );
+          result = await this.tools.getGoals(typedArgs || {});
           break;
 
         case 'get_investment_prices':
-          result = await this.tools.getInvestmentPrices(
-            (typedArgs as Parameters<typeof this.tools.getInvestmentPrices>[0]) || {}
-          );
+          result = await this.tools.getInvestmentPrices(typedArgs || {});
           break;
 
         case 'get_investment_splits':
-          result = await this.tools.getInvestmentSplits(
-            (typedArgs as Parameters<typeof this.tools.getInvestmentSplits>[0]) || {}
-          );
+          result = await this.tools.getInvestmentSplits(typedArgs || {});
           break;
 
         case 'get_holdings':
-          result = await this.tools.getHoldings(
-            (typedArgs as Parameters<typeof this.tools.getHoldings>[0]) || {}
-          );
+          result = await this.tools.getHoldings(typedArgs || {});
           break;
 
         case 'get_balance_history':
@@ -320,27 +304,19 @@ export class CopilotMoneyServer {
           break;
 
         case 'get_investment_performance':
-          result = await this.tools.getInvestmentPerformance(
-            (typedArgs as Parameters<typeof this.tools.getInvestmentPerformance>[0]) || {}
-          );
+          result = await this.tools.getInvestmentPerformance(typedArgs || {});
           break;
 
         case 'get_twr_returns':
-          result = await this.tools.getTwrReturns(
-            (typedArgs as Parameters<typeof this.tools.getTwrReturns>[0]) || {}
-          );
+          result = await this.tools.getTwrReturns(typedArgs || {});
           break;
 
         case 'get_securities':
-          result = await this.tools.getSecurities(
-            (typedArgs as Parameters<typeof this.tools.getSecurities>[0]) || {}
-          );
+          result = await this.tools.getSecurities(typedArgs || {});
           break;
 
         case 'get_goal_history':
-          result = await this.tools.getGoalHistory(
-            (typedArgs as Parameters<typeof this.tools.getGoalHistory>[0]) || {}
-          );
+          result = await this.tools.getGoalHistory(typedArgs || {});
           break;
 
         case 'create_transaction':


### PR DESCRIPTION
## Summary

- Removes 13 type assertions that the upcoming typescript-eslint 8.59.0 `no-unnecessary-type-assertion` rule flags as redundant ([PR #11789](https://github.com/typescript-eslint/typescript-eslint/pull/11789), *"report more cases based on assignability"*).
- Unblocks dependabot's production-dependencies bump (#335), which currently fails CI on the typescript-eslint 8.57.2 → 8.59.0 step with 13 lint errors.
- All assertions confirmed redundant against current typescript-eslint 8.57.2 too: `bun run check` is fully green (typecheck, lint, format, 1689 tests).

## Changes

- `src/core/graphql/queries/accounts.ts:55` — drop `{} as Record<string, never>` (typed by generic param).
- `src/core/protobuf-parser.ts:176` — drop `(tag & 0x07) as WireType` (numeric enum accepts the bitmasked number).
- `src/server.ts` (11 sites) — drop `typedArgs as Parameters<typeof this.tools.X>[0]` casts in the tool dispatch switch.

## Test plan

- [x] `bun run check` (typecheck + lint + format:check + tests) passes locally
- [ ] CI Tests + Quality Checks pass on PR
- [ ] After merge: comment `@dependabot rebase` on #335 and verify it goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)