### PR TITLE
feat(recurring): join category_name from categoriesCache (audit R1)

### DIFF
--- a/src/tools/live/recurring.ts
+++ b/src/tools/live/recurring.ts
@@ -20,9 +20,19 @@ export interface GetRecurringLiveArgs {
   // No filters yet; reserved for future args (e.g., state filter).
 }
 
+export interface GetRecurringLiveRow extends RecurringNode {
+  /**
+   * Joined from `categoriesCache.peek()` by `categoryId`. `null` if the
+   * categories cache is cold (no fetch is triggered to populate it) or
+   * if the category for this recurring's `categoryId` was not found
+   * (e.g., deleted upstream). Mirrors `get_transactions_live`'s same join.
+   */
+  category_name: string | null;
+}
+
 export interface GetRecurringLiveResult {
   count: number;
-  recurring: RecurringNode[];
+  recurring: GetRecurringLiveRow[];
   _cache_oldest_fetched_at: string;
   _cache_newest_fetched_at: string;
   _cache_hit: boolean;
@@ -40,7 +50,20 @@ export class LiveRecurringTools {
       hit,
     } = await cache.read(() => fetchRecurrings(this.live.getClient()));
 
-    const rows = [...cached].sort((a, b) => a.name.localeCompare(b.name));
+    const cachedCategories = this.live.getCategoriesCache().peek();
+    const categoryNameById = new Map<string, string>();
+    if (cachedCategories) {
+      for (const cat of cachedCategories) {
+        categoryNameById.set(cat.id, cat.name);
+      }
+    }
+
+    const rows: GetRecurringLiveRow[] = cached
+      .map((r) => ({
+        ...r,
+        category_name: r.categoryId ? (categoryNameById.get(r.categoryId) ?? null) : null,
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
 
     this.live.logReadCall({
       op: 'Recurrings',
@@ -68,7 +91,9 @@ export function createLiveRecurringToolSchema() {
       'Get user-confirmed recurring/subscription items (live, GraphQL-backed). ' +
       'Replaces get_recurring_transactions when --live-reads is on. ' +
       "NOTE: pattern-based detection from transactions is NOT included — only Copilot's " +
-      'native subscription tracking. Run without --live-reads if you need pattern detection.',
+      'native subscription tracking. Run without --live-reads if you need pattern detection. ' +
+      'Each row carries a `category_name` field joined from the categories cache; ' +
+      '`null` if the cache is cold or the category was deleted upstream.',
     inputSchema: {
       type: 'object' as const,
       properties: {},

--- a/src/tools/live/recurring.ts
+++ b/src/tools/live/recurring.ts
@@ -93,7 +93,9 @@ export function createLiveRecurringToolSchema() {
       "NOTE: pattern-based detection from transactions is NOT included — only Copilot's " +
       'native subscription tracking. Run without --live-reads if you need pattern detection. ' +
       'Each row carries a `category_name` field joined from the categories cache; ' +
-      '`null` if the cache is cold or the category was deleted upstream.',
+      '`null` if the cache is cold or the category was deleted upstream. ' +
+      'To guarantee `category_name` is populated, call `get_categories_live` first ' +
+      'in the same session to warm the cache.',
     inputSchema: {
       type: 'object' as const,
       properties: {},

--- a/tests/tools/live/recurring.test.ts
+++ b/tests/tools/live/recurring.test.ts
@@ -3,6 +3,7 @@ import { LiveCopilotDatabase } from '../../../src/core/live-database.js';
 import type { GraphQLClient } from '../../../src/core/graphql/client.js';
 import type { CopilotDatabase } from '../../../src/core/database.js';
 import type { RecurringNode } from '../../../src/core/graphql/queries/recurrings.js';
+import type { CategoryNode } from '../../../src/core/graphql/queries/categories.js';
 
 const FAKE_DB = {} as CopilotDatabase;
 
@@ -17,6 +18,19 @@ function mkRec(partial: Partial<RecurringNode> & { id: string; name: string }): 
     icon: null,
     rule: null,
     payments: [],
+    ...partial,
+  };
+}
+
+function mkCat(partial: Partial<CategoryNode> & { id: string; name: string }): CategoryNode {
+  return {
+    templateId: null,
+    colorName: null,
+    icon: null,
+    isExcluded: false,
+    isRolloverDisabled: false,
+    canBeDeleted: true,
+    budget: null,
     ...partial,
   };
 }
@@ -83,27 +97,16 @@ describe('LiveRecurringTools.getRecurring', () => {
     ]);
 
     // Pre-warm categoriesCache with the matching category.
-    await live.getCategoriesCache().read(async () => [
-      {
-        id: 'cat-utils',
-        parentId: null,
-        name: 'Utilities',
-        templateId: 'Utilities',
-        colorName: 'YELLOW1',
-        icon: { __typename: 'EmojiUnicode', unicode: '🧹' },
-        isExcluded: false,
-        isRolloverDisabled: false,
-        canBeDeleted: true,
-        budget: null,
-      },
-    ]);
+    await live
+      .getCategoriesCache()
+      .read(async () => [mkCat({ id: 'cat-utils', name: 'Utilities' })]);
 
     const { LiveRecurringTools } = await import('../../../src/tools/live/recurring.js');
     const tools = new LiveRecurringTools(live);
     const result = await tools.getRecurring({});
 
     const item = result.recurring.find((r) => r.id === 'r1');
-    expect((item as { category_name?: string | null })?.category_name).toBe('Utilities');
+    expect(item?.category_name).toBe('Utilities');
   });
 
   test('regression R1: category_name is null when categoriesCache is cold', async () => {
@@ -123,7 +126,7 @@ describe('LiveRecurringTools.getRecurring', () => {
     const result = await tools.getRecurring({});
 
     const item = result.recurring.find((r) => r.id === 'r1');
-    expect((item as { category_name?: string | null })?.category_name).toBeNull();
+    expect(item?.category_name).toBeNull();
   });
 
   test('regression R1: category_name is null when categoryId does not match any category', async () => {
@@ -137,26 +140,13 @@ describe('LiveRecurringTools.getRecurring', () => {
       }),
     ]);
     // Warm with a category that does NOT match.
-    await live.getCategoriesCache().read(async () => [
-      {
-        id: 'cat-other',
-        parentId: null,
-        name: 'Other',
-        templateId: null,
-        colorName: 'GRAY1',
-        icon: null,
-        isExcluded: false,
-        isRolloverDisabled: false,
-        canBeDeleted: true,
-        budget: null,
-      },
-    ]);
+    await live.getCategoriesCache().read(async () => [mkCat({ id: 'cat-other', name: 'Other' })]);
 
     const { LiveRecurringTools } = await import('../../../src/tools/live/recurring.js');
     const tools = new LiveRecurringTools(live);
     const result = await tools.getRecurring({});
 
     const item = result.recurring.find((r) => r.id === 'r1');
-    expect((item as { category_name?: string | null })?.category_name).toBeNull();
+    expect(item?.category_name).toBeNull();
   });
 });

--- a/tests/tools/live/recurring.test.ts
+++ b/tests/tools/live/recurring.test.ts
@@ -70,4 +70,93 @@ describe('LiveRecurringTools.getRecurring', () => {
     expect(result.recurring).toEqual([]);
     expect(result._cache_hit).toBe(false);
   });
+
+  test('regression R1: category_name populated when categoriesCache is warm', async () => {
+    const { live } = mkLiveReturning([
+      mkRec({
+        id: 'r1',
+        name: 'Cellphone Plan',
+        nextPaymentAmount: 52.37,
+        nextPaymentDate: '2026-05-10',
+        categoryId: 'cat-utils',
+      }),
+    ]);
+
+    // Pre-warm categoriesCache with the matching category.
+    await live.getCategoriesCache().read(async () => [
+      {
+        id: 'cat-utils',
+        parentId: null,
+        name: 'Utilities',
+        templateId: 'Utilities',
+        colorName: 'YELLOW1',
+        icon: { __typename: 'EmojiUnicode', unicode: '🧹' },
+        isExcluded: false,
+        isRolloverDisabled: false,
+        canBeDeleted: true,
+        budget: null,
+      },
+    ]);
+
+    const { LiveRecurringTools } = await import('../../../src/tools/live/recurring.js');
+    const tools = new LiveRecurringTools(live);
+    const result = await tools.getRecurring({});
+
+    const item = result.recurring.find((r) => r.id === 'r1');
+    expect((item as { category_name?: string | null })?.category_name).toBe('Utilities');
+  });
+
+  test('regression R1: category_name is null when categoriesCache is cold', async () => {
+    const { live } = mkLiveReturning([
+      mkRec({
+        id: 'r1',
+        name: 'Mystery Sub',
+        nextPaymentAmount: 5,
+        nextPaymentDate: '2026-05-10',
+        categoryId: 'cat-unknown',
+      }),
+    ]);
+    // Do NOT pre-warm categoriesCache — verify the cold-cache fallback.
+
+    const { LiveRecurringTools } = await import('../../../src/tools/live/recurring.js');
+    const tools = new LiveRecurringTools(live);
+    const result = await tools.getRecurring({});
+
+    const item = result.recurring.find((r) => r.id === 'r1');
+    expect((item as { category_name?: string | null })?.category_name).toBeNull();
+  });
+
+  test('regression R1: category_name is null when categoryId does not match any category', async () => {
+    const { live } = mkLiveReturning([
+      mkRec({
+        id: 'r1',
+        name: 'Stale link',
+        nextPaymentAmount: 9,
+        nextPaymentDate: '2026-05-10',
+        categoryId: 'cat-deleted',
+      }),
+    ]);
+    // Warm with a category that does NOT match.
+    await live.getCategoriesCache().read(async () => [
+      {
+        id: 'cat-other',
+        parentId: null,
+        name: 'Other',
+        templateId: null,
+        colorName: 'GRAY1',
+        icon: null,
+        isExcluded: false,
+        isRolloverDisabled: false,
+        canBeDeleted: true,
+        budget: null,
+      },
+    ]);
+
+    const { LiveRecurringTools } = await import('../../../src/tools/live/recurring.js');
+    const tools = new LiveRecurringTools(live);
+    const result = await tools.getRecurring({});
+
+    const item = result.recurring.find((r) => r.id === 'r1');
+    expect((item as { category_name?: string | null })?.category_name).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

Fixes audit finding **R1** — `get_recurring_live` exposed `categoryId` but not `category_name`, forcing consumers to maintain their own lookup. Mirrors the join `get_transactions_live` already does.

- **Field added:** `GetRecurringLiveRow.category_name: string | null`.
- **Join source:** `categoriesCache.peek()` — no fetch trigger if cache is cold.
- **Null semantics:** cache cold OR `categoryId` not found in the warm cache (e.g., category deleted upstream).

## Test plan

- [x] R1 regression: cache-warm join populates `category_name`.
- [x] R1 regression: cache-cold returns `null`.
- [x] R1 regression: missing-category (cache warm but no match) returns `null`.
- [x] All existing recurring tests pass.
- [x] `bun run check` green (1797 pass).
- [x] Manual re-validation against live endpoint: confirmed Cellphone Plan recurring item carries `categoryId: GQlelOOpMpAIvHM6B9dJ`, which matches the `Utilities` category id — so the join would produce `category_name: "Utilities"` after rebuild.

## Notes

- Wave 1 in the audit-fix batch. Fully isolated to `recurring.ts`; no dependencies on other audit-fix PRs.
- Spec: `docs/superpowers/specs/2026-05-03-live-mode-audit-fixes-design.md` § PR 5 (R1 portion).