### PR TITLE
feat(budgets): default-trim amounts to 12-month window (audit C4)

### DIFF
--- a/src/tools/live/budgets.ts
+++ b/src/tools/live/budgets.ts
@@ -49,10 +49,12 @@ function parseAmount(value: string | null | undefined): number | undefined {
 }
 
 /**
- * Return a trimmed amounts map containing only the trailing N months from
- * "now" (current calendar month inclusive). Months are sorted lexicographically;
- * the most recent N keys are kept. If the input has fewer than N months,
- * returns the input unchanged.
+ * Return a trimmed amounts map containing only the most recent N months
+ * by lexicographic key order. `YYYY-MM` keys sort chronologically, so this
+ * is equivalent to "trailing N months" for normal data. The function does
+ * NOT consult the current date; if the input contains future-dated keys
+ * (e.g., projected budgets), they win the trailing-N selection. If the
+ * input has fewer than N months, returns the input unchanged.
  */
 function trimAmountsToWindow(
   amounts: Record<string, number>,

--- a/src/tools/live/budgets.ts
+++ b/src/tools/live/budgets.ts
@@ -16,8 +16,14 @@ import type { LiveCopilotDatabase } from '../../core/live-database.js';
 import { fetchCategories, type CategoryNode } from '../../core/graphql/queries/categories.js';
 import { roundAmount } from '../../utils/round.js';
 
-// Reserved for future filters (e.g., active_only).
-export type GetBudgetsLiveArgs = Record<string, never>;
+export interface GetBudgetsLiveArgs {
+  /**
+   * Trailing-N-months window for the per-budget `amounts` map. Default 12.
+   * Set to 0 to return the full multi-year history (matches the historical
+   * pre-fix behavior). Months are relative to the current month inclusive.
+   */
+  months_window?: number;
+}
 
 export interface GetBudgetsLiveBudget {
   budget_id: string;
@@ -40,6 +46,24 @@ function parseAmount(value: string | null | undefined): number | undefined {
   if (value === null || value === undefined) return undefined;
   const n = Number(value);
   return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * Return a trimmed amounts map containing only the trailing N months from
+ * "now" (current calendar month inclusive). Months are sorted lexicographically;
+ * the most recent N keys are kept. If the input has fewer than N months,
+ * returns the input unchanged.
+ */
+function trimAmountsToWindow(
+  amounts: Record<string, number>,
+  windowMonths: number
+): Record<string, number> {
+  const keys = Object.keys(amounts).sort();
+  if (keys.length <= windowMonths) return amounts;
+  const kept = keys.slice(-windowMonths);
+  const trimmed: Record<string, number> = {};
+  for (const k of kept) trimmed[k] = amounts[k]!;
+  return trimmed;
 }
 
 function projectCategory(cat: CategoryNode): GetBudgetsLiveBudget | null {
@@ -72,7 +96,7 @@ function projectCategory(cat: CategoryNode): GetBudgetsLiveBudget | null {
 export class LiveBudgetsTools {
   constructor(private readonly live: LiveCopilotDatabase) {}
 
-  async getBudgets(_args: GetBudgetsLiveArgs): Promise<GetBudgetsLiveResult> {
+  async getBudgets(args: GetBudgetsLiveArgs): Promise<GetBudgetsLiveResult> {
     const cache = this.live.getCategoriesCache();
     const startedAt = Date.now();
     const {
@@ -81,13 +105,19 @@ export class LiveBudgetsTools {
       hit,
     } = await cache.read(() => fetchCategories(this.live.getClient()));
 
+    const monthsWindow = args.months_window ?? 12;
+
     const projected: GetBudgetsLiveBudget[] = [];
     let totalBudgeted = 0;
     for (const cat of cats) {
       const row = projectCategory(cat);
       if (!row) continue;
-      projected.push(row);
-      if (row.amount !== undefined) totalBudgeted += row.amount;
+      const trimmed =
+        monthsWindow > 0 && row.amounts
+          ? { ...row, amounts: trimAmountsToWindow(row.amounts, monthsWindow) }
+          : row;
+      projected.push(trimmed);
+      if (trimmed.amount !== undefined) totalBudgeted += trimmed.amount;
     }
 
     // Sort by category_name for stable output (mirrors LiveCategoriesTools convention).
@@ -123,7 +153,16 @@ export function createLiveBudgetsToolSchema() {
       'powers get_categories_live populates this. Replaces get_budgets when --live-reads is on.',
     inputSchema: {
       type: 'object' as const,
-      properties: {},
+      properties: {
+        months_window: {
+          type: 'integer',
+          minimum: 0,
+          description:
+            "Number of trailing months to include in each budget's `amounts` map. " +
+            'Default: 12. Set to 0 to return the full multi-year history (large response).',
+          default: 12,
+        },
+      },
     },
     annotations: {
       readOnlyHint: true,

--- a/tests/tools/live/budgets.test.ts
+++ b/tests/tools/live/budgets.test.ts
@@ -65,6 +65,43 @@ const sampleCategoryWithoutBudget = {
   budget: null,
 };
 
+// Builds a Restaurants category with `monthCount` consecutive months of
+// history ending at 2026-05 (inclusive). Used by the C4 regression tests
+// to exercise the months_window trim with various input sizes.
+function makeRestaurantsCategory(monthCount: number) {
+  const months = Array.from({ length: monthCount }, (_, i) => {
+    // Date.UTC months are 0-indexed (May = 4). Anchor the last entry at
+    // 2026-05; first entry is 2026-05 minus (monthCount - 1) months.
+    const d = new Date(Date.UTC(2026, 4 - (monthCount - 1) + i, 1));
+    return d.toISOString().slice(0, 7);
+  });
+  return {
+    id: 'cat-restaurants',
+    name: 'Restaurants',
+    templateId: 'Restaurants',
+    colorName: 'PURPLE2',
+    icon: { __typename: 'EmojiUnicode', unicode: '🍔' },
+    isExcluded: false,
+    isRolloverDisabled: false,
+    canBeDeleted: true,
+    budget: {
+      current: null,
+      histories: months.map((m, i) => ({
+        unassignedRolloverAmount: null,
+        childRolloverAmount: null,
+        unassignedAmount: null,
+        resolvedAmount: '500',
+        rolloverAmount: '0',
+        childAmount: null,
+        goalAmount: '0',
+        amount: '500',
+        month: m,
+        id: `b-${i}`,
+      })),
+    },
+  };
+}
+
 describe('LiveBudgetsTools.getBudgets', () => {
   test('cold call: projects per-category budgets from categoriesCache', async () => {
     const client = makeClient([sampleCategoryWithBudget, sampleCategoryWithoutBudget]);
@@ -122,86 +159,42 @@ describe('LiveBudgetsTools.getBudgets', () => {
     expect(result.budgets[0]?.amounts).toEqual({ '2026-04': 400 });
   });
 
-  test('regression C4: default months_window=12 trims amounts to 12 entries', async () => {
-    // Build a category with budget history spanning 24 months ending on
-    // 2026-05. Default behavior should return only the trailing 12.
-    const months = Array.from({ length: 24 }, (_, i) => {
-      const d = new Date(Date.UTC(2024, 5 + i, 1)); // 2024-06 through 2026-05
-      return d.toISOString().slice(0, 7);
-    });
-    const fixtureCategory = {
-      id: 'cat-restaurants',
-      name: 'Restaurants',
-      templateId: 'Restaurants',
-      colorName: 'PURPLE2',
-      icon: { __typename: 'EmojiUnicode', unicode: '🍔' },
-      isExcluded: false,
-      isRolloverDisabled: false,
-      canBeDeleted: true,
-      budget: {
-        current: null,
-        histories: months.map((m, i) => ({
-          unassignedRolloverAmount: null,
-          childRolloverAmount: null,
-          unassignedAmount: null,
-          resolvedAmount: '500',
-          rolloverAmount: '0',
-          childAmount: null,
-          goalAmount: '0',
-          amount: '500',
-          month: m,
-          id: `b-${i}`,
-        })),
-      },
-    };
-    const client = makeClient([fixtureCategory]);
+  test('regression C4: default months_window=12 trims amounts to exactly 12 entries', async () => {
+    // 24-month fixture; default trim should return exactly the trailing 12.
+    const client = makeClient([makeRestaurantsCategory(24)]);
     const tools = new LiveBudgetsTools(makeLive(client));
 
     const result = await tools.getBudgets({});
 
     const restaurants = result.budgets.find((b) => b.category_id === 'cat-restaurants');
     expect(restaurants?.amounts).toBeDefined();
-    expect(Object.keys(restaurants?.amounts ?? {}).length).toBeLessThanOrEqual(12);
+    expect(Object.keys(restaurants?.amounts ?? {}).length).toBe(12);
   });
 
   test('regression C4: months_window=0 returns all amounts', async () => {
-    // 24 months in fixture; opt-out should return all 24.
-    const months = Array.from({ length: 24 }, (_, i) => {
-      const d = new Date(Date.UTC(2024, 5 + i, 1));
-      return d.toISOString().slice(0, 7);
-    });
-    const fixtureCategory = {
-      id: 'cat-restaurants',
-      name: 'Restaurants',
-      templateId: 'Restaurants',
-      colorName: 'PURPLE2',
-      icon: { __typename: 'EmojiUnicode', unicode: '🍔' },
-      isExcluded: false,
-      isRolloverDisabled: false,
-      canBeDeleted: true,
-      budget: {
-        current: null,
-        histories: months.map((m, i) => ({
-          unassignedRolloverAmount: null,
-          childRolloverAmount: null,
-          unassignedAmount: null,
-          resolvedAmount: '500',
-          rolloverAmount: '0',
-          childAmount: null,
-          goalAmount: '0',
-          amount: '500',
-          month: m,
-          id: `b-${i}`,
-        })),
-      },
-    };
-    const client = makeClient([fixtureCategory]);
+    // 24-month fixture; opt-out should return all 24.
+    const client = makeClient([makeRestaurantsCategory(24)]);
     const tools = new LiveBudgetsTools(makeLive(client));
 
     const result = await tools.getBudgets({ months_window: 0 });
 
     const restaurants = result.budgets.find((b) => b.category_id === 'cat-restaurants');
     expect(Object.keys(restaurants?.amounts ?? {}).length).toBe(24);
+  });
+
+  test('regression C4: explicit months_window trims to that exact count', async () => {
+    // 24-month fixture, custom window of 3 — covers a non-boundary value
+    // (neither the default 12 nor the opt-out sentinel 0).
+    const client = makeClient([makeRestaurantsCategory(24)]);
+    const tools = new LiveBudgetsTools(makeLive(client));
+
+    const result = await tools.getBudgets({ months_window: 3 });
+
+    const restaurants = result.budgets.find((b) => b.category_id === 'cat-restaurants');
+    const keys = Object.keys(restaurants?.amounts ?? {}).sort();
+    expect(keys.length).toBe(3);
+    // The trailing 3 months ending at 2026-05 are 2026-03, 2026-04, 2026-05.
+    expect(keys).toEqual(['2026-03', '2026-04', '2026-05']);
   });
 
   test('handles category with budget.current present but current.amount=null', async () => {

--- a/tests/tools/live/budgets.test.ts
+++ b/tests/tools/live/budgets.test.ts
@@ -122,6 +122,88 @@ describe('LiveBudgetsTools.getBudgets', () => {
     expect(result.budgets[0]?.amounts).toEqual({ '2026-04': 400 });
   });
 
+  test('regression C4: default months_window=12 trims amounts to 12 entries', async () => {
+    // Build a category with budget history spanning 24 months ending on
+    // 2026-05. Default behavior should return only the trailing 12.
+    const months = Array.from({ length: 24 }, (_, i) => {
+      const d = new Date(Date.UTC(2024, 5 + i, 1)); // 2024-06 through 2026-05
+      return d.toISOString().slice(0, 7);
+    });
+    const fixtureCategory = {
+      id: 'cat-restaurants',
+      name: 'Restaurants',
+      templateId: 'Restaurants',
+      colorName: 'PURPLE2',
+      icon: { __typename: 'EmojiUnicode', unicode: '🍔' },
+      isExcluded: false,
+      isRolloverDisabled: false,
+      canBeDeleted: true,
+      budget: {
+        current: null,
+        histories: months.map((m, i) => ({
+          unassignedRolloverAmount: null,
+          childRolloverAmount: null,
+          unassignedAmount: null,
+          resolvedAmount: '500',
+          rolloverAmount: '0',
+          childAmount: null,
+          goalAmount: '0',
+          amount: '500',
+          month: m,
+          id: `b-${i}`,
+        })),
+      },
+    };
+    const client = makeClient([fixtureCategory]);
+    const tools = new LiveBudgetsTools(makeLive(client));
+
+    const result = await tools.getBudgets({});
+
+    const restaurants = result.budgets.find((b) => b.category_id === 'cat-restaurants');
+    expect(restaurants?.amounts).toBeDefined();
+    expect(Object.keys(restaurants?.amounts ?? {}).length).toBeLessThanOrEqual(12);
+  });
+
+  test('regression C4: months_window=0 returns all amounts', async () => {
+    // 24 months in fixture; opt-out should return all 24.
+    const months = Array.from({ length: 24 }, (_, i) => {
+      const d = new Date(Date.UTC(2024, 5 + i, 1));
+      return d.toISOString().slice(0, 7);
+    });
+    const fixtureCategory = {
+      id: 'cat-restaurants',
+      name: 'Restaurants',
+      templateId: 'Restaurants',
+      colorName: 'PURPLE2',
+      icon: { __typename: 'EmojiUnicode', unicode: '🍔' },
+      isExcluded: false,
+      isRolloverDisabled: false,
+      canBeDeleted: true,
+      budget: {
+        current: null,
+        histories: months.map((m, i) => ({
+          unassignedRolloverAmount: null,
+          childRolloverAmount: null,
+          unassignedAmount: null,
+          resolvedAmount: '500',
+          rolloverAmount: '0',
+          childAmount: null,
+          goalAmount: '0',
+          amount: '500',
+          month: m,
+          id: `b-${i}`,
+        })),
+      },
+    };
+    const client = makeClient([fixtureCategory]);
+    const tools = new LiveBudgetsTools(makeLive(client));
+
+    const result = await tools.getBudgets({ months_window: 0 });
+
+    const restaurants = result.budgets.find((b) => b.category_id === 'cat-restaurants');
+    expect(Object.keys(restaurants?.amounts ?? {}).length).toBe(24);
+  });
+
   test('handles category with budget.current present but current.amount=null', async () => {
     const cat = {
       id: 'cat-misc',


### PR DESCRIPTION
## Summary

Fixes audit finding **C4** — `get_budgets_live` was returning the full multi-year `amounts` map per budget (61 entries × 37 budgets ≈ 70 KB on this user's data), exceeding the LLM tool-result token budget.

- **New arg:** `months_window: integer` (default `12`).
- **Default behavior:** trim each budget's `amounts` map to the trailing 12 months (lexicographic sort, last-N).
- **Opt-out:** `months_window: 0` returns the full history (large response — caller's responsibility).
- **Cache safety:** trim is a read-side projection; the `categoriesCache.budget.histories` cache stores the full data and is never mutated.

## Test plan

- [x] C4 regression: default trims to 12 entries.
- [x] C4 regression: `months_window: 0` returns all 24 fixture months.
- [x] All existing budgets tests pass (8/8).
- [x] `bun run check` green (1796 pass, 0 fail).
- [x] Manual re-validation against live endpoint: default response **11.18 KB** (raw JSON) / ~22 KB (escaped MCP envelope), down from **70 KB pre-fix** (~3× reduction in escaped form, ~6× in raw JSON). Opt-in via `months_window: 0` returns 37 KB raw / full 61-month history.

## Notes

- Wave 1 in the audit-fix batch. Fully isolated to `budgets.ts`; no dependencies on other audit-fix PRs.
- Spec: `docs/superpowers/specs/2026-05-03-live-mode-audit-fixes-design.md` § PR 5 (C4 portion).