### PR TITLE
fix(decoder): filter soft-deleted transactions (user_deleted=true) — #326

### DIFF
--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -747,6 +747,13 @@ function processTransaction(
     return null;
   }
 
+  // Soft delete: Copilot does not write Firestore tombstones for transaction
+  // deletes — it flips `user_deleted: true` on the Document and leaves the
+  // rest in place. Drop these the same way `getAccounts` does (#326).
+  if (getBoolean(fields, 'user_deleted') === true) {
+    return null;
+  }
+
   const txnData: Record<string, unknown> = {
     transaction_id: transactionId,
     amount,

--- a/tests/core/decoder-leveldb.test.ts
+++ b/tests/core/decoder-leveldb.test.ts
@@ -200,6 +200,36 @@ describe('LevelDB Decoder', () => {
       }
     });
 
+    test('skips soft-deleted transactions (user_deleted=true) — issue #326', async () => {
+      // Copilot's app does not write Firestore tombstones for transaction
+      // deletes. It soft-deletes by flipping `user_deleted: true` on the
+      // Document and leaving everything else intact. The decoder must
+      // filter these out, the same way `tools.getAccounts` filters
+      // accounts with user_deleted=true.
+      const dbPath = path.join(FIXTURES_DIR, 'soft-deleted-txn-db');
+      const transactions: TestTransaction[] = [
+        {
+          transaction_id: 'txn_active',
+          amount: 50.0,
+          date: '2024-01-15',
+          name: 'Active Transaction',
+        },
+        {
+          transaction_id: 'txn_soft_deleted',
+          amount: 99.99,
+          date: '2024-01-16',
+          name: 'GQL-TEST-deleted',
+          user_deleted: true,
+        },
+      ];
+
+      await createTransactionDb(dbPath, transactions);
+      const result = await decodeTransactions(dbPath);
+
+      expect(result.length).toBe(1);
+      expect(result[0]?.transaction_id).toBe('txn_active');
+    });
+
     test('skips transactions with zero amount', async () => {
       const dbPath = path.join(FIXTURES_DIR, 'zero-amount-db');
       const transactions: TestTransaction[] = [

--- a/tests/core/decoder-leveldb.test.ts
+++ b/tests/core/decoder-leveldb.test.ts
@@ -206,13 +206,24 @@ describe('LevelDB Decoder', () => {
       // Document and leaving everything else intact. The decoder must
       // filter these out, the same way `tools.getAccounts` filters
       // accounts with user_deleted=true.
+      //
+      // The filter must use `=== true`: rows with the field absent (most
+      // transactions) and rows with explicit `user_deleted: false` should
+      // both pass through.
       const dbPath = path.join(FIXTURES_DIR, 'soft-deleted-txn-db');
       const transactions: TestTransaction[] = [
         {
-          transaction_id: 'txn_active',
+          transaction_id: 'txn_no_field',
           amount: 50.0,
           date: '2024-01-15',
-          name: 'Active Transaction',
+          name: 'Active (field absent)',
+        },
+        {
+          transaction_id: 'txn_explicit_false',
+          amount: 25.0,
+          date: '2024-01-15',
+          name: 'Active (user_deleted=false)',
+          user_deleted: false,
         },
         {
           transaction_id: 'txn_soft_deleted',
@@ -226,8 +237,8 @@ describe('LevelDB Decoder', () => {
       await createTransactionDb(dbPath, transactions);
       const result = await decodeTransactions(dbPath);
 
-      expect(result.length).toBe(1);
-      expect(result[0]?.transaction_id).toBe('txn_active');
+      const ids = result.map((t) => t.transaction_id).sort();
+      expect(ids).toEqual(['txn_explicit_false', 'txn_no_field']);
     });
 
     test('skips transactions with zero amount', async () => {

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -27,6 +27,7 @@ export interface TestTransaction {
   is_transfer?: boolean;
   note?: string;
   tags?: string[];
+  user_deleted?: boolean;
 }
 
 export interface TestAccount {
@@ -198,6 +199,7 @@ export async function createTransactionDb(
       is_transfer: t.is_transfer,
       note: t.note,
       tags: t.tags,
+      user_deleted: t.user_deleted,
     },
   }));
 


### PR DESCRIPTION
## Summary

Closes #326.

The original issue hypothesized that the decoder was failing to honor Firestore `NoDocument` tombstones. It turns out the decoder handles tombstones correctly — Copilot just doesn't *use* tombstones for transaction deletes. It uses **soft delete via a `user_deleted: true` boolean** on the Document itself, leaving everything else intact. Our decoder captured the field but never filtered on it, so deleted transactions kept appearing in `get_transactions` until LevelDB compaction (uncertain cadence).

On a real Copilot DB the leak was **3.62% (43 of 1188 transactions)**, all `GQL-TEST-*` stragglers. After the fix: 0 leaked.

The fix mirrors the existing accounts filter at `tools.ts:991`.

## Investigation evidence

| Data point | Value |
|---|---|
| Strict `remote_document` keyspace entries | 5,225 |
| Transaction Documents (field tag 2) | 1,574 |
| Transaction `NoDocument` tombstones (field tag 1) | **0** |
| Transactions returned before fix | 1,188 |
| Of those, with `user_deleted=true` | **43 (3.62%)** |
| After fix | 0 leaks |

The orphan from the original repro (`YF943XqMCKtguESuk4cE`) parses to a regular Document with `user_deleted: true`, not a tombstone:
```json
{ "amount": 1.11, "name": "GQL-TEST-...", "user_deleted": true, ... }
```

`NoDocument` tombstones DO exist in this LevelDB (205 of them), but for *other* collections — Copilot uses two deletion strategies depending on the entity type. Our parser already handles tombstones correctly (returns empty fields → `processTransaction` returns null).

## Test plan

- [x] New unit test in `tests/core/decoder-leveldb.test.ts` reproduces the bug (RED) and confirms the fix (GREEN)
- [x] Full suite passes (`bun run check`): 1751 pass, 0 fail
- [x] Verified on live Copilot LevelDB: 43 leaked → 0 leaked

## Out of scope

- The decoder's main-thread `tempDbCache` (in `src/core/leveldb-reader.ts`) returns stale snapshots for 5 minutes after the source LevelDB changes. Reproduced cleanly during this investigation. **Doesn't affect production** because the real read path goes through a worker thread (fresh module state per call), but worth tracking as a separate issue.
- Extending `scripts/smoke-graphql.ts` to assert post-`refresh_database` cache eviction (the issue suggested this; deferred to a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)