### PR TITLE
chore: address audit followups from #325 and #332

### DIFF
--- a/docs/graphql-capture/hidden-mutations.md
+++ b/docs/graphql-capture/hidden-mutations.md
@@ -21,14 +21,16 @@ Signatures below reflect only what the server confirmed via validation errors. O
 | [`dismissAnnouncement`](#accepttermsdismissannouncement-editinvestmentconfig) | ❌ | low | Dismiss an in-app announcement |
 | [`editInvestmentConfig`](#accepttermsdismissannouncement-editinvestmentconfig) | ❌ | low | User-level investment config (odd — no required args) |
 | [`confirmConnection`](#connection-lifecycle) | ❌ | low-medium | Confirm a Plaid-link connection after institution challenge |
-| [`deleteConnection`](#connection-lifecycle) | ❌ | **high (cascades)** | Remove a Plaid connection |
+| [`deleteConnection`](#connection-lifecycle) | ❌ | **high (assumed cascade)** | Remove a Plaid connection |
 | [`startSubscription`](#subscription-lifecycle) | ❌ | **do not expose** | Start a Copilot paid plan |
 | [`changeSubscription`](#subscription-lifecycle) | ❌ | **do not expose** | Switch between Copilot plans |
 | [`cancelSubscription`](#subscription-lifecycle) | ❌ | **do not expose** | Cancel the Copilot subscription |
 | [`claimPromotion`](#subscription-lifecycle) | ❌ | low | Redeem a promo code |
 | [`deletePaymentMethod`](#subscription-lifecycle) | ❌ | medium | Remove a saved payment method |
 
-**Sweep coverage (2026-04-22, after PRs #320-#323 shipped):** a second broad sweep across ~170 additional candidates covered Amazon, Plaid, Account, Holdings/Investments, Rules, Notifications, User preferences, Subscription/billing, Attachments, Sharing, AI/assistant, Reports, Search, and miscellaneous (password/PIN/2FA/device). The nine new mutations above came out of that sweep; everything else in those categories returned "Cannot query field" on all tested candidates. Tested-and-absent candidates are catalogued in the "Tested-and-absent surface" section below so future authors don't re-probe the same names.
+### Sweep coverage — 2026-04-22
+
+A second broad sweep across ~170 additional candidates covered Amazon, Plaid, Account, Holdings/Investments, Rules, Notifications, User preferences, Subscription/billing, Attachments, Sharing, AI/assistant, Reports, Search, and miscellaneous (password/PIN/2FA/device). The nine new mutations above came out of that sweep; everything else in those categories returned "Cannot query field" on all tested candidates. Tested-and-absent candidates are catalogued in the "Tested-and-absent surface" section below so future authors don't re-probe the same names.
 
 ## Budget mutations — finding
 
@@ -266,7 +268,7 @@ mutation Probe { deleteConnection(id: ID!) }                                    
 
 ## Subscription lifecycle
 
-Copilot's in-app paid-plan management. Five mutations, all billing-sensitive.
+Copilot's in-app paid-plan management. Four billing-sensitive mutations plus one lower-risk payment-method mutation.
 
 ```graphql
 mutation Probe { startSubscription(input: StartSubscriptionInput!) { id } }    # StartSubscriptionResult!
@@ -281,6 +283,8 @@ Confirmed input shapes:
 - `ChangeSubscriptionInput`: has `planId: ID!` (confirmed via "Did you mean planId" error on a `plan` probe); other fields unknown.
 
 **Do not expose any of these via MCP tools.** Billing operations — cancelling, changing plans, or claiming promotions — should always be user-driven through Copilot's own UI. The right safety-posture is to explicitly refuse these even if asked; leave them documented here only so the recon surface is complete.
+
+**`deletePaymentMethod` is lower-risk than the other four** — it removes a saved card from the user's wallet without changing the active plan or charging anything. Still left out of MCP scope: payment-method management is account-administration UX that belongs in Copilot's own settings screen, and a stale removal can break the next renewal. Same "user-driven only" posture, but for ergonomic reasons rather than billing-impact reasons.
 
 ---
 

--- a/src/core/graphql/queries/transactions.ts
+++ b/src/core/graphql/queries/transactions.ts
@@ -187,7 +187,7 @@ export async function paginateTransactions(
   const collected: TransactionNode[] = [];
   let cursor: string | null = null;
 
-  for (let page_count = 0; page_count < MAX_PAGES; page_count++) {
+  for (let pageCount = 0; pageCount < MAX_PAGES; pageCount++) {
     const page = await fetcher(cursor);
     for (const edge of page.edges) {
       collected.push(edge.node);

--- a/src/core/graphql/queries/transactions.ts
+++ b/src/core/graphql/queries/transactions.ts
@@ -164,13 +164,21 @@ export interface PaginateOptions {
 
 export type TransactionsFetcher = (after: string | null) => Promise<TransactionsPage>;
 
+// Server caps page size at 25, so 1000 pages = 25k transactions — far above any
+// realistic personal-finance window. The cap exists to escape pathological
+// server responses (empty edges + hasNextPage=true + stable cursor) that
+// would otherwise spin forever, since the startDate early-exit only fires
+// when edges is non-empty.
+const MAX_PAGES = 1000;
+
 /**
  * Paginate a Transactions query until no more pages are needed.
  *
  * Pure pagination driver — the fetcher callback owns the actual
  * network call. Early-exits when the trailing edge of a page precedes
  * opts.startDate (requires DATE DESC sort to be meaningful). Otherwise
- * follows pageInfo.endCursor until pageInfo.hasNextPage === false.
+ * follows pageInfo.endCursor until pageInfo.hasNextPage === false, with
+ * a hard MAX_PAGES safety cap.
  */
 export async function paginateTransactions(
   fetcher: TransactionsFetcher,
@@ -179,24 +187,26 @@ export async function paginateTransactions(
   const collected: TransactionNode[] = [];
   let cursor: string | null = null;
 
-  while (true) {
+  for (let page_count = 0; page_count < MAX_PAGES; page_count++) {
     const page = await fetcher(cursor);
     for (const edge of page.edges) {
       collected.push(edge.node);
     }
 
-    if (!page.pageInfo.hasNextPage) break;
+    if (!page.pageInfo.hasNextPage) return collected;
 
     if (opts.startDate && page.edges.length > 0) {
       const tail = page.edges[page.edges.length - 1]!.node.date;
-      if (tail < opts.startDate) break;
+      if (tail < opts.startDate) return collected;
     }
 
     cursor = page.pageInfo.endCursor;
-    if (cursor === null) break;
+    if (cursor === null) return collected;
   }
 
-  return collected;
+  throw new Error(
+    `paginateTransactions exceeded max page count (${MAX_PAGES}) — server kept returning hasNextPage=true. Likely a server-side pagination bug; narrow the date range or report upstream.`
+  );
 }
 
 export interface FetchTransactionsArgs {

--- a/src/tools/live/transactions.ts
+++ b/src/tools/live/transactions.ts
@@ -347,6 +347,12 @@ export class LiveTransactionsTools {
       );
     }
 
+    if (opts.exclude_deleted === false) {
+      throw new Error(
+        `Parameter 'exclude_deleted=false' is not supported in live mode — the GraphQL server omits deleted transactions. Retry without 'exclude_deleted' or set it to true.`
+      );
+    }
+
     if (opts.transaction_id !== undefined) {
       if (!opts.account_id || !opts.item_id) {
         throw new Error(
@@ -378,7 +384,7 @@ export function createLiveToolSchemas(): ToolSchema[] {
     {
       name: 'get_transactions_live',
       description:
-        "Reads transactions live from Copilot's GraphQL API (requires --live-reads flag and network connectivity). Use this when the user asks about historical date ranges that may not be in the local cache, or when fresh data is required. Unlike get_transactions, the following filters are NOT supported and must not be included: city, lat, lon, radius_km, region, country, transaction_type=foreign, transaction_type=duplicates, and exclude_split_parents=false — any of these returns an error telling you to retry without the parameter. Single-transaction lookup requires transaction_id + account_id + item_id AND a date range (start_date, end_date, or period) — pass the transaction's date from the prior list result; the server has no single-row-by-id filter so unbounded lookups paginate the whole account. If the backend is unreachable, this tool returns an isError result; it does NOT fall back to the local cache.",
+        "Reads transactions live from Copilot's GraphQL API (requires --live-reads flag and network connectivity). Use this when the user asks about historical date ranges that may not be in the local cache, or when fresh data is required. Unlike get_transactions, the following filters are NOT supported and must not be included: city, lat, lon, radius_km, region, country, transaction_type=foreign, transaction_type=duplicates, exclude_split_parents=false, and exclude_deleted=false — any of these returns an error telling you to retry without the parameter. Single-transaction lookup requires transaction_id + account_id + item_id AND a date range (start_date, end_date, or period) — pass the transaction's date from the prior list result; the server has no single-row-by-id filter so unbounded lookups paginate the whole account. If the backend is unreachable, this tool returns an isError result; it does NOT fall back to the local cache.",
       inputSchema: {
         type: 'object',
         properties: {
@@ -435,7 +441,7 @@ export function createLiveToolSchemas(): ToolSchema[] {
           exclude_deleted: {
             type: 'boolean',
             description:
-              'Exclude deleted transactions (default: true). No-op in live mode — the server already excludes deleted rows.',
+              'Must be true or omitted — the GraphQL server already excludes deleted transactions. Passing false returns an error.',
             default: true,
           },
           exclude_excluded: {

--- a/tests/core/graphql/queries/transactions.test.ts
+++ b/tests/core/graphql/queries/transactions.test.ts
@@ -205,6 +205,22 @@ describe('paginateTransactions', () => {
     expect(rows).toHaveLength(2);
   });
 
+  test('throws after max-page cap when fetcher returns empty edges + hasNextPage=true + stable cursor', async () => {
+    let calls = 0;
+    const fetcher = async (): Promise<TransactionsPage> => {
+      calls += 1;
+      return {
+        edges: [],
+        pageInfo: { endCursor: 'stuck-cursor', hasNextPage: true },
+      };
+    };
+    await expect(paginateTransactions(fetcher, {})).rejects.toThrow(
+      /max page|page (count|cap|limit)|too many pages/i
+    );
+    // Sanity: bounded — well under 10k calls even if the cap is high.
+    expect(calls).toBeLessThan(10_000);
+  });
+
   test('passes previous endCursor to fetcher', async () => {
     const received: (string | null)[] = [];
     const pages: TransactionsPage[] = [

--- a/tests/tools/live/transactions.test.ts
+++ b/tests/tools/live/transactions.test.ts
@@ -64,6 +64,13 @@ describe('LiveTransactionsTools — input validation', () => {
     );
   });
 
+  test('rejects exclude_deleted=false (server-side filter cannot be disabled)', async () => {
+    const tools = new LiveTransactionsTools(mkLive());
+    await expect(tools.getTransactions({ exclude_deleted: false } as never)).rejects.toThrow(
+      /exclude_deleted.*not supported/i
+    );
+  });
+
   test('rejects transaction_id lookup without account_id+item_id', async () => {
     const tools = new LiveTransactionsTools(mkLive());
     await expect(tools.getTransactions({ transaction_id: 't1' } as never)).rejects.toThrow(


### PR DESCRIPTION
## Summary

Single cleanup PR batching all LOW/MED nits from the two open audit issues, per the audit-followup batching convention.

**Closes #325** — three LOW docs nits in `docs/graphql-capture/hidden-mutations.md`.
**Closes #332** — two MEDIUM + one LOW code nits in the live-reads transactions surface.

### Code (#332)
- `src/tools/live/transactions.ts:347` — add `exclude_deleted=false` guard in `validate()` mirroring the existing `exclude_split_parents=false` guard. An LLM passing `exclude_deleted: false` hoping to surface deleted rows now gets a clear error instead of a silent no-op. Schema description + tool-level description updated to match.
- `src/core/graphql/queries/transactions.ts:175` — replace `while (true)` with a 1000-page `MAX_PAGES` cap. Prior loop would spin forever if the server returned `hasNextPage=true` with empty edges and a stable cursor (the startDate early-exit only fires when edges is non-empty). Now throws a diagnostic error pointing at "server-side pagination bug, narrow the date range or report upstream."
- The third nit (`item_id` advisory-only on `transaction_id` lookups) was **already fixed** by PR #334's windowed-cache refactor — `singleTransactionLookup` now uses `opts.item_id` directly in the `nodes.find()` predicate at line 155. No change needed.

### Docs (#325)
- Hedge `deleteConnection` cascade risk in summary table to match hedged body text ("**high (assumed cascade)**").
- Promote "Sweep coverage" block from bold inline paragraph to `### Sweep coverage — 2026-04-22` subheading.
- Add a sentence in the Subscription lifecycle section distinguishing `deletePaymentMethod`'s lower risk from the four billing-sensitive mutations, while keeping it out of MCP scope.

## Test plan

- [x] `bun test tests/tools/live/transactions.test.ts` — new `exclude_deleted=false` guard test passes (44/44)
- [x] `bun test tests/core/graphql/queries/transactions.test.ts` — new pagination max-page-cap test passes (21/21); confirmed it hangs against the prior unbounded loop before the fix
- [x] `bun run check` — full suite green (1739 pass, 21 skip, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)