### PR TITLE
feat(live): add get_networth_live

### DIFF
--- a/src/core/graphql/queries/networth.ts
+++ b/src/core/graphql/queries/networth.ts
@@ -37,10 +37,8 @@ export async function fetchNetworthHistory(
   client: GraphQLClient,
   opts: FetchNetworthHistoryOpts
 ): Promise<NetworthHistoryNode[]> {
-  const data = await client.query<{ timeFrame: string }, NetworthResponse>(
-    'Networth',
-    NETWORTH,
-    { timeFrame: opts.timeFrame }
-  );
+  const data = await client.query<{ timeFrame: string }, NetworthResponse>('Networth', NETWORTH, {
+    timeFrame: opts.timeFrame,
+  });
   return data.networthHistory;
 }

--- a/src/core/graphql/queries/networth.ts
+++ b/src/core/graphql/queries/networth.ts
@@ -1,0 +1,46 @@
+/**
+ * GraphQL query wrapper for Networth (net-worth-over-time history).
+ *
+ * Returns a flat, date-sorted list of `{date, assets, debt}` snapshots.
+ * The captured `Networth` query takes a `$timeFrame: TimeFrame` enum
+ * (commonly `"ALL"`, `"YEAR"`, `"MONTH"`); response shape is a simple
+ * array (no nesting, no pagination).
+ *
+ * The response includes a client-side `total` field stripped by the
+ * operations generator — net worth at each point is `assets - debt`.
+ *
+ * The captured query at docs/graphql-capture/operations/queries/Networth.md
+ * exposes only `assets`, `debt`, `date` on each NetworthHistory entry
+ * (after the @client `total` is stripped). `assets` and `debt` are
+ * nullable strings — early dates in the user's history may have
+ * `assets: null` until backfilled.
+ */
+
+import type { GraphQLClient } from '../client.js';
+import { NETWORTH } from '../operations.generated.js';
+
+export interface NetworthHistoryNode {
+  date: string;
+  assets: string | null;
+  debt: string | null;
+}
+
+export interface FetchNetworthHistoryOpts {
+  timeFrame: string;
+}
+
+interface NetworthResponse {
+  networthHistory: NetworthHistoryNode[];
+}
+
+export async function fetchNetworthHistory(
+  client: GraphQLClient,
+  opts: FetchNetworthHistoryOpts
+): Promise<NetworthHistoryNode[]> {
+  const data = await client.query<{ timeFrame: string }, NetworthResponse>(
+    'Networth',
+    NETWORTH,
+    { timeFrame: opts.timeFrame }
+  );
+  return data.networthHistory;
+}

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -36,6 +36,7 @@ import type { AccountNode } from './graphql/queries/accounts.js';
 import type { CategoryNode } from './graphql/queries/categories.js';
 import type { TagNode } from './graphql/queries/tags.js';
 import type { RecurringNode } from './graphql/queries/recurrings.js';
+import type { NetworthHistoryNode } from './graphql/queries/networth.js';
 import { fetchUser, type UserNode } from './graphql/queries/user.js';
 import type { Transaction } from '../models/index.js';
 
@@ -72,6 +73,11 @@ export class LiveCopilotDatabase {
   // refresh-cache and TTL machinery works without a special case. `keyFn` keys
   // on the user id.
   private readonly userCache: SnapshotCache<UserNode>;
+  // networthCache holds the most-recently-requested timeFrame's history.
+  // Requests for a different timeFrame trigger a fresh fetch (the cache is
+  // not partitioned by timeFrame to keep the SnapshotCache primitive simple);
+  // the 1h TTL still applies to the most-recently-requested timeFrame.
+  private readonly networthCache: SnapshotCache<NetworthHistoryNode>;
   private readonly transactionsWindowCache: TransactionWindowCache<TransactionNode>;
 
   constructor(
@@ -101,6 +107,10 @@ export class LiveCopilotDatabase {
     );
     this.userCache = new SnapshotCache<UserNode>(
       { key: 'user', ttlMs: ONE_DAY_MS, keyFn: (u) => u.id },
+      this.inflight
+    );
+    this.networthCache = new SnapshotCache<NetworthHistoryNode>(
+      { key: 'networth', ttlMs: ONE_HOUR_MS, keyFn: (n) => n.date },
       this.inflight
     );
     this.transactionsWindowCache = new TransactionWindowCache<TransactionNode>(
@@ -329,6 +339,10 @@ export class LiveCopilotDatabase {
 
   getUserCache(): SnapshotCache<UserNode> {
     return this.userCache;
+  }
+
+  getNetworthCache(): SnapshotCache<NetworthHistoryNode> {
+    return this.networthCache;
   }
 
   /**

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -109,6 +109,12 @@ export class LiveCopilotDatabase {
       { key: 'user', ttlMs: ONE_DAY_MS, keyFn: (u) => u.id },
       this.inflight
     );
+    // keyFn assumes the upstream Networth query returns at most one row per
+    // date (true today — daily snapshots). If a future schema change ever
+    // returns multiple rows per date (e.g., intraday), upsert() would
+    // silently overwrite the first match. No write-through patches exist
+    // for networth today, so this is latent — but worth pinning the
+    // assumption here for future maintainers.
     this.networthCache = new SnapshotCache<NetworthHistoryNode>(
       { key: 'networth', ttlMs: ONE_HOUR_MS, keyFn: (n) => n.date },
       this.inflight

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,7 @@ import { LiveCategoriesTools, createLiveCategoriesToolSchema } from './tools/liv
 import { LiveTagsTools, createLiveTagsToolSchema } from './tools/live/tags.js';
 import { LiveBudgetsTools, createLiveBudgetsToolSchema } from './tools/live/budgets.js';
 import { LiveRecurringTools, createLiveRecurringToolSchema } from './tools/live/recurring.js';
+import { LiveNetworthTools, createLiveNetworthToolSchema } from './tools/live/networth.js';
 import { RefreshCacheTool, createRefreshCacheToolSchema } from './tools/live/refresh-cache.js';
 
 // Read version from package.json
@@ -46,6 +47,7 @@ export class CopilotMoneyServer {
   private liveTagsTools?: LiveTagsTools;
   private liveBudgetsTools?: LiveBudgetsTools;
   private liveRecurringTools?: LiveRecurringTools;
+  private liveNetworthTools?: LiveNetworthTools;
   private refreshCacheTool?: RefreshCacheTool;
 
   /**
@@ -82,6 +84,7 @@ export class CopilotMoneyServer {
       this.liveTagsTools = new LiveTagsTools(liveDb);
       this.liveBudgetsTools = new LiveBudgetsTools(liveDb);
       this.liveRecurringTools = new LiveRecurringTools(liveDb);
+      this.liveNetworthTools = new LiveNetworthTools(liveDb);
       this.refreshCacheTool = new RefreshCacheTool(liveDb);
     }
 
@@ -125,6 +128,7 @@ export class CopilotMoneyServer {
           createLiveTagsToolSchema(),
           createLiveBudgetsToolSchema(),
           createLiveRecurringToolSchema(),
+          createLiveNetworthToolSchema(),
           createRefreshCacheToolSchema(),
         ]
       : [];
@@ -259,6 +263,18 @@ export class CopilotMoneyServer {
       };
     }
 
+    if (name === 'get_networth_live' && !this.liveNetworthTools) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'get_networth_live is only available when the server runs with --live-reads.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
     if (name === 'refresh_cache' && !this.refreshCacheTool) {
       return {
         content: [
@@ -338,6 +354,15 @@ export class CopilotMoneyServer {
           result = await this.liveRecurringTools!.getRecurring(
             (typedArgs as Parameters<
               NonNullable<typeof this.liveRecurringTools>['getRecurring']
+            >[0]) ?? {}
+          );
+          break;
+
+        case 'get_networth_live':
+          // liveNetworthTools non-null invariant enforced by the early guard above.
+          result = await this.liveNetworthTools!.getNetworth(
+            (typedArgs as Parameters<
+              NonNullable<typeof this.liveNetworthTools>['getNetworth']
             >[0]) ?? {}
           );
           break;

--- a/src/tools/live/networth.ts
+++ b/src/tools/live/networth.ts
@@ -1,0 +1,114 @@
+/**
+ * Live-mode get_networth_live tool.
+ *
+ * Fetches net-worth-over-time history via GraphQL through the
+ * SnapshotCache<NetworthHistoryNode> exposed by LiveCopilotDatabase
+ * (1h TTL). Output envelope mirrors the other live read tools (count,
+ * networth_history) plus the freshness-envelope fields.
+ *
+ * The `total` field from the upstream NetworthHistory type is a client-side
+ * (`@client`) projection stripped by the operations generator and is not
+ * present on the wire. Consumers that want net worth at each point should
+ * compute `assets - debt` per row.
+ *
+ * timeFrame caching: a single SnapshotCache holds the most-recently-requested
+ * timeFrame's rows. Requests for a different timeFrame invalidate the cache
+ * and trigger a fresh fetch (we track the last requested timeFrame to detect
+ * the change). The 1h TTL still applies to the most-recently-requested
+ * timeFrame.
+ */
+
+import type { LiveCopilotDatabase } from '../../core/live-database.js';
+import {
+  fetchNetworthHistory,
+  type NetworthHistoryNode,
+} from '../../core/graphql/queries/networth.js';
+
+const DEFAULT_TIME_FRAME = 'ALL';
+
+export interface GetNetworthLiveArgs {
+  time_frame?: string;
+}
+
+export interface GetNetworthLiveResult {
+  count: number;
+  networth_history: NetworthHistoryNode[];
+  _cache_oldest_fetched_at: string;
+  _cache_newest_fetched_at: string;
+  _cache_hit: boolean;
+}
+
+export class LiveNetworthTools {
+  private lastTimeFrame: string | null = null;
+
+  constructor(private readonly live: LiveCopilotDatabase) {}
+
+  async getNetworth(args: GetNetworthLiveArgs): Promise<GetNetworthLiveResult> {
+    const timeFrame = args.time_frame ?? DEFAULT_TIME_FRAME;
+    const cache = this.live.getNetworthCache();
+
+    // If the requested timeFrame differs from the last one cached, invalidate
+    // so the next read fetches fresh rows for the new timeFrame instead of
+    // returning stale rows from the previous timeFrame.
+    if (this.lastTimeFrame !== null && this.lastTimeFrame !== timeFrame) {
+      cache.invalidate();
+    }
+    this.lastTimeFrame = timeFrame;
+
+    const startedAt = Date.now();
+    const {
+      rows: cached,
+      fetched_at,
+      hit,
+    } = await cache.read(() => fetchNetworthHistory(this.live.getClient(), { timeFrame }));
+
+    const rows = [...cached].sort((a, b) => a.date.localeCompare(b.date));
+
+    // Log after sort so `rows` reflects what's returned to the caller.
+    this.live.logReadCall({
+      op: 'Networth',
+      pages: hit ? 0 : 1,
+      latencyMs: Date.now() - startedAt,
+      rows: rows.length,
+      cache_hit: hit,
+    });
+
+    const fetchedAtIso = new Date(fetched_at).toISOString();
+    return {
+      count: rows.length,
+      networth_history: rows,
+      _cache_oldest_fetched_at: fetchedAtIso,
+      _cache_newest_fetched_at: fetchedAtIso,
+      _cache_hit: hit,
+    };
+  }
+}
+
+export function createLiveNetworthToolSchema() {
+  return {
+    name: 'get_networth_live',
+    description:
+      'Get net-worth-over-time history (live, GraphQL-backed). Returns daily snapshots ' +
+      'sorted oldest→newest by date; for each row, `assets - debt` gives the net worth ' +
+      'at that point in time. Both `assets` and `debt` are nullable strings — early dates ' +
+      'in the user\'s history may have `assets: null` until backfilled. Available when ' +
+      '--live-reads is on. Optional `time_frame` arg (default "ALL"; other server-supported ' +
+      'values include "YEAR", "MONTH"). The cache holds the most-recently-requested ' +
+      'time_frame; requesting a different value triggers a fresh fetch.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        time_frame: {
+          type: 'string',
+          description:
+            'TimeFrame enum passed through to the Networth query. Default "ALL". ' +
+            'Validation is left to the server.',
+          default: DEFAULT_TIME_FRAME,
+        },
+      },
+    },
+    annotations: {
+      readOnlyHint: true,
+    },
+  };
+}

--- a/src/tools/live/networth.ts
+++ b/src/tools/live/networth.ts
@@ -39,6 +39,12 @@ export interface GetNetworthLiveResult {
 }
 
 export class LiveNetworthTools {
+  // Tracks the timeFrame of the currently-cached snapshot. Assumes serial
+  // callers — MCP tool calls are processed one-at-a-time by the server's
+  // request loop, so concurrent getNetworth calls with different time_frame
+  // values can't race on the assignment below. If that assumption ever
+  // changes (e.g., a worker pool is added), move this into SnapshotCache
+  // metadata so it's guarded by the same lock as the cache itself.
   private lastTimeFrame: string | null = null;
 
   constructor(private readonly live: LiveCopilotDatabase) {}
@@ -49,7 +55,8 @@ export class LiveNetworthTools {
 
     // If the requested timeFrame differs from the last one cached, invalidate
     // so the next read fetches fresh rows for the new timeFrame instead of
-    // returning stale rows from the previous timeFrame.
+    // returning stale rows from the previous timeFrame. (See lastTimeFrame
+    // comment above for the serial-callers assumption.)
     if (this.lastTimeFrame !== null && this.lastTimeFrame !== timeFrame) {
       cache.invalidate();
     }
@@ -74,6 +81,9 @@ export class LiveNetworthTools {
     });
 
     const fetchedAtIso = new Date(fetched_at).toISOString();
+    // Both `_cache_oldest_fetched_at` and `_cache_newest_fetched_at` reflect
+    // the same single-snapshot fetch time — unlike the windowed transaction
+    // cache where they can differ across month windows.
     return {
       count: rows.length,
       networth_history: rows,
@@ -100,9 +110,11 @@ export function createLiveNetworthToolSchema() {
       properties: {
         time_frame: {
           type: 'string',
+          enum: ['ALL', 'YEAR', 'MONTH'],
           description:
             'TimeFrame enum passed through to the Networth query. Default "ALL". ' +
-            'Validation is left to the server.',
+            'Other values are passed through unchanged; the server is the source of truth ' +
+            'on which TimeFrame values it accepts.',
           default: DEFAULT_TIME_FRAME,
         },
       },

--- a/src/tools/live/networth.ts
+++ b/src/tools/live/networth.ts
@@ -91,7 +91,7 @@ export function createLiveNetworthToolSchema() {
       'Get net-worth-over-time history (live, GraphQL-backed). Returns daily snapshots ' +
       'sorted oldest→newest by date; for each row, `assets - debt` gives the net worth ' +
       'at that point in time. Both `assets` and `debt` are nullable strings — early dates ' +
-      'in the user\'s history may have `assets: null` until backfilled. Available when ' +
+      "in the user's history may have `assets: null` until backfilled. Available when " +
       '--live-reads is on. Optional `time_frame` arg (default "ALL"; other server-supported ' +
       'values include "YEAR", "MONTH"). The cache holds the most-recently-requested ' +
       'time_frame; requesting a different value triggers a fresh fetch.',

--- a/src/tools/live/refresh-cache.ts
+++ b/src/tools/live/refresh-cache.ts
@@ -19,6 +19,7 @@ const VALID_SCOPES = [
   'budgets',
   'recurring',
   'user',
+  'networth',
 ] as const;
 
 const YEAR_MONTH_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
@@ -38,6 +39,7 @@ export interface RefreshCacheResult {
     budgets?: boolean;
     recurring?: boolean;
     user?: boolean;
+    networth?: boolean;
     transactions_months?: string[] | 'all';
   };
 }
@@ -78,6 +80,8 @@ export class RefreshCacheTool {
       flushed.recurring = true;
       this.live.getUserCache().invalidate();
       flushed.user = true;
+      this.live.getNetworthCache().invalidate();
+      flushed.networth = true;
     };
 
     const flushTransactions = () => {
@@ -126,6 +130,10 @@ export class RefreshCacheTool {
         this.live.getCategoriesCache().invalidate();
         flushed.user = true;
         flushed.categories = true;
+        break;
+      case 'networth':
+        this.live.getNetworthCache().invalidate();
+        flushed.networth = true;
         break;
     }
 

--- a/tests/core/graphql/queries/networth.test.ts
+++ b/tests/core/graphql/queries/networth.test.ts
@@ -14,9 +14,8 @@ describe('fetchNetworthHistory', () => {
       ),
     } as unknown as GraphQLClient;
 
-    const { fetchNetworthHistory } = await import(
-      '../../../../src/core/graphql/queries/networth.js'
-    );
+    const { fetchNetworthHistory } =
+      await import('../../../../src/core/graphql/queries/networth.js');
     const rows = await fetchNetworthHistory(client, { timeFrame: 'ALL' });
 
     expect(rows).toHaveLength(2);
@@ -30,9 +29,8 @@ describe('fetchNetworthHistory', () => {
       query: mock(() => Promise.resolve({ networthHistory: [] })),
     } as unknown as GraphQLClient;
 
-    const { fetchNetworthHistory } = await import(
-      '../../../../src/core/graphql/queries/networth.js'
-    );
+    const { fetchNetworthHistory } =
+      await import('../../../../src/core/graphql/queries/networth.js');
     await fetchNetworthHistory(client, { timeFrame: 'YEAR' });
 
     expect(client.query).toHaveBeenCalledWith('Networth', expect.any(String), {
@@ -45,9 +43,8 @@ describe('fetchNetworthHistory', () => {
       query: mock(() => Promise.resolve({ networthHistory: [] })),
     } as unknown as GraphQLClient;
 
-    const { fetchNetworthHistory } = await import(
-      '../../../../src/core/graphql/queries/networth.js'
-    );
+    const { fetchNetworthHistory } =
+      await import('../../../../src/core/graphql/queries/networth.js');
     const rows = await fetchNetworthHistory(client, { timeFrame: 'ALL' });
     expect(rows).toEqual([]);
   });
@@ -61,9 +58,8 @@ describe('fetchNetworthHistory', () => {
       ),
     } as unknown as GraphQLClient;
 
-    const { fetchNetworthHistory } = await import(
-      '../../../../src/core/graphql/queries/networth.js'
-    );
+    const { fetchNetworthHistory } =
+      await import('../../../../src/core/graphql/queries/networth.js');
     const rows = await fetchNetworthHistory(client, { timeFrame: 'ALL' });
 
     expect(rows[0]?.assets).toBeNull();

--- a/tests/core/graphql/queries/networth.test.ts
+++ b/tests/core/graphql/queries/networth.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../../src/core/graphql/client.js';
+
+describe('fetchNetworthHistory', () => {
+  test('returns the flat list as-is from the GraphQL response', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          networthHistory: [
+            { date: '2026-01-01', assets: '100000', debt: '5000' },
+            { date: '2026-01-02', assets: '101000', debt: '5100' },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchNetworthHistory } = await import(
+      '../../../../src/core/graphql/queries/networth.js'
+    );
+    const rows = await fetchNetworthHistory(client, { timeFrame: 'ALL' });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.date).toBe('2026-01-01');
+    expect(rows[0]?.assets).toBe('100000');
+    expect(rows[0]?.debt).toBe('5000');
+  });
+
+  test('passes timeFrame variable to the query', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ networthHistory: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchNetworthHistory } = await import(
+      '../../../../src/core/graphql/queries/networth.js'
+    );
+    await fetchNetworthHistory(client, { timeFrame: 'YEAR' });
+
+    expect(client.query).toHaveBeenCalledWith('Networth', expect.any(String), {
+      timeFrame: 'YEAR',
+    });
+  });
+
+  test('handles empty response without throwing', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ networthHistory: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchNetworthHistory } = await import(
+      '../../../../src/core/graphql/queries/networth.js'
+    );
+    const rows = await fetchNetworthHistory(client, { timeFrame: 'ALL' });
+    expect(rows).toEqual([]);
+  });
+
+  test('passes through nullable assets/debt fields (early dates can be null)', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          networthHistory: [{ date: '2022-09-13', assets: null, debt: '500' }],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchNetworthHistory } = await import(
+      '../../../../src/core/graphql/queries/networth.js'
+    );
+    const rows = await fetchNetworthHistory(client, { timeFrame: 'ALL' });
+
+    expect(rows[0]?.assets).toBeNull();
+    expect(rows[0]?.debt).toBe('500');
+  });
+});

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -360,11 +360,16 @@ describe('LiveCopilotDatabase — cache accessors', () => {
     expect(mkLive().getUserCache()).toBeInstanceOf(SnapshotCache);
   });
 
+  test('getNetworthCache returns a SnapshotCache instance', () => {
+    expect(mkLive().getNetworthCache()).toBeInstanceOf(SnapshotCache);
+  });
+
   test('each call returns the same instance (not a new one)', () => {
     const live = mkLive();
     expect(live.getTagsCache()).toBe(live.getTagsCache());
     expect(live.getTransactionsWindowCache()).toBe(live.getTransactionsWindowCache());
     expect(live.getUserCache()).toBe(live.getUserCache());
+    expect(live.getNetworthCache()).toBe(live.getNetworthCache());
   });
 });
 

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -2553,3 +2553,59 @@ describe('--live-reads recurring wiring', () => {
     expect(data._cache_hit).toBe(false);
   });
 });
+
+// ============================================
+// --live-reads networth wiring tests
+// ============================================
+
+describe('--live-reads networth wiring', () => {
+  test('handleListTools when --live-reads is OFF excludes get_networth_live', () => {
+    const server = new CopilotMoneyServer(FAKE_DB_DIR);
+    const { tools } = server.handleListTools();
+    const names = tools.map((t) => t.name);
+    expect(names).not.toContain('get_networth_live');
+  });
+
+  test('handleListTools when --live-reads is ON includes get_networth_live', () => {
+    const mockClient = createMockGraphQLClient({});
+    const server = new CopilotMoneyServer(FAKE_DB_DIR, undefined, false, true, mockClient);
+    const { tools } = server.handleListTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('get_networth_live');
+  });
+
+  test('get_networth_live without --live-reads returns isError with --live-reads hint', async () => {
+    const server = new CopilotMoneyServer(FAKE_DB_DIR);
+    const db = createMockDb();
+    server._injectForTesting(db, new CopilotMoneyTools(db));
+
+    const result = await server.handleCallTool('get_networth_live', {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('--live-reads');
+  });
+
+  test('get_networth_live with --live-reads dispatches to liveNetworthTools.getNetworth', async () => {
+    const mockClient = createMockGraphQLClient({});
+    const server = new CopilotMoneyServer(FAKE_DB_DIR, undefined, false, true, mockClient);
+    const db = createMockDb();
+    server._injectForTesting(db, new CopilotMoneyTools(db));
+
+    const stubResult = {
+      count: 1,
+      networth_history: [{ date: '2026-01-01', assets: '100000', debt: '5000' }],
+      _cache_oldest_fetched_at: '2025-01-01T00:00:00.000Z',
+      _cache_newest_fetched_at: '2025-01-01T00:00:00.000Z',
+      _cache_hit: false,
+    };
+    (server as any).liveNetworthTools = {
+      getNetworth: async (_args: unknown) => stubResult,
+    };
+
+    const result = await server.handleCallTool('get_networth_live', {});
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text) as typeof stubResult;
+    expect(data.count).toBe(1);
+    expect(data.networth_history[0]?.date).toBe('2026-01-01');
+    expect(data._cache_hit).toBe(false);
+  });
+});

--- a/tests/tools/live/networth.test.ts
+++ b/tests/tools/live/networth.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../src/core/graphql/client.js';
+import { CopilotDatabase } from '../../../src/core/database.js';
+import { LiveCopilotDatabase } from '../../../src/core/live-database.js';
+import { LiveNetworthTools } from '../../../src/tools/live/networth.js';
+
+function makeClient(rows: unknown[]): GraphQLClient {
+  return {
+    query: mock(() => Promise.resolve({ networthHistory: rows })),
+  } as unknown as GraphQLClient;
+}
+
+function makeLive(client: GraphQLClient): LiveCopilotDatabase {
+  return new LiveCopilotDatabase(client, new CopilotDatabase('/tmp/no-such-db'));
+}
+
+const sampleRow = { date: '2026-01-01', assets: '100000', debt: '5000' };
+
+describe('LiveNetworthTools.getNetworth', () => {
+  test('cold call: fetches and returns rows with cache_hit=false', async () => {
+    const client = makeClient([sampleRow]);
+    const tools = new LiveNetworthTools(makeLive(client));
+
+    const result = await tools.getNetworth({});
+
+    expect(result.count).toBe(1);
+    expect(result.networth_history[0]?.date).toBe('2026-01-01');
+    expect(result.networth_history[0]?.assets).toBe('100000');
+    expect(result.networth_history[0]?.debt).toBe('5000');
+    expect(result._cache_hit).toBe(false);
+    expect(typeof result._cache_oldest_fetched_at).toBe('string');
+    expect(typeof result._cache_newest_fetched_at).toBe('string');
+  });
+
+  test('warm call with same timeFrame: cache hit, no second fetch', async () => {
+    const client = makeClient([sampleRow]);
+    const tools = new LiveNetworthTools(makeLive(client));
+
+    await tools.getNetworth({});
+    const second = await tools.getNetworth({});
+
+    expect(second._cache_hit).toBe(true);
+    expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  test('empty result returns count 0, no throw', async () => {
+    const client = makeClient([]);
+    const tools = new LiveNetworthTools(makeLive(client));
+
+    const result = await tools.getNetworth({});
+
+    expect(result.count).toBe(0);
+    expect(result.networth_history).toEqual([]);
+  });
+
+  test('output sorted oldest→newest by date', async () => {
+    const client = makeClient([
+      { date: '2026-03-01', assets: '300', debt: '30' },
+      { date: '2026-01-01', assets: '100', debt: '10' },
+      { date: '2026-02-01', assets: '200', debt: '20' },
+    ]);
+    const tools = new LiveNetworthTools(makeLive(client));
+
+    const result = await tools.getNetworth({});
+
+    expect(result.networth_history.map((n) => n.date)).toEqual([
+      '2026-01-01',
+      '2026-02-01',
+      '2026-03-01',
+    ]);
+  });
+
+  test('default timeFrame is "ALL" when not provided', async () => {
+    const client = makeClient([]);
+    const tools = new LiveNetworthTools(makeLive(client));
+
+    await tools.getNetworth({});
+
+    expect(client.query).toHaveBeenCalledWith('Networth', expect.any(String), {
+      timeFrame: 'ALL',
+    });
+  });
+
+  test('passes through caller-supplied timeFrame', async () => {
+    const client = makeClient([]);
+    const tools = new LiveNetworthTools(makeLive(client));
+
+    await tools.getNetworth({ time_frame: 'YEAR' });
+
+    expect(client.query).toHaveBeenCalledWith('Networth', expect.any(String), {
+      timeFrame: 'YEAR',
+    });
+  });
+
+  test('different timeFrame triggers a fresh fetch (cache invalidated)', async () => {
+    const client = makeClient([sampleRow]);
+    const tools = new LiveNetworthTools(makeLive(client));
+
+    await tools.getNetworth({ time_frame: 'ALL' });
+    const second = await tools.getNetworth({ time_frame: 'YEAR' });
+
+    expect(client.query).toHaveBeenCalledTimes(2);
+    expect(second._cache_hit).toBe(false);
+  });
+
+  test('preserves null assets/debt in passthrough (early dates)', async () => {
+    const client = makeClient([{ date: '2022-09-13', assets: null, debt: '500' }]);
+    const tools = new LiveNetworthTools(makeLive(client));
+
+    const result = await tools.getNetworth({});
+
+    expect(result.networth_history[0]?.assets).toBeNull();
+    expect(result.networth_history[0]?.debt).toBe('500');
+  });
+});
+
+describe('createLiveNetworthToolSchema', () => {
+  test('returns a schema with readOnlyHint=true and time_frame arg', async () => {
+    const { createLiveNetworthToolSchema } = await import(
+      '../../../src/tools/live/networth.js'
+    );
+    const schema = createLiveNetworthToolSchema();
+    expect(schema.name).toBe('get_networth_live');
+    expect(schema.annotations?.readOnlyHint).toBe(true);
+    expect(schema.inputSchema.properties).toHaveProperty('time_frame');
+  });
+});

--- a/tests/tools/live/networth.test.ts
+++ b/tests/tools/live/networth.test.ts
@@ -116,9 +116,7 @@ describe('LiveNetworthTools.getNetworth', () => {
 
 describe('createLiveNetworthToolSchema', () => {
   test('returns a schema with readOnlyHint=true and time_frame arg', async () => {
-    const { createLiveNetworthToolSchema } = await import(
-      '../../../src/tools/live/networth.js'
-    );
+    const { createLiveNetworthToolSchema } = await import('../../../src/tools/live/networth.js');
     const schema = createLiveNetworthToolSchema();
     expect(schema.name).toBe('get_networth_live');
     expect(schema.annotations?.readOnlyHint).toBe(true);

--- a/tests/tools/live/refresh-cache.test.ts
+++ b/tests/tools/live/refresh-cache.test.ts
@@ -17,6 +17,7 @@ function makeMockLive(): {
     tags: ReturnType<typeof makeInvalidateCache>;
     recurring: ReturnType<typeof makeInvalidateCache>;
     user: ReturnType<typeof makeInvalidateCache>;
+    networth: ReturnType<typeof makeInvalidateCache>;
     transactions: { invalidate: ReturnType<typeof mock> };
   };
 } {
@@ -25,6 +26,7 @@ function makeMockLive(): {
   const tags = makeInvalidateCache();
   const recurring = makeInvalidateCache();
   const user = makeInvalidateCache();
+  const networth = makeInvalidateCache();
   const transactions = { invalidate: mock((_arg: string[] | 'all') => {}) };
 
   const live = {
@@ -33,10 +35,14 @@ function makeMockLive(): {
     getTagsCache: mock(() => tags),
     getRecurringCache: mock(() => recurring),
     getUserCache: mock(() => user),
+    getNetworthCache: mock(() => networth),
     getTransactionsWindowCache: mock(() => transactions),
   } as unknown as LiveCopilotDatabase;
 
-  return { live, mocks: { accounts, categories, tags, recurring, user, transactions } };
+  return {
+    live,
+    mocks: { accounts, categories, tags, recurring, user, networth, transactions },
+  };
 }
 
 describe('RefreshCacheTool — scope: all', () => {
@@ -51,6 +57,7 @@ describe('RefreshCacheTool — scope: all', () => {
     expect(mocks.tags.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.recurring.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.user.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.networth.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.transactions.invalidate).toHaveBeenCalledTimes(1);
     expect(result.flushed.accounts).toBe(true);
     expect(result.flushed.categories).toBe(true);
@@ -58,6 +65,7 @@ describe('RefreshCacheTool — scope: all', () => {
     expect(result.flushed.budgets).toBe(true);
     expect(result.flushed.recurring).toBe(true);
     expect(result.flushed.user).toBe(true);
+    expect(result.flushed.networth).toBe(true);
     expect(result.flushed.transactions_months).toBe('all');
   });
 
@@ -139,6 +147,20 @@ describe('RefreshCacheTool — scope: tags', () => {
     expect(mocks.tags.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.categories.invalidate).not.toHaveBeenCalled();
     expect(result.flushed.tags).toBe(true);
+  });
+});
+
+describe('RefreshCacheTool — scope: networth', () => {
+  test('invalidates only networthCache', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'networth' });
+
+    expect(mocks.networth.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.categories.invalidate).not.toHaveBeenCalled();
+    expect(mocks.accounts.invalidate).not.toHaveBeenCalled();
+    expect(result.flushed.networth).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a new live-mode MCP tool `get_networth_live` that wraps Copilot's `Networth` GraphQL query and returns net-worth-over-time history.

- New `fetchNetworthHistory(client, { timeFrame })` GraphQL wrapper in `src/core/graphql/queries/networth.ts`. Returns `NetworthHistoryNode[]` with `{ date, assets, debt }` (the upstream `total` field is `@client` and stripped by the operations generator; consumers compute `assets - debt` per row instead).
- New `networthCache: SnapshotCache<NetworthHistoryNode>` on `LiveCopilotDatabase` with a 1h TTL (net worth changes daily; 24h was too stale for some use cases).
- New `LiveNetworthTools` class + `createLiveNetworthToolSchema()` in `src/tools/live/networth.ts`. Result envelope mirrors the other live tools (`count`, `networth_history`, `_cache_oldest_fetched_at`, `_cache_newest_fetched_at`, `_cache_hit`). Output is sorted oldest -> newest by date.
- Optional `time_frame` arg (default `"ALL"`); other server-supported values likely include `"YEAR"` and `"MONTH"`. Validation is left to the server. Cache holds the most-recently-requested `time_frame`; requesting a different value invalidates the cache and triggers a fresh fetch (the 1h TTL still applies to the most-recently-requested `time_frame`).
- Wired into `src/server.ts` (`get_networth_live` switch case + availability guard + live-tool list).
- Added `'networth'` to `refresh_cache` `VALID_SCOPES` and the `flushed.networth` flag; `scope: 'all'` now also flushes `networthCache`.

## Test plan

- [x] `bun test tests/core/graphql/queries/networth.test.ts` -- 4 tests (returns rows, passes timeFrame, empty response, nullable assets/debt)
- [x] `bun test tests/tools/live/networth.test.ts` -- 9 tests (cold/warm cache, sort, empty, default `time_frame`, custom `time_frame`, time_frame change invalidates cache, nullable passthrough, schema shape)
- [x] `bun test tests/core/live-database.test.ts` -- 47 tests (added `getNetworthCache` accessor + same-instance assertions)
- [x] `bun test tests/tools/live/refresh-cache.test.ts` -- 19 tests (added `scope: 'networth'` test + extended `scope: 'all'` to assert networth gets flushed)
- [x] `bun test tests/e2e/server.test.ts -t "networth wiring"` -- 4 tests (list-tools includes/excludes, error without `--live-reads`, dispatches to `liveNetworthTools.getNetworth`)
- [x] `bun run check` -- 1841 pass / 0 fail across 87 files

Live verification was skipped per the implementation plan (the running MCP host is on pre-merge code; the new tool will be testable end-to-end after merge + restart).