### PR TITLE
feat(categories): preserve parentId during flatten (audit C3)

### DIFF
--- a/src/core/graphql/queries/categories.ts
+++ b/src/core/graphql/queries/categories.ts
@@ -42,6 +42,20 @@ export interface CategoryBudget {
 
 export interface CategoryNode {
   id: string;
+  /**
+   * The id of this category's parent, or `null` if this is a top-level
+   * category (parent OR standalone).
+   *
+   * Note: `parentId === null` does NOT distinguish parents-with-children
+   * from standalone categories. To detect parents specifically, build a
+   * Set of parent ids: `new Set(categories.filter(c => c.parentId !== null).map(c => c.parentId))`.
+   *
+   * Populated by `fetchCategories` during flatten — Copilot's GraphQL
+   * `Categories` query returns a tree (`categories[].childCategories[]`)
+   * which we collapse to a single keyed list, recording the relationship
+   * here so consumers can rebuild the hierarchy.
+   */
+  parentId: string | null;
   name: string;
   templateId: string | null;
   colorName: string | null;
@@ -53,8 +67,12 @@ export interface CategoryNode {
   budget?: CategoryBudget | null;
 }
 
-interface CategoryResponseNode extends CategoryNode {
-  childCategories?: CategoryNode[];
+// Raw GraphQL response shape — does NOT include parentId. The flatten step
+// synthesizes parentId for both parent rows (null) and child rows (parent.id).
+type CategoryRawFields = Omit<CategoryNode, 'parentId'>;
+
+interface CategoryResponseNode extends CategoryRawFields {
+  childCategories?: CategoryRawFields[];
 }
 
 interface CategoriesResponse {
@@ -67,11 +85,11 @@ export async function fetchCategories(client: GraphQLClient): Promise<CategoryNo
   const data = await client.query<typeof VARS, CategoriesResponse>('Categories', CATEGORIES, VARS);
   const flat: CategoryNode[] = [];
   for (const cat of data.categories) {
-    const { childCategories, ...parent } = cat;
-    flat.push(parent);
+    const { childCategories, ...rawParent } = cat;
+    flat.push({ ...rawParent, parentId: null });
     if (childCategories) {
       for (const child of childCategories) {
-        flat.push(child);
+        flat.push({ ...child, parentId: rawParent.id });
       }
     }
   }

--- a/src/core/graphql/queries/categories.ts
+++ b/src/core/graphql/queries/categories.ts
@@ -48,7 +48,10 @@ export interface CategoryNode {
    *
    * Note: `parentId === null` does NOT distinguish parents-with-children
    * from standalone categories. To detect parents specifically, build a
-   * Set of parent ids: `new Set(categories.filter(c => c.parentId !== null).map(c => c.parentId))`.
+   * Set of parent ids:
+   * `new Set(categories.filter((c): c is CategoryNode & { parentId: string } => c.parentId !== null).map(c => c.parentId))`.
+   * The type predicate narrows the result to `Set<string>` (without it
+   * TypeScript infers `Set<string | null>`).
    *
    * Populated by `fetchCategories` during flatten — Copilot's GraphQL
    * `Categories` query returns a tree (`categories[].childCategories[]`)

--- a/src/tools/live/categories.ts
+++ b/src/tools/live/categories.ts
@@ -76,7 +76,10 @@ export function createLiveCategoriesToolSchema() {
   return {
     name: 'get_categories_live',
     description:
-      'Get user categories (live, GraphQL-backed). Includes per-category budget data so get_budgets_live can read from the same cache. Replaces get_categories when --live-reads is on.',
+      'Get user categories (live, GraphQL-backed). Includes per-category budget data so get_budgets_live can read from the same cache. ' +
+      'Each row carries a `parentId` field: `null` for top-level categories (parents AND standalones), or the parent category id for children. ' +
+      'To detect a parent specifically: build a Set of parent ids from the rows where `parentId !== null`. ' +
+      'Replaces get_categories when --live-reads is on.',
     inputSchema: {
       type: 'object' as const,
       properties: {

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2348,9 +2348,7 @@ export class CopilotMoneyTools {
       // is bounded to the window before the next read.
       this.liveDb?.patchLiveCategoryUpsert({
         id: result.id,
-        // Copilot's GraphQL mutation doesn't accept parentId on
-        // CreateCategoryInput, so newly-created categories are always
-        // top-level. See the early-throw above on args.parent_id.
+        // CreateCategoryInput doesn't accept parentId; new categories are always top-level.
         parentId: null,
         name: result.name,
         templateId: null,

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2348,6 +2348,10 @@ export class CopilotMoneyTools {
       // is bounded to the window before the next read.
       this.liveDb?.patchLiveCategoryUpsert({
         id: result.id,
+        // Copilot's GraphQL mutation doesn't accept parentId on
+        // CreateCategoryInput, so newly-created categories are always
+        // top-level. See the early-throw above on args.parent_id.
+        parentId: null,
         name: result.name,
         templateId: null,
         colorName: result.colorName,

--- a/tests/core/graphql/queries/categories.test.ts
+++ b/tests/core/graphql/queries/categories.test.ts
@@ -153,6 +153,83 @@ describe('fetchCategories', () => {
     expect(rows[1]?.budget?.current?.amount).toBe('500');
   });
 
+  test('regression C3: parentId set to null for parents, parent.id for children', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          categories: [
+            {
+              id: 'home-id',
+              name: '🏠 Home',
+              templateId: 'Household',
+              colorName: 'ORANGE2',
+              icon: { __typename: 'EmojiUnicode', unicode: '🏠' },
+              isExcluded: false,
+              isRolloverDisabled: false,
+              canBeDeleted: false,
+              budget: null,
+              childCategories: [
+                {
+                  id: 'rent-id',
+                  name: 'Rent',
+                  templateId: 'Rent',
+                  colorName: 'ORANGE2',
+                  icon: { __typename: 'EmojiUnicode', unicode: '🔑' },
+                  isExcluded: false,
+                  isRolloverDisabled: false,
+                  canBeDeleted: true,
+                  budget: null,
+                },
+                {
+                  id: 'utilities-id',
+                  name: 'Utilities',
+                  templateId: 'Utilities',
+                  colorName: 'ORANGE2',
+                  icon: { __typename: 'EmojiUnicode', unicode: '🧹' },
+                  isExcluded: false,
+                  isRolloverDisabled: false,
+                  canBeDeleted: true,
+                  budget: null,
+                },
+              ],
+            },
+            {
+              id: 'standalone-id',
+              name: 'Insurance',
+              templateId: 'Insurance',
+              colorName: 'YELLOW1',
+              icon: { __typename: 'EmojiUnicode', unicode: '☂️' },
+              isExcluded: false,
+              isRolloverDisabled: false,
+              canBeDeleted: true,
+              budget: null,
+              childCategories: [],
+            },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchCategories } = await import('../../../../src/core/graphql/queries/categories.js');
+    const flat = await fetchCategories(client);
+
+    const home = flat.find((c) => c.id === 'home-id');
+    const rent = flat.find((c) => c.id === 'rent-id');
+    const utilities = flat.find((c) => c.id === 'utilities-id');
+    const insurance = flat.find((c) => c.id === 'standalone-id');
+
+    // Parents and standalone categories: parentId is null.
+    expect(home?.parentId).toBeNull();
+    expect(insurance?.parentId).toBeNull();
+
+    // Children: parentId points at their parent's id.
+    expect(rent?.parentId).toBe('home-id');
+    expect(utilities?.parentId).toBe('home-id');
+
+    // No childCategories field on flattened output.
+    expect((home as Record<string, unknown>)?.childCategories).toBeUndefined();
+  });
+
   test('passes {spend:false, budget:true, rollovers:false} variables', async () => {
     const client = {
       query: mock(() => Promise.resolve({ categories: [] })),

--- a/tests/core/graphql/queries/categories.test.ts
+++ b/tests/core/graphql/queries/categories.test.ts
@@ -230,6 +230,41 @@ describe('fetchCategories', () => {
     expect((home as Record<string, unknown>)?.childCategories).toBeUndefined();
   });
 
+  test('regression C3: parentId is null when childCategories key is absent (vs empty array)', async () => {
+    // CategoryResponseNode.childCategories is optional — the server may omit
+    // the key entirely on top-level categories with no children. The
+    // `if (childCategories)` guard handles both undefined and []. This test
+    // pins the absent-key path explicitly (the existing standalone test
+    // covers the empty-array path).
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          categories: [
+            {
+              id: 'no-children-key',
+              name: 'Bare Standalone',
+              templateId: 'Misc',
+              colorName: 'GRAY1',
+              icon: null,
+              isExcluded: false,
+              isRolloverDisabled: false,
+              canBeDeleted: true,
+              budget: null,
+              // childCategories key intentionally omitted (not undefined, not [])
+            },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchCategories } = await import('../../../../src/core/graphql/queries/categories.js');
+    const flat = await fetchCategories(client);
+
+    expect(flat).toHaveLength(1);
+    expect(flat[0]?.id).toBe('no-children-key');
+    expect(flat[0]?.parentId).toBeNull();
+  });
+
   test('passes {spend:false, budget:true, rollovers:false} variables', async () => {
     const client = {
       query: mock(() => Promise.resolve({ categories: [] })),

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -485,6 +485,7 @@ describe('LiveCopilotDatabase.patchLiveCategoryUpsert (CategoryNode shape)', () 
       Promise.resolve([
         {
           id: 'cat-1',
+          parentId: null,
           name: 'Old Name',
           templateId: 'Food',
           colorName: 'ORANGE2',
@@ -499,6 +500,7 @@ describe('LiveCopilotDatabase.patchLiveCategoryUpsert (CategoryNode shape)', () 
 
     live.patchLiveCategoryUpsert({
       id: 'cat-1',
+      parentId: null,
       name: 'New Name',
       templateId: 'Food',
       colorName: 'ORANGE2',
@@ -517,6 +519,7 @@ describe('LiveCopilotDatabase.patchLiveCategoryUpsert (CategoryNode shape)', () 
     const live = new LiveCopilotDatabase(mkClient(), mkCache());
     const catNode1: CategoryNode = {
       id: 'cat-1',
+      parentId: null,
       name: 'Dining',
       templateId: 'Food',
       colorName: 'ORANGE2',
@@ -528,6 +531,7 @@ describe('LiveCopilotDatabase.patchLiveCategoryUpsert (CategoryNode shape)', () 
     };
     const catNode2: CategoryNode = {
       id: 'cat-2',
+      parentId: null,
       name: 'Travel',
       templateId: 'Travel',
       colorName: 'BLUE1',
@@ -556,6 +560,7 @@ describe('LiveCopilotDatabase.patchLiveCategoryBudget', () => {
       Promise.resolve([
         {
           id: 'cat-1',
+          parentId: null,
           name: 'Food',
           templateId: 'Food',
           colorName: null,
@@ -588,6 +593,7 @@ describe('LiveCopilotDatabase.patchLiveCategoryBudget', () => {
       Promise.resolve([
         {
           id: 'cat-1',
+          parentId: null,
           name: 'Food',
           templateId: 'Food',
           colorName: null,
@@ -623,6 +629,7 @@ describe('LiveCopilotDatabase.patchLiveCategoryBudget', () => {
       Promise.resolve([
         {
           id: 'cat-1',
+          parentId: null,
           name: 'Food',
           templateId: 'Food',
           colorName: null,
@@ -667,6 +674,7 @@ describe('LiveCopilotDatabase.patchLiveCategoryBudget', () => {
       Promise.resolve([
         {
           id: 'cat-1',
+          parentId: null,
           name: 'Food',
           templateId: 'Food',
           colorName: null,


### PR DESCRIPTION
## Summary

Fixes audit finding **C3** — `CategoryNode` lost its parent reference when `fetchCategories` flattened the GraphQL `categories[].childCategories[]` tree. There was no other field on the response that distinguished parents from children (both have `templateId: null`), so consumers couldn't rebuild the hierarchy from `get_categories_live` output alone.

- **Field added:** `CategoryNode.parentId: string | null`. Synthesized at flatten time — Copilot's GraphQL response doesn't carry it.
- **Semantics:** `parentId === null` means top-level (parent OR standalone). Children get their parent's id.
- **Detection recipe** (documented in the tool description): a category is a parent iff `parentId !== null` for some other category. Standalones have no children pointing at them.
- **Cascade:** TypeScript compiler enforced that every `CategoryNode` literal site in `src/` was updated. One source-side write-through (`createCategory` synthesis — sets `parentId: null` since the GraphQL mutation doesn't accept parentId on creation). Test fixtures in `tests/core/live-database.test.ts` (the only test file that uses explicit `CategoryNode` annotations) updated for shape parity. Other test files build mock GraphQL response objects (the raw shape, which correctly omits `parentId` — `fetchCategories` synthesizes it post-flatten), so they need no update.

## Test plan

- [x] New regression test asserts `parentId === null` for parents/standalones and `parentId === <parent.id>` for children, both in the flat output and via direct property read.
- [x] All existing tests still pass after fixture updates (1795 pass).
- [x] \`bun run check\` green.
- [x] Manual re-validation against live endpoint: confirmed user's \`🏠 Home\` parent (id \`9erOLuAzZyBpEss6pHml\`) and its \`Rent\`/\`Utilities\`/\`Household things\` children exist in the live response. Direct \`parentId\` observation requires MCP host restart with the new code; the regression test exhaustively covers the synthesis logic.

## Notes

- Second of 5 PRs in the audit-fix batch. Spec: \`docs/superpowers/specs/2026-05-03-live-mode-audit-fixes-design.md\`.
- This unblocks PR follow-up for audit finding C2 (budget total mismatch), which needed \`parentId\` to identify and exclude parent categories from the headline total.
- No write-tool API change. \`create_category\` still rejects \`parent_id\` (Copilot's GraphQL mutation doesn't accept it).
- Plan-level callout: the plan anticipated \~10 fixture sites needing updates across 6 test files due to typecheck cascade. In practice, \`tsconfig.json\` excludes \`tests/\` from the typecheck, so only \`tests/core/live-database.test.ts\` has explicit \`CategoryNode\` annotations that benefit from the update for shape accuracy. The other 5 files only build mock GraphQL responses (raw shape).