### PR TITLE
fix(leveldb-reader): tolerate compaction TOCTOU in copy + fingerprint

### DIFF
--- a/src/core/leveldb-reader.ts
+++ b/src/core/leveldb-reader.ts
@@ -75,8 +75,15 @@ function sourceFingerprint(srcPath: string): number {
   let max = fs.statSync(srcPath).mtimeMs;
   for (const file of fs.readdirSync(srcPath)) {
     if (!isLevelDBFile(file)) continue;
-    const m = fs.statSync(path.join(srcPath, file)).mtimeMs;
-    if (m > max) max = m;
+    try {
+      const m = fs.statSync(path.join(srcPath, file)).mtimeMs;
+      if (m > max) max = m;
+    } catch (err) {
+      // TOCTOU: a LevelDB compaction can delete an .ldb between readdir
+      // and stat. The vanished file is no longer part of the source's
+      // current state, so skipping it is correct. Other errors propagate.
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
   }
   return max;
 }
@@ -133,8 +140,14 @@ function copyDatabaseToTemp(srcPath: string): string {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-leveldb-'));
   const files = fs.readdirSync(srcPath);
   for (const file of files) {
-    if (isLevelDBFile(file)) {
+    if (!isLevelDBFile(file)) continue;
+    try {
       fs.copyFileSync(path.join(srcPath, file), path.join(tempDir, file));
+    } catch (err) {
+      // TOCTOU: a LevelDB compaction can delete an .ldb between readdir
+      // and copyFile. LevelDB's MANIFEST has already removed the file,
+      // so the resulting copy correctly omits it. Other errors propagate.
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
     }
   }
 

--- a/src/core/leveldb-reader.ts
+++ b/src/core/leveldb-reader.ts
@@ -79,9 +79,7 @@ function sourceFingerprint(srcPath: string): number {
       const m = fs.statSync(path.join(srcPath, file)).mtimeMs;
       if (m > max) max = m;
     } catch (err) {
-      // TOCTOU: a LevelDB compaction can delete an .ldb between readdir
-      // and stat. The vanished file is no longer part of the source's
-      // current state, so skipping it is correct. Other errors propagate.
+      // TOCTOU: compaction may delete .ldb between readdir and stat; vanished file is safe to skip (dir mtime bumps), others propagate.
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
     }
   }
@@ -144,9 +142,7 @@ function copyDatabaseToTemp(srcPath: string): string {
     try {
       fs.copyFileSync(path.join(srcPath, file), path.join(tempDir, file));
     } catch (err) {
-      // TOCTOU: a LevelDB compaction can delete an .ldb between readdir
-      // and copyFile. LevelDB's MANIFEST has already removed the file,
-      // so the resulting copy correctly omits it. Other errors propagate.
+      // TOCTOU: compaction may delete .ldb between readdir and copyFile; MANIFEST already dropped it, so omitting is correct, others propagate.
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
     }
   }

--- a/tests/core/leveldb-reader.test.ts
+++ b/tests/core/leveldb-reader.test.ts
@@ -529,4 +529,127 @@ describe('leveldb-reader', () => {
       expect(count2).toBe(0);
     });
   });
+
+  describe('compaction TOCTOU resilience', () => {
+    // Simulate a LevelDB compaction deleting an .ldb between readdir and the
+    // per-file stat/copyFile call by stubbing readdirSync to inject a phantom
+    // filename that doesn't exist on disk. Real readdir/stat/copyFile are used
+    // for everything else, so the genuine race is reproduced exactly: the
+    // listing contains a name, the per-file syscall hits ENOENT.
+
+    function injectPhantom(targetDir: string, phantom: string): () => void {
+      const original = fs.readdirSync;
+      (fs as { readdirSync: typeof fs.readdirSync }).readdirSync = ((
+        p: fs.PathLike,
+        opts?: Parameters<typeof fs.readdirSync>[1]
+      ) => {
+        const real = (original as (p: fs.PathLike, opts?: unknown) => unknown)(p, opts);
+        if (typeof p === 'string' && path.resolve(p) === path.resolve(targetDir)) {
+          return [...(real as string[]), phantom];
+        }
+        return real;
+      }) as typeof fs.readdirSync;
+      return () => {
+        (fs as { readdirSync: typeof fs.readdirSync }).readdirSync = original;
+      };
+    }
+
+    test('copy loop skips files that vanish between readdir and copyFile', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'copy-toctou-db');
+      await createTestDatabase(dbPath, [{ collection: 'test', id: 'doc1', fields: { x: 1 } }]);
+
+      // First call exercises the copy loop. Phantom must be ignored.
+      const restore = injectPhantom(dbPath, 'vanished-9999.ldb');
+      try {
+        const docs = [];
+        for await (const doc of iterateDocuments(dbPath)) docs.push(doc);
+        expect(docs.length).toBe(1);
+      } finally {
+        restore();
+      }
+    });
+
+    test('sourceFingerprint skips files that vanish between readdir and stat', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'fingerprint-toctou-db');
+      await createTestDatabase(dbPath, [{ collection: 'test', id: 'doc1', fields: { x: 1 } }]);
+
+      // Prime the temp cache so the next call goes through the fingerprint
+      // (cache-hit) path rather than the copy loop.
+      for await (const _doc of iterateDocuments(dbPath)) {
+        // drain
+      }
+
+      const restore = injectPhantom(dbPath, 'vanished-9999.ldb');
+      try {
+        const docs = [];
+        for await (const doc of iterateDocuments(dbPath)) docs.push(doc);
+        expect(docs.length).toBe(1);
+      } finally {
+        restore();
+      }
+    });
+
+    test('sourceFingerprint propagates non-ENOENT stat errors', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'fingerprint-eacces-db');
+      await createTestDatabase(dbPath, [{ collection: 'test', id: 'doc1', fields: { x: 1 } }]);
+
+      // Prime cache so the next call goes through sourceFingerprint.
+      for await (const _doc of iterateDocuments(dbPath)) {
+        // drain
+      }
+
+      const originalStat = fs.statSync;
+      (fs as { statSync: typeof fs.statSync }).statSync = ((
+        p: fs.PathLike,
+        opts?: Parameters<typeof fs.statSync>[1]
+      ) => {
+        // Throw on any per-file stat inside the source DB directory; allow
+        // the directory-itself stat through so we hit the per-file branch.
+        if (typeof p === 'string' && p.startsWith(dbPath + path.sep)) {
+          const err: NodeJS.ErrnoException = new Error('permission denied');
+          err.code = 'EACCES';
+          throw err;
+        }
+        return (originalStat as (p: fs.PathLike, opts?: unknown) => fs.Stats)(p, opts);
+      }) as typeof fs.statSync;
+
+      try {
+        const gen = iterateDocuments(dbPath);
+        await expect(gen.next()).rejects.toThrow('permission denied');
+      } finally {
+        (fs as { statSync: typeof fs.statSync }).statSync = originalStat;
+      }
+    });
+
+    test('copy loop propagates non-ENOENT copy errors', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'copy-eacces-db');
+      await createTestDatabase(dbPath, [{ collection: 'test', id: 'doc1', fields: { x: 1 } }]);
+
+      const originalCopy = fs.copyFileSync;
+      (fs as { copyFileSync: typeof fs.copyFileSync }).copyFileSync = ((
+        src: fs.PathLike,
+        dest: fs.PathLike,
+        mode?: number
+      ) => {
+        // Throw on any copy out of the source DB directory.
+        if (typeof src === 'string' && src.startsWith(dbPath + path.sep)) {
+          const err: NodeJS.ErrnoException = new Error('permission denied');
+          err.code = 'EACCES';
+          throw err;
+        }
+        return (originalCopy as (s: fs.PathLike, d: fs.PathLike, m?: number) => void)(
+          src,
+          dest,
+          mode
+        );
+      }) as typeof fs.copyFileSync;
+
+      try {
+        const gen = iterateDocuments(dbPath);
+        await expect(gen.next()).rejects.toThrow('permission denied');
+      } finally {
+        (fs as { copyFileSync: typeof fs.copyFileSync }).copyFileSync = originalCopy;
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Both `copyDatabaseToTemp`'s copy loop and `sourceFingerprint` (added in #349) iterate the source via `fs.readdirSync` and then call `fs.statSync` / `fs.copyFileSync` per file. A LevelDB compaction in Copilot's app can delete an `.ldb` between listing and the per-file syscall, causing `ENOENT`.

This PR wraps each per-file syscall in a `try`/`catch` that silently skips `ENOENT` and re-throws every other error.

Closes #350.

## Why skipping ENOENT is correct

- **Fingerprint path** — a vanished file is no longer part of the source's current state. The directory mtime bumped when the compaction removed it, so the next call sees a new fingerprint and re-copies anyway.
- **Copy path** — LevelDB's MANIFEST has already removed the file, so the resulting temp copy correctly omits it.

## Production impact

Remains **low** as the issue documents — compactions are minutes-apart, the race window is microseconds, the main read path runs in worker isolates that start cache-empty per worker, and this race has not been observed in practice. Defensive hardening, not a fix for a known incident.

## Tests added (in `tests/core/leveldb-reader.test.ts`)

- **Copy loop skips ENOENT** — stub `fs.readdirSync` to inject a phantom `.ldb` filename that doesn't exist on disk; real `fs.copyFileSync` hits `ENOENT`; iteration completes and yields the real document. Without the fix this rejects.
- **Fingerprint skips ENOENT** — same shape via the cache-hit path: prime the cache, inject the phantom, second iteration must succeed.
- **Non-ENOENT errors propagate** — stub `fs.statSync` / `fs.copyFileSync` to throw `EACCES`; verify the generator rejects, both for the fingerprint path and the copy path.

## Test plan

- [x] `bun run check` clean — 1794 pass, 0 fail
- [x] Lint clean (no new warnings)
- [x] Prettier-formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)