### PR TITLE
fix(budgets): sum total_budgeted from top-level categories only (audit C2)

### DIFF
--- a/src/tools/live/budgets.ts
+++ b/src/tools/live/budgets.ts
@@ -124,7 +124,11 @@ export class LiveBudgetsTools {
           ? { ...row, amounts: trimAmountsToWindow(row.amounts, monthsWindow) }
           : row;
       projected.push(trimmed);
-      if (trimmed.amount !== undefined) totalBudgeted += trimmed.amount;
+      // parent.amount already includes children's base via the GraphQL
+      // childAmount field, so summing children separately double-counts.
+      if (trimmed.amount !== undefined && cat.parentId === null) {
+        totalBudgeted += trimmed.amount;
+      }
     }
 
     // Sort by category_name for stable output (mirrors LiveCategoriesTools convention).

--- a/tests/tools/live/budgets.test.ts
+++ b/tests/tools/live/budgets.test.ts
@@ -266,6 +266,167 @@ describe('LiveBudgetsTools.getBudgets', () => {
     // projectCategory drops the row entirely (no current amount AND no history amounts).
     expect(result.count).toBe(0);
   });
+
+  test('regression C2: total_budgeted sums only top-level categories (parents + standalones), not children', async () => {
+    // Parent with amount 200 and one child with amount 100. Pre-fix the
+    // headline summed 300, double-counting because the parent's amount
+    // already includes the child's base via the GraphQL `childAmount` field.
+    // Post-fix: only the parent (200) contributes; the child is skipped.
+    // Fixture mirrors the GraphQL tree shape so fetchCategories synthesizes
+    // child.parentId = parent.id during flatten.
+    const childRow = {
+      id: 'child-rent',
+      name: 'Rent',
+      templateId: 'Rent',
+      colorName: 'ORANGE2',
+      isExcluded: false,
+      isRolloverDisabled: false,
+      canBeDeleted: true,
+      icon: { __typename: 'EmojiUnicode', unicode: '🔑' },
+      budget: {
+        current: {
+          unassignedRolloverAmount: null,
+          childRolloverAmount: null,
+          unassignedAmount: null,
+          resolvedAmount: '100',
+          rolloverAmount: '0',
+          childAmount: null,
+          goalAmount: '0',
+          amount: '100',
+          month: '2026-05',
+          id: 'b-child-current',
+        },
+        histories: [],
+      },
+    };
+    const parentRow = {
+      id: 'parent-home',
+      name: 'Home',
+      templateId: null,
+      colorName: 'ORANGE2',
+      isExcluded: false,
+      isRolloverDisabled: false,
+      canBeDeleted: true,
+      icon: null,
+      budget: {
+        current: {
+          unassignedRolloverAmount: '50',
+          childRolloverAmount: '0',
+          unassignedAmount: '100',
+          resolvedAmount: '200',
+          rolloverAmount: '50',
+          childAmount: '100',
+          goalAmount: '0',
+          amount: '200',
+          month: '2026-05',
+          id: 'b-parent-current',
+        },
+        histories: [],
+      },
+      childCategories: [childRow],
+    };
+
+    const client = makeClient([parentRow]);
+    const live = makeLive(client);
+    await prewarmUserCacheRolloversOff(live);
+    const tools = new LiveBudgetsTools(live);
+
+    const result = await tools.getBudgets({});
+
+    expect(result.count).toBe(2);
+    expect(result.total_budgeted).toBe(200);
+  });
+
+  test('regression C2: standalones are still counted in total_budgeted', async () => {
+    // Standalone (no children) + parent (with one child). Headline = standalone + parent.
+    const standalone = {
+      id: 'standalone-sub',
+      name: 'Subscriptions',
+      templateId: 'Subscriptions',
+      colorName: 'PINK1',
+      isExcluded: false,
+      isRolloverDisabled: false,
+      canBeDeleted: true,
+      icon: { __typename: 'EmojiUnicode', unicode: '💳' },
+      budget: {
+        current: {
+          unassignedRolloverAmount: null,
+          childRolloverAmount: null,
+          unassignedAmount: null,
+          resolvedAmount: '50',
+          rolloverAmount: '0',
+          childAmount: null,
+          goalAmount: '0',
+          amount: '50',
+          month: '2026-05',
+          id: 'b-standalone-current',
+        },
+        histories: [],
+      },
+    };
+    const parentWithChild = {
+      id: 'parent-home',
+      name: 'Home',
+      templateId: null,
+      colorName: 'ORANGE2',
+      isExcluded: false,
+      isRolloverDisabled: false,
+      canBeDeleted: true,
+      icon: null,
+      budget: {
+        current: {
+          unassignedRolloverAmount: '50',
+          childRolloverAmount: '0',
+          unassignedAmount: '100',
+          resolvedAmount: '200',
+          rolloverAmount: '50',
+          childAmount: '100',
+          goalAmount: '0',
+          amount: '200',
+          month: '2026-05',
+          id: 'b-parent-current2',
+        },
+        histories: [],
+      },
+      childCategories: [
+        {
+          id: 'child-rent',
+          name: 'Rent',
+          templateId: 'Rent',
+          colorName: 'ORANGE2',
+          isExcluded: false,
+          isRolloverDisabled: false,
+          canBeDeleted: true,
+          icon: { __typename: 'EmojiUnicode', unicode: '🔑' },
+          budget: {
+            current: {
+              unassignedRolloverAmount: null,
+              childRolloverAmount: null,
+              unassignedAmount: null,
+              resolvedAmount: '100',
+              rolloverAmount: '0',
+              childAmount: null,
+              goalAmount: '0',
+              amount: '100',
+              month: '2026-05',
+              id: 'b-child-current2',
+            },
+            histories: [],
+          },
+        },
+      ],
+    };
+
+    const client = makeClient([standalone, parentWithChild]);
+    const live = makeLive(client);
+    await prewarmUserCacheRolloversOff(live);
+    const tools = new LiveBudgetsTools(live);
+
+    const result = await tools.getBudgets({});
+
+    expect(result.count).toBe(3);
+    expect(result.total_budgeted).toBe(250); // 50 standalone + 200 parent
+  });
 });
 
 describe('createLiveBudgetsToolSchema', () => {


### PR DESCRIPTION
## Summary

Fixes audit finding **C2** — `get_budgets_live` returned a `total_budgeted` that double-counted child categories.

- **Bug:** `total_budgeted` summed every budget's `amount`, but each parent's `amount` already aggregates its children's base budgets via the GraphQL `current.childAmount` field. Children were counted both as their own row and as part of the parent's `amount`.
- **Fix:** filter the aggregator on `cat.parentId === null` so only top-level categories (parents + standalones) contribute to the headline total. Each per-row `amount` in `result.budgets[]` is unchanged.
- **Cache safety:** none affected — pure aggregation change.

## Why

Empirically, the parent shape on real GraphQL responses is:

```
parent.amount = parent.unassignedAmount  // budget allocated to the parent itself
              + parent.childAmount       // sum of children's base (pre-rollover) budgets
              + parent.rolloverAmount    // parent's own rollover
```

So summing `parent.amount` plus each child's `amount` separately double-counts the children's bases (once via the parent's `childAmount`, once via the child's own row).

## Test plan

- [x] **Top-level-only sum** — fixture with one parent + one child. Headline excludes the child; per-row data still includes both.
- [x] **Standalones still counted** — fixture with one standalone + one parent/child pair. Headline = standalone + parent; child excluded.
- [x] All existing budgets tests pass.
- [x] `bun run check` green (1843 tests across 85 files).
- [x] Manually re-validated against the live endpoint post-fix; the headline now matches the web app within the rollover-snapshot timing skew.

## Notes

- Follow-up to the audit-fix batch (Wave 1: A1/C3/C4/R1; Wave 2: A2/C1/C6). C2 was deferred until the prior waves landed so the post-fix `total_budgeted` could be measured against an accurate baseline.