### PR TITLE
feat(live): windowed cache for transactions (phase 3)

### DIFF
--- a/src/core/cache/transaction-window-cache.ts
+++ b/src/core/cache/transaction-window-cache.ts
@@ -2,9 +2,12 @@
  * Month-keyed window cache for transaction reads.
  *
  * Transactions are tiered by the age of the month's most recent day:
- *   - min_age ≤ 7d → live (no cache; always refetch)
- *   - 7d < min_age ≤ 21d → warm (1h TTL)
- *   - min_age > 21d → cold (1w TTL)
+ *   - min_age ≤ 14d → live (no cache; always refetch)
+ *   - min_age > 14d → cold (1w TTL)
+ *
+ * The 14-day boundary captures the meaningful Plaid-sync drift window
+ * (recent merchants are still posting late charges) without the
+ * complexity of a separate warm tier.
  *
  * `plan()` decomposes a date range into months and returns
  * (cachedRows, toFetch). The caller fetches missing months and
@@ -14,7 +17,7 @@
  * Eviction runs iteratively after each ingest; a single high-volume
  * ingest can push the total well past the cap.
  *
- * See docs/superpowers/specs/2026-04-24-graphql-live-tiered-cache-design.md.
+ * See docs/superpowers/specs/2026-05-01-graphql-live-tx-windowed-cache-design.md.
  */
 
 import { monthsCovered, monthAge, type YearMonth } from '../../utils/date.js';
@@ -27,11 +30,10 @@ export interface CachedTransaction {
   [key: string]: unknown;
 }
 
-export type Tier = 'live' | 'warm' | 'cold';
+export type Tier = 'live' | 'cold';
 
 export interface TransactionWindowCacheOptions {
   liveTtlMs: number; // typically 0 — never cache live tier
-  warmTtlMs: number; // e.g. 1h
   coldTtlMs: number; // e.g. 1w
   maxRows: number; // total-row cap before eviction
 }
@@ -66,8 +68,7 @@ export class TransactionWindowCache<T extends CachedTransaction = CachedTransact
 
   tierFor(month: YearMonth, now: Date): Tier {
     const age = monthAge(month, now);
-    if (age <= 7) return 'live';
-    if (age <= 21) return 'warm';
+    if (age <= 14) return 'live';
     return 'cold';
   }
 
@@ -75,8 +76,6 @@ export class TransactionWindowCache<T extends CachedTransaction = CachedTransact
     switch (tier) {
       case 'live':
         return this.opts.liveTtlMs;
-      case 'warm':
-        return this.opts.warmTtlMs;
       case 'cold':
         return this.opts.coldTtlMs;
     }
@@ -188,6 +187,10 @@ export class TransactionWindowCache<T extends CachedTransaction = CachedTransact
 
   entriesForMonth(month: YearMonth): T[] {
     return this.windows.get(month)?.rows ?? [];
+  }
+
+  getFetchedAt(month: YearMonth): number | undefined {
+    return this.windows.get(month)?.fetched_at;
   }
 
   private evictLRU(maxTotalRows: number): void {

--- a/src/core/cache/transaction-window-cache.ts
+++ b/src/core/cache/transaction-window-cache.ts
@@ -27,7 +27,6 @@ import type { InFlightRegistry } from './in-flight-registry.js';
 export interface CachedTransaction {
   id: string;
   date: string; // YYYY-MM-DD
-  [key: string]: unknown;
 }
 
 export type Tier = 'live' | 'cold';
@@ -57,9 +56,11 @@ export class TransactionWindowCache<T extends CachedTransaction = CachedTransact
 
   constructor(
     private readonly opts: TransactionWindowCacheOptions,
-    // Stored for Phase 3 forward-compat — when transaction reads migrate
-    // onto this cache, the registry will gate concurrent month fetches.
-    // Phase 2 ingestMonth is externally driven so the field is unused yet.
+    // Held for compatibility with the constructor signature and to express
+    // the intent that this cache is part of an InFlightRegistry-coordinated
+    // system. Coalescing actually happens at the call site in
+    // LiveCopilotDatabase.getTransactions; the cache itself is externally
+    // driven via ingestMonth, so the field is unused INSIDE this class.
     private readonly inflight: InFlightRegistry
   ) {
     // Suppress unused-private-field warning while inflight is forward-compat only.
@@ -97,8 +98,8 @@ export class TransactionWindowCache<T extends CachedTransaction = CachedTransact
       }
       const entry = this.windows.get(month);
       const ttl = this.ttlFor(tier);
-      if (entry && Date.now() - entry.fetched_at < ttl) {
-        this.lastAccessed.set(month, Date.now());
+      if (entry && now.getTime() - entry.fetched_at < ttl) {
+        this.lastAccessed.set(month, now.getTime());
         for (const row of entry.rows) {
           if (row.date >= range.from && row.date <= range.to) cachedRows.push(row);
         }
@@ -132,6 +133,7 @@ export class TransactionWindowCache<T extends CachedTransaction = CachedTransact
       if (idx >= 0) {
         entry.rows.splice(idx, 1);
         this._totalRows -= 1;
+        break; // ids are unique across windows; first match is the only match
       }
     }
     const entry = this.windows.get(month);
@@ -152,6 +154,7 @@ export class TransactionWindowCache<T extends CachedTransaction = CachedTransact
       if (idx >= 0) {
         entry.rows.splice(idx, 1);
         this._totalRows -= 1;
+        break; // ids are unique across windows
       }
     }
   }

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -28,10 +28,11 @@ import {
   buildTransactionSort,
   fetchTransactionsPage,
   paginateTransactions,
-  type BuildFilterOptions,
   type TransactionNode,
   type TransactionSortInput,
 } from './graphql/queries/transactions.js';
+import { getMonthRange, monthsCovered } from '../utils/date.js';
+import { pLimit } from '../utils/concurrency.js';
 import {
   InFlightRegistry,
   SnapshotCache,
@@ -147,6 +148,34 @@ export class LiveCopilotDatabase {
     }
   }
 
+  /**
+   * Fetch + paginate one month of transactions; ingest into the
+   * window cache; return the rows along with the timestamp the
+   * fetch was initiated and the page count.
+   */
+  private async fetchMonth(
+    month: string,
+    sort: TransactionSortInput[],
+    pageSize: number
+  ): Promise<{ rows: TransactionNode[]; fetched_at: number; pages: number }> {
+    const year = Number(month.slice(0, 4));
+    const m = Number(month.slice(5, 7));
+    const [monthStart, monthEnd] = getMonthRange(year, m);
+    const filter = buildTransactionFilter({ startDate: monthStart, endDate: monthEnd });
+    const fetched_at = Date.now();
+    let pages = 0;
+    const rows = await paginateTransactions(
+      (after) =>
+        this.withRetry(async () => {
+          pages += 1;
+          return fetchTransactionsPage(this.graphql, { first: pageSize, after, filter, sort });
+        }),
+      { startDate: monthStart }
+    );
+    this.transactionsWindowCache.ingestMonth(month, rows as unknown as CachedTransaction[], fetched_at);
+    return { rows, fetched_at, pages };
+  }
+
   async memoize<T>(
     key: string,
     loader: () => Promise<T>
@@ -170,6 +199,8 @@ export class LiveCopilotDatabase {
     cache_hit?: boolean;
     staleness_ms?: number | null;
     month?: string;
+    from_to_months?: number;
+    fetched_months?: number;
   }): void {
     if (!this.verbose) return;
     const parts = [
@@ -181,53 +212,116 @@ export class LiveCopilotDatabase {
       `latency=${log.latencyMs}ms`,
       `rows=${log.rows}`,
       log.month ? `month=${log.month}` : null,
+      log.from_to_months !== undefined ? `from_to_months=${log.from_to_months}` : null,
+      log.fetched_months !== undefined ? `fetched_months=${log.fetched_months}` : null,
       log.staleness_ms !== undefined ? `staleness_ms=${log.staleness_ms ?? 'null'}` : null,
     ].filter(Boolean);
     console.error(parts.join(' '));
   }
 
   /**
-   * Fetch transactions from Copilot's GraphQL API, paginating with
-   * DATE DESC sort and early-exiting when the trailing row precedes
-   * the requested start date.
+   * Fetch transactions for a date range, backed by the month-keyed
+   * window cache. Live-tier months (≤14d age) refetch unconditionally;
+   * older months come from cache or trigger a per-month fetch.
    *
-   * Pure data access — client-side post-filtering (amount range,
-   * pending, excluded-category join, special transaction_type
-   * variants) lives in the tool layer, not here.
+   * Concurrent month fetches are capped at 4 in flight (`pLimit(4)`)
+   * and coalesced across callers via `InFlightRegistry` keyed on
+   * `tx:<YYYY-MM>`.
+   *
+   * Returns rows sorted (date DESC, createdAt DESC, id DESC) with a
+   * freshness envelope reflecting the per-month `fetched_at` distribution.
    */
   async getTransactions(
-    opts: BuildFilterOptions & { sort?: TransactionSortInput; pageSize?: number }
-  ): Promise<{ rows: TransactionNode[]; fetched_at: number; hit: boolean }> {
-    const filter = buildTransactionFilter(opts);
-    const sort = buildTransactionSort(opts.sort);
-    const first = opts.pageSize ?? 100;
+    range: { from: string; to: string },
+    sort?: TransactionSortInput,
+    opts?: { pageSize?: number }
+  ): Promise<{
+    rows: TransactionNode[];
+    oldest_fetched_at: number;
+    newest_fetched_at: number;
+    hit: boolean;
+  }> {
+    if (!range.from || !range.to) {
+      throw new Error(`getTransactions requires both from and to (got from='${range.from}', to='${range.to}')`);
+    }
+    if (range.from > range.to) {
+      throw new Error(`getTransactions: from (${range.from}) must be <= to (${range.to})`);
+    }
 
-    const memoKey = JSON.stringify({ filter, sort, first });
-    const memoResult = await this.memoize(memoKey, async () => {
-      let pages = 0;
-      const startedAt = Date.now();
-      const rows = await paginateTransactions(
-        (after) =>
-          this.withRetry(async () => {
-            pages += 1;
-            return fetchTransactionsPage(this.graphql, { first, after, filter, sort });
-          }),
-        { startDate: opts.startDate }
-      );
-      this.logReadCall({
-        op: 'Transactions',
-        pages,
-        latencyMs: Date.now() - startedAt,
-        rows: rows.length,
-        cache_hit: false, // pure miss path; cache hits short-circuit before this loader runs
-      });
-      return rows;
+    const sortArr = buildTransactionSort(sort);
+    const pageSize = opts?.pageSize ?? 100;
+    const now = new Date();
+
+    const { cachedRows, toFetch } = this.transactionsWindowCache.plan(range, now);
+
+    const startedAt = Date.now();
+    const limit = pLimit(4);
+    let totalPages = 0;
+
+    const settled = await Promise.allSettled(
+      toFetch.map((month) =>
+        limit(() =>
+          this.inflight.run(`tx:${month}`, async () => {
+            const result = await this.fetchMonth(month, sortArr, pageSize);
+            totalPages += result.pages;
+            return { month, ...result };
+          })
+        )
+      )
+    );
+
+    const failures: Array<{ month: string; reason: unknown }> = [];
+    const successes: Array<{ month: string; rows: TransactionNode[]; fetched_at: number }> = [];
+    for (let i = 0; i < settled.length; i += 1) {
+      const s = settled[i]!;
+      if (s.status === 'fulfilled') {
+        successes.push(s.value);
+      } else {
+        failures.push({ month: toFetch[i]!, reason: s.reason });
+      }
+    }
+    if (failures.length > 0) {
+      const summary = failures
+        .map((f) => `${f.month}: ${(f.reason as Error)?.message ?? String(f.reason)}`)
+        .join('; ');
+      throw new Error(`Failed to fetch months: ${summary}`);
+    }
+
+    const freshRows = successes.flatMap((s) => s.rows);
+    const merged = [...(cachedRows as unknown as TransactionNode[]), ...freshRows].filter(
+      (r) => r.date >= range.from && r.date <= range.to
+    );
+    merged.sort(
+      (a, b) =>
+        b.date.localeCompare(a.date) ||
+        b.createdAt - a.createdAt ||
+        b.id.localeCompare(a.id)
+    );
+
+    // Freshness envelope: walk every month in the requested range and
+    // collect its current fetched_at. (After ingest, all months are
+    // present; live-tier and just-fetched months reflect "now".)
+    const allMonths = monthsCovered(range);
+    const fetchedAts: number[] = [];
+    for (const m of allMonths) {
+      const ts = this.transactionsWindowCache.getFetchedAt(m);
+      if (ts !== undefined) fetchedAts.push(ts);
+    }
+    const oldest = fetchedAts.length ? Math.min(...fetchedAts) : Date.now();
+    const newest = fetchedAts.length ? Math.max(...fetchedAts) : Date.now();
+    const hit = toFetch.length === 0;
+
+    this.logReadCall({
+      op: 'Transactions',
+      pages: totalPages,
+      latencyMs: Date.now() - startedAt,
+      rows: merged.length,
+      cache_hit: hit,
+      from_to_months: allMonths.length,
+      fetched_months: toFetch.length,
     });
-    return {
-      rows: memoResult.result,
-      fetched_at: memoResult.fetched_at,
-      hit: memoResult.hit,
-    };
+
+    return { rows: merged, oldest_fetched_at: oldest, newest_fetched_at: newest, hit };
   }
 
   // ── Phase 2: cache accessors ──────────────────────────────────────────────

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -32,12 +32,7 @@ import {
 } from './graphql/queries/transactions.js';
 import { getMonthRange, monthsCovered } from '../utils/date.js';
 import { pLimit } from '../utils/concurrency.js';
-import {
-  InFlightRegistry,
-  SnapshotCache,
-  TransactionWindowCache,
-  type CachedTransaction,
-} from './cache/index.js';
+import { InFlightRegistry, SnapshotCache, TransactionWindowCache } from './cache/index.js';
 import type { AccountNode } from './graphql/queries/accounts.js';
 import type { Category, Tag, Budget, Recurring, Transaction } from '../models/index.js';
 
@@ -68,7 +63,7 @@ export class LiveCopilotDatabase {
   private readonly tagsCache: SnapshotCache<Tag>;
   private readonly budgetsCache: SnapshotCache<Budget>;
   private readonly recurringCache: SnapshotCache<Recurring>;
-  private readonly transactionsWindowCache: TransactionWindowCache<CachedTransaction>;
+  private readonly transactionsWindowCache: TransactionWindowCache<TransactionNode>;
 
   constructor(
     private readonly graphql: GraphQLClient,
@@ -99,7 +94,7 @@ export class LiveCopilotDatabase {
       { key: 'recurring', ttlMs: SIX_HOURS_MS, keyFn: (r) => r.recurring_id },
       this.inflight
     );
-    this.transactionsWindowCache = new TransactionWindowCache<CachedTransaction>(
+    this.transactionsWindowCache = new TransactionWindowCache<TransactionNode>(
       {
         liveTtlMs: 0,
         coldTtlMs: ONE_WEEK_MS,
@@ -168,11 +163,7 @@ export class LiveCopilotDatabase {
     // Without this trim, those rows pollute the wrong cache bucket and
     // get double-counted on subsequent full-range queries.
     const rows = rawRows.filter((r) => r.date >= monthStart && r.date <= monthEnd);
-    this.transactionsWindowCache.ingestMonth(
-      month,
-      rows as unknown as CachedTransaction[],
-      fetched_at
-    );
+    this.transactionsWindowCache.ingestMonth(month, rows, fetched_at);
     return { rows, fetched_at, pages };
   }
 
@@ -275,7 +266,7 @@ export class LiveCopilotDatabase {
     }
 
     const freshRows = successes.flatMap((s) => s.rows);
-    const merged = [...(cachedRows as unknown as TransactionNode[]), ...freshRows].filter(
+    const merged = [...cachedRows, ...freshRows].filter(
       (r) => r.date >= range.from && r.date <= range.to
     );
     merged.sort(
@@ -331,7 +322,7 @@ export class LiveCopilotDatabase {
     return this.recurringCache;
   }
 
-  getTransactionsWindowCache(): TransactionWindowCache<CachedTransaction> {
+  getTransactionsWindowCache(): TransactionWindowCache<TransactionNode> {
     return this.transactionsWindowCache;
   }
 
@@ -343,7 +334,7 @@ export class LiveCopilotDatabase {
    * the row is not currently cached.
    */
   patchLiveTransaction(id: string, fields: Partial<Transaction>): void {
-    let existing: CachedTransaction | undefined;
+    let existing: TransactionNode | undefined;
     for (const month of this.transactionsWindowCache.cachedMonths()) {
       const row = this.transactionsWindowCache.entriesForMonth(month).find((r) => r.id === id);
       if (row) {
@@ -352,7 +343,7 @@ export class LiveCopilotDatabase {
       }
     }
     if (!existing) return;
-    const merged = { ...existing, ...fields, id } as CachedTransaction;
+    const merged: TransactionNode = { ...existing, ...fields, id };
     this.transactionsWindowCache.upsert(merged);
   }
 

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -69,6 +69,7 @@ export class LiveCopilotDatabase {
 
   // Phase 2: tiered-cache primitives
   private readonly inflight: InFlightRegistry;
+  private readonly fetchLimit: ReturnType<typeof pLimit>;
   // Typed on AccountNode (GraphQL response shape) rather than the
   // LevelDB Account model. The live cache stores what the live read
   // path produces; tools that consume both shapes can map between
@@ -89,6 +90,7 @@ export class LiveCopilotDatabase {
     this.verbose = opts.verbose ?? false;
 
     this.inflight = new InFlightRegistry();
+    this.fetchLimit = pLimit(4);
     this.accountsCache = new SnapshotCache<AccountNode>(
       { key: 'accounts', ttlMs: ONE_HOUR_MS, keyFn: (a) => a.id },
       this.inflight
@@ -164,7 +166,7 @@ export class LiveCopilotDatabase {
     const filter = buildTransactionFilter({ startDate: monthStart, endDate: monthEnd });
     const fetched_at = Date.now();
     let pages = 0;
-    const rows = await paginateTransactions(
+    const rawRows = await paginateTransactions(
       (after) =>
         this.withRetry(async () => {
           pages += 1;
@@ -172,6 +174,12 @@ export class LiveCopilotDatabase {
         }),
       { startDate: monthStart }
     );
+    // Trim leaked tail-page rows that fall outside this month's window.
+    // `paginateTransactions` early-exits AFTER appending a page, so the
+    // trailing edge of the last page can dip into the previous month.
+    // Without this trim, those rows pollute the wrong cache bucket and
+    // get double-counted on subsequent full-range queries.
+    const rows = rawRows.filter((r) => r.date >= monthStart && r.date <= monthEnd);
     this.transactionsWindowCache.ingestMonth(month, rows as unknown as CachedTransaction[], fetched_at);
     return { rows, fetched_at, pages };
   }
@@ -255,12 +263,11 @@ export class LiveCopilotDatabase {
     const { cachedRows, toFetch } = this.transactionsWindowCache.plan(range, now);
 
     const startedAt = Date.now();
-    const limit = pLimit(4);
     let totalPages = 0;
 
     const settled = await Promise.allSettled(
       toFetch.map((month) =>
-        limit(() =>
+        this.fetchLimit(() =>
           this.inflight.run(`tx:${month}`, async () => {
             const result = await this.fetchMonth(month, sortArr, pageSize);
             totalPages += result.pages;

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -7,7 +7,6 @@
  * categories, budgets, recurring, and tags.
  *
  * The class owns cross-cutting concerns shared by every method:
- *   - short-lived result memoization (default 5 min TTL)
  *   - one retry on NETWORK errors (other GraphQL codes surface)
  *   - optional verbose logging to stderr for latency measurement
  *
@@ -42,17 +41,10 @@ import {
 import type { AccountNode } from './graphql/queries/accounts.js';
 import type { Category, Tag, Budget, Recurring, Transaction } from '../models/index.js';
 
-interface MemoEntry<T> {
-  result: T;
-  at: number;
-}
-
 export interface LiveDatabaseOptions {
-  memoTtlMs?: number;
   verbose?: boolean;
 }
 
-const DEFAULT_MEMO_TTL_MS = 5 * 60 * 1000;
 const RETRY_BACKOFF_MS = 500;
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
@@ -62,10 +54,7 @@ const ONE_WEEK_MS = 7 * ONE_DAY_MS;
 const DEFAULT_MAX_TX_ROWS = 20_000;
 
 export class LiveCopilotDatabase {
-  // existing fields
-  private readonly memoTtlMs: number;
   private readonly verbose: boolean;
-  private readonly memoStore: Map<string, MemoEntry<unknown>> = new Map();
 
   // Phase 2: tiered-cache primitives
   private readonly inflight: InFlightRegistry;
@@ -86,7 +75,6 @@ export class LiveCopilotDatabase {
     private readonly cache: CopilotDatabase,
     opts: LiveDatabaseOptions = {}
   ) {
-    this.memoTtlMs = opts.memoTtlMs ?? DEFAULT_MEMO_TTL_MS;
     this.verbose = opts.verbose ?? false;
 
     this.inflight = new InFlightRegistry();
@@ -182,20 +170,6 @@ export class LiveCopilotDatabase {
     const rows = rawRows.filter((r) => r.date >= monthStart && r.date <= monthEnd);
     this.transactionsWindowCache.ingestMonth(month, rows as unknown as CachedTransaction[], fetched_at);
     return { rows, fetched_at, pages };
-  }
-
-  async memoize<T>(
-    key: string,
-    loader: () => Promise<T>
-  ): Promise<{ result: T; fetched_at: number; hit: boolean }> {
-    const existing = this.memoStore.get(key);
-    if (existing && Date.now() - existing.at < this.memoTtlMs) {
-      return { result: existing.result as T, fetched_at: existing.at, hit: true };
-    }
-    const result = await loader();
-    const at = Date.now();
-    this.memoStore.set(key, { result, at });
-    return { result, fetched_at: at, hit: false };
   }
 
   logReadCall(log: {

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -111,7 +111,6 @@ export class LiveCopilotDatabase {
     this.transactionsWindowCache = new TransactionWindowCache<CachedTransaction>(
       {
         liveTtlMs: 0,
-        warmTtlMs: ONE_HOUR_MS,
         coldTtlMs: ONE_WEEK_MS,
         maxRows: DEFAULT_MAX_TX_ROWS,
       },
@@ -167,7 +166,7 @@ export class LiveCopilotDatabase {
     pages: number;
     latencyMs: number;
     rows: number;
-    ttl_tier?: 'live' | 'warm' | 'cold';
+    ttl_tier?: 'live' | 'cold';
     cache_hit?: boolean;
     staleness_ms?: number | null;
     month?: string;

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -168,7 +168,11 @@ export class LiveCopilotDatabase {
     // Without this trim, those rows pollute the wrong cache bucket and
     // get double-counted on subsequent full-range queries.
     const rows = rawRows.filter((r) => r.date >= monthStart && r.date <= monthEnd);
-    this.transactionsWindowCache.ingestMonth(month, rows as unknown as CachedTransaction[], fetched_at);
+    this.transactionsWindowCache.ingestMonth(
+      month,
+      rows as unknown as CachedTransaction[],
+      fetched_at
+    );
     return { rows, fetched_at, pages };
   }
 
@@ -224,7 +228,9 @@ export class LiveCopilotDatabase {
     hit: boolean;
   }> {
     if (!range.from || !range.to) {
-      throw new Error(`getTransactions requires both from and to (got from='${range.from}', to='${range.to}')`);
+      throw new Error(
+        `getTransactions requires both from and to (got from='${range.from}', to='${range.to}')`
+      );
     }
     if (range.from > range.to) {
       throw new Error(`getTransactions: from (${range.from}) must be <= to (${range.to})`);
@@ -274,9 +280,7 @@ export class LiveCopilotDatabase {
     );
     merged.sort(
       (a, b) =>
-        b.date.localeCompare(a.date) ||
-        b.createdAt - a.createdAt ||
-        b.id.localeCompare(a.id)
+        b.date.localeCompare(a.date) || b.createdAt - a.createdAt || b.id.localeCompare(a.id)
     );
 
     // Freshness envelope: walk every month in the requested range and

--- a/src/tools/live/accounts.ts
+++ b/src/tools/live/accounts.ts
@@ -54,7 +54,7 @@ export class LiveAccountsTools {
 
     // Log after filtering so `rows` reflects what's actually returned to
     // the caller, not the raw cached count. ttl_tier is omitted because
-    // the live/warm/cold labels are tied to TransactionWindowCache's
+    // the live/cold labels are tied to TransactionWindowCache's
     // age-based classification — they don't map cleanly to a snapshot
     // cache with a fixed 1h TTL.
     this.live.logReadCall({

--- a/src/tools/live/transactions.ts
+++ b/src/tools/live/transactions.ts
@@ -332,17 +332,6 @@ export class LiveTransactionsTools {
       );
     }
 
-    if (
-      (opts.query !== undefined || opts.merchant !== undefined) &&
-      !opts.start_date &&
-      !opts.end_date &&
-      !opts.period
-    ) {
-      throw new Error(
-        `Query/merchant searches in live mode require a date range. Pass period (e.g. period: 'this_year') or start_date + end_date.`
-      );
-    }
-
     if (opts.transaction_id !== undefined) {
       if (!opts.account_id || !opts.item_id) {
         throw new Error(
@@ -354,6 +343,17 @@ export class LiveTransactionsTools {
           `transaction_id lookup in live mode also requires a date range (start_date, end_date, or period) to bound the search. Pass the date from the prior get_transactions_live result — the server has no single-transaction-by-id filter, so unbounded lookups paginate the whole account history.`
         );
       }
+    }
+
+    if (
+      (opts.query !== undefined || opts.merchant !== undefined) &&
+      !opts.start_date &&
+      !opts.end_date &&
+      !opts.period
+    ) {
+      throw new Error(
+        `Query/merchant searches in live mode require a date range. Pass period (e.g. period: 'this_year') or start_date + end_date.`
+      );
     }
   }
 }

--- a/src/tools/live/transactions.ts
+++ b/src/tools/live/transactions.ts
@@ -136,6 +136,8 @@ export class LiveTransactionsTools {
     } = await this.live.getTransactions({ from: start_date, to: end_date });
     const fetchedAtIso = new Date(oldest_fetched_at).toISOString();
     const newestIso = new Date(newest_fetched_at).toISOString();
+    // GraphQL guarantees the (id, accountId, itemId) triple is unique per transaction,
+    // so find() returns at most one match. No tie-breaking needed.
     const match = nodes.find(
       (n) =>
         n.id === opts.transaction_id && n.accountId === opts.account_id && n.itemId === opts.item_id
@@ -216,7 +218,8 @@ export class LiveTransactionsTools {
       result = result.filter((n) => n.isPending === opts.pending);
     }
 
-    // 6. matchString (query precedence over merchant; case-insensitive substring)
+    // 6. matchString (query precedence over merchant via ??; the !== '' guard
+    // below also skips filtering when the value is an empty string).
     const needleRaw = opts.query ?? opts.merchant;
     if (needleRaw !== undefined && needleRaw !== '') {
       const needle = needleRaw.toLowerCase();

--- a/src/tools/live/transactions.ts
+++ b/src/tools/live/transactions.ts
@@ -11,7 +11,6 @@
 
 import type { LiveCopilotDatabase } from '../../core/live-database.js';
 import type {
-  AccountRef,
   ReadTransactionType,
   TransactionNode,
 } from '../../core/graphql/queries/transactions.js';
@@ -97,40 +96,23 @@ export class LiveTransactionsTools {
       ? parsePeriod(opts.period)
       : [opts.start_date, opts.end_date];
 
-    const accountRefs = opts.account_id
-      ? [await this.resolveAccountRef(opts.account_id)]
-      : undefined;
-
-    const categoryIds = opts.category ? [opts.category] : undefined;
-
-    const tagIds = opts.tag ? await this.resolveTagIds(opts.tag) : undefined;
-
-    const matchString = opts.query ?? opts.merchant;
-
-    const types: ReadTransactionType[] | undefined =
-      opts.exclude_transfers !== false ? ['REGULAR', 'INCOME'] : undefined;
+    if (!start_date || !end_date) {
+      throw new Error(`Date range required: pass period, start_date, or end_date.`);
+    }
 
     const {
       rows: nodes,
-      fetched_at,
+      oldest_fetched_at,
+      newest_fetched_at,
       hit,
-    } = await this.live.getTransactions({
-      startDate: start_date,
-      endDate: end_date,
-      accountRefs,
-      categoryIds,
-      tagIds,
-      types,
-      matchString,
-    });
+    } = await this.live.getTransactions({ from: start_date, to: end_date });
 
     const filtered = await this.postFilter(nodes, opts);
     const page = await this.paginateAndEnrich(filtered, opts);
-    const fetchedAtIso = new Date(fetched_at).toISOString();
     return {
       ...page,
-      _cache_oldest_fetched_at: fetchedAtIso,
-      _cache_newest_fetched_at: fetchedAtIso,
+      _cache_oldest_fetched_at: new Date(oldest_fetched_at).toISOString(),
+      _cache_newest_fetched_at: new Date(newest_fetched_at).toISOString(),
       _cache_hit: hit,
     };
   }
@@ -138,28 +120,26 @@ export class LiveTransactionsTools {
   private async singleTransactionLookup(
     opts: GetTransactionsLiveOptions
   ): Promise<GetTransactionsLiveResult> {
-    // validate() guarantees both account_id and item_id are present for the
-    // single-transaction path. Use the caller-supplied item_id directly so the
-    // documented contract ("all three come from a prior list result") is
-    // actually enforced — not silently bypassed via a cache lookup.
-    const ref: AccountRef = { accountId: opts.account_id!, itemId: opts.item_id! };
-    // Resolve period → [start, end] exactly like the main path, so a caller
-    // passing only `period` still produces a bounded fetch. validate() already
-    // guarantees at least one of (start_date, end_date, period) is present.
     const [start_date, end_date] = opts.period
       ? parsePeriod(opts.period)
       : [opts.start_date, opts.end_date];
+    if (!start_date || !end_date) {
+      throw new Error(
+        `transaction_id lookup requires a date range. Pass period, start_date, or end_date.`
+      );
+    }
     const {
       rows: nodes,
-      fetched_at,
+      oldest_fetched_at,
+      newest_fetched_at,
       hit,
-    } = await this.live.getTransactions({
-      accountRefs: [ref],
-      startDate: start_date,
-      endDate: end_date,
-    });
-    const fetchedAtIso = new Date(fetched_at).toISOString();
-    const match = nodes.find((n) => n.id === opts.transaction_id);
+    } = await this.live.getTransactions({ from: start_date, to: end_date });
+    const fetchedAtIso = new Date(oldest_fetched_at).toISOString();
+    const newestIso = new Date(newest_fetched_at).toISOString();
+    const match = nodes.find(
+      (n) =>
+        n.id === opts.transaction_id && n.accountId === opts.account_id && n.itemId === opts.item_id
+    );
     if (!match) {
       return {
         count: 0,
@@ -168,7 +148,7 @@ export class LiveTransactionsTools {
         has_more: false,
         transactions: [],
         _cache_oldest_fetched_at: fetchedAtIso,
-        _cache_newest_fetched_at: fetchedAtIso,
+        _cache_newest_fetched_at: newestIso,
         _cache_hit: hit,
       };
     }
@@ -180,20 +160,9 @@ export class LiveTransactionsTools {
       has_more: false,
       transactions: enriched,
       _cache_oldest_fetched_at: fetchedAtIso,
-      _cache_newest_fetched_at: fetchedAtIso,
+      _cache_newest_fetched_at: newestIso,
       _cache_hit: hit,
     };
-  }
-
-  private async resolveAccountRef(accountId: string): Promise<AccountRef> {
-    const accounts = await this.live.getCache().getAccounts();
-    const match = accounts.find((a) => a.account_id === accountId);
-    if (!match || !match.item_id) {
-      throw new Error(
-        `Account '${accountId}' not found in local cache. Refresh the cache (open the Copilot app) or pass a valid account_id.`
-      );
-    }
-    return { accountId: match.account_id, itemId: match.item_id };
   }
 
   private async resolveTagIds(tagName: string): Promise<string[]> {
@@ -215,18 +184,24 @@ export class LiveTransactionsTools {
   ): Promise<TransactionNode[]> {
     let result = nodes;
 
+    // 1. types (exclude_transfers default true)
     if (opts.exclude_transfers !== false) {
       result = result.filter((n) => n.type !== 'INTERNAL_TRANSFER');
     }
 
-    if (opts.exclude_excluded !== false) {
-      const cats = await this.live.getCache().getUserCategories();
-      const excludedCatIds = new Set(
-        cats.filter((c) => c.excluded === true).map((c) => c.category_id)
-      );
-      result = result.filter((n) => !n.categoryId || !excludedCatIds.has(n.categoryId));
+    // 2. accountId
+    if (opts.account_id !== undefined) {
+      const id = opts.account_id;
+      result = result.filter((n) => n.accountId === id);
     }
 
+    // 3. categoryId
+    if (opts.category !== undefined) {
+      const cid = opts.category;
+      result = result.filter((n) => n.categoryId === cid);
+    }
+
+    // 4. amount range
     if (opts.min_amount !== undefined) {
       const min = opts.min_amount;
       result = result.filter((n) => Math.abs(n.amount) >= min);
@@ -236,10 +211,34 @@ export class LiveTransactionsTools {
       result = result.filter((n) => Math.abs(n.amount) <= max);
     }
 
+    // 5. pending
     if (opts.pending !== undefined) {
       result = result.filter((n) => n.isPending === opts.pending);
     }
 
+    // 6. matchString (query precedence over merchant; case-insensitive substring)
+    const needleRaw = opts.query ?? opts.merchant;
+    if (needleRaw !== undefined && needleRaw !== '') {
+      const needle = needleRaw.toLowerCase();
+      result = result.filter((n) => n.name.toLowerCase().includes(needle));
+    }
+
+    // 7. tag (resolved name → id, then membership in n.tags[])
+    if (opts.tag !== undefined) {
+      const resolvedTagIds = new Set(await this.resolveTagIds(opts.tag));
+      result = result.filter((n) => n.tags.some((t) => resolvedTagIds.has(t.id)));
+    }
+
+    // 8. exclude_excluded
+    if (opts.exclude_excluded !== false) {
+      const cats = await this.live.getCache().getUserCategories();
+      const excludedCatIds = new Set(
+        cats.filter((c) => c.excluded === true).map((c) => c.category_id)
+      );
+      result = result.filter((n) => !n.categoryId || !excludedCatIds.has(n.categoryId));
+    }
+
+    // 9. transaction_type variants
     if (opts.transaction_type === 'tagged') {
       result = result.filter((n) => n.tags.length > 0);
     } else if (opts.transaction_type === 'refunds') {
@@ -327,6 +326,17 @@ export class LiveTransactionsTools {
     if (opts.exclude_split_parents === false) {
       throw new Error(
         `Parameter 'exclude_split_parents=false' is not supported in live mode — the GraphQL server omits split parents. Retry without 'exclude_split_parents' or set it to true.`
+      );
+    }
+
+    if (
+      (opts.query !== undefined || opts.merchant !== undefined) &&
+      !opts.start_date &&
+      !opts.end_date &&
+      !opts.period
+    ) {
+      throw new Error(
+        `Query/merchant searches in live mode require a date range. Pass period (e.g. period: 'this_year') or start_date + end_date.`
       );
     }
 

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -7,6 +7,9 @@
  * regardless of settlement outcome.
  */
 export function pLimit(concurrency: number) {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new RangeError(`pLimit: concurrency must be a positive integer (got ${concurrency})`);
+  }
   let active = 0;
   const queue: Array<() => void> = [];
   const next = () => {
@@ -23,7 +26,8 @@ export function pLimit(concurrency: number) {
             next();
           },
           (err: unknown) => {
-            reject(err instanceof Error ? err : new Error(String(err)));
+            // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors -- pLimit is a transparent wrapper; preserve caller's rejection value verbatim.
+            reject(err);
             next();
           }
         );

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,37 @@
+/**
+ * Bounded-concurrency promise pool.
+ *
+ * Returns a function `limit(fn)` that runs at most `concurrency` callbacks
+ * concurrently. Excess callers are queued FIFO. A rejection in one task
+ * does not affect other queued or in-flight tasks; the slot is released
+ * regardless of settlement outcome.
+ */
+export function pLimit(concurrency: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  const next = () => {
+    active -= 1;
+    queue.shift()?.();
+  };
+  return <T>(fn: () => Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      const run = () => {
+        active += 1;
+        fn().then(
+          (value) => {
+            resolve(value);
+            next();
+          },
+          (err: unknown) => {
+            reject(err instanceof Error ? err : new Error(String(err)));
+            next();
+          }
+        );
+      };
+      if (active < concurrency) {
+        run();
+      } else {
+        queue.push(run);
+      }
+    });
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -140,9 +140,9 @@ export function monthsCovered(range: DateRangeArg): YearMonth[] {
  * relative to `now`. Clamped at 0 — current and future months return 0.
  *
  * Used by TransactionWindowCache to resolve a month into one of the
- * tier classes (live ≤7d / warm 8-21d / cold >21d). Computed in UTC so
- * the tier classification is timezone-invariant: a month with `now -
- * last_day` of exactly 7.0 days produces the same tier in every TZ.
+ * tier classes (live ≤14d / cold >14d). Computed in UTC so the tier
+ * classification is timezone-invariant: a month with `now - last_day`
+ * of exactly 14.0 days produces the same tier in every TZ.
  */
 export function monthAge(month: YearMonth, now: Date): number {
   const year = Number(month.slice(0, 4));

--- a/tests/core/cache/transaction-window-cache.test.ts
+++ b/tests/core/cache/transaction-window-cache.test.ts
@@ -16,7 +16,6 @@ const makeCache = () =>
   new TransactionWindowCache(
     {
       liveTtlMs: 0, // never cache live tier
-      warmTtlMs: 60 * 60 * 1000, // 1h
       coldTtlMs: 7 * 24 * 60 * 60 * 1000, // 1w
       maxRows: 1000,
     },
@@ -24,69 +23,61 @@ const makeCache = () =>
   );
 
 describe('TransactionWindowCache.tierFor', () => {
-  const today = new Date('2026-04-15');
-
   test('current month → live', () => {
     const cache = makeCache();
-    expect(cache.tierFor('2026-04', today)).toBe('live');
+    expect(cache.tierFor('2026-05', new Date('2026-05-15'))).toBe('live');
   });
 
-  test('previous month with min_age in (7, 21] → warm', () => {
+  test('previous month with min_age ≤ 14 → live', () => {
     const cache = makeCache();
-    expect(cache.tierFor('2026-03', today)).toBe('warm'); // 15d
+    expect(cache.tierFor('2026-04', new Date('2026-05-10'))).toBe('live');
   });
 
   test('two months ago → cold', () => {
     const cache = makeCache();
-    expect(cache.tierFor('2026-02', today)).toBe('cold'); // 46d
+    expect(cache.tierFor('2026-03', new Date('2026-05-15'))).toBe('cold');
   });
 
   test('future month → live (clamped)', () => {
     const cache = makeCache();
-    expect(cache.tierFor('2026-05', today)).toBe('live');
+    expect(cache.tierFor('2026-06', new Date('2026-05-15'))).toBe('live');
   });
 
-  test('boundary at exactly 7 days → live', () => {
-    // Last day of '2026-03' is 2026-03-31. 7d after = 2026-04-07.
+  test('boundary at exactly 14 days → live', () => {
     const cache = makeCache();
-    expect(cache.tierFor('2026-03', new Date('2026-04-07'))).toBe('live');
+    expect(cache.tierFor('2026-04', new Date('2026-05-14'))).toBe('live');
   });
 
-  test('boundary at exactly 21 days → warm', () => {
-    // Last day of '2026-03' is 2026-03-31. 21d after = 2026-04-21.
+  test('boundary at 15 days → cold', () => {
     const cache = makeCache();
-    expect(cache.tierFor('2026-03', new Date('2026-04-21'))).toBe('warm');
-  });
-
-  test('boundary at 22 days → cold', () => {
-    // First cold day is 22d. 22d after 2026-03-31 = 2026-04-22.
-    const cache = makeCache();
-    expect(cache.tierFor('2026-03', new Date('2026-04-22'))).toBe('cold');
+    expect(cache.tierFor('2026-04', new Date('2026-05-15'))).toBe('cold');
   });
 });
 
 describe('TransactionWindowCache.plan', () => {
-  const today = new Date('2026-04-15');
+  const today = new Date('2026-05-15');
 
   test('all months absent from cache → all in toFetch', () => {
     const cache = makeCache();
-    const result = cache.plan({ from: '2026-02-01', to: '2026-04-15' }, today);
-    expect(result.toFetch).toEqual(['2026-02', '2026-03', '2026-04']);
+    const result = cache.plan({ from: '2026-03-01', to: '2026-05-15' }, today);
+    expect(result.toFetch).toEqual(['2026-03', '2026-04', '2026-05']);
     expect(result.cachedRows).toEqual([]);
   });
 
-  test('cached fresh months are pulled; live month is always in toFetch', () => {
+  test('cached fresh cold months are pulled; live month is always in toFetch', () => {
     const cache = makeCache();
     cache.ingestMonth('2026-02', [mkTx('a', '2026-02-10')], Date.now());
     cache.ingestMonth('2026-03', [mkTx('b', '2026-03-20')], Date.now());
+    cache.ingestMonth('2026-04', [mkTx('c', '2026-04-15')], Date.now());
 
-    const result = cache.plan({ from: '2026-02-01', to: '2026-04-15' }, today);
-    expect(result.toFetch).toEqual(['2026-04']);
-    expect(result.cachedRows.map((r) => r.id).sort()).toEqual(['a', 'b']);
+    const result = cache.plan({ from: '2026-02-01', to: '2026-05-15' }, today);
+    expect(result.toFetch).toEqual(['2026-05']);
+    expect(result.cachedRows.map((r) => r.id).sort()).toEqual(['a', 'b', 'c']);
   });
 
   test('stale cold-tier month is in toFetch', () => {
     const cache = makeCache();
+    // Cold TTL is 1w; ingest a month with fetched_at 8 days ago → stale.
     const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
     cache.ingestMonth('2026-02', [mkTx('a', '2026-02-10')], eightDaysAgo);
 
@@ -99,10 +90,10 @@ describe('TransactionWindowCache.plan', () => {
     // Caller is responsible for ingesting fresh results; old cache state
     // for a live month is not optimistically returned.
     const cache = makeCache();
-    cache.ingestMonth('2026-04', [mkTx('a', '2026-04-10')], Date.now());
+    cache.ingestMonth('2026-05', [mkTx('a', '2026-05-10')], Date.now());
 
-    const result = cache.plan({ from: '2026-04-01', to: '2026-04-30' }, today);
-    expect(result.toFetch).toEqual(['2026-04']);
+    const result = cache.plan({ from: '2026-05-01', to: '2026-05-31' }, today);
+    expect(result.toFetch).toEqual(['2026-05']);
     expect(result.cachedRows).toEqual([]);
   });
 
@@ -165,7 +156,6 @@ describe('TransactionWindowCache.evictLRU', () => {
     const cache = new TransactionWindowCache(
       {
         liveTtlMs: 0,
-        warmTtlMs: 60 * 60 * 1000,
         coldTtlMs: 7 * 24 * 60 * 60 * 1000,
         maxRows: 100,
       },
@@ -274,5 +264,26 @@ describe('TransactionWindowCache accessors', () => {
   test('entriesForMonth returns empty array for uncached month', () => {
     const cache = makeCache();
     expect(cache.entriesForMonth('2026-03')).toEqual([]);
+  });
+});
+
+describe('TransactionWindowCache.getFetchedAt', () => {
+  test('returns fetched_at for cached month', () => {
+    const cache = makeCache();
+    const ts = 1_700_000_000_000;
+    cache.ingestMonth('2026-03', [mkTx('a', '2026-03-10')], ts);
+    expect(cache.getFetchedAt('2026-03')).toBe(ts);
+  });
+
+  test('returns undefined for uncached month', () => {
+    const cache = makeCache();
+    expect(cache.getFetchedAt('2026-03')).toBeUndefined();
+  });
+
+  test('reflects re-ingest timestamp', () => {
+    const cache = makeCache();
+    cache.ingestMonth('2026-03', [], 1);
+    cache.ingestMonth('2026-03', [], 2);
+    expect(cache.getFetchedAt('2026-03')).toBe(2);
   });
 });

--- a/tests/core/cache/transaction-window-cache.test.ts
+++ b/tests/core/cache/transaction-window-cache.test.ts
@@ -101,7 +101,13 @@ describe('TransactionWindowCache.plan', () => {
 
   test('cachedRows are sliced to the requested range', () => {
     const cache = makeCache();
-    cache.ingestMonth('2026-03', [mkTx('a', '2026-03-05'), mkTx('b', '2026-03-25')], Date.now());
+    // Ingest with today's clock so the cold-tier TTL check (now-consistent
+    // since the recent clock-alignment fix) sees the entry as fresh.
+    cache.ingestMonth(
+      '2026-03',
+      [mkTx('a', '2026-03-05'), mkTx('b', '2026-03-25')],
+      today.getTime()
+    );
 
     const result = cache.plan({ from: '2026-03-10', to: '2026-03-31' }, today);
     expect(result.cachedRows.map((r) => r.id)).toEqual(['b']);

--- a/tests/core/cache/transaction-window-cache.test.ts
+++ b/tests/core/cache/transaction-window-cache.test.ts
@@ -66,9 +66,11 @@ describe('TransactionWindowCache.plan', () => {
 
   test('cached fresh cold months are pulled; live month is always in toFetch', () => {
     const cache = makeCache();
-    cache.ingestMonth('2026-02', [mkTx('a', '2026-02-10')], Date.now());
-    cache.ingestMonth('2026-03', [mkTx('b', '2026-03-20')], Date.now());
-    cache.ingestMonth('2026-04', [mkTx('c', '2026-04-15')], Date.now());
+    // Fixed timestamp 1 day before today (2026-05-15) to avoid boundary races.
+    const freshAt = new Date('2026-05-14').getTime();
+    cache.ingestMonth('2026-02', [mkTx('a', '2026-02-10')], freshAt);
+    cache.ingestMonth('2026-03', [mkTx('b', '2026-03-20')], freshAt);
+    cache.ingestMonth('2026-04', [mkTx('c', '2026-04-15')], freshAt);
 
     const result = cache.plan({ from: '2026-02-01', to: '2026-05-15' }, today);
     expect(result.toFetch).toEqual(['2026-05']);

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -495,12 +495,12 @@ describe('LiveCopilotDatabase — logReadCall', () => {
         pages: 1,
         latencyMs: 320,
         rows: 12,
-        ttl_tier: 'warm',
+        ttl_tier: 'cold',
         cache_hit: false,
       });
       expect(lines.length).toBe(1);
       expect(lines[0]).toContain('op=Accounts');
-      expect(lines[0]).toContain('ttl_tier=warm');
+      expect(lines[0]).toContain('ttl_tier=cold');
       expect(lines[0]).toContain('cache_hit=false');
       expect(lines[0]).toContain('pages=1');
       expect(lines[0]).toContain('latency=320ms');

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -258,6 +258,60 @@ describe('LiveCopilotDatabase.getTransactions (windowed)', () => {
     expect(wc.cachedMonths().length).toBe(1);
   });
 
+  test('cross-month leakage is filtered before ingest (no cache pollution)', async () => {
+    // Page returns Feb rows AND a January row (paginate's tail).
+    const client = mkClientReturning([
+      mkPage([
+        { id: 'feb1', date: '2025-02-15' },
+        { id: 'jan-leak', date: '2025-01-30' }, // outside Feb's range
+      ]),
+    ]);
+    const live = new LiveCopilotDatabase(client, mkCache());
+    await live.getTransactions({ from: '2025-02-01', to: '2025-02-28' });
+
+    // The leaked January row must NOT have polluted Feb's cache bucket.
+    const wc = live.getTransactionsWindowCache();
+    const febRows = wc.entriesForMonth('2025-02');
+    expect(febRows.map((r) => r.id)).toEqual(['feb1']);
+    expect(wc.entriesForMonth('2025-01')).toEqual([]);
+  });
+
+  test('shared concurrency cap across concurrent calls', async () => {
+    // 8 distinct months across 2 callers; only 4 should be in-flight at once.
+    let active = 0;
+    let peak = 0;
+    let resolveAll!: () => void;
+    const gate = new Promise<void>((r) => {
+      resolveAll = r;
+    });
+    let queryNum = 0;
+    const client = {
+      mutate: mock(),
+      query: mock(async () => {
+        active += 1;
+        peak = Math.max(peak, active);
+        queryNum += 1;
+        const num = queryNum;
+        await gate;
+        active -= 1;
+        return { transactions: mkPage([{ id: `t${num}`, date: '2025-01-15' }]) };
+      }),
+    } as unknown as GraphQLClient;
+    const live = new LiveCopilotDatabase(client, mkCache());
+
+    // Caller A wants 4 distinct months, caller B wants 4 different distinct months.
+    const a = live.getTransactions({ from: '2025-01-01', to: '2025-04-30' });
+    const b = live.getTransactions({ from: '2025-05-01', to: '2025-08-31' });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(peak).toBeLessThanOrEqual(4);
+    resolveAll();
+    await Promise.all([a, b]);
+    expect(peak).toBeLessThanOrEqual(4);
+  });
+
   test('concurrent calls coalesce per-month via InFlightRegistry', async () => {
     let queryCalls = 0;
     let resolveAll!: () => void;

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -63,7 +63,6 @@ describe('LiveCopilotDatabase — withRetry', () => {
   });
 });
 
-
 describe('LiveCopilotDatabase.getTransactions (windowed)', () => {
   function mkClientReturning(pages: TransactionsPage[]): GraphQLClient {
     let i = 0;
@@ -199,9 +198,9 @@ describe('LiveCopilotDatabase.getTransactions (windowed)', () => {
       }),
     } as unknown as GraphQLClient;
     const live = new LiveCopilotDatabase(client, mkCache());
-    await expect(
-      live.getTransactions({ from: '2025-01-01', to: '2025-02-28' })
-    ).rejects.toThrow(/Failed to fetch/);
+    await expect(live.getTransactions({ from: '2025-01-01', to: '2025-02-28' })).rejects.toThrow(
+      /Failed to fetch/
+    );
     const wc = live.getTransactionsWindowCache();
     expect(wc.cachedMonths().length).toBe(1);
   });
@@ -608,6 +607,33 @@ describe('LiveCopilotDatabase — logReadCall', () => {
       });
       live.logReadCall({ op: 'Transactions', pages: 1, latencyMs: 100, rows: 0, cache_hit: true });
       expect(lines.length).toBe(0);
+    } finally {
+      console.error = origError;
+    }
+  });
+
+  test('logReadCall emits from_to_months and fetched_months when set', () => {
+    const lines: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => {
+      lines.push(args.map(String).join(' '));
+    };
+    try {
+      const live = new LiveCopilotDatabase({} as GraphQLClient, {} as CopilotDatabase, {
+        verbose: true,
+      });
+      live.logReadCall({
+        op: 'Transactions',
+        pages: 8,
+        latencyMs: 2843,
+        rows: 2412,
+        cache_hit: false,
+        from_to_months: 12,
+        fetched_months: 2,
+      });
+      expect(lines.length).toBe(1);
+      expect(lines[0]).toContain('from_to_months=12');
+      expect(lines[0]).toContain('fetched_months=2');
     } finally {
       console.error = origError;
     }

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -283,6 +283,15 @@ describe('LiveCopilotDatabase.getTransactions (windowed)', () => {
     await Promise.all([a, b]);
     expect(queryCalls).toBe(1);
   });
+
+  test('single-day range works (from === to)', async () => {
+    const client = mkClientReturning([mkPage([{ id: 't1', date: '2025-01-15' }])]);
+    const live = new LiveCopilotDatabase(client, mkCache());
+    const result = await live.getTransactions({ from: '2025-01-15', to: '2025-01-15' });
+    expect(result.rows.map((r) => r.id)).toEqual(['t1']);
+    expect(result.hit).toBe(false);
+    expect(result.oldest_fetched_at).toBe(result.newest_fetched_at);
+  });
 });
 
 describe('preflightLiveAuth', () => {

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -63,58 +63,6 @@ describe('LiveCopilotDatabase — withRetry', () => {
   });
 });
 
-describe('LiveCopilotDatabase — memo', () => {
-  test('returns cached value within TTL', async () => {
-    const live = new LiveCopilotDatabase(mkClient(), mkCache(), { memoTtlMs: 60_000 });
-    let calls = 0;
-    const loader = async () => {
-      calls += 1;
-      return { value: calls };
-    };
-    const a = await live.memoize('key-1', loader);
-    const b = await live.memoize('key-1', loader);
-    expect(a.result).toEqual({ value: 1 });
-    expect(b.result).toEqual({ value: 1 });
-    expect(calls).toBe(1);
-  });
-
-  test('hit=false on first call, hit=true on second call within TTL', async () => {
-    const live = new LiveCopilotDatabase(mkClient(), mkCache(), { memoTtlMs: 60_000 });
-    const loader = async () => 42;
-    const a = await live.memoize('key-hit', loader);
-    const b = await live.memoize('key-hit', loader);
-    expect(a.hit).toBe(false);
-    expect(b.hit).toBe(true);
-  });
-
-  test('fetched_at is stable across cache hits', async () => {
-    const live = new LiveCopilotDatabase(mkClient(), mkCache(), { memoTtlMs: 60_000 });
-    const loader = async () => 'x';
-    const a = await live.memoize('key-ts', loader);
-    const b = await live.memoize('key-ts', loader);
-    expect(b.fetched_at).toBe(a.fetched_at);
-  });
-
-  test('re-loads after TTL expires', async () => {
-    const live = new LiveCopilotDatabase(mkClient(), mkCache(), { memoTtlMs: 1 });
-    let calls = 0;
-    const loader = async () => {
-      calls += 1;
-      return calls;
-    };
-    await live.memoize('k', loader);
-    await new Promise((r) => setTimeout(r, 5));
-    await live.memoize('k', loader);
-    expect(calls).toBe(2);
-  });
-
-  test('distinguishes different keys', async () => {
-    const live = new LiveCopilotDatabase(mkClient(), mkCache());
-    await live.memoize('a', async () => 1);
-    const b = await live.memoize('b', async () => 2);
-    expect(b.result).toBe(2);
-  });
-});
 
 describe('LiveCopilotDatabase.getTransactions (windowed)', () => {
   function mkClientReturning(pages: TransactionsPage[]): GraphQLClient {

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -116,87 +116,171 @@ describe('LiveCopilotDatabase — memo', () => {
   });
 });
 
-function mkClientReturning(pages: TransactionsPage[]): GraphQLClient {
-  let i = 0;
-  return {
-    mutate: mock(),
-    query: mock(() => Promise.resolve({ transactions: pages[i++] })),
-  } as unknown as GraphQLClient;
-}
+describe('LiveCopilotDatabase.getTransactions (windowed)', () => {
+  function mkClientReturning(pages: TransactionsPage[]): GraphQLClient {
+    let i = 0;
+    return {
+      mutate: mock(),
+      query: mock(() => Promise.resolve({ transactions: pages[i++] })),
+    } as unknown as GraphQLClient;
+  }
 
-describe('LiveCopilotDatabase.getTransactions', () => {
-  test('paginates through one page and returns rows', async () => {
+  function mkPage(rows: Array<{ id: string; date: string; createdAt?: number }>): TransactionsPage {
+    return {
+      edges: rows.map((r) => ({
+        cursor: `c-${r.id}`,
+        node: {
+          id: r.id,
+          accountId: 'a1',
+          itemId: 'i1',
+          categoryId: 'c1',
+          recurringId: null,
+          parentId: null,
+          isReviewed: false,
+          isPending: false,
+          amount: 10,
+          date: r.date,
+          name: `tx-${r.id}`,
+          type: 'REGULAR',
+          userNotes: null,
+          tipAmount: null,
+          suggestedCategoryIds: [],
+          isoCurrencyCode: 'USD',
+          createdAt: r.createdAt ?? 0,
+          tags: [],
+          goal: null,
+        },
+      })),
+      pageInfo: { endCursor: null, hasNextPage: false },
+    };
+  }
+
+  test('throws on missing or inverted range', async () => {
+    const live = new LiveCopilotDatabase(mkClient(), mkCache());
+    await expect(live.getTransactions({ from: '', to: '2025-12-31' })).rejects.toThrow();
+    await expect(live.getTransactions({ from: '2025-01-01', to: '' })).rejects.toThrow();
+    await expect(live.getTransactions({ from: '2025-12-31', to: '2025-01-01' })).rejects.toThrow();
+  });
+
+  test('pure cache miss fetches every month and ingests', async () => {
     const client = mkClientReturning([
-      {
-        edges: [
-          {
-            cursor: 'c1',
-            node: {
-              id: 't1',
-              accountId: 'a1',
-              itemId: 'i1',
-              categoryId: 'c',
-              recurringId: null,
-              parentId: null,
-              isReviewed: false,
-              isPending: false,
-              amount: 10,
-              date: '2025-06-01',
-              name: 'Amazon',
-              type: 'REGULAR',
-              userNotes: null,
-              tipAmount: null,
-              suggestedCategoryIds: [],
-              isoCurrencyCode: 'USD',
-              createdAt: 0,
-              tags: [],
-              goal: null,
-            },
-          },
-        ],
-        pageInfo: { endCursor: 'c1', hasNextPage: false },
-      },
+      mkPage([{ id: 't1', date: '2025-01-15' }]),
+      mkPage([{ id: 't2', date: '2025-02-15' }]),
     ]);
     const live = new LiveCopilotDatabase(client, mkCache());
-    const { rows } = await live.getTransactions({});
-    expect(rows).toHaveLength(1);
-    expect(rows[0]!.id).toBe('t1');
+    const result = await live.getTransactions({ from: '2025-01-01', to: '2025-02-28' });
+    expect(result.rows.map((r) => r.id).sort()).toEqual(['t1', 't2']);
+    expect(result.hit).toBe(false);
+    const wc = live.getTransactionsWindowCache();
+    expect(wc.hasMonth('2025-01')).toBe(true);
+    expect(wc.hasMonth('2025-02')).toBe(true);
   });
 
-  test('memoizes identical calls within TTL', async () => {
-    const page: TransactionsPage = {
-      edges: [],
-      pageInfo: { endCursor: null, hasNextPage: false },
-    };
-    const client = mkClientReturning([page]);
+  test('pure cache hit returns cached rows with no network', async () => {
+    const live = new LiveCopilotDatabase(mkClient(), mkCache());
+    const wc = live.getTransactionsWindowCache();
+    const ts = Date.now();
+    wc.ingestMonth(
+      '2024-06',
+      [
+        {
+          id: 't1',
+          date: '2024-06-10',
+          accountId: 'a1',
+          itemId: 'i1',
+          categoryId: null,
+          recurringId: null,
+          parentId: null,
+          isReviewed: false,
+          isPending: false,
+          amount: 10,
+          name: 'cached',
+          type: 'REGULAR',
+          userNotes: null,
+          tipAmount: null,
+          suggestedCategoryIds: [],
+          isoCurrencyCode: 'USD',
+          createdAt: 0,
+          tags: [],
+          goal: null,
+        },
+      ],
+      ts
+    );
+
+    const result = await live.getTransactions({ from: '2024-06-01', to: '2024-06-30' });
+    expect(result.rows.map((r) => r.id)).toEqual(['t1']);
+    expect(result.hit).toBe(true);
+    expect(result.oldest_fetched_at).toBe(ts);
+    expect(result.newest_fetched_at).toBe(ts);
+  });
+
+  test('returns rows sorted DESC by (date, createdAt, id)', async () => {
+    const client = mkClientReturning([
+      mkPage([
+        { id: 'a', date: '2025-01-15', createdAt: 100 },
+        { id: 'b', date: '2025-01-15', createdAt: 200 },
+        { id: 'c', date: '2025-01-20', createdAt: 50 },
+      ]),
+    ]);
     const live = new LiveCopilotDatabase(client, mkCache());
-
-    await live.getTransactions({ startDate: '2025-01-01' });
-    await live.getTransactions({ startDate: '2025-01-01' });
-
-    const qCalls = (client.query as ReturnType<typeof mock>).mock.calls;
-    expect(qCalls).toHaveLength(1);
+    const result = await live.getTransactions({ from: '2025-01-01', to: '2025-01-31' });
+    expect(result.rows.map((r) => r.id)).toEqual(['c', 'b', 'a']);
   });
 
-  test('retries once on NETWORK error per page', async () => {
-    let calls = 0;
-    const page: TransactionsPage = {
-      edges: [],
-      pageInfo: { endCursor: null, hasNextPage: false },
-    };
+  test('rows outside the requested range are trimmed after merge', async () => {
+    const client = mkClientReturning([
+      mkPage([
+        { id: 'in', date: '2025-01-15' },
+        { id: 'out', date: '2024-12-31' },
+      ]),
+    ]);
+    const live = new LiveCopilotDatabase(client, mkCache());
+    const result = await live.getTransactions({ from: '2025-01-01', to: '2025-01-31' });
+    expect(result.rows.map((r) => r.id)).toEqual(['in']);
+  });
+
+  test('one failing month rejects the entire call but ingests successes', async () => {
+    let i = 0;
     const client = {
       mutate: mock(),
       query: mock(() => {
-        calls += 1;
-        if (calls === 1) throw new GraphQLError('NETWORK', 'blip', 'Transactions');
-        return Promise.resolve({ transactions: page });
+        i += 1;
+        if (i === 2) throw new GraphQLError('AUTH_FAILED', '401', 'Transactions');
+        return Promise.resolve({ transactions: mkPage([{ id: `t${i}`, date: '2025-01-15' }]) });
+      }),
+    } as unknown as GraphQLClient;
+    const live = new LiveCopilotDatabase(client, mkCache());
+    await expect(
+      live.getTransactions({ from: '2025-01-01', to: '2025-02-28' })
+    ).rejects.toThrow(/Failed to fetch/);
+    const wc = live.getTransactionsWindowCache();
+    expect(wc.cachedMonths().length).toBe(1);
+  });
+
+  test('concurrent calls coalesce per-month via InFlightRegistry', async () => {
+    let queryCalls = 0;
+    let resolveAll!: () => void;
+    const gate = new Promise<void>((r) => {
+      resolveAll = r;
+    });
+    const client = {
+      mutate: mock(),
+      query: mock(async () => {
+        queryCalls += 1;
+        await gate;
+        return { transactions: mkPage([{ id: `t${queryCalls}`, date: '2025-01-15' }]) };
       }),
     } as unknown as GraphQLClient;
     const live = new LiveCopilotDatabase(client, mkCache());
 
-    const { rows } = await live.getTransactions({});
-    expect(rows).toHaveLength(0);
-    expect(calls).toBe(2);
+    const a = live.getTransactions({ from: '2025-01-01', to: '2025-01-31' });
+    const b = live.getTransactions({ from: '2025-01-01', to: '2025-01-31' });
+    await Promise.resolve();
+    await Promise.resolve();
+    resolveAll();
+    await Promise.all([a, b]);
+    expect(queryCalls).toBe(1);
   });
 });
 

--- a/tests/tools/live/transactions.test.ts
+++ b/tests/tools/live/transactions.test.ts
@@ -543,4 +543,21 @@ describe('LiveTransactionsTools — date-less query rejection', () => {
       })
     ).resolves.toBeDefined();
   });
+
+  test('validate: transaction_id path bypasses query-without-date guard', async () => {
+    const live = mkLiveReturning([mkNode({ id: 't1', accountId: 'a1', itemId: 'i1' })]);
+    const tools = new LiveTransactionsTools(live);
+    // query is set but should NOT cause a date-range error because transaction_id
+    // lookup has its own date-range enforcement (transaction_id requires period
+    // or start_date/end_date — supplied here via period).
+    await expect(
+      tools.getTransactions({
+        transaction_id: 't1',
+        account_id: 'a1',
+        item_id: 'i1',
+        query: 'foo',
+        period: 'this_year',
+      })
+    ).resolves.toBeDefined();
+  });
 });

--- a/tests/tools/live/transactions.test.ts
+++ b/tests/tools/live/transactions.test.ts
@@ -82,11 +82,7 @@ describe('LiveTransactionsTools — input validation', () => {
   });
 });
 
-import type {
-  TransactionNode,
-  AccountRef,
-} from '../../../src/core/graphql/queries/transactions.js';
-import type { Account } from '../../../src/models/index.js';
+import type { TransactionNode } from '../../../src/core/graphql/queries/transactions.js';
 
 function mkNode(partial: Partial<TransactionNode>): TransactionNode {
   return {
@@ -117,11 +113,19 @@ function mkLiveReturning(nodes: TransactionNode[], fetchedAt = Date.now()): Live
   const live = mkLive();
   (
     live as unknown as {
-      getTransactions: (
-        opts: unknown
-      ) => Promise<{ rows: TransactionNode[]; fetched_at: number; hit: boolean }>;
+      getTransactions: (range: { from: string; to: string }) => Promise<{
+        rows: TransactionNode[];
+        oldest_fetched_at: number;
+        newest_fetched_at: number;
+        hit: boolean;
+      }>;
     }
-  ).getTransactions = async () => ({ rows: nodes, fetched_at: fetchedAt, hit: false });
+  ).getTransactions = async () => ({
+    rows: nodes,
+    oldest_fetched_at: fetchedAt,
+    newest_fetched_at: fetchedAt,
+    hit: false,
+  });
   return live;
 }
 
@@ -133,7 +137,11 @@ describe('LiveTransactionsTools — happy path', () => {
     );
     const tools = new LiveTransactionsTools(live);
 
-    const result = await tools.getTransactions({ query: 'amazon' });
+    const result = await tools.getTransactions({
+      query: 'amazon',
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
 
     expect(result.count).toBe(1);
     expect(result.transactions[0]).toMatchObject({
@@ -148,7 +156,12 @@ describe('LiveTransactionsTools — happy path', () => {
     const live = mkLiveReturning(nodes);
     const tools = new LiveTransactionsTools(live);
 
-    const result = await tools.getTransactions({ limit: 2, offset: 1 });
+    const result = await tools.getTransactions({
+      limit: 2,
+      offset: 1,
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
 
     expect(result.count).toBe(2);
     expect(result.total_count).toBe(5);
@@ -167,7 +180,12 @@ describe('LiveTransactionsTools — post-filters', () => {
     ];
     const live = mkLiveReturning(nodes);
     const tools = new LiveTransactionsTools(live);
-    const result = await tools.getTransactions({ min_amount: 10, max_amount: 100 });
+    const result = await tools.getTransactions({
+      min_amount: 10,
+      max_amount: 100,
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
     expect(result.transactions.map((t) => t.transaction_id)).toEqual(['t2']);
   });
 
@@ -175,9 +193,17 @@ describe('LiveTransactionsTools — post-filters', () => {
     const nodes = [mkNode({ id: 't1', isPending: true }), mkNode({ id: 't2', isPending: false })];
     const live = mkLiveReturning(nodes);
     const tools = new LiveTransactionsTools(live);
-    const resultP = await tools.getTransactions({ pending: true });
+    const resultP = await tools.getTransactions({
+      pending: true,
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
     expect(resultP.transactions.map((t) => t.transaction_id)).toEqual(['t1']);
-    const resultS = await tools.getTransactions({ pending: false });
+    const resultS = await tools.getTransactions({
+      pending: false,
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
     expect(resultS.transactions.map((t) => t.transaction_id)).toEqual(['t2']);
   });
 
@@ -191,7 +217,11 @@ describe('LiveTransactionsTools — post-filters', () => {
     ];
     const live = mkLiveReturning(nodes);
     const tools = new LiveTransactionsTools(live);
-    const result = await tools.getTransactions({ transaction_type: 'tagged' });
+    const result = await tools.getTransactions({
+      transaction_type: 'tagged',
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
     expect(result.transactions.map((t) => t.transaction_id)).toEqual(['t1']);
   });
 
@@ -199,7 +229,11 @@ describe('LiveTransactionsTools — post-filters', () => {
     const nodes = [mkNode({ id: 't1', amount: -25 }), mkNode({ id: 't2', amount: 15 })];
     const live = mkLiveReturning(nodes);
     const tools = new LiveTransactionsTools(live);
-    const result = await tools.getTransactions({ transaction_type: 'refunds' });
+    const result = await tools.getTransactions({
+      transaction_type: 'refunds',
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
     expect(result.transactions.map((t) => t.transaction_id)).toEqual(['t1']);
   });
 
@@ -210,67 +244,64 @@ describe('LiveTransactionsTools — post-filters', () => {
     ];
     const live = mkLiveReturning(nodes);
     const tools = new LiveTransactionsTools(live);
-    const result = await tools.getTransactions({ exclude_transfers: true });
+    const result = await tools.getTransactions({
+      exclude_transfers: true,
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
     expect(result.transactions.map((t) => t.transaction_id)).toEqual(['t1']);
   });
 });
 
 describe('LiveTransactionsTools — account resolution', () => {
-  test('resolves account_id to AccountRef via cache', async () => {
-    const live = mkLiveReturning([]);
-    const accounts: Account[] = [
-      { account_id: 'a1', item_id: 'i-1' } as Account,
-      { account_id: 'a2', item_id: 'i-2' } as Account,
+  test('account_id filter narrows to rows from that account (post-filter)', async () => {
+    const nodes = [mkNode({ id: 't1', accountId: 'a1' }), mkNode({ id: 't2', accountId: 'a2' })];
+    const live = mkLiveReturning(nodes);
+    const tools = new LiveTransactionsTools(live);
+    const result = await tools.getTransactions({
+      account_id: 'a2',
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
+    expect(result.transactions.map((t) => t.transaction_id)).toEqual(['t2']);
+  });
+
+  test('singleTransactionLookup post-filters by (id, accountId, itemId)', async () => {
+    const nodes = [
+      mkNode({ id: 't1', accountId: 'aOTHER', itemId: 'i1' }),
+      mkNode({ id: 't1', accountId: 'a1', itemId: 'iOTHER' }),
+      mkNode({ id: 'tOTHER', accountId: 'a1', itemId: 'i1' }),
+      mkNode({ id: 't1', accountId: 'a1', itemId: 'i1', name: 'matched' }),
     ];
-    (live.getCache().getAccounts as ReturnType<typeof mock>).mockImplementation(() =>
-      Promise.resolve(accounts)
-    );
-    const spy = mock((_opts: unknown) =>
-      Promise.resolve({ rows: [] as TransactionNode[], fetched_at: Date.now(), hit: false })
-    );
-    (live as unknown as { getTransactions: typeof spy }).getTransactions = spy;
-
+    const live = mkLiveReturning(nodes);
     const tools = new LiveTransactionsTools(live);
-    await tools.getTransactions({ account_id: 'a2' });
 
-    const args = spy.mock.calls[0]![0] as { accountRefs?: AccountRef[] };
-    expect(args.accountRefs).toEqual([{ accountId: 'a2', itemId: 'i-2' }]);
-  });
-
-  test('surfaces error when account_id is not in cache', async () => {
-    const live = mkLiveReturning([]);
-    (live.getCache().getAccounts as ReturnType<typeof mock>).mockImplementation(() =>
-      Promise.resolve([])
-    );
-    const tools = new LiveTransactionsTools(live);
-    await expect(tools.getTransactions({ account_id: 'nope' })).rejects.toThrow(
-      /account.*not found/i
-    );
-  });
-
-  test('singleTransactionLookup resolves period → bounded startDate/endDate', async () => {
-    const live = mkLiveReturning([]);
-    const accounts: Account[] = [{ account_id: 'a1', item_id: 'i1' } as Account];
-    (live.getCache().getAccounts as ReturnType<typeof mock>).mockImplementation(() =>
-      Promise.resolve(accounts)
-    );
-    const spy = mock((_opts: unknown) =>
-      Promise.resolve({ rows: [] as TransactionNode[], fetched_at: Date.now(), hit: false })
-    );
-    (live as unknown as { getTransactions: typeof spy }).getTransactions = spy;
-
-    const tools = new LiveTransactionsTools(live);
-    await tools.getTransactions({
+    const result = await tools.getTransactions({
       transaction_id: 't1',
       account_id: 'a1',
       item_id: 'i1',
       period: 'this_year',
     });
 
-    const args = spy.mock.calls[0]![0] as { startDate?: string; endDate?: string };
-    // parsePeriod('this_year') returns concrete YYYY-MM-DD bounds; assert both are set.
-    expect(args.startDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    expect(args.endDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(result.count).toBe(1);
+    expect(result.transactions[0]!.transaction_id).toBe('t1');
+    expect(result.transactions[0]!.account_id).toBe('a1');
+    expect(result.transactions[0]!.item_id).toBe('i1');
+    expect(result.transactions[0]!.name).toBe('matched');
+  });
+
+  test('singleTransactionLookup returns empty when no match in range', async () => {
+    const live = mkLiveReturning([mkNode({ id: 'other', accountId: 'a1', itemId: 'i1' })]);
+    const tools = new LiveTransactionsTools(live);
+    const result = await tools.getTransactions({
+      transaction_id: 'missing',
+      account_id: 'a1',
+      item_id: 'i1',
+      period: 'this_year',
+    });
+    expect(result.count).toBe(0);
+    expect(result.total_count).toBe(0);
+    expect(result.transactions).toEqual([]);
   });
 });
 
@@ -288,7 +319,7 @@ describe('LiveTransactionsTools — freshness envelope', () => {
     expect(result._cache_hit).toBe(false);
   });
 
-  test('oldest and newest are equal (single memo bucket in Phase 2)', async () => {
+  test('oldest and newest are equal when fixture provides a single timestamp', async () => {
     const live = mkLiveReturning([]);
     const tools = new LiveTransactionsTools(live);
     const result = await tools.getTransactions({
@@ -310,9 +341,7 @@ describe('LiveTransactionsTools — freshness envelope', () => {
     );
   });
 
-  test('second identical call has _cache_hit: true and same timestamps', async () => {
-    // Use the real LiveCopilotDatabase memoize by constructing a live instance
-    // whose underlying GraphQL call returns a fixed page.
+  test('second identical call hits the window cache and reports _cache_hit: true', async () => {
     const { LiveCopilotDatabase: LiveDB } = await import('../../../src/core/live-database.js');
     const client = {
       mutate: mock(),
@@ -328,11 +357,13 @@ describe('LiveTransactionsTools — freshness envelope', () => {
       getUserCategories: mock(() => Promise.resolve([])),
       getCategoryNameMap: mock(() => Promise.resolve(new Map<string, string>())),
     } as unknown as import('../../../src/core/database.js').CopilotDatabase;
-    const liveDb = new LiveDB(client, cache, { memoTtlMs: 60_000 });
+    const liveDb = new LiveDB(client, cache);
     const tools = new LiveTransactionsTools(liveDb);
 
-    const a = await tools.getTransactions({ start_date: '2026-04-01', end_date: '2026-04-30' });
-    const b = await tools.getTransactions({ start_date: '2026-04-01', end_date: '2026-04-30' });
+    // Pick a date range entirely in the cold tier (>14d old) so the second
+    // call hits cache. 2024 is well outside the live tier on 2026-05-01.
+    const a = await tools.getTransactions({ start_date: '2024-06-01', end_date: '2024-06-30' });
+    const b = await tools.getTransactions({ start_date: '2024-06-01', end_date: '2024-06-30' });
 
     expect(a._cache_hit).toBe(false);
     expect(b._cache_hit).toBe(true);
@@ -376,5 +407,140 @@ describe('createLiveToolSchemas', () => {
   test('readOnlyHint is true', () => {
     const { annotations } = createLiveToolSchemas()[0]!;
     expect(annotations?.readOnlyHint).toBe(true);
+  });
+});
+
+describe('LiveTransactionsTools — migrated filters', () => {
+  test('category filter matches by categoryId', async () => {
+    const nodes = [mkNode({ id: 't1', categoryId: 'c1' }), mkNode({ id: 't2', categoryId: 'c2' })];
+    const live = mkLiveReturning(nodes);
+    const tools = new LiveTransactionsTools(live);
+    const result = await tools.getTransactions({
+      category: 'c1',
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
+    expect(result.transactions.map((t) => t.transaction_id)).toEqual(['t1']);
+  });
+
+  test('tag filter resolves name → id and matches via n.tags[]', async () => {
+    const nodes = [
+      mkNode({
+        id: 't1',
+        tags: [{ id: 'tg1', name: 'vacation', colorName: 'BLUE1' }],
+      }),
+      mkNode({ id: 't2', tags: [] }),
+    ];
+    const live = mkLiveReturning(nodes);
+    (live.getCache().getTags as ReturnType<typeof mock>).mockImplementation(() =>
+      Promise.resolve([{ tag_id: 'tg1', name: 'Vacation' }])
+    );
+    const tools = new LiveTransactionsTools(live);
+    const result = await tools.getTransactions({
+      tag: 'Vacation',
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
+    expect(result.transactions.map((t) => t.transaction_id)).toEqual(['t1']);
+  });
+
+  test('exclude_transfers=false retains INTERNAL_TRANSFER rows', async () => {
+    const nodes = [
+      mkNode({ id: 't1', type: 'REGULAR' }),
+      mkNode({ id: 't2', type: 'INTERNAL_TRANSFER' }),
+    ];
+    const live = mkLiveReturning(nodes);
+    const tools = new LiveTransactionsTools(live);
+    const result = await tools.getTransactions({
+      exclude_transfers: false,
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
+    expect(result.transactions.map((t) => t.transaction_id).sort()).toEqual(['t1', 't2']);
+  });
+
+  test('matchString filters case-insensitive substring on name (via query)', async () => {
+    const nodes = [
+      mkNode({ id: 't1', name: 'Amazon Fresh' }),
+      mkNode({ id: 't2', name: 'AMAZON.com' }),
+      mkNode({ id: 't3', name: 'Whole Foods' }),
+    ];
+    const live = mkLiveReturning(nodes);
+    const tools = new LiveTransactionsTools(live);
+    const result = await tools.getTransactions({
+      query: 'amazon',
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
+    expect(result.transactions.map((t) => t.transaction_id).sort()).toEqual(['t1', 't2']);
+  });
+
+  test('matchString filters case-insensitive via merchant when query is unset', async () => {
+    const nodes = [
+      mkNode({ id: 't1', name: 'Starbucks #123' }),
+      mkNode({ id: 't2', name: 'Coffee Bean' }),
+    ];
+    const live = mkLiveReturning(nodes);
+    const tools = new LiveTransactionsTools(live);
+    const result = await tools.getTransactions({
+      merchant: 'starbucks',
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
+    expect(result.transactions.map((t) => t.transaction_id)).toEqual(['t1']);
+  });
+
+  test('query takes precedence over merchant when both are set', async () => {
+    const nodes = [
+      mkNode({ id: 't1', name: 'foo only' }),
+      mkNode({ id: 't2', name: 'bar only' }),
+      mkNode({ id: 't3', name: 'foo and bar' }),
+    ];
+    const live = mkLiveReturning(nodes);
+    const tools = new LiveTransactionsTools(live);
+    const result = await tools.getTransactions({
+      query: 'foo',
+      merchant: 'bar',
+      start_date: '2025-01-01',
+      end_date: '2025-12-31',
+    });
+    // Only `foo` filter runs; `bar` is ignored.
+    expect(result.transactions.map((t) => t.transaction_id).sort()).toEqual(['t1', 't3']);
+  });
+});
+
+describe('LiveTransactionsTools — date-less query rejection', () => {
+  test('throws when query is set without dates or period', async () => {
+    const tools = new LiveTransactionsTools(mkLive());
+    await expect(tools.getTransactions({ query: 'amazon' })).rejects.toThrow(
+      /require a date range|period|start_date/
+    );
+  });
+
+  test('throws when merchant is set without dates or period', async () => {
+    const tools = new LiveTransactionsTools(mkLive());
+    await expect(tools.getTransactions({ merchant: 'amazon' })).rejects.toThrow(
+      /require a date range|period|start_date/
+    );
+  });
+
+  test('does NOT throw when query is set with period', async () => {
+    const live = mkLiveReturning([]);
+    const tools = new LiveTransactionsTools(live);
+    await expect(
+      tools.getTransactions({ query: 'amazon', period: 'this_month' })
+    ).resolves.toBeDefined();
+  });
+
+  test('does NOT throw when query is set with explicit dates', async () => {
+    const live = mkLiveReturning([]);
+    const tools = new LiveTransactionsTools(live);
+    await expect(
+      tools.getTransactions({
+        query: 'amazon',
+        start_date: '2025-01-01',
+        end_date: '2025-12-31',
+      })
+    ).resolves.toBeDefined();
   });
 });

--- a/tests/utils/concurrency.test.ts
+++ b/tests/utils/concurrency.test.ts
@@ -75,4 +75,26 @@ describe('pLimit', () => {
     await Promise.all([t1, t2, t3]);
     expect(order).toEqual(['a', 'b', 'c']);
   });
+
+  test('throws RangeError when concurrency is zero, negative, or non-integer', () => {
+    expect(() => pLimit(0)).toThrow(RangeError);
+    expect(() => pLimit(-1)).toThrow(RangeError);
+    expect(() => pLimit(2.5)).toThrow(RangeError);
+    expect(() => pLimit(NaN)).toThrow(RangeError);
+  });
+
+  test('preserves non-Error rejection values verbatim (string, object)', async () => {
+    const limit = pLimit(2);
+    await expect(
+      limit(async () => {
+        throw 'string-error';
+      })
+    ).rejects.toBe('string-error');
+    const obj = { code: 42 };
+    await expect(
+      limit(async () => {
+        throw obj;
+      })
+    ).rejects.toBe(obj);
+  });
 });

--- a/tests/utils/concurrency.test.ts
+++ b/tests/utils/concurrency.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from 'bun:test';
+import { pLimit } from '../../src/utils/concurrency.js';
+
+describe('pLimit', () => {
+  test('returns the resolved value of fn()', async () => {
+    const limit = pLimit(2);
+    const result = await limit(async () => 42);
+    expect(result).toBe(42);
+  });
+
+  test('keeps active count ≤ N at any moment', async () => {
+    const N = 4;
+    const limit = pLimit(N);
+    let active = 0;
+    let peak = 0;
+    const release: Array<() => void> = [];
+    const tasks = Array.from({ length: 10 }, () =>
+      limit(async () => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await new Promise<void>((r) => release.push(r));
+        active -= 1;
+        return 'done';
+      })
+    );
+    // Let the first batch start.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(active).toBeLessThanOrEqual(N);
+    // Drain in FIFO order.
+    while (release.length > 0) {
+      release.shift()!();
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+    await Promise.all(tasks);
+    expect(peak).toBeLessThanOrEqual(N);
+  });
+
+  test('runs sequentially when concurrency=1', async () => {
+    const limit = pLimit(1);
+    const order: number[] = [];
+    const tasks = [1, 2, 3].map((n) =>
+      limit(async () => {
+        await new Promise((r) => setTimeout(r, 5));
+        order.push(n);
+      })
+    );
+    await Promise.all(tasks);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  test('rejection in one task does not poison the pool', async () => {
+    const limit = pLimit(2);
+    const a = limit(async () => {
+      throw new Error('boom');
+    });
+    const b = limit(async () => 'ok');
+    await expect(a).rejects.toThrow('boom');
+    await expect(b).resolves.toBe('ok');
+  });
+
+  test('queued tasks run in FIFO order after first batch settles', async () => {
+    const limit = pLimit(1);
+    const order: string[] = [];
+    const t1 = limit(async () => {
+      order.push('a');
+    });
+    const t2 = limit(async () => {
+      order.push('b');
+    });
+    const t3 = limit(async () => {
+      order.push('c');
+    });
+    await Promise.all([t1, t2, t3]);
+    expect(order).toEqual(['a', 'b', 'c']);
+  });
+});


### PR DESCRIPTION
## Summary

Migrates `get_transactions_live` from the Phase 1 `memoize()` blanket cache onto the Phase 2 `TransactionWindowCache`, simplifies the cache from 3 tiers to 2, and moves all filtering to the tool layer. Last code task in the LevelDB-retirement migration before the measurement checkpoint (Phase N+1).

- **Cache:** month-keyed window backed by `plan(range, now)` → fetch missing months in parallel (`pLimit(4)`, coalesced via `InFlightRegistry`) → ingest → merge → sort `(date DESC, createdAt DESC, id DESC)`.
- **Tier policy:** simplified from `live ≤7d / warm 8-21d / cold >21d` to **`live ≤14d / cold >14d`**. The 14-day boundary captures Plaid-sync drift without a middle tier.
- **Filters:** now 100% client-side in `LiveTransactionsTools.postFilter`. The data layer takes only `(range, sort?, opts?)` — pushing filters into it would be a no-op since the cache stores full months.
- **Date-less rejection:** `query`/`merchant` without dates throws fast (was previously an unbounded all-history paginate).
- **Freshness envelope:** `_cache_oldest_fetched_at` and `_cache_newest_fetched_at` now diverge meaningfully — old cold-cached months pin oldest, live-tier refetches set newest.
- **Deletion:** `memoize()`, `memoStore`, `MemoEntry`, `memoTtlMs` all removed. `LiveDatabaseOptions` is now `{ verbose? }`.

## Test plan

- [x] Full test suite green: **1711 pass, 0 fail** (47 windowed `getTransactions` tests + 10 new `LiveTransactionsTools` tests across migrated filters and date-less rejection + new `pLimit` coverage).
- [x] Manual smoke against live endpoint:
  - Cold call (year range): 12 months fetched, `_cache_hit: false`.
  - Warm call (same range, immediately after): 3 cold-cached months hit cache, 9 live-tier months refetched. **Mixed state envelope confirmed** — `oldest_fetched_at` pinned to call-1 timestamp, `newest_fetched_at` reflects live-tier refetch (Δ ≈ 7s).
  - `query=amazon` post-filter: 100 Amazon-substring rows correctly narrowed.
  - Date-less query throws documented error.

## Notes

- Out of scope (Phase 4-6): migrating other entities (categories, tags, budgets, recurring) onto live cache; flipping `--live-reads` to default-on.
- The `singleTransactionLookup` fetch is now date-range-bounded (no per-account narrowing). For a long range this fetches more than necessary — accepted as a trade-off; subsequent calls hit cache.