### PR TITLE
fix(accounts): bucket liabilities by uppercase type (audit A1)

### DIFF
--- a/src/tools/live/accounts.ts
+++ b/src/tools/live/accounts.ts
@@ -27,7 +27,10 @@ export interface GetAccountsLiveResult {
   _cache_hit: boolean;
 }
 
-const LIABILITY_TYPES = new Set(['credit', 'loan']);
+// GraphQL Account.type returns uppercase enum values ('CREDIT', 'DEPOSITORY',
+// 'LOAN', 'INVESTMENT', 'OTHER'). The set holds the canonical uppercase form;
+// callers normalize via .toUpperCase() at the comparison site.
+const LIABILITY_TYPES = new Set(['CREDIT', 'LOAN']);
 
 export class LiveAccountsTools {
   constructor(private readonly live: LiveCopilotDatabase) {}
@@ -49,7 +52,8 @@ export class LiveAccountsTools {
       rows = rows.filter((a) => !a.isUserHidden && !a.isUserClosed);
     }
     if (account_type) {
-      rows = rows.filter((a) => a.type === account_type);
+      const normalized = account_type.toUpperCase();
+      rows = rows.filter((a) => a.type.toUpperCase() === normalized);
     }
 
     // Log after filtering so `rows` reflects what's actually returned to
@@ -68,7 +72,7 @@ export class LiveAccountsTools {
     let totalAssets = 0;
     let totalLiabilities = 0;
     for (const a of rows) {
-      if (LIABILITY_TYPES.has(a.type)) totalLiabilities += a.balance;
+      if (LIABILITY_TYPES.has(a.type.toUpperCase())) totalLiabilities += a.balance;
       else totalAssets += a.balance;
     }
 
@@ -96,7 +100,8 @@ export function createLiveAccountsToolSchema() {
       properties: {
         account_type: {
           type: 'string',
-          description: 'Filter by account type (depository, credit, loan, investment, etc.)',
+          description:
+            'Filter by account type (case-insensitive — depository, credit, loan, investment, etc.).',
         },
         include_hidden: {
           type: 'boolean',

--- a/src/tools/live/accounts.ts
+++ b/src/tools/live/accounts.ts
@@ -72,7 +72,8 @@ export class LiveAccountsTools {
     let totalAssets = 0;
     let totalLiabilities = 0;
     for (const a of rows) {
-      if (LIABILITY_TYPES.has(a.type.toUpperCase())) totalLiabilities += a.balance;
+      const typeUpper = a.type.toUpperCase();
+      if (LIABILITY_TYPES.has(typeUpper)) totalLiabilities += a.balance;
       else totalAssets += a.balance;
     }
 

--- a/tests/tools/live/accounts.test.ts
+++ b/tests/tools/live/accounts.test.ts
@@ -14,7 +14,7 @@ const A = (id: string, opts: Partial<AccountNode> = {}): AccountNode => ({
   name: `Account ${id}`,
   balance: 100,
   liveBalance: true,
-  type: 'depository',
+  type: 'DEPOSITORY',
   subType: 'checking',
   mask: '0001',
   isUserHidden: false,
@@ -80,7 +80,7 @@ describe('LiveAccountsTools.getAccounts', () => {
   });
 
   test('account_type filter applied', async () => {
-    const live = mkLive([A('a', { type: 'depository' }), A('b', { type: 'credit' })]);
+    const live = mkLive([A('a', { type: 'DEPOSITORY' }), A('b', { type: 'CREDIT' })]);
     const tools = new LiveAccountsTools(live);
 
     const result = await tools.getAccounts({ account_type: 'credit' });
@@ -90,9 +90,9 @@ describe('LiveAccountsTools.getAccounts', () => {
 
   test('totals calculated correctly: assets minus liabilities', async () => {
     const live = mkLive([
-      A('a', { type: 'depository', balance: 1000 }),
-      A('b', { type: 'credit', balance: 200 }),
-      A('c', { type: 'loan', balance: 500 }),
+      A('a', { type: 'DEPOSITORY', balance: 1000 }),
+      A('b', { type: 'CREDIT', balance: 200 }),
+      A('c', { type: 'LOAN', balance: 500 }),
     ]);
     const tools = new LiveAccountsTools(live);
 
@@ -123,10 +123,7 @@ describe('LiveAccountsTools.getAccounts', () => {
   test('regression A1: account_type filter is case-insensitive', async () => {
     // Real server returns uppercase. Tool description documents lowercase examples
     // ("depository, credit, loan, investment, etc."). Both must work.
-    const live = mkLive([
-      A('a', { type: 'DEPOSITORY' }),
-      A('b', { type: 'CREDIT' }),
-    ]);
+    const live = mkLive([A('a', { type: 'DEPOSITORY' }), A('b', { type: 'CREDIT' })]);
     const tools = new LiveAccountsTools(live);
 
     const lower = await tools.getAccounts({ account_type: 'credit' });

--- a/tests/tools/live/accounts.test.ts
+++ b/tests/tools/live/accounts.test.ts
@@ -102,6 +102,42 @@ describe('LiveAccountsTools.getAccounts', () => {
     expect(result.total_balance).toBe(300); // 1000 - 700
   });
 
+  test('regression A1: real-shape uppercase types are bucketed correctly', async () => {
+    // GraphQL returns Account.type as uppercase enum values ('CREDIT', 'DEPOSITORY',
+    // 'LOAN'). Pre-fix code held lowercase in LIABILITY_TYPES, so production saw
+    // every credit-card balance summed into total_assets and total_liabilities=0.
+    // See docs/superpowers/audits/2026-05-03-live-mode-parity-audit.md § Issue A1.
+    const live = mkLive([
+      A('chk', { type: 'DEPOSITORY', balance: 5000 }),
+      A('cc', { type: 'CREDIT', balance: 1500 }),
+      A('ln', { type: 'LOAN', balance: 800 }),
+    ]);
+    const tools = new LiveAccountsTools(live);
+
+    const result = await tools.getAccounts({});
+    expect(result.total_assets).toBe(5000);
+    expect(result.total_liabilities).toBe(2300);
+    expect(result.total_balance).toBe(2700);
+  });
+
+  test('regression A1: account_type filter is case-insensitive', async () => {
+    // Real server returns uppercase. Tool description documents lowercase examples
+    // ("depository, credit, loan, investment, etc."). Both must work.
+    const live = mkLive([
+      A('a', { type: 'DEPOSITORY' }),
+      A('b', { type: 'CREDIT' }),
+    ]);
+    const tools = new LiveAccountsTools(live);
+
+    const lower = await tools.getAccounts({ account_type: 'credit' });
+    expect(lower.count).toBe(1);
+    expect(lower.accounts[0]?.id).toBe('b');
+
+    const upper = await tools.getAccounts({ account_type: 'CREDIT' });
+    expect(upper.count).toBe(1);
+    expect(upper.accounts[0]?.id).toBe('b');
+  });
+
   test('schema definition exposes filter args', () => {
     const schema = createLiveAccountsToolSchema();
     expect(schema.name).toBe('get_accounts_live');


### PR DESCRIPTION
## Summary

Fixes audit finding **A1** — `get_accounts_live` returned `total_liabilities: 0` and double-counted credit-card balances into `total_assets` because the partition logic compared lowercase strings to uppercase server enums.

- **Bug:** `LIABILITY_TYPES = new Set(['credit', 'loan'])` (lowercase) vs server returning `'CREDIT'` / `'LOAN'`. Bucket loop never matched. All credit-card balances fell through to the `else` branch and were counted as assets.
- **Why tests didn't catch it:** existing fixtures used lowercase types, masking the production-shape mismatch. First finding documented in the 2026-05-03 live-mode parity audit.
- **Fix:** normalize via `.toUpperCase()` at the bucket-comparison and `account_type`-filter sites. `LIABILITY_TYPES` now holds uppercase canonical values to match the server's enum. Schema description notes case-insensitivity.
- **Test fixture cleanup:** existing fixtures updated to uppercase to mirror the real server response shape (preventing reintroduction).

## Test plan

- [x] New regression tests cover (a) uppercase-fixture bucketing and (b) case-insensitive `account_type` filter.
- [x] All existing tests still pass (now with uppercase fixtures matching real server shape).
- [x] `bun run check` green.
- [x] Manually re-validated against the live endpoint: post-fix totals correctly partition CREDIT/LOAN balances into liabilities (web app's Assets/Debts split now matches MCP within rounding).

## Notes

- First of the audit-fix batch. Spec: `docs/superpowers/specs/2026-05-03-live-mode-audit-fixes-design.md`.
- Audit finding tracking lives at `docs/superpowers/audits/2026-05-03-live-mode-parity-audit.md` (untracked per project rule); A1 marked RESOLVED locally.