### PR TITLE
feat(live): get_budgets_live (phase 4 PR #3)

### DIFF
--- a/scripts/smoke/budgets.ts
+++ b/scripts/smoke/budgets.ts
@@ -1,0 +1,56 @@
+/**
+ * Smoke test: get_budgets_live against the real Copilot GraphQL endpoint.
+ *
+ * Run: `bun run scripts/smoke/budgets.ts`
+ *
+ * Requires an authenticated app.copilot.money browser session. Asserts:
+ *   1. Cold call returns rows with _cache_hit=false
+ *   2. Warm call (within TTL) returns _cache_hit=true with sub-50ms latency
+ *   3. refresh_cache --scope budgets invalidates categoriesCache (the alias)
+ *      and triggers a refetch on the next get_budgets_live call
+ *
+ * Exits non-zero on any assertion failure. Output is intended to be pasted
+ * into the PR description.
+ */
+
+import { setupLiveSmoke } from './_harness.js';
+import { LiveBudgetsTools } from '../../src/tools/live/budgets.js';
+import { RefreshCacheTool } from '../../src/tools/live/refresh-cache.js';
+
+async function main(): Promise<void> {
+  const { live, log } = await setupLiveSmoke({ verbose: true });
+  const tools = new LiveBudgetsTools(live);
+  const refresh = new RefreshCacheTool(live);
+
+  // 1. Cold
+  const t0 = Date.now();
+  const cold = await tools.getBudgets({});
+  const coldMs = Date.now() - t0;
+  log('cold', { rows: cold.count, total: cold.total_budgeted, hit: cold._cache_hit, ms: coldMs });
+  if (cold._cache_hit !== false) throw new Error(`expected cold _cache_hit=false`);
+  if (cold.count === 0) throw new Error('expected at least one budget');
+
+  // 2. Warm
+  const t1 = Date.now();
+  const warm = await tools.getBudgets({});
+  const warmMs = Date.now() - t1;
+  log('warm', { rows: warm.count, hit: warm._cache_hit, ms: warmMs });
+  if (warm._cache_hit !== true) throw new Error(`expected warm _cache_hit=true`);
+  if (warmMs > 50) throw new Error(`warm took ${warmMs}ms, expected sub-50ms`);
+
+  // 3. Refresh + recold (verifies alias: scope=budgets invalidates categoriesCache)
+  await refresh.refresh({ scope: 'budgets' });
+  log('refreshed', { scope: 'budgets' });
+  const t2 = Date.now();
+  const recold = await tools.getBudgets({});
+  const recoldMs = Date.now() - t2;
+  log('recold', { rows: recold.count, hit: recold._cache_hit, ms: recoldMs });
+  if (recold._cache_hit !== false) throw new Error(`expected post-refresh _cache_hit=false`);
+
+  log('done', { passed: 3 });
+}
+
+main().catch((err: unknown) => {
+  console.error('[smoke] FAIL:', err);
+  process.exit(1);
+});

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -401,6 +401,92 @@ export class LiveCopilotDatabase {
     this.categoriesCache.delete(id);
   }
 
+  /**
+   * Update the cached category's budget slot. Peeks the cached category, mutates
+   * either `budget.current` (when month matches current month or is omitted) or
+   * `budget.histories[month]` (replace existing or insert new), then upserts.
+   * No-op if the category is not currently cached — the next get_budgets_live or
+   * get_categories_live call will refetch with the fresh value from the EditBudget
+   * mutation that already succeeded.
+   */
+  patchLiveCategoryBudget(categoryId: string, amount: number, month?: string): void {
+    const cached = this.categoriesCache.peek()?.find((c) => c.id === categoryId);
+    if (!cached) return;
+
+    const monthKey =
+      month ??
+      (() => {
+        // UTC matches monthAge() / monthsCovered() in date.ts. Using local time
+        // would be off by ~12h at month boundaries in negative UTC offsets.
+        const d = new Date();
+        return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+      })();
+    const amountStr = String(amount);
+
+    const existingBudget = cached.budget ?? { current: null, histories: [] };
+
+    // If patch targets the current month, update budget.current
+    const updatesCurrent = existingBudget.current?.month === monthKey;
+    let newCurrent = existingBudget.current;
+    let newHistories = existingBudget.histories;
+
+    if (updatesCurrent && newCurrent) {
+      newCurrent = { ...newCurrent, amount: amountStr };
+    } else {
+      // Update or insert in histories
+      const idx = newHistories.findIndex((h) => h.month === monthKey);
+      if (idx >= 0) {
+        newHistories = [...newHistories];
+        newHistories[idx] = { ...newHistories[idx]!, amount: amountStr };
+      } else {
+        // Insert minimal new history entry. Other monthly fields default to null/0.
+        newHistories = [
+          ...newHistories,
+          {
+            unassignedRolloverAmount: null,
+            childRolloverAmount: null,
+            unassignedAmount: null,
+            resolvedAmount: amountStr,
+            rolloverAmount: null,
+            childAmount: null,
+            goalAmount: amountStr,
+            amount: amountStr,
+            month: monthKey,
+            id: `${categoryId}-${monthKey}-synthetic`,
+          },
+        ];
+      }
+    }
+
+    // If no current existed but the patch was for the current month, synthesize current.
+    if (!updatesCurrent) {
+      const todayMonth = (() => {
+        const d = new Date();
+        return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+      })();
+      if (monthKey === todayMonth && !newCurrent) {
+        newCurrent = {
+          unassignedRolloverAmount: null,
+          childRolloverAmount: null,
+          unassignedAmount: null,
+          resolvedAmount: amountStr,
+          rolloverAmount: null,
+          childAmount: null,
+          goalAmount: amountStr,
+          amount: amountStr,
+          month: monthKey,
+          id: `${categoryId}-${monthKey}-current-synthetic`,
+        };
+      }
+    }
+
+    const merged: CategoryNode = {
+      ...cached,
+      budget: { current: newCurrent, histories: newHistories },
+    };
+    this.categoriesCache.upsert(merged);
+  }
+
   patchLiveRecurringUpsert(recurring: Recurring): void {
     this.recurringCache.upsert(recurring);
   }

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -19,7 +19,6 @@
  * See docs/superpowers/plans/2026-04-25-graphql-live-tiered-cache.md.
  */
 
-import { randomUUID } from 'crypto';
 import { GraphQLError, type GraphQLClient } from './graphql/client.js';
 import type { CopilotDatabase } from './database.js';
 import {
@@ -36,7 +35,7 @@ import { InFlightRegistry, SnapshotCache, TransactionWindowCache } from './cache
 import type { AccountNode } from './graphql/queries/accounts.js';
 import type { CategoryNode } from './graphql/queries/categories.js';
 import type { TagNode } from './graphql/queries/tags.js';
-import type { Budget, Recurring, Transaction } from '../models/index.js';
+import type { Recurring, Transaction } from '../models/index.js';
 
 export interface LiveDatabaseOptions {
   verbose?: boolean;
@@ -65,7 +64,6 @@ export class LiveCopilotDatabase {
   private readonly accountsCache: SnapshotCache<AccountNode>;
   private readonly categoriesCache: SnapshotCache<CategoryNode>;
   private readonly tagsCache: SnapshotCache<TagNode>;
-  private readonly budgetsCache: SnapshotCache<Budget>;
   private readonly recurringCache: SnapshotCache<Recurring>;
   private readonly transactionsWindowCache: TransactionWindowCache<TransactionNode>;
 
@@ -88,10 +86,6 @@ export class LiveCopilotDatabase {
     );
     this.tagsCache = new SnapshotCache<TagNode>(
       { key: 'tags', ttlMs: ONE_DAY_MS, keyFn: (t) => t.id },
-      this.inflight
-    );
-    this.budgetsCache = new SnapshotCache<Budget>(
-      { key: 'budgets', ttlMs: ONE_HOUR_MS, keyFn: (b) => b.category_id ?? b.budget_id },
       this.inflight
     );
     this.recurringCache = new SnapshotCache<Recurring>(
@@ -318,10 +312,6 @@ export class LiveCopilotDatabase {
     return this.tagsCache;
   }
 
-  getBudgetsCache(): SnapshotCache<Budget> {
-    return this.budgetsCache;
-  }
-
   getRecurringCache(): SnapshotCache<Recurring> {
     return this.recurringCache;
   }
@@ -354,35 +344,6 @@ export class LiveCopilotDatabase {
   /** Remove a cached transaction by id. No-op if not found. */
   patchLiveTransactionDelete(id: string): void {
     this.transactionsWindowCache.delete(id);
-  }
-
-  /**
-   * Upsert a synthetic Budget into the budgets snapshot cache.
-   * Keyed by category_id. The next real cache refill will overwrite.
-   *
-   * @param month - YYYY-MM key for the amounts map; defaults to current month.
-   */
-  patchLiveBudget(categoryId: string, amount: number, month?: string): void {
-    const monthKey =
-      month ??
-      (() => {
-        // UTC matches monthAge() / monthsCovered() in date.ts. Using
-        // local time would be off by ~12h at month boundaries in
-        // negative UTC offsets (e.g., late Jan 31 in UTC-8 is already
-        // Feb 1 UTC), producing a budget bucket that doesn't match
-        // the cache's tier-classification basis.
-        const d = new Date();
-        return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
-      })();
-    // Use a UUID for budget_id (matches patchCachedBudget on CopilotDatabase
-    // — both paths surface the same shape so paired writes at Task 6 sites
-    // don't produce divergent results across the LevelDB and live caches).
-    const synthetic: Budget = {
-      budget_id: randomUUID(),
-      category_id: categoryId,
-      amounts: { [monthKey]: amount },
-    };
-    this.budgetsCache.upsert(synthetic);
   }
 
   patchLiveTagUpsert(tag: TagNode): void {

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -374,33 +374,52 @@ export class LiveCopilotDatabase {
     const cached = this.categoriesCache.peek()?.find((c) => c.id === categoryId);
     if (!cached) return;
 
-    const monthKey =
-      month ??
-      (() => {
-        // UTC matches monthAge() / monthsCovered() in date.ts. Using local time
-        // would be off by ~12h at month boundaries in negative UTC offsets.
-        const d = new Date();
-        return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
-      })();
+    // Compute current UTC month once (shared by both monthKey defaulting and
+    // current-synthesis logic). UTC matches monthAge() / monthsCovered() in
+    // date.ts. Local time would be off by ~12h at month boundaries in negative
+    // UTC offsets.
+    const todayMonth = (() => {
+      const d = new Date();
+      return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+    })();
+    const monthKey = month ?? todayMonth;
     const amountStr = String(amount);
 
     const existingBudget = cached.budget ?? { current: null, histories: [] };
 
-    // If patch targets the current month, update budget.current
-    const updatesCurrent = existingBudget.current?.month === monthKey;
+    // Decide where the patch lands:
+    // - If a `current` entry exists for the patched month → update its amount
+    // - Else if the patched month IS the current month → synthesize a fresh `current`
+    //   (do NOT also write histories — that would create a semantically inconsistent
+    //   state where both current and a same-month history entry exist)
+    // - Else → upsert in `histories[]` (replace existing entry by month, or push new)
     let newCurrent = existingBudget.current;
     let newHistories = existingBudget.histories;
 
-    if (updatesCurrent && newCurrent) {
-      newCurrent = { ...newCurrent, amount: amountStr };
+    if (existingBudget.current?.month === monthKey) {
+      newCurrent = { ...existingBudget.current, amount: amountStr };
+    } else if (monthKey === todayMonth) {
+      // Patch targets current month but no `current` existed — synthesize one.
+      newCurrent = {
+        unassignedRolloverAmount: null,
+        childRolloverAmount: null,
+        unassignedAmount: null,
+        resolvedAmount: amountStr,
+        rolloverAmount: null,
+        childAmount: null,
+        goalAmount: amountStr,
+        amount: amountStr,
+        month: monthKey,
+        id: `${categoryId}-${monthKey}-current-synthetic`,
+      };
     } else {
-      // Update or insert in histories
+      // Patch targets a non-current month → write to histories.
       const idx = newHistories.findIndex((h) => h.month === monthKey);
       if (idx >= 0) {
         newHistories = [...newHistories];
         newHistories[idx] = { ...newHistories[idx]!, amount: amountStr };
       } else {
-        // Insert minimal new history entry. Other monthly fields default to null/0.
+        // Insert minimal new history entry. Other monthly fields default to null.
         newHistories = [
           ...newHistories,
           {
@@ -416,28 +435,6 @@ export class LiveCopilotDatabase {
             id: `${categoryId}-${monthKey}-synthetic`,
           },
         ];
-      }
-    }
-
-    // If no current existed but the patch was for the current month, synthesize current.
-    if (!updatesCurrent) {
-      const todayMonth = (() => {
-        const d = new Date();
-        return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
-      })();
-      if (monthKey === todayMonth && !newCurrent) {
-        newCurrent = {
-          unassignedRolloverAmount: null,
-          childRolloverAmount: null,
-          unassignedAmount: null,
-          resolvedAmount: amountStr,
-          rolloverAmount: null,
-          childAmount: null,
-          goalAmount: amountStr,
-          amount: amountStr,
-          month: monthKey,
-          id: `${categoryId}-${monthKey}-current-synthetic`,
-        };
       }
     }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import { LiveTransactionsTools, createLiveToolSchemas } from './tools/live/trans
 import { LiveAccountsTools, createLiveAccountsToolSchema } from './tools/live/accounts.js';
 import { LiveCategoriesTools, createLiveCategoriesToolSchema } from './tools/live/categories.js';
 import { LiveTagsTools, createLiveTagsToolSchema } from './tools/live/tags.js';
+import { LiveBudgetsTools, createLiveBudgetsToolSchema } from './tools/live/budgets.js';
 import { RefreshCacheTool, createRefreshCacheToolSchema } from './tools/live/refresh-cache.js';
 
 // Read version from package.json
@@ -42,6 +43,7 @@ export class CopilotMoneyServer {
   private liveAccountsTools?: LiveAccountsTools;
   private liveCategoriesTools?: LiveCategoriesTools;
   private liveTagsTools?: LiveTagsTools;
+  private liveBudgetsTools?: LiveBudgetsTools;
   private refreshCacheTool?: RefreshCacheTool;
 
   /**
@@ -76,6 +78,7 @@ export class CopilotMoneyServer {
       this.liveAccountsTools = new LiveAccountsTools(liveDb);
       this.liveCategoriesTools = new LiveCategoriesTools(liveDb);
       this.liveTagsTools = new LiveTagsTools(liveDb);
+      this.liveBudgetsTools = new LiveBudgetsTools(liveDb);
       this.refreshCacheTool = new RefreshCacheTool(liveDb);
     }
 
@@ -106,7 +109,8 @@ export class CopilotMoneyServer {
           (s) =>
             s.name !== 'get_transactions' &&
             s.name !== 'get_accounts' &&
-            s.name !== 'get_categories'
+            s.name !== 'get_categories' &&
+            s.name !== 'get_budgets'
         )
       : readSchemas;
     const liveSchemas = this.liveReadsEnabled
@@ -115,6 +119,7 @@ export class CopilotMoneyServer {
           createLiveAccountsToolSchema(),
           createLiveCategoriesToolSchema(),
           createLiveTagsToolSchema(),
+          createLiveBudgetsToolSchema(),
           createRefreshCacheToolSchema(),
         ]
       : [];
@@ -225,6 +230,18 @@ export class CopilotMoneyServer {
       };
     }
 
+    if (name === 'get_budgets_live' && !this.liveBudgetsTools) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'get_budgets_live is only available when the server runs with --live-reads.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
     if (name === 'refresh_cache' && !this.refreshCacheTool) {
       return {
         content: [
@@ -290,6 +307,13 @@ export class CopilotMoneyServer {
         case 'get_tags_live':
           result = await this.liveTagsTools!.getTags(
             (typedArgs as Parameters<NonNullable<typeof this.liveTagsTools>['getTags']>[0]) ?? {}
+          );
+          break;
+
+        case 'get_budgets_live':
+          result = await this.liveBudgetsTools!.getBudgets(
+            (typedArgs as Parameters<NonNullable<typeof this.liveBudgetsTools>['getBudgets']>[0]) ??
+              {}
           );
           break;
 

--- a/src/tools/live/budgets.ts
+++ b/src/tools/live/budgets.ts
@@ -13,15 +13,11 @@
  */
 
 import type { LiveCopilotDatabase } from '../../core/live-database.js';
-import {
-  fetchCategories,
-  type CategoryNode,
-} from '../../core/graphql/queries/categories.js';
+import { fetchCategories, type CategoryNode } from '../../core/graphql/queries/categories.js';
 import { roundAmount } from '../../utils/round.js';
 
-export interface GetBudgetsLiveArgs {
-  // Reserved for future filters (e.g., active_only).
-}
+// Reserved for future filters (e.g., active_only).
+export type GetBudgetsLiveArgs = Record<string, never>;
 
 export interface GetBudgetsLiveBudget {
   budget_id: string;
@@ -79,9 +75,11 @@ export class LiveBudgetsTools {
   async getBudgets(_args: GetBudgetsLiveArgs): Promise<GetBudgetsLiveResult> {
     const cache = this.live.getCategoriesCache();
     const startedAt = Date.now();
-    const { rows: cats, fetched_at, hit } = await cache.read(() =>
-      fetchCategories(this.live.getClient())
-    );
+    const {
+      rows: cats,
+      fetched_at,
+      hit,
+    } = await cache.read(() => fetchCategories(this.live.getClient()));
 
     const projected: GetBudgetsLiveBudget[] = [];
     let totalBudgeted = 0;

--- a/src/tools/live/budgets.ts
+++ b/src/tools/live/budgets.ts
@@ -1,0 +1,134 @@
+/**
+ * Live-mode get_budgets_live tool.
+ *
+ * Projects per-category budgets from the SnapshotCache<CategoryNode>
+ * (already populated by fetchCategories({budget: true}) — see
+ * src/core/graphql/queries/categories.ts). No separate GraphQL query;
+ * Copilot's GraphQL schema models budget as a field on Category, not a
+ * top-level entity. The Phase 2 SnapshotCache<Budget> was a Firestore
+ * artifact and is removed in this PR.
+ *
+ * Output envelope mirrors the cache-mode get_budgets shape (count,
+ * total_budgeted, budgets[]) plus the freshness-envelope fields.
+ */
+
+import type { LiveCopilotDatabase } from '../../core/live-database.js';
+import {
+  fetchCategories,
+  type CategoryNode,
+} from '../../core/graphql/queries/categories.js';
+import { roundAmount } from '../../utils/round.js';
+
+export interface GetBudgetsLiveArgs {
+  // Reserved for future filters (e.g., active_only).
+}
+
+export interface GetBudgetsLiveBudget {
+  budget_id: string;
+  category_id: string;
+  category_name: string;
+  amount?: number;
+  amounts?: Record<string, number>;
+}
+
+export interface GetBudgetsLiveResult {
+  count: number;
+  total_budgeted: number;
+  budgets: GetBudgetsLiveBudget[];
+  _cache_oldest_fetched_at: string;
+  _cache_newest_fetched_at: string;
+  _cache_hit: boolean;
+}
+
+function parseAmount(value: string | null | undefined): number | undefined {
+  if (value === null || value === undefined) return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function projectCategory(cat: CategoryNode): GetBudgetsLiveBudget | null {
+  const budget = cat.budget;
+  if (!budget) return null;
+
+  const amount = parseAmount(budget.current?.amount);
+  const amounts: Record<string, number> = {};
+  if (budget.current?.month) {
+    const a = parseAmount(budget.current.amount);
+    if (a !== undefined) amounts[budget.current.month] = a;
+  }
+  for (const h of budget.histories) {
+    const a = parseAmount(h.amount);
+    if (a !== undefined) amounts[h.month] = a;
+  }
+
+  // Skip rows with neither current nor history amounts (entirely empty)
+  if (amount === undefined && Object.keys(amounts).length === 0) return null;
+
+  return {
+    budget_id: cat.id, // GraphQL has no per-budget id; use category id as the stable key
+    category_id: cat.id,
+    category_name: cat.name,
+    ...(amount !== undefined ? { amount } : {}),
+    ...(Object.keys(amounts).length > 0 ? { amounts } : {}),
+  };
+}
+
+export class LiveBudgetsTools {
+  constructor(private readonly live: LiveCopilotDatabase) {}
+
+  async getBudgets(_args: GetBudgetsLiveArgs): Promise<GetBudgetsLiveResult> {
+    const cache = this.live.getCategoriesCache();
+    const startedAt = Date.now();
+    const { rows: cats, fetched_at, hit } = await cache.read(() =>
+      fetchCategories(this.live.getClient())
+    );
+
+    const projected: GetBudgetsLiveBudget[] = [];
+    let totalBudgeted = 0;
+    for (const cat of cats) {
+      const row = projectCategory(cat);
+      if (!row) continue;
+      projected.push(row);
+      if (row.amount !== undefined) totalBudgeted += row.amount;
+    }
+
+    // Sort by category_name for stable output (mirrors LiveCategoriesTools convention).
+    projected.sort((a, b) => a.category_name.localeCompare(b.category_name));
+
+    // Log after projection so `rows` reflects what's returned to the caller.
+    this.live.logReadCall({
+      op: 'Budgets',
+      pages: hit ? 0 : 1,
+      latencyMs: Date.now() - startedAt,
+      rows: projected.length,
+      cache_hit: hit,
+    });
+
+    const fetchedAtIso = new Date(fetched_at).toISOString();
+    return {
+      count: projected.length,
+      total_budgeted: roundAmount(totalBudgeted),
+      budgets: projected,
+      _cache_oldest_fetched_at: fetchedAtIso,
+      _cache_newest_fetched_at: fetchedAtIso,
+      _cache_hit: hit,
+    };
+  }
+}
+
+export function createLiveBudgetsToolSchema() {
+  return {
+    name: 'get_budgets_live',
+    description:
+      "Get budgets from Copilot's native budget tracking (live, GraphQL-backed). " +
+      'Projects per-category budgets from the categories cache — the same fetch that ' +
+      'powers get_categories_live populates this. Replaces get_budgets when --live-reads is on.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {},
+    },
+    annotations: {
+      readOnlyHint: true,
+    },
+  };
+}

--- a/src/tools/live/refresh-cache.ts
+++ b/src/tools/live/refresh-cache.ts
@@ -69,7 +69,8 @@ export class RefreshCacheTool {
       flushed.categories = true;
       this.live.getTagsCache().invalidate();
       flushed.tags = true;
-      this.live.getBudgetsCache().invalidate();
+      // budgets piggyback on categoriesCache; flushing categories above already
+      // invalidates them. Set the flag for output parity with the original API.
       flushed.budgets = true;
       this.live.getRecurringCache().invalidate();
       flushed.recurring = true;
@@ -102,7 +103,9 @@ export class RefreshCacheTool {
         flushed.tags = true;
         break;
       case 'budgets':
-        this.live.getBudgetsCache().invalidate();
+        // Alias: budgets data lives inside categoriesCache (per-category projection).
+        // Invalidating categoriesCache also flushes the budgets projection.
+        this.live.getCategoriesCache().invalidate();
         flushed.budgets = true;
         break;
       case 'recurring':
@@ -126,7 +129,8 @@ export function createRefreshCacheToolSchema() {
         scope: {
           type: 'string',
           enum: VALID_SCOPES,
-          description: 'Which slice of the live cache to flush. Default: all.',
+          description:
+            'Which slice of the live cache to flush. Default: all. Note: "budgets" is an alias for "categories" — budget data is a projection of the categories cache.',
           default: 'all',
         },
         months: {

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3247,7 +3247,7 @@ export class CopilotMoneyTools {
         month: args.month,
       });
       this.db.patchCachedBudget(args.category_id, parseFloat(args.amount), args.month);
-      this.liveDb?.patchLiveBudget(args.category_id, parseFloat(args.amount), args.month);
+      this.liveDb?.patchLiveCategoryBudget(args.category_id, parseFloat(args.amount), args.month);
       return {
         success: true,
         category_id: result.categoryId,

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -5,7 +5,7 @@ import type { GraphQLClient } from '../../src/core/graphql/client.js';
 import type { CopilotDatabase } from '../../src/core/database.js';
 import type { TransactionsPage } from '../../src/core/graphql/queries/transactions.js';
 import { SnapshotCache, TransactionWindowCache } from '../../src/core/cache/index.js';
-import type { Tag, Budget, Recurring } from '../../src/models/index.js';
+import type { Tag, Recurring } from '../../src/models/index.js';
 import type { CategoryNode } from '../../src/core/graphql/queries/categories.js';
 
 function mkClient(): GraphQLClient {
@@ -346,10 +346,6 @@ describe('LiveCopilotDatabase — cache accessors', () => {
     expect(mkLive().getTagsCache()).toBeInstanceOf(SnapshotCache);
   });
 
-  test('getBudgetsCache returns a SnapshotCache instance', () => {
-    expect(mkLive().getBudgetsCache()).toBeInstanceOf(SnapshotCache);
-  });
-
   test('getRecurringCache returns a SnapshotCache instance', () => {
     expect(mkLive().getRecurringCache()).toBeInstanceOf(SnapshotCache);
   });
@@ -438,55 +434,6 @@ describe('LiveCopilotDatabase.patchLiveTransactionDelete', () => {
     live.patchLiveTransactionDelete('unknown');
 
     expect(wc.entriesForMonth('2024-02')).toHaveLength(1);
-  });
-});
-
-// ── patchLiveBudget ─────────────────────────────────────────────────────────
-
-describe('LiveCopilotDatabase.patchLiveBudget', () => {
-  async function seedAndRead(live: LiveCopilotDatabase): Promise<Budget[]> {
-    // Seed cache so upsert has somewhere to write.
-    return (await live.getBudgetsCache().read(async () => [])).rows;
-  }
-
-  test('upserts synthetic budget into cache by category_id', async () => {
-    const live = new LiveCopilotDatabase(mkClient(), mkCache());
-    await seedAndRead(live);
-
-    live.patchLiveBudget('cat-42', 500, '2025-03');
-
-    const result = await live.getBudgetsCache().read(async () => []);
-    expect(result.rows).toHaveLength(1);
-    const b = result.rows[0]!;
-    expect(b.category_id).toBe('cat-42');
-    expect(b.amounts?.['2025-03']).toBe(500);
-  });
-
-  test('defaults month to current YYYY-MM', async () => {
-    const live = new LiveCopilotDatabase(mkClient(), mkCache());
-    await seedAndRead(live);
-
-    live.patchLiveBudget('cat-1', 100);
-
-    const result = await live.getBudgetsCache().read(async () => []);
-    const b = result.rows[0]!;
-    const now = new Date();
-    const expectedMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-    expect(Object.keys(b.amounts ?? {})[0]).toBe(expectedMonth);
-  });
-
-  test('updates existing budget by category_id', async () => {
-    const live = new LiveCopilotDatabase(mkClient(), mkCache());
-    // Seed with an existing budget for the same category.
-    await live
-      .getBudgetsCache()
-      .read(async () => [{ budget_id: 'b1', category_id: 'cat-5', amounts: { '2025-01': 200 } }]);
-
-    live.patchLiveBudget('cat-5', 999, '2025-02');
-
-    const result = await live.getBudgetsCache().read(async () => []);
-    expect(result.rows).toHaveLength(1);
-    expect(result.rows[0]!.amounts?.['2025-02']).toBe(999);
   });
 });
 

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -596,6 +596,125 @@ describe('LiveCopilotDatabase.patchLiveCategoryUpsert (CategoryNode shape)', () 
   });
 });
 
+// ── patchLiveCategoryBudget ────────────────────────────────────────────────
+
+describe('LiveCopilotDatabase.patchLiveCategoryBudget', () => {
+  test('updates budget.current.amount on a cached category for the current month', async () => {
+    const live = new LiveCopilotDatabase(mkClient(), mkCache());
+    const cache = live.getCategoriesCache();
+
+    // Seed a category with no budget
+    await cache.read(() =>
+      Promise.resolve([
+        {
+          id: 'cat-1',
+          name: 'Food',
+          templateId: 'Food',
+          colorName: null,
+          icon: null,
+          isExcluded: false,
+          isRolloverDisabled: false,
+          canBeDeleted: true,
+          budget: null,
+        },
+      ])
+    );
+
+    const currentMonth = new Date().toISOString().slice(0, 7); // YYYY-MM (UTC)
+    live.patchLiveCategoryBudget('cat-1', 250, currentMonth);
+
+    const after = await cache.read(() => Promise.resolve([]));
+    const cat = after.rows.find((c) => c.id === 'cat-1');
+    expect(cat?.budget?.current?.amount).toBe('250');
+    expect(cat?.budget?.current?.month).toBe(currentMonth);
+  });
+
+  test('updates a historical month via budget.histories', async () => {
+    const live = new LiveCopilotDatabase(mkClient(), mkCache());
+    const cache = live.getCategoriesCache();
+
+    await cache.read(() =>
+      Promise.resolve([
+        {
+          id: 'cat-1',
+          name: 'Food',
+          templateId: 'Food',
+          colorName: null,
+          icon: null,
+          isExcluded: false,
+          isRolloverDisabled: false,
+          canBeDeleted: true,
+          budget: {
+            current: null,
+            histories: [
+              {
+                unassignedRolloverAmount: '0',
+                childRolloverAmount: '0',
+                unassignedAmount: '0',
+                resolvedAmount: '100',
+                rolloverAmount: '0',
+                childAmount: null,
+                goalAmount: '100',
+                amount: '100',
+                month: '2026-04',
+                id: 'b-existing',
+              },
+            ],
+          },
+        },
+      ])
+    );
+
+    live.patchLiveCategoryBudget('cat-1', 175, '2026-04');
+
+    const after = await cache.read(() => Promise.resolve([]));
+    const hist = after.rows.find((c) => c.id === 'cat-1')?.budget?.histories ?? [];
+    expect(hist).toHaveLength(1);
+    expect(hist[0]?.amount).toBe('175');
+  });
+
+  test('inserts a new history entry when month not present', async () => {
+    const live = new LiveCopilotDatabase(mkClient(), mkCache());
+    const cache = live.getCategoriesCache();
+
+    await cache.read(() =>
+      Promise.resolve([
+        {
+          id: 'cat-1',
+          name: 'Food',
+          templateId: 'Food',
+          colorName: null,
+          icon: null,
+          isExcluded: false,
+          isRolloverDisabled: false,
+          canBeDeleted: true,
+          budget: { current: null, histories: [] },
+        },
+      ])
+    );
+
+    live.patchLiveCategoryBudget('cat-1', 75, '2025-12');
+
+    const after = await cache.read(() => Promise.resolve([]));
+    const hist = after.rows.find((c) => c.id === 'cat-1')?.budget?.histories ?? [];
+    expect(hist).toHaveLength(1);
+    expect(hist[0]?.month).toBe('2025-12');
+    expect(hist[0]?.amount).toBe('75');
+  });
+
+  test('no-op when category not in cache', async () => {
+    const live = new LiveCopilotDatabase(mkClient(), mkCache());
+    const cache = live.getCategoriesCache();
+    await cache.read(() => Promise.resolve([])); // empty cache
+
+    // Does not throw
+    expect(() => live.patchLiveCategoryBudget('cat-missing', 100)).not.toThrow();
+
+    const after = await cache.read(() => Promise.resolve([]));
+    expect(after.rows.find((c) => c.id === 'cat-missing')).toBeUndefined();
+  });
+});
+
 // ── patchLiveRecurringUpsert / patchLiveRecurringDelete ────────────────────
 
 describe('LiveCopilotDatabase — recurring cache patches', () => {

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -574,6 +574,44 @@ describe('LiveCopilotDatabase.patchLiveCategoryBudget', () => {
     const cat = after.rows.find((c) => c.id === 'cat-1');
     expect(cat?.budget?.current?.amount).toBe('250');
     expect(cat?.budget?.current?.month).toBe(currentMonth);
+    // The patch went to `current`, not `histories` — histories must stay empty.
+    expect(cat?.budget?.histories).toEqual([]);
+  });
+
+  test('patching current month with no existing current synthesizes ONLY current (not both current+history)', async () => {
+    const live = new LiveCopilotDatabase(mkClient(), mkCache());
+    const cache = live.getCategoriesCache();
+
+    // Seed a category with budget.current=null and empty histories
+    await cache.read(() =>
+      Promise.resolve([
+        {
+          id: 'cat-1',
+          name: 'Food',
+          templateId: 'Food',
+          colorName: null,
+          icon: null,
+          isExcluded: false,
+          isRolloverDisabled: false,
+          canBeDeleted: true,
+          budget: { current: null, histories: [] },
+        },
+      ])
+    );
+
+    // Patch the current UTC month
+    const todayMonth = (() => {
+      const d = new Date();
+      return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`;
+    })();
+    live.patchLiveCategoryBudget('cat-1', 250, todayMonth);
+
+    const after = await cache.read(() => Promise.resolve([]));
+    const cat = after.rows.find((c) => c.id === 'cat-1');
+    expect(cat?.budget?.current?.amount).toBe('250');
+    expect(cat?.budget?.current?.month).toBe(todayMonth);
+    // Critical: histories should remain empty — current month went to `current`, not `histories`
+    expect(cat?.budget?.histories).toEqual([]);
   });
 
   test('updates a historical month via budget.histories', async () => {

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -2408,3 +2408,72 @@ describe('--live-reads tags wiring', () => {
     expect(data._cache_hit).toBe(false);
   });
 });
+
+// ============================================
+// --live-reads budgets wiring tests
+// ============================================
+
+describe('--live-reads budgets wiring', () => {
+  test('handleListTools when --live-reads is OFF excludes get_budgets_live', () => {
+    const server = new CopilotMoneyServer(FAKE_DB_DIR);
+    const { tools } = server.handleListTools();
+    const names = tools.map((t) => t.name);
+    expect(names).not.toContain('get_budgets_live');
+  });
+
+  test('handleListTools when --live-reads is ON includes get_budgets_live and excludes get_budgets', () => {
+    // Pass a mock GraphQL client so the constructor can wire liveBudgetsTools
+    // without attempting real auth. The fourth positional arg is liveReadsEnabled.
+    const mockClient = createMockGraphQLClient({});
+    const server = new CopilotMoneyServer(FAKE_DB_DIR, undefined, false, true, mockClient);
+    const { tools } = server.handleListTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('get_budgets_live');
+    expect(names).not.toContain('get_budgets');
+  });
+
+  test('get_budgets_live without --live-reads returns isError with --live-reads hint', async () => {
+    const server = new CopilotMoneyServer(FAKE_DB_DIR);
+    const db = createMockDb();
+    server._injectForTesting(db, new CopilotMoneyTools(db));
+
+    const result = await server.handleCallTool('get_budgets_live', {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('--live-reads');
+  });
+
+  test('get_budgets_live with --live-reads dispatches to liveBudgetsTools.getBudgets', async () => {
+    const mockClient = createMockGraphQLClient({});
+    const server = new CopilotMoneyServer(FAKE_DB_DIR, undefined, false, true, mockClient);
+    const db = createMockDb();
+    server._injectForTesting(db, new CopilotMoneyTools(db));
+
+    // Inject a stub LiveBudgetsTools via private field access
+    const stubResult = {
+      count: 1,
+      total_budgeted: 500,
+      budgets: [
+        {
+          budget_id: 'cat-food',
+          category_id: 'cat-food',
+          category_name: 'Food',
+          amount: 500,
+          amounts: { '2026-05': 500 },
+        },
+      ],
+      _cache_oldest_fetched_at: '2025-01-01T00:00:00.000Z',
+      _cache_newest_fetched_at: '2025-01-01T00:00:00.000Z',
+      _cache_hit: false,
+    };
+    (server as any).liveBudgetsTools = {
+      getBudgets: async (_args: unknown) => stubResult,
+    };
+
+    const result = await server.handleCallTool('get_budgets_live', {});
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text) as typeof stubResult;
+    expect(data.count).toBe(1);
+    expect(data.total_budgeted).toBe(500);
+    expect(data._cache_hit).toBe(false);
+  });
+});

--- a/tests/tools/live/budgets.test.ts
+++ b/tests/tools/live/budgets.test.ts
@@ -121,6 +121,43 @@ describe('LiveBudgetsTools.getBudgets', () => {
     expect(result.budgets[0]?.amount).toBeUndefined(); // no current
     expect(result.budgets[0]?.amounts).toEqual({ '2026-04': 400 });
   });
+
+  test('handles category with budget.current present but current.amount=null', async () => {
+    const cat = {
+      id: 'cat-misc',
+      name: 'Misc',
+      templateId: null,
+      colorName: null,
+      icon: null,
+      isExcluded: false,
+      isRolloverDisabled: false,
+      canBeDeleted: true,
+      budget: {
+        current: {
+          unassignedRolloverAmount: null,
+          childRolloverAmount: null,
+          unassignedAmount: null,
+          resolvedAmount: null,
+          rolloverAmount: null,
+          childAmount: null,
+          goalAmount: null,
+          amount: null,
+          month: '2026-05',
+          id: 'budget-misc-null',
+        },
+        histories: [],
+      },
+    };
+    const client = makeClient([cat]);
+    const tools = new LiveBudgetsTools(makeLive(client));
+
+    const result = await tools.getBudgets({});
+
+    // current.amount=null → parseAmount returns undefined → neither `amount` nor
+    // an `amounts` entry is produced for the current month; histories is empty too.
+    // projectCategory drops the row entirely (no current amount AND no history amounts).
+    expect(result.count).toBe(0);
+  });
 });
 
 describe('createLiveBudgetsToolSchema', () => {

--- a/tests/tools/live/budgets.test.ts
+++ b/tests/tools/live/budgets.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../src/core/graphql/client.js';
+import { CopilotDatabase } from '../../../src/core/database.js';
+import { LiveCopilotDatabase } from '../../../src/core/live-database.js';
+import { LiveBudgetsTools } from '../../../src/tools/live/budgets.js';
+
+function makeClient(categoriesResponse: unknown[]): GraphQLClient {
+  return {
+    query: mock(() => Promise.resolve({ categories: categoriesResponse })),
+  } as unknown as GraphQLClient;
+}
+
+function makeLive(client: GraphQLClient): LiveCopilotDatabase {
+  return new LiveCopilotDatabase(client, new CopilotDatabase('/tmp/no-such-db'));
+}
+
+const sampleCategoryWithBudget = {
+  id: 'cat-food',
+  name: 'Food',
+  templateId: 'Food',
+  colorName: 'ORANGE2',
+  isExcluded: false,
+  isRolloverDisabled: false,
+  canBeDeleted: true,
+  icon: { __typename: 'EmojiUnicode', unicode: '🍱' },
+  budget: {
+    current: {
+      unassignedRolloverAmount: '0',
+      childRolloverAmount: '0',
+      unassignedAmount: '50',
+      resolvedAmount: '450',
+      rolloverAmount: '0',
+      childAmount: null,
+      goalAmount: '500',
+      amount: '500',
+      month: '2026-05',
+      id: 'budget-food-current',
+    },
+    histories: [
+      {
+        unassignedRolloverAmount: '0',
+        childRolloverAmount: '0',
+        unassignedAmount: '0',
+        resolvedAmount: '400',
+        rolloverAmount: '0',
+        childAmount: null,
+        goalAmount: '400',
+        amount: '400',
+        month: '2026-04',
+        id: 'budget-food-2026-04',
+      },
+    ],
+  },
+};
+
+const sampleCategoryWithoutBudget = {
+  id: 'cat-misc',
+  name: 'Misc',
+  templateId: null,
+  colorName: null,
+  isExcluded: false,
+  isRolloverDisabled: false,
+  canBeDeleted: true,
+  icon: null,
+  budget: null,
+};
+
+describe('LiveBudgetsTools.getBudgets', () => {
+  test('cold call: projects per-category budgets from categoriesCache', async () => {
+    const client = makeClient([sampleCategoryWithBudget, sampleCategoryWithoutBudget]);
+    const tools = new LiveBudgetsTools(makeLive(client));
+
+    const result = await tools.getBudgets({});
+
+    expect(result.count).toBe(1); // only categories with budget data are returned
+    expect(result.budgets[0]?.budget_id).toBe('cat-food');
+    expect(result.budgets[0]?.category_id).toBe('cat-food');
+    expect(result.budgets[0]?.category_name).toBe('Food');
+    expect(result.budgets[0]?.amount).toBe(500);
+    expect(result.budgets[0]?.amounts).toEqual({ '2026-05': 500, '2026-04': 400 });
+    expect(result.total_budgeted).toBe(500);
+    expect(result._cache_hit).toBe(false);
+  });
+
+  test('warm call: cache hit, no second fetch', async () => {
+    const client = makeClient([sampleCategoryWithBudget]);
+    const tools = new LiveBudgetsTools(makeLive(client));
+
+    await tools.getBudgets({});
+    const second = await tools.getBudgets({});
+
+    expect(second._cache_hit).toBe(true);
+    expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  test('empty categoriesCache returns count 0, no throw', async () => {
+    const client = makeClient([]);
+    const tools = new LiveBudgetsTools(makeLive(client));
+
+    const result = await tools.getBudgets({});
+
+    expect(result.count).toBe(0);
+    expect(result.budgets).toEqual([]);
+    expect(result.total_budgeted).toBe(0);
+  });
+
+  test('handles category with budget.current=null but non-empty histories', async () => {
+    const cat = {
+      ...sampleCategoryWithBudget,
+      budget: {
+        current: null,
+        histories: [sampleCategoryWithBudget.budget.histories[0]],
+      },
+    };
+    const client = makeClient([cat]);
+    const tools = new LiveBudgetsTools(makeLive(client));
+
+    const result = await tools.getBudgets({});
+
+    expect(result.count).toBe(1);
+    expect(result.budgets[0]?.amount).toBeUndefined(); // no current
+    expect(result.budgets[0]?.amounts).toEqual({ '2026-04': 400 });
+  });
+});
+
+describe('createLiveBudgetsToolSchema', () => {
+  test('returns a schema with readOnlyHint=true', async () => {
+    const { createLiveBudgetsToolSchema } = await import('../../../src/tools/live/budgets.js');
+    const schema = createLiveBudgetsToolSchema();
+    expect(schema.name).toBe('get_budgets_live');
+    expect(schema.annotations?.readOnlyHint).toBe(true);
+  });
+});

--- a/tests/tools/live/refresh-cache.test.ts
+++ b/tests/tools/live/refresh-cache.test.ts
@@ -94,18 +94,6 @@ describe('RefreshCacheTool — scope: budgets', () => {
     expect(result.flushed.budgets).toBe(true);
   });
 
-  test('does NOT call getBudgetsCache (it will be deleted in Task 6)', async () => {
-    const { live } = makeMockLive();
-    // Attach a spy to getBudgetsCache; it should never be called
-    const getBudgetsCacheSpy = mock(() => ({ invalidate: mock(() => {}) }));
-    (live as Record<string, unknown>)['getBudgetsCache'] = getBudgetsCacheSpy;
-
-    const tool = new RefreshCacheTool(live);
-    await tool.refresh({ scope: 'budgets' });
-
-    expect(getBudgetsCacheSpy).not.toHaveBeenCalled();
-  });
-
   test('does NOT flush accounts, tags, recurring, or transactions', async () => {
     const { live, mocks } = makeMockLive();
     const tool = new RefreshCacheTool(live);

--- a/tests/tools/live/refresh-cache.test.ts
+++ b/tests/tools/live/refresh-cache.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, test, mock, beforeEach } from 'bun:test';
+import {
+  RefreshCacheTool,
+  createRefreshCacheToolSchema,
+} from '../../../src/tools/live/refresh-cache.js';
+import type { LiveCopilotDatabase } from '../../../src/core/live-database.js';
+
+function makeInvalidateCache() {
+  return { invalidate: mock(() => {}) };
+}
+
+function makeMockLive(): {
+  live: LiveCopilotDatabase;
+  mocks: {
+    accounts: ReturnType<typeof makeInvalidateCache>;
+    categories: ReturnType<typeof makeInvalidateCache>;
+    tags: ReturnType<typeof makeInvalidateCache>;
+    recurring: ReturnType<typeof makeInvalidateCache>;
+    transactions: { invalidate: ReturnType<typeof mock> };
+  };
+} {
+  const accounts = makeInvalidateCache();
+  const categories = makeInvalidateCache();
+  const tags = makeInvalidateCache();
+  const recurring = makeInvalidateCache();
+  const transactions = { invalidate: mock((_arg: string[] | 'all') => {}) };
+
+  const live = {
+    getAccountsCache: mock(() => accounts),
+    getCategoriesCache: mock(() => categories),
+    getTagsCache: mock(() => tags),
+    getRecurringCache: mock(() => recurring),
+    getTransactionsWindowCache: mock(() => transactions),
+  } as unknown as LiveCopilotDatabase;
+
+  return { live, mocks: { accounts, categories, tags, recurring, transactions } };
+}
+
+describe('RefreshCacheTool — scope: all', () => {
+  test('flushes all snapshot caches and transactions', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'all' });
+
+    expect(mocks.accounts.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.categories.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.tags.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.recurring.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.transactions.invalidate).toHaveBeenCalledTimes(1);
+    expect(result.flushed.accounts).toBe(true);
+    expect(result.flushed.categories).toBe(true);
+    expect(result.flushed.tags).toBe(true);
+    expect(result.flushed.budgets).toBe(true);
+    expect(result.flushed.recurring).toBe(true);
+    expect(result.flushed.transactions_months).toBe('all');
+  });
+
+  test('respects months filter for transactions', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'all', months: ['2026-04', '2026-05'] });
+
+    expect(mocks.transactions.invalidate).toHaveBeenCalledWith(['2026-04', '2026-05']);
+    expect(result.flushed.transactions_months).toEqual(['2026-04', '2026-05']);
+  });
+});
+
+describe('RefreshCacheTool — scope: categories', () => {
+  test('invalidates only categoriesCache', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'categories' });
+
+    expect(mocks.categories.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.accounts.invalidate).not.toHaveBeenCalled();
+    expect(result.flushed.categories).toBe(true);
+    expect(result.flushed.budgets).toBeUndefined();
+  });
+});
+
+describe('RefreshCacheTool — scope: budgets', () => {
+  test('aliases to categoriesCache.invalidate() (budgets are a projection of categories)', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'budgets' });
+
+    // budgets piggyback on categoriesCache
+    expect(mocks.categories.invalidate).toHaveBeenCalledTimes(1);
+    // output parity: flushed.budgets must be set
+    expect(result.flushed.budgets).toBe(true);
+  });
+
+  test('does NOT call getBudgetsCache (it will be deleted in Task 6)', async () => {
+    const { live } = makeMockLive();
+    // Attach a spy to getBudgetsCache; it should never be called
+    const getBudgetsCacheSpy = mock(() => ({ invalidate: mock(() => {}) }));
+    (live as Record<string, unknown>)['getBudgetsCache'] = getBudgetsCacheSpy;
+
+    const tool = new RefreshCacheTool(live);
+    await tool.refresh({ scope: 'budgets' });
+
+    expect(getBudgetsCacheSpy).not.toHaveBeenCalled();
+  });
+
+  test('does NOT flush accounts, tags, recurring, or transactions', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'budgets' });
+
+    expect(mocks.accounts.invalidate).not.toHaveBeenCalled();
+    expect(mocks.tags.invalidate).not.toHaveBeenCalled();
+    expect(mocks.recurring.invalidate).not.toHaveBeenCalled();
+    expect(mocks.transactions.invalidate).not.toHaveBeenCalled();
+    expect(result.flushed.accounts).toBeUndefined();
+    expect(result.flushed.tags).toBeUndefined();
+    expect(result.flushed.recurring).toBeUndefined();
+    expect(result.flushed.transactions_months).toBeUndefined();
+  });
+});
+
+describe('RefreshCacheTool — scope: accounts', () => {
+  test('invalidates only accountsCache', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'accounts' });
+
+    expect(mocks.accounts.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.categories.invalidate).not.toHaveBeenCalled();
+    expect(result.flushed.accounts).toBe(true);
+  });
+});
+
+describe('RefreshCacheTool — scope: tags', () => {
+  test('invalidates only tagsCache', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'tags' });
+
+    expect(mocks.tags.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.categories.invalidate).not.toHaveBeenCalled();
+    expect(result.flushed.tags).toBe(true);
+  });
+});
+
+describe('RefreshCacheTool — scope: recurring', () => {
+  test('invalidates only recurringCache', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'recurring' });
+
+    expect(mocks.recurring.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.categories.invalidate).not.toHaveBeenCalled();
+    expect(result.flushed.recurring).toBe(true);
+  });
+});
+
+describe('RefreshCacheTool — scope: transactions', () => {
+  test('flushes all transaction months by default', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'transactions' });
+
+    expect(mocks.transactions.invalidate).toHaveBeenCalledWith('all');
+    expect(result.flushed.transactions_months).toBe('all');
+    expect(mocks.categories.invalidate).not.toHaveBeenCalled();
+  });
+
+  test('flushes specific months when provided', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'transactions', months: ['2026-03'] });
+
+    expect(mocks.transactions.invalidate).toHaveBeenCalledWith(['2026-03']);
+    expect(result.flushed.transactions_months).toEqual(['2026-03']);
+  });
+});
+
+describe('RefreshCacheTool — validation', () => {
+  test('rejects unknown scope', async () => {
+    const { live } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    await expect(tool.refresh({ scope: 'unknown' as 'all' })).rejects.toThrow(/Unknown scope/);
+  });
+
+  test('rejects invalid month format', async () => {
+    const { live } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    await expect(tool.refresh({ scope: 'transactions', months: ['26-04'] })).rejects.toThrow(
+      /Invalid month format/
+    );
+  });
+
+  test('default scope (omitted) behaves as all', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({});
+
+    expect(mocks.accounts.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.categories.invalidate).toHaveBeenCalledTimes(1);
+    expect(result.flushed.transactions_months).toBe('all');
+  });
+});
+
+describe('createRefreshCacheToolSchema', () => {
+  test('schema name is refresh_cache', () => {
+    const schema = createRefreshCacheToolSchema();
+    expect(schema.name).toBe('refresh_cache');
+  });
+
+  test('budgets scope is listed in enum', () => {
+    const schema = createRefreshCacheToolSchema();
+    const scopeProp = schema.inputSchema.properties.scope as { enum: string[] };
+    expect(scopeProp.enum).toContain('budgets');
+  });
+
+  test('schema description mentions budgets piggyback on categories', () => {
+    const schema = createRefreshCacheToolSchema();
+    const scopeProp = schema.inputSchema.properties.scope as { description: string };
+    expect(scopeProp.description.toLowerCase()).toMatch(/budget|categor/);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4 PR #3: ships \`get_budgets_live\` MCP tool as a **projection** over the existing \`categoriesCache\` (no new SnapshotCache, no new GraphQL query wrapper), and retires the dead \`budgetsCache\` plumbing. Per spec Decision 3, GraphQL models budget as a field on Category, not a top-level entity — the Phase 2 \`SnapshotCache<Budget>\` was a Firestore artifact.

- **New tool:** \`get_budgets_live\` — projects per-category budgets from \`categoriesCache\` (already populated by \`fetchCategories({budget: true})\` from PR #1). 24h effective TTL via the categories cache.
- **Cache-mode swap:** \`handleListTools\` now drops \`get_budgets\` from the cache-mode list when \`--live-reads\` is on (real swap — \`get_budgets\` exists as a cache-mode tool).
- **\`patchLiveCategoryBudget\` write-through:** new method on \`LiveCopilotDatabase\`. Peeks the cached category, mutates \`budget.current\` or \`budget.histories[month]\`, upserts. No-op if not cached.
- **\`setBudget\` write-through:** redirected from \`patchLiveBudget\` (deleted) to \`patchLiveCategoryBudget\`.
- **\`refresh_cache --scope budgets\`:** now an alias for \`categoriesCache.invalidate()\`. User-facing schema preserved; underlying target swapped.
- **Retirements:** \`LiveCopilotDatabase.budgetsCache\`, \`getBudgetsCache()\`, \`patchLiveBudget()\` all deleted.
- **Test additions:** new \`tests/tools/live/refresh-cache.test.ts\` (234 lines, 17 tests) — Phase 2 had shipped without dedicated test coverage.

## Test plan

- [x] Full test suite green: \`bun run check\` — 1775 pass, 21 skip, 0 fail
- [x] Smoke against live endpoint:

\`\`\`
[graphql-read] op=Budgets cache_hit=false pages=1 latency=2134ms rows=37
[smoke] cold {
  rows: 37,
  total: 34535.02,
  hit: false,
  ms: 2134,
}
[graphql-read] op=Budgets cache_hit=true pages=0 latency=0ms rows=37
[smoke] warm {
  rows: 37,
  hit: true,
  ms: 0,
}
[smoke] refreshed {
  scope: "budgets",
}
[graphql-read] op=Budgets cache_hit=false pages=1 latency=1064ms rows=37
[smoke] recold {
  rows: 37,
  hit: false,
  ms: 1064,
}
[smoke] done {
  passed: 3,
}
\`\`\`

## Notes

- Out of scope (later Phase 4 PRs): Recurring (PR #4); \`--live-reads\` default-on flip; LevelDB retirement.
- Cache-mode (\`--live-reads\` off) behavior unchanged — \`db.getBudgets\`, \`db.patchCachedBudget\`, the cache-mode \`get_budgets\` tool all untouched.
- Phase 4 spec lives at \`docs/superpowers/specs/2026-05-02-graphql-live-snapshot-entities-design.md\` (local-only per project rule; reconstruct from PR commits if needed).