### PR TITLE
feat(categories): default-strip budget.histories in get_categories_live (audit C1)

### DIFF
--- a/src/tools/live/categories.ts
+++ b/src/tools/live/categories.ts
@@ -14,6 +14,14 @@ import { fetchCategories, type CategoryNode } from '../../core/graphql/queries/c
 
 export interface GetCategoriesLiveArgs {
   excluded_only?: boolean;
+  /**
+   * Whether to include the per-category `budget.histories[]` array in the
+   * response. Default: `false` — histories are stripped to keep the response
+   * within the LLM tool-result token budget. The cache still stores the full
+   * history; this only affects the serialized output. Set to `true` for
+   * historical analysis or budget-trend charting.
+   */
+  include_history?: boolean;
 }
 
 export interface GetCategoriesLiveResult {
@@ -61,10 +69,19 @@ export class LiveCategoriesTools {
       cache_hit: hit,
     });
 
+    const includeHistory = args.include_history === true;
+    // Default-strip budget.histories to keep response under the LLM token
+    // budget (~25 KB). The cache still holds the full history — this is a
+    // read-side projection only. Critical: shallow clone each row's budget
+    // so we never mutate the cached references.
+    const projected = includeHistory
+      ? rows
+      : rows.map((c) => (c.budget ? { ...c, budget: { ...c.budget, histories: [] } } : c));
+
     const fetchedAtIso = new Date(fetched_at).toISOString();
     return {
-      count: rows.length,
-      categories: rows,
+      count: projected.length,
+      categories: projected,
       _cache_oldest_fetched_at: fetchedAtIso,
       _cache_newest_fetched_at: fetchedAtIso,
       _cache_hit: hit,
@@ -79,6 +96,7 @@ export function createLiveCategoriesToolSchema() {
       'Get user categories (live, GraphQL-backed). Includes per-category budget data so get_budgets_live can read from the same cache. ' +
       'Each row carries a `parentId` field: `null` for top-level categories (parents AND standalones), or the parent category id for children. ' +
       'To detect a parent specifically: build a Set of parent ids from the rows where `parentId !== null`. ' +
+      'By default, `budget.histories[]` is stripped to keep the response small — pass `include_history: true` to receive the full multi-year history. ' +
       'Replaces get_categories when --live-reads is on.',
     inputSchema: {
       type: 'object' as const,
@@ -86,6 +104,14 @@ export function createLiveCategoriesToolSchema() {
         excluded_only: {
           type: 'boolean',
           description: 'Return only categories marked as excluded. Default: false.',
+          default: false,
+        },
+        include_history: {
+          type: 'boolean',
+          description:
+            'Include per-category budget.histories array (multi-year monthly data). ' +
+            'Default: false — stripped to keep response under the LLM tool-result ' +
+            'token budget. Set to true for trend analysis or budget-history queries.',
           default: false,
         },
       },

--- a/tests/tools/live/categories.test.ts
+++ b/tests/tools/live/categories.test.ts
@@ -157,6 +157,44 @@ describe('LiveCategoriesTools.getCategories', () => {
     const cached = live.getCategoriesCache().peek();
     expect(cached?.[0]?.budget?.histories).toHaveLength(2);
   });
+
+  test('regression C1: include_history=true preserves budget.histories', async () => {
+    const fixture: CategoryNode = {
+      id: 'cat-1',
+      parentId: null,
+      name: 'Restaurants',
+      templateId: 'Restaurants',
+      colorName: 'PURPLE2',
+      icon: { __typename: 'EmojiUnicode', unicode: '🍔' },
+      isExcluded: false,
+      isRolloverDisabled: false,
+      canBeDeleted: true,
+      budget: {
+        current: null,
+        histories: [
+          {
+            unassignedRolloverAmount: null,
+            childRolloverAmount: null,
+            unassignedAmount: null,
+            resolvedAmount: '500',
+            rolloverAmount: '0',
+            childAmount: null,
+            goalAmount: '0',
+            amount: '500',
+            month: '2026-04',
+            id: 'budget-history-1',
+          },
+        ],
+      },
+    };
+    const live = makeLive(makeClient([fixture]));
+    const tools = new LiveCategoriesTools(live);
+
+    const result = await tools.getCategories({ include_history: true });
+
+    expect(result.categories[0]?.budget?.histories).toHaveLength(1);
+    expect(result.categories[0]?.budget?.histories[0]?.month).toBe('2026-04');
+  });
 });
 
 describe('createLiveCategoriesToolSchema', () => {

--- a/tests/tools/live/categories.test.ts
+++ b/tests/tools/live/categories.test.ts
@@ -3,6 +3,7 @@ import type { GraphQLClient } from '../../../src/core/graphql/client.js';
 import { CopilotDatabase } from '../../../src/core/database.js';
 import { LiveCopilotDatabase } from '../../../src/core/live-database.js';
 import { LiveCategoriesTools } from '../../../src/tools/live/categories.js';
+import type { CategoryNode } from '../../../src/core/graphql/queries/categories.js';
 
 function makeClient(rows: unknown[]): GraphQLClient {
   return {
@@ -86,6 +87,75 @@ describe('LiveCategoriesTools.getCategories', () => {
 
     // Drink < Food < null-sentinel; within Food, Apple < Zebra
     expect(result.categories.map((c) => c.id)).toEqual(['c', 'b', 'a', 'd']);
+  });
+
+  test('regression C1: default include_history=false strips budget.histories', async () => {
+    const fixture: CategoryNode = {
+      id: 'cat-1',
+      parentId: null,
+      name: 'Restaurants',
+      templateId: 'Restaurants',
+      colorName: 'PURPLE2',
+      icon: { __typename: 'EmojiUnicode', unicode: '🍔' },
+      isExcluded: false,
+      isRolloverDisabled: false,
+      canBeDeleted: true,
+      budget: {
+        current: {
+          unassignedRolloverAmount: null,
+          childRolloverAmount: null,
+          unassignedAmount: null,
+          resolvedAmount: '500',
+          rolloverAmount: '0',
+          childAmount: null,
+          goalAmount: '0',
+          amount: '500',
+          month: '2026-05',
+          id: 'budget-current-id',
+        },
+        histories: [
+          {
+            unassignedRolloverAmount: null,
+            childRolloverAmount: null,
+            unassignedAmount: null,
+            resolvedAmount: '500',
+            rolloverAmount: '0',
+            childAmount: null,
+            goalAmount: '0',
+            amount: '500',
+            month: '2026-04',
+            id: 'budget-history-1',
+          },
+          {
+            unassignedRolloverAmount: null,
+            childRolloverAmount: null,
+            unassignedAmount: null,
+            resolvedAmount: '500',
+            rolloverAmount: '0',
+            childAmount: null,
+            goalAmount: '0',
+            amount: '500',
+            month: '2026-03',
+            id: 'budget-history-2',
+          },
+        ],
+      },
+    };
+    const live = makeLive(makeClient([fixture]));
+    const tools = new LiveCategoriesTools(live);
+
+    const result = await tools.getCategories({});
+
+    expect(result.count).toBe(1);
+    // Default behavior: histories must be stripped to keep response small.
+    expect(result.categories[0]?.budget?.histories).toEqual([]);
+    // Current month is preserved.
+    expect(result.categories[0]?.budget?.current?.amount).toBe('500');
+
+    // Cache must NOT be mutated — second read should still see histories
+    // (verifies the projection clones rather than mutates).
+    const cached = live.getCategoriesCache().peek();
+    expect(cached?.[0]?.budget?.histories).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes audit finding **C1** — `get_categories_live` was returning ~1.15 MB of JSON on a typical multi-year data set. ~95% was `budget.histories[]` (61 monthly entries × 38 categories × ~12 fields per entry). The response exceeded the LLM tool-result token budget, forcing consumers to read saved files with `jq`.

- **New arg:** `include_history: boolean` (default `false`).
- **Default behavior:** strips `budget.histories[]` to `[]` in a shallow clone of each row before serialization. `budget.current` is preserved (current-month figures are what most queries want).
- **Opt-in:** pass `include_history: true` for trend analysis or multi-year budget queries. Caller's responsibility to manage the larger response.
- **Cache safety:** the projection clones (`{...c, budget: {...c.budget, histories: []}}`) — the cached rows are never mutated, so `get_budgets_live` (which projects from the same cache) and any concurrent `include_history: true` calls still see the full history.

## Test plan

- [x] New regression test confirms default strips histories.
- [x] New regression test confirms opt-in preserves histories.
- [x] Cache-mutation regression test (post-strip, the cache still has full histories).
- [x] `get_budgets_live` tests still pass (verifies cache isn't corrupted).
- [x] `bun run check` green (1806 pass, 0 fail).
- [x] Manual re-validation against real data (38 categories, 2257 history entries):

\`\`\`
Pre-fix:  default response 1028.4 KB (1.15 MB measured by host)
Post-fix: default response 21.7 KB  (97.9% reduction; well under 50 KB target)
Opt-in:   include_history=true returns 630.1 KB (full multi-year history)
Cache:    2257 total history entries preserved after both calls (non-mutation verified)
\`\`\`

## Notes

- Third of 5 PRs in the audit-fix batch. Spec: `docs/superpowers/specs/2026-05-03-live-mode-audit-fixes-design.md`.
- Same shape pattern as the upcoming PR for audit C4 (which trims `get_budgets_live`'s `amounts` map). Bundled into the cleanup PR (#5) per the project's audit-nit-batching rule.