### PR TITLE
docs(smoke): update transactions-write skip-comment after #326 fix

### DIFF
--- a/scripts/smoke-graphql.ts
+++ b/scripts/smoke-graphql.ts
@@ -795,11 +795,15 @@ async function smokeTransactionsHappyPath(
  * rows; manual accounts have no such upstream feed.
  *
  * Verifies server-side state only. Does NOT assert deleted transactions
- * disappear from `db.getAllTransactions()` — see issue #326 (the decoder
- * does not handle Firestore NoDocument tombstones, so deleted docs persist
- * in the decoded LevelDB cache until the next full pull). Once #326 is
- * fixed, this section can be extended to assert cache eviction after
- * `refresh_database`.
+ * disappear from `db.getAllTransactions()` after `refresh_database`.
+ * Cache eviction is covered by unit tests in
+ * `tests/core/decoder-leveldb.test.ts` (the `user_deleted=true` filter
+ * fixed in #326 / PR #344). Adding a live end-to-end assertion here was
+ * considered and declined — see issue #346: it would require polling on
+ * Copilot's desktop-app sync window (deletes only land in LevelDB once
+ * the app flushes them locally), and the marginal value over the unit
+ * tests didn't justify the extra smoke runtime on a script that's
+ * already manual-only.
  */
 interface CleanupEntry {
   id: string;


### PR DESCRIPTION
## Summary

- Updates the `smokeTransactionsWrites` skip-comment in `scripts/smoke-graphql.ts` to reflect post-#326 reality.
- Closes #346 — the follow-up live assertion was considered and declined.

## Context

The previous comment claimed deletes persisted "until the next full pull" because of unhandled NoDocument tombstones, and promised to extend the section once #326 was fixed. PR #344 fixed #326 — but the actual mechanism was a `user_deleted=true` flag on the Document (not tombstones), so the comment was both stale and inaccurate.

#346 was opened to track adding a live end-to-end cache-eviction assertion. After review:

- Cache eviction is already covered by unit tests in `tests/core/decoder-leveldb.test.ts` (PR #344 added all three branches: `user_deleted=true` excluded, `=false` passes, field-absent passes).
- A live assertion would need polling on Copilot's desktop-app sync window — deletes only land in LevelDB after the app flushes them locally — adding meaningful runtime to a script that's already manual-only and opt-in.
- Marginal value over the unit tests doesn't justify the cost.

The new comment documents the decision so future readers (human or agent) don't re-litigate.

## Test plan

- [x] `bun run check` passes (1778 tests, 0 fail)
- [x] No code-path changes — comment-only

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)