### PR TITLE
fix(accounts): map limit:0 to null for charge cards (audit A2)

### DIFF
--- a/src/tools/live/accounts.ts
+++ b/src/tools/live/accounts.ts
@@ -77,9 +77,7 @@ export class LiveAccountsTools {
       else totalAssets += a.balance;
     }
 
-    // A2: charge cards (e.g., AmEx Platinum) have no preset spending limit;
-    // the server returns limit:0 which would cause /0 in utilization
-    // calculations. Project null so consumers get a clean signal.
+    // A2: server returns limit:0 for charge cards (no preset limit); project null to prevent /0 in utilization.
     const projectedAccounts = rows.map((a) => (a.limit === 0 ? { ...a, limit: null } : a));
 
     const fetchedAtIso = new Date(fetched_at).toISOString();

--- a/src/tools/live/accounts.ts
+++ b/src/tools/live/accounts.ts
@@ -77,13 +77,18 @@ export class LiveAccountsTools {
       else totalAssets += a.balance;
     }
 
+    // A2: charge cards (e.g., AmEx Platinum) have no preset spending limit;
+    // the server returns limit:0 which would cause /0 in utilization
+    // calculations. Project null so consumers get a clean signal.
+    const projectedAccounts = rows.map((a) => (a.limit === 0 ? { ...a, limit: null } : a));
+
     const fetchedAtIso = new Date(fetched_at).toISOString();
     return {
       count: rows.length,
       total_balance: roundAmount(totalAssets - totalLiabilities),
       total_assets: roundAmount(totalAssets),
       total_liabilities: roundAmount(totalLiabilities),
-      accounts: rows,
+      accounts: projectedAccounts,
       _cache_oldest_fetched_at: fetchedAtIso,
       _cache_newest_fetched_at: fetchedAtIso,
       _cache_hit: hit,

--- a/tests/tools/live/accounts.test.ts
+++ b/tests/tools/live/accounts.test.ts
@@ -135,6 +135,29 @@ describe('LiveAccountsTools.getAccounts', () => {
     expect(upper.accounts[0]?.id).toBe('b');
   });
 
+  test('regression A2: limit:0 mapped to null for charge cards', async () => {
+    // AmEx Platinum is a charge card with no preset spending limit.
+    // Server returns limit:0; consumers computing utilization (balance/limit)
+    // would divide by zero. Project null instead.
+    const live = mkLive([
+      A('chk', { type: 'DEPOSITORY', balance: 5000, limit: null }),
+      A('cc-with-limit', { type: 'CREDIT', balance: 100, limit: 5000 }),
+      A('charge', { type: 'CREDIT', balance: 1500, limit: 0 }),
+    ]);
+    const tools = new LiveAccountsTools(live);
+    const result = await tools.getAccounts({});
+
+    const charge = result.accounts.find((a) => a.id === 'charge');
+    const ccLimit = result.accounts.find((a) => a.id === 'cc-with-limit');
+    const chk = result.accounts.find((a) => a.id === 'chk');
+
+    expect(charge?.limit).toBeNull();
+    // Sanity: a real-limit credit card retains its limit.
+    expect(ccLimit?.limit).toBe(5000);
+    // Sanity: depository accounts (already null in fixture) stay null.
+    expect(chk?.limit).toBeNull();
+  });
+
   test('schema definition exposes filter args', () => {
     const schema = createLiveAccountsToolSchema();
     expect(schema.name).toBe('get_accounts_live');

--- a/tests/tools/live/accounts.test.ts
+++ b/tests/tools/live/accounts.test.ts
@@ -136,9 +136,7 @@ describe('LiveAccountsTools.getAccounts', () => {
   });
 
   test('regression A2: limit:0 mapped to null for charge cards', async () => {
-    // AmEx Platinum is a charge card with no preset spending limit.
-    // Server returns limit:0; consumers computing utilization (balance/limit)
-    // would divide by zero. Project null instead.
+    // Charge cards (e.g., AmEx Platinum) have no preset limit; server returns 0, project null to prevent /0.
     const live = mkLive([
       A('chk', { type: 'DEPOSITORY', balance: 5000, limit: null }),
       A('cc-with-limit', { type: 'CREDIT', balance: 100, limit: 5000 }),


### PR DESCRIPTION
## Summary

Fixes audit finding **A2** — `LiveAccountsTools` returned `limit: 0` for charge cards (charge cards have no preset spending limit) when the consumer expects `null`. Computing utilization (`balance / limit`) would divide by zero.

- **Fix:** project `limit === 0 → limit: null` in `getAccounts`. Real-limit credit cards retain their limits; depository accounts (already `null`) unchanged.
- **Scope:** projection-only. The cache itself still holds the raw server values; this is a read-side normalization.

## Test plan

- [x] A2 regression: charge card with `limit: 0` returns `limit: null` in projection; real-limit credit cards retain their limit; depository unchanged.
- [x] All existing accounts tests pass.
- [x] `bun run check` green.
- [x] Verification covered deterministically by the unit test; live-endpoint check deferred until the running MCP host picks up the merged build (post-A1 + post-A2).

## Notes

- Wave 2 in the audit-fix batch. Depends on PR A1 (`fix/audit-a1-account-totals`) which restructures the surrounding partition loop; rebases cleanly post-A1-merge.
- Spec: `docs/superpowers/specs/2026-05-03-live-mode-audit-fixes-design.md`.