### PR TITLE
feat(live): add get_upcoming_recurrings_live

### DIFF
--- a/src/core/graphql/queries/upcoming-recurrings.ts
+++ b/src/core/graphql/queries/upcoming-recurrings.ts
@@ -1,0 +1,44 @@
+/**
+ * GraphQL query wrapper for UpcomingRecurrings.
+ *
+ * Returns the next-due recurring/subscription items ("about to bill" view).
+ * Distinct from `fetchRecurrings`, which returns the full configured set
+ * (historical view). The captured query takes no variables and returns
+ * `unpaidUpcomingRecurrings: Recurring[]` shaped exactly like `Recurrings`
+ * (RecurringFields + rule + payments). The `category @client` block is
+ * stripped by the operations generator. The `payments @connection(key:
+ * "upcoming")` directive is preserved by design — server tolerates it,
+ * affects only Apollo's local cache.
+ *
+ * The node shape is structurally identical to `RecurringNode`. We re-export
+ * a distinct alias (`UpcomingRecurringNode`) so consumers that distinguish
+ * the two views can import the matching type.
+ */
+
+import type { GraphQLClient } from '../client.js';
+import { UPCOMING_RECURRINGS } from '../operations.generated.js';
+import type {
+  RecurringIcon,
+  RecurringNode,
+  RecurringPaymentNode,
+  RecurringRuleNode,
+} from './recurrings.js';
+
+export type { RecurringIcon, RecurringPaymentNode, RecurringRuleNode };
+
+export type UpcomingRecurringNode = RecurringNode;
+
+interface UpcomingRecurringsResponse {
+  unpaidUpcomingRecurrings: UpcomingRecurringNode[];
+}
+
+export async function fetchUpcomingRecurrings(
+  client: GraphQLClient
+): Promise<UpcomingRecurringNode[]> {
+  const data = await client.query<Record<string, never>, UpcomingRecurringsResponse>(
+    'UpcomingRecurrings',
+    UPCOMING_RECURRINGS,
+    {}
+  );
+  return data.unpaidUpcomingRecurrings;
+}

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -36,7 +36,11 @@ import type { AccountNode } from './graphql/queries/accounts.js';
 import type { CategoryNode } from './graphql/queries/categories.js';
 import type { TagNode } from './graphql/queries/tags.js';
 import type { RecurringNode } from './graphql/queries/recurrings.js';
+<<<<<<< HEAD
 import type { NetworthHistoryNode } from './graphql/queries/networth.js';
+=======
+import type { UpcomingRecurringNode } from './graphql/queries/upcoming-recurrings.js';
+>>>>>>> f59958b (feat(live-db): add upcomingRecurringsCache (1h TTL))
 import { fetchUser, type UserNode } from './graphql/queries/user.js';
 import type { Transaction } from '../models/index.js';
 
@@ -68,6 +72,11 @@ export class LiveCopilotDatabase {
   private readonly categoriesCache: SnapshotCache<CategoryNode>;
   private readonly tagsCache: SnapshotCache<TagNode>;
   private readonly recurringCache: SnapshotCache<RecurringNode>;
+  // upcomingRecurringsCache holds the "about-to-bill" view (next-due
+  // unpaid items). Distinct from recurringCache (configured/historical
+  // view). Short 1h TTL because items move out of this view as bills get
+  // paid throughout the day.
+  private readonly upcomingRecurringsCache: SnapshotCache<UpcomingRecurringNode>;
   // userCache always holds at most one row — the current user — but we use the
   // SnapshotCache primitive uniformly with the rest of the entities so the
   // refresh-cache and TTL machinery works without a special case. `keyFn` keys
@@ -103,6 +112,10 @@ export class LiveCopilotDatabase {
     );
     this.recurringCache = new SnapshotCache<RecurringNode>(
       { key: 'recurring', ttlMs: SIX_HOURS_MS, keyFn: (r) => r.id },
+      this.inflight
+    );
+    this.upcomingRecurringsCache = new SnapshotCache<UpcomingRecurringNode>(
+      { key: 'upcoming_recurrings', ttlMs: ONE_HOUR_MS, keyFn: (r) => r.id },
       this.inflight
     );
     this.userCache = new SnapshotCache<UserNode>(
@@ -341,6 +354,10 @@ export class LiveCopilotDatabase {
 
   getRecurringCache(): SnapshotCache<RecurringNode> {
     return this.recurringCache;
+  }
+
+  getUpcomingRecurringsCache(): SnapshotCache<UpcomingRecurringNode> {
+    return this.upcomingRecurringsCache;
   }
 
   getUserCache(): SnapshotCache<UserNode> {

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -36,11 +36,8 @@ import type { AccountNode } from './graphql/queries/accounts.js';
 import type { CategoryNode } from './graphql/queries/categories.js';
 import type { TagNode } from './graphql/queries/tags.js';
 import type { RecurringNode } from './graphql/queries/recurrings.js';
-<<<<<<< HEAD
 import type { NetworthHistoryNode } from './graphql/queries/networth.js';
-=======
 import type { UpcomingRecurringNode } from './graphql/queries/upcoming-recurrings.js';
->>>>>>> f59958b (feat(live-db): add upcomingRecurringsCache (1h TTL))
 import { fetchUser, type UserNode } from './graphql/queries/user.js';
 import type { Transaction } from '../models/index.js';
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,6 +25,10 @@ import { LiveTagsTools, createLiveTagsToolSchema } from './tools/live/tags.js';
 import { LiveBudgetsTools, createLiveBudgetsToolSchema } from './tools/live/budgets.js';
 import { LiveRecurringTools, createLiveRecurringToolSchema } from './tools/live/recurring.js';
 import { LiveNetworthTools, createLiveNetworthToolSchema } from './tools/live/networth.js';
+import {
+  LiveUpcomingRecurringsTools,
+  createLiveUpcomingRecurringsToolSchema,
+} from './tools/live/upcoming-recurrings.js';
 import { RefreshCacheTool, createRefreshCacheToolSchema } from './tools/live/refresh-cache.js';
 
 // Read version from package.json
@@ -48,6 +52,7 @@ export class CopilotMoneyServer {
   private liveBudgetsTools?: LiveBudgetsTools;
   private liveRecurringTools?: LiveRecurringTools;
   private liveNetworthTools?: LiveNetworthTools;
+  private liveUpcomingRecurringsTools?: LiveUpcomingRecurringsTools;
   private refreshCacheTool?: RefreshCacheTool;
 
   /**
@@ -85,6 +90,7 @@ export class CopilotMoneyServer {
       this.liveBudgetsTools = new LiveBudgetsTools(liveDb);
       this.liveRecurringTools = new LiveRecurringTools(liveDb);
       this.liveNetworthTools = new LiveNetworthTools(liveDb);
+      this.liveUpcomingRecurringsTools = new LiveUpcomingRecurringsTools(liveDb);
       this.refreshCacheTool = new RefreshCacheTool(liveDb);
     }
 
@@ -129,6 +135,7 @@ export class CopilotMoneyServer {
           createLiveBudgetsToolSchema(),
           createLiveRecurringToolSchema(),
           createLiveNetworthToolSchema(),
+          createLiveUpcomingRecurringsToolSchema(),
           createRefreshCacheToolSchema(),
         ]
       : [];
@@ -275,6 +282,18 @@ export class CopilotMoneyServer {
       };
     }
 
+    if (name === 'get_upcoming_recurrings_live' && !this.liveUpcomingRecurringsTools) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'get_upcoming_recurrings_live is only available when the server runs with --live-reads.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
     if (name === 'refresh_cache' && !this.refreshCacheTool) {
       return {
         content: [
@@ -363,6 +382,15 @@ export class CopilotMoneyServer {
           result = await this.liveNetworthTools!.getNetworth(
             (typedArgs as Parameters<
               NonNullable<typeof this.liveNetworthTools>['getNetworth']
+            >[0]) ?? {}
+          );
+          break;
+
+        case 'get_upcoming_recurrings_live':
+          // liveUpcomingRecurringsTools non-null invariant enforced by the early guard above.
+          result = await this.liveUpcomingRecurringsTools!.getUpcomingRecurrings(
+            (typedArgs as Parameters<
+              NonNullable<typeof this.liveUpcomingRecurringsTools>['getUpcomingRecurrings']
             >[0]) ?? {}
           );
           break;

--- a/src/tools/live/refresh-cache.ts
+++ b/src/tools/live/refresh-cache.ts
@@ -18,6 +18,7 @@ const VALID_SCOPES = [
   'tags',
   'budgets',
   'recurring',
+  'upcoming_recurrings',
   'user',
   'networth',
 ] as const;
@@ -38,6 +39,7 @@ export interface RefreshCacheResult {
     tags?: boolean;
     budgets?: boolean;
     recurring?: boolean;
+    upcoming_recurrings?: boolean;
     user?: boolean;
     networth?: boolean;
     transactions_months?: string[] | 'all';
@@ -78,6 +80,8 @@ export class RefreshCacheTool {
       flushed.budgets = true;
       this.live.getRecurringCache().invalidate();
       flushed.recurring = true;
+      this.live.getUpcomingRecurringsCache().invalidate();
+      flushed.upcoming_recurrings = true;
       this.live.getUserCache().invalidate();
       flushed.user = true;
       this.live.getNetworthCache().invalidate();
@@ -119,6 +123,10 @@ export class RefreshCacheTool {
       case 'recurring':
         this.live.getRecurringCache().invalidate();
         flushed.recurring = true;
+        break;
+      case 'upcoming_recurrings':
+        this.live.getUpcomingRecurringsCache().invalidate();
+        flushed.upcoming_recurrings = true;
         break;
       case 'user':
         // Cascade: user settings only affect category queries (resolveRolloversFlag

--- a/src/tools/live/upcoming-recurrings.ts
+++ b/src/tools/live/upcoming-recurrings.ts
@@ -1,0 +1,120 @@
+/**
+ * Live-mode get_upcoming_recurrings_live tool.
+ *
+ * Fetches the next-due recurring/subscription items ("about to bill" view)
+ * via the GraphQL UpcomingRecurrings query through a SnapshotCache with a
+ * 1h TTL. Items move out of this view as bills get paid throughout the day,
+ * so the TTL is intentionally shorter than the configured/historical
+ * recurringCache (6h).
+ *
+ * This is distinct from get_recurring_live, which exposes the full set of
+ * user-confirmed recurrings (configured/historical view). Use this tool to
+ * answer "what's about to bill", and use get_recurring_live to answer
+ * "what subscriptions do I have".
+ */
+
+import type { LiveCopilotDatabase } from '../../core/live-database.js';
+import {
+  fetchUpcomingRecurrings,
+  type UpcomingRecurringNode,
+} from '../../core/graphql/queries/upcoming-recurrings.js';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface GetUpcomingRecurringsLiveArgs {
+  // No filters yet; reserved for future args.
+}
+
+export interface GetUpcomingRecurringsLiveRow extends UpcomingRecurringNode {
+  /**
+   * Joined from `categoriesCache.peek()` by `categoryId`. `null` if the
+   * categories cache is cold (no fetch is triggered to populate it) or
+   * if the category for this row's `categoryId` was not found
+   * (e.g., deleted upstream). Mirrors `get_recurring_live`'s same join.
+   */
+  category_name: string | null;
+}
+
+export interface GetUpcomingRecurringsLiveResult {
+  count: number;
+  upcoming: GetUpcomingRecurringsLiveRow[];
+  _cache_oldest_fetched_at: string;
+  _cache_newest_fetched_at: string;
+  _cache_hit: boolean;
+}
+
+export class LiveUpcomingRecurringsTools {
+  constructor(private readonly live: LiveCopilotDatabase) {}
+
+  async getUpcomingRecurrings(
+    _args: GetUpcomingRecurringsLiveArgs
+  ): Promise<GetUpcomingRecurringsLiveResult> {
+    const cache = this.live.getUpcomingRecurringsCache();
+    const startedAt = Date.now();
+    const {
+      rows: cached,
+      fetched_at,
+      hit,
+    } = await cache.read(() => fetchUpcomingRecurrings(this.live.getClient()));
+
+    const cachedCategories = this.live.getCategoriesCache().peek();
+    const categoryNameById = new Map<string, string>();
+    if (cachedCategories) {
+      for (const cat of cachedCategories) {
+        categoryNameById.set(cat.id, cat.name);
+      }
+    }
+
+    const rows: GetUpcomingRecurringsLiveRow[] = cached
+      .map((r) => ({
+        ...r,
+        category_name: r.categoryId ? (categoryNameById.get(r.categoryId) ?? null) : null,
+      }))
+      .sort((a, b) => {
+        // Soonest-due first; rows with null nextPaymentDate sort to the end.
+        if (a.nextPaymentDate === null && b.nextPaymentDate === null) return 0;
+        if (a.nextPaymentDate === null) return 1;
+        if (b.nextPaymentDate === null) return -1;
+        return a.nextPaymentDate.localeCompare(b.nextPaymentDate);
+      });
+
+    this.live.logReadCall({
+      op: 'UpcomingRecurrings',
+      pages: hit ? 0 : 1,
+      latencyMs: Date.now() - startedAt,
+      rows: rows.length,
+      cache_hit: hit,
+    });
+
+    const fetchedAtIso = new Date(fetched_at).toISOString();
+    return {
+      count: rows.length,
+      upcoming: rows,
+      _cache_oldest_fetched_at: fetchedAtIso,
+      _cache_newest_fetched_at: fetchedAtIso,
+      _cache_hit: hit,
+    };
+  }
+}
+
+export function createLiveUpcomingRecurringsToolSchema() {
+  return {
+    name: 'get_upcoming_recurrings_live',
+    description:
+      'Get the next-due recurring/subscription items — the "about to bill" view ' +
+      '(live, GraphQL-backed). Returns unpaid upcoming payments sorted by due date ' +
+      '(soonest first). DISTINCT from `get_recurring_live`, which returns the ' +
+      'full set of configured/historical recurrings; use this tool when the user ' +
+      'asks "what\'s coming up" or "what bills am I about to pay". ' +
+      'Each row carries a `category_name` field joined from the categories cache; ' +
+      '`null` if the cache is cold or the category was deleted upstream. ' +
+      'To guarantee `category_name` is populated, call `get_categories_live` first ' +
+      'in the same session to warm the cache.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {},
+    },
+    annotations: {
+      readOnlyHint: true,
+    },
+  };
+}

--- a/tests/core/graphql/queries/upcoming-recurrings.test.ts
+++ b/tests/core/graphql/queries/upcoming-recurrings.test.ts
@@ -38,9 +38,8 @@ describe('fetchUpcomingRecurrings', () => {
       ),
     } as unknown as GraphQLClient;
 
-    const { fetchUpcomingRecurrings } = await import(
-      '../../../../src/core/graphql/queries/upcoming-recurrings.js'
-    );
+    const { fetchUpcomingRecurrings } =
+      await import('../../../../src/core/graphql/queries/upcoming-recurrings.js');
     const rows = await fetchUpcomingRecurrings(client);
 
     expect(rows).toHaveLength(2);
@@ -55,9 +54,8 @@ describe('fetchUpcomingRecurrings', () => {
       query: mock(() => Promise.resolve({ unpaidUpcomingRecurrings: [] })),
     } as unknown as GraphQLClient;
 
-    const { fetchUpcomingRecurrings } = await import(
-      '../../../../src/core/graphql/queries/upcoming-recurrings.js'
-    );
+    const { fetchUpcomingRecurrings } =
+      await import('../../../../src/core/graphql/queries/upcoming-recurrings.js');
     await fetchUpcomingRecurrings(client);
 
     expect(client.query).toHaveBeenCalledWith('UpcomingRecurrings', expect.any(String), {});
@@ -68,9 +66,8 @@ describe('fetchUpcomingRecurrings', () => {
       query: mock(() => Promise.resolve({ unpaidUpcomingRecurrings: [] })),
     } as unknown as GraphQLClient;
 
-    const { fetchUpcomingRecurrings } = await import(
-      '../../../../src/core/graphql/queries/upcoming-recurrings.js'
-    );
+    const { fetchUpcomingRecurrings } =
+      await import('../../../../src/core/graphql/queries/upcoming-recurrings.js');
     const rows = await fetchUpcomingRecurrings(client);
     expect(rows).toEqual([]);
   });

--- a/tests/core/graphql/queries/upcoming-recurrings.test.ts
+++ b/tests/core/graphql/queries/upcoming-recurrings.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../../src/core/graphql/client.js';
+
+describe('fetchUpcomingRecurrings', () => {
+  test('returns the unpaidUpcomingRecurrings list as-is from the GraphQL response', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          unpaidUpcomingRecurrings: [
+            {
+              id: 'r1',
+              name: 'Subscription A',
+              state: 'ACTIVE',
+              frequency: 'MONTHLY',
+              nextPaymentAmount: 100,
+              nextPaymentDate: '2026-05-10',
+              categoryId: 'cat-1',
+              emoji: 'A',
+              icon: { __typename: 'EmojiUnicode', unicode: 'A' },
+              rule: { nameContains: 'A', minAmount: 99, maxAmount: 101, days: [10] },
+              payments: [{ amount: 100, isPaid: false, date: '2026-05-10' }],
+            },
+            {
+              id: 'r2',
+              name: 'Subscription B',
+              state: 'ACTIVE',
+              frequency: 'MONTHLY',
+              nextPaymentAmount: 200,
+              nextPaymentDate: '2026-05-15',
+              categoryId: 'cat-2',
+              emoji: 'B',
+              icon: { __typename: 'EmojiUnicode', unicode: 'B' },
+              rule: null,
+              payments: [],
+            },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchUpcomingRecurrings } = await import(
+      '../../../../src/core/graphql/queries/upcoming-recurrings.js'
+    );
+    const rows = await fetchUpcomingRecurrings(client);
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.id)).toEqual(['r1', 'r2']);
+    expect(rows[0]?.nextPaymentDate).toBe('2026-05-10');
+    expect(rows[0]?.rule?.nameContains).toBe('A');
+    expect(rows[1]?.rule).toBeNull();
+  });
+
+  test('calls UpcomingRecurrings operation with no variables', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ unpaidUpcomingRecurrings: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchUpcomingRecurrings } = await import(
+      '../../../../src/core/graphql/queries/upcoming-recurrings.js'
+    );
+    await fetchUpcomingRecurrings(client);
+
+    expect(client.query).toHaveBeenCalledWith('UpcomingRecurrings', expect.any(String), {});
+  });
+
+  test('handles empty response without throwing', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ unpaidUpcomingRecurrings: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchUpcomingRecurrings } = await import(
+      '../../../../src/core/graphql/queries/upcoming-recurrings.js'
+    );
+    const rows = await fetchUpcomingRecurrings(client);
+    expect(rows).toEqual([]);
+  });
+});

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -352,6 +352,46 @@ describe('LiveCopilotDatabase — cache accessors', () => {
     expect(mkLive().getRecurringCache()).toBeInstanceOf(SnapshotCache);
   });
 
+  test('getUpcomingRecurringsCache returns a SnapshotCache instance', () => {
+    expect(mkLive().getUpcomingRecurringsCache()).toBeInstanceOf(SnapshotCache);
+  });
+
+  test('getUpcomingRecurringsCache returns the same instance across calls', () => {
+    const live = mkLive();
+    expect(live.getUpcomingRecurringsCache()).toBe(live.getUpcomingRecurringsCache());
+  });
+
+  test('upcomingRecurringsCache stores UpcomingRecurringNode shape and serves cached reads', async () => {
+    const live = mkLive();
+    const cache = live.getUpcomingRecurringsCache();
+    const fetcher = mock(() =>
+      Promise.resolve([
+        {
+          id: 'r1',
+          name: 'Subscription A',
+          state: 'ACTIVE',
+          frequency: 'MONTHLY',
+          nextPaymentAmount: 100,
+          nextPaymentDate: '2026-05-10',
+          categoryId: 'cat-1',
+          emoji: 'A',
+          icon: { __typename: 'EmojiUnicode' as const, unicode: 'A' },
+          rule: null,
+          payments: [{ amount: 100, isPaid: false, date: '2026-05-10' }],
+        },
+      ])
+    );
+
+    const first = await cache.read(fetcher);
+    const second = await cache.read(fetcher);
+
+    expect(first.rows[0]?.id).toBe('r1');
+    expect(first.hit).toBe(false);
+    expect(second.hit).toBe(true);
+    // Loader runs only on cold; second call hits cache (1h TTL).
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
   test('getTransactionsWindowCache returns a TransactionWindowCache instance', () => {
     expect(mkLive().getTransactionsWindowCache()).toBeInstanceOf(TransactionWindowCache);
   });

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -2609,3 +2609,76 @@ describe('--live-reads networth wiring', () => {
     expect(data._cache_hit).toBe(false);
   });
 });
+
+// ============================================
+// --live-reads upcoming-recurrings wiring tests
+// ============================================
+
+describe('--live-reads upcoming-recurrings wiring', () => {
+  test('handleListTools when --live-reads is OFF excludes get_upcoming_recurrings_live', () => {
+    const server = new CopilotMoneyServer(FAKE_DB_DIR);
+    const { tools } = server.handleListTools();
+    const names = tools.map((t) => t.name);
+    expect(names).not.toContain('get_upcoming_recurrings_live');
+  });
+
+  test('handleListTools when --live-reads is ON includes get_upcoming_recurrings_live', () => {
+    const mockClient = createMockGraphQLClient({});
+    const server = new CopilotMoneyServer(FAKE_DB_DIR, undefined, false, true, mockClient);
+    const { tools } = server.handleListTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('get_upcoming_recurrings_live');
+    // Sibling tool stays present (this is a net-new tool, not a swap)
+    expect(names).toContain('get_recurring_live');
+  });
+
+  test('get_upcoming_recurrings_live without --live-reads returns isError with --live-reads hint', async () => {
+    const server = new CopilotMoneyServer(FAKE_DB_DIR);
+    const db = createMockDb();
+    server._injectForTesting(db, new CopilotMoneyTools(db));
+
+    const result = await server.handleCallTool('get_upcoming_recurrings_live', {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('--live-reads');
+  });
+
+  test('get_upcoming_recurrings_live with --live-reads dispatches to liveUpcomingRecurringsTools.getUpcomingRecurrings', async () => {
+    const mockClient = createMockGraphQLClient({});
+    const server = new CopilotMoneyServer(FAKE_DB_DIR, undefined, false, true, mockClient);
+    const db = createMockDb();
+    server._injectForTesting(db, new CopilotMoneyTools(db));
+
+    const stubResult = {
+      count: 1,
+      upcoming: [
+        {
+          id: 'r1',
+          name: 'Subscription A',
+          state: 'ACTIVE',
+          frequency: 'MONTHLY',
+          nextPaymentAmount: 100,
+          nextPaymentDate: '2026-05-10',
+          categoryId: 'cat-1',
+          emoji: 'A',
+          icon: { __typename: 'EmojiUnicode', unicode: 'A' },
+          rule: null,
+          payments: [{ amount: 100, isPaid: false, date: '2026-05-10' }],
+          category_name: null,
+        },
+      ],
+      _cache_oldest_fetched_at: '2025-01-01T00:00:00.000Z',
+      _cache_newest_fetched_at: '2025-01-01T00:00:00.000Z',
+      _cache_hit: false,
+    };
+    (server as any).liveUpcomingRecurringsTools = {
+      getUpcomingRecurrings: async (_args: unknown) => stubResult,
+    };
+
+    const result = await server.handleCallTool('get_upcoming_recurrings_live', {});
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text) as typeof stubResult;
+    expect(data.count).toBe(1);
+    expect(data.upcoming[0]?.name).toBe('Subscription A');
+    expect(data._cache_hit).toBe(false);
+  });
+});

--- a/tests/tools/live/refresh-cache.test.ts
+++ b/tests/tools/live/refresh-cache.test.ts
@@ -44,7 +44,16 @@ function makeMockLive(): {
 
   return {
     live,
-    mocks: { accounts, categories, tags, recurring, upcomingRecurrings, user, networth, transactions },
+    mocks: {
+      accounts,
+      categories,
+      tags,
+      recurring,
+      upcomingRecurrings,
+      user,
+      networth,
+      transactions,
+    },
   };
 }
 

--- a/tests/tools/live/refresh-cache.test.ts
+++ b/tests/tools/live/refresh-cache.test.ts
@@ -16,6 +16,7 @@ function makeMockLive(): {
     categories: ReturnType<typeof makeInvalidateCache>;
     tags: ReturnType<typeof makeInvalidateCache>;
     recurring: ReturnType<typeof makeInvalidateCache>;
+    upcomingRecurrings: ReturnType<typeof makeInvalidateCache>;
     user: ReturnType<typeof makeInvalidateCache>;
     networth: ReturnType<typeof makeInvalidateCache>;
     transactions: { invalidate: ReturnType<typeof mock> };
@@ -25,6 +26,7 @@ function makeMockLive(): {
   const categories = makeInvalidateCache();
   const tags = makeInvalidateCache();
   const recurring = makeInvalidateCache();
+  const upcomingRecurrings = makeInvalidateCache();
   const user = makeInvalidateCache();
   const networth = makeInvalidateCache();
   const transactions = { invalidate: mock((_arg: string[] | 'all') => {}) };
@@ -34,6 +36,7 @@ function makeMockLive(): {
     getCategoriesCache: mock(() => categories),
     getTagsCache: mock(() => tags),
     getRecurringCache: mock(() => recurring),
+    getUpcomingRecurringsCache: mock(() => upcomingRecurrings),
     getUserCache: mock(() => user),
     getNetworthCache: mock(() => networth),
     getTransactionsWindowCache: mock(() => transactions),
@@ -41,7 +44,7 @@ function makeMockLive(): {
 
   return {
     live,
-    mocks: { accounts, categories, tags, recurring, user, networth, transactions },
+    mocks: { accounts, categories, tags, recurring, upcomingRecurrings, user, networth, transactions },
   };
 }
 
@@ -56,6 +59,7 @@ describe('RefreshCacheTool — scope: all', () => {
     expect(mocks.categories.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.tags.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.recurring.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.upcomingRecurrings.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.user.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.networth.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.transactions.invalidate).toHaveBeenCalledTimes(1);
@@ -64,6 +68,7 @@ describe('RefreshCacheTool — scope: all', () => {
     expect(result.flushed.tags).toBe(true);
     expect(result.flushed.budgets).toBe(true);
     expect(result.flushed.recurring).toBe(true);
+    expect(result.flushed.upcoming_recurrings).toBe(true);
     expect(result.flushed.user).toBe(true);
     expect(result.flushed.networth).toBe(true);
     expect(result.flushed.transactions_months).toBe('all');
@@ -173,7 +178,22 @@ describe('RefreshCacheTool — scope: recurring', () => {
 
     expect(mocks.recurring.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.categories.invalidate).not.toHaveBeenCalled();
+    expect(mocks.upcomingRecurrings.invalidate).not.toHaveBeenCalled();
     expect(result.flushed.recurring).toBe(true);
+  });
+});
+
+describe('RefreshCacheTool — scope: upcoming_recurrings', () => {
+  test('invalidates only upcomingRecurringsCache', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'upcoming_recurrings' });
+
+    expect(mocks.upcomingRecurrings.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.recurring.invalidate).not.toHaveBeenCalled();
+    expect(mocks.categories.invalidate).not.toHaveBeenCalled();
+    expect(result.flushed.upcoming_recurrings).toBe(true);
   });
 });
 
@@ -269,6 +289,12 @@ describe('createRefreshCacheToolSchema', () => {
     const schema = createRefreshCacheToolSchema();
     const scopeProp = schema.inputSchema.properties.scope as { enum: string[] };
     expect(scopeProp.enum).toContain('user');
+  });
+
+  test('upcoming_recurrings scope is listed in enum', () => {
+    const schema = createRefreshCacheToolSchema();
+    const scopeProp = schema.inputSchema.properties.scope as { enum: string[] };
+    expect(scopeProp.enum).toContain('upcoming_recurrings');
   });
 
   test('schema description mentions budgets piggyback on categories', () => {

--- a/tests/tools/live/upcoming-recurrings.test.ts
+++ b/tests/tools/live/upcoming-recurrings.test.ts
@@ -152,6 +152,22 @@ describe('LiveUpcomingRecurringsTools.getUpcomingRecurrings', () => {
     expect(item?.category_name).toBeNull();
   });
 
+  test('category_name is null when the row has no categoryId (null categoryId)', async () => {
+    const { live } = mkLiveReturning([
+      mkUpcoming({ id: 'r1', name: 'Uncategorized', categoryId: null }),
+    ]);
+    // Warm categoriesCache so this isn't conflated with the cold-cache case.
+    await live.getCategoriesCache().read(async () => [mkCat({ id: 'cat-x', name: 'X' })]);
+
+    const { LiveUpcomingRecurringsTools } =
+      await import('../../../src/tools/live/upcoming-recurrings.js');
+    const tools = new LiveUpcomingRecurringsTools(live);
+    const result = await tools.getUpcomingRecurrings({});
+
+    const item = result.upcoming.find((r) => r.id === 'r1');
+    expect(item?.category_name).toBeNull();
+  });
+
   test('category_name is null when categoryId does not match any category', async () => {
     const { live } = mkLiveReturning([
       mkUpcoming({

--- a/tests/tools/live/upcoming-recurrings.test.ts
+++ b/tests/tools/live/upcoming-recurrings.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test, mock } from 'bun:test';
+import { LiveCopilotDatabase } from '../../../src/core/live-database.js';
+import type { GraphQLClient } from '../../../src/core/graphql/client.js';
+import type { CopilotDatabase } from '../../../src/core/database.js';
+import type { UpcomingRecurringNode } from '../../../src/core/graphql/queries/upcoming-recurrings.js';
+import type { CategoryNode } from '../../../src/core/graphql/queries/categories.js';
+
+const FAKE_DB = {} as CopilotDatabase;
+
+function mkUpcoming(
+  partial: Partial<UpcomingRecurringNode> & { id: string; name: string }
+): UpcomingRecurringNode {
+  return {
+    state: 'ACTIVE',
+    frequency: 'MONTHLY',
+    nextPaymentAmount: null,
+    nextPaymentDate: null,
+    categoryId: null,
+    emoji: null,
+    icon: null,
+    rule: null,
+    payments: [],
+    ...partial,
+  };
+}
+
+function mkCat(partial: Partial<CategoryNode> & { id: string; name: string }): CategoryNode {
+  return {
+    templateId: null,
+    colorName: null,
+    icon: null,
+    isExcluded: false,
+    isRolloverDisabled: false,
+    canBeDeleted: true,
+    budget: null,
+    ...partial,
+  };
+}
+
+function mkLiveReturning(rows: UpcomingRecurringNode[]): {
+  live: LiveCopilotDatabase;
+  client: { query: ReturnType<typeof mock> };
+} {
+  const client = {
+    query: mock(() => Promise.resolve({ unpaidUpcomingRecurrings: rows })),
+  } as unknown as GraphQLClient & { query: ReturnType<typeof mock> };
+  const live = new LiveCopilotDatabase(client, FAKE_DB);
+  return { live, client };
+}
+
+describe('LiveUpcomingRecurringsTools.getUpcomingRecurrings', () => {
+  test('cold call returns rows sorted by nextPaymentDate ascending with _cache_hit=false', async () => {
+    const { live } = mkLiveReturning([
+      mkUpcoming({ id: 'r1', name: 'Item Late', nextPaymentDate: '2026-05-20' }),
+      mkUpcoming({ id: 'r2', name: 'Item Early', nextPaymentDate: '2026-05-05' }),
+      mkUpcoming({ id: 'r3', name: 'Item Mid', nextPaymentDate: '2026-05-10' }),
+    ]);
+    const { LiveUpcomingRecurringsTools } = await import(
+      '../../../src/tools/live/upcoming-recurrings.js'
+    );
+    const tools = new LiveUpcomingRecurringsTools(live);
+
+    const result = await tools.getUpcomingRecurrings({});
+
+    expect(result.count).toBe(3);
+    expect(result.upcoming.map((r) => r.id)).toEqual(['r2', 'r3', 'r1']);
+    expect(result._cache_hit).toBe(false);
+  });
+
+  test('warm call returns _cache_hit=true and does not re-query', async () => {
+    const { live, client } = mkLiveReturning([
+      mkUpcoming({ id: 'r1', name: 'Item', nextPaymentDate: '2026-05-10' }),
+    ]);
+    const { LiveUpcomingRecurringsTools } = await import(
+      '../../../src/tools/live/upcoming-recurrings.js'
+    );
+    const tools = new LiveUpcomingRecurringsTools(live);
+
+    await tools.getUpcomingRecurrings({});
+    const result = await tools.getUpcomingRecurrings({});
+
+    expect(result._cache_hit).toBe(true);
+    expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns empty list and count=0 when nothing is upcoming', async () => {
+    const { live } = mkLiveReturning([]);
+    const { LiveUpcomingRecurringsTools } = await import(
+      '../../../src/tools/live/upcoming-recurrings.js'
+    );
+    const tools = new LiveUpcomingRecurringsTools(live);
+
+    const result = await tools.getUpcomingRecurrings({});
+    expect(result.count).toBe(0);
+    expect(result.upcoming).toEqual([]);
+    expect(result._cache_hit).toBe(false);
+  });
+
+  test('rows with null nextPaymentDate sort to the end', async () => {
+    const { live } = mkLiveReturning([
+      mkUpcoming({ id: 'r1', name: 'Has date', nextPaymentDate: '2026-05-10' }),
+      mkUpcoming({ id: 'r2', name: 'No date', nextPaymentDate: null }),
+      mkUpcoming({ id: 'r3', name: 'Earliest', nextPaymentDate: '2026-05-01' }),
+    ]);
+    const { LiveUpcomingRecurringsTools } = await import(
+      '../../../src/tools/live/upcoming-recurrings.js'
+    );
+    const tools = new LiveUpcomingRecurringsTools(live);
+
+    const result = await tools.getUpcomingRecurrings({});
+    expect(result.upcoming.map((r) => r.id)).toEqual(['r3', 'r1', 'r2']);
+  });
+
+  test('category_name populated when categoriesCache is warm', async () => {
+    const { live } = mkLiveReturning([
+      mkUpcoming({
+        id: 'r1',
+        name: 'Cellphone Plan',
+        nextPaymentAmount: 50,
+        nextPaymentDate: '2026-05-10',
+        categoryId: 'cat-utils',
+      }),
+    ]);
+
+    await live
+      .getCategoriesCache()
+      .read(async () => [mkCat({ id: 'cat-utils', name: 'Utilities' })]);
+
+    const { LiveUpcomingRecurringsTools } = await import(
+      '../../../src/tools/live/upcoming-recurrings.js'
+    );
+    const tools = new LiveUpcomingRecurringsTools(live);
+    const result = await tools.getUpcomingRecurrings({});
+
+    const item = result.upcoming.find((r) => r.id === 'r1');
+    expect(item?.category_name).toBe('Utilities');
+  });
+
+  test('category_name is null when categoriesCache is cold', async () => {
+    const { live } = mkLiveReturning([
+      mkUpcoming({
+        id: 'r1',
+        name: 'Mystery Sub',
+        nextPaymentAmount: 5,
+        nextPaymentDate: '2026-05-10',
+        categoryId: 'cat-unknown',
+      }),
+    ]);
+    // Do NOT pre-warm categoriesCache.
+
+    const { LiveUpcomingRecurringsTools } = await import(
+      '../../../src/tools/live/upcoming-recurrings.js'
+    );
+    const tools = new LiveUpcomingRecurringsTools(live);
+    const result = await tools.getUpcomingRecurrings({});
+
+    const item = result.upcoming.find((r) => r.id === 'r1');
+    expect(item?.category_name).toBeNull();
+  });
+
+  test('category_name is null when categoryId does not match any category', async () => {
+    const { live } = mkLiveReturning([
+      mkUpcoming({
+        id: 'r1',
+        name: 'Stale link',
+        nextPaymentAmount: 9,
+        nextPaymentDate: '2026-05-10',
+        categoryId: 'cat-deleted',
+      }),
+    ]);
+    await live.getCategoriesCache().read(async () => [mkCat({ id: 'cat-other', name: 'Other' })]);
+
+    const { LiveUpcomingRecurringsTools } = await import(
+      '../../../src/tools/live/upcoming-recurrings.js'
+    );
+    const tools = new LiveUpcomingRecurringsTools(live);
+    const result = await tools.getUpcomingRecurrings({});
+
+    const item = result.upcoming.find((r) => r.id === 'r1');
+    expect(item?.category_name).toBeNull();
+  });
+
+  test('result includes ISO _cache_oldest_fetched_at and _cache_newest_fetched_at', async () => {
+    const { live } = mkLiveReturning([
+      mkUpcoming({ id: 'r1', name: 'Item', nextPaymentDate: '2026-05-10' }),
+    ]);
+    const { LiveUpcomingRecurringsTools } = await import(
+      '../../../src/tools/live/upcoming-recurrings.js'
+    );
+    const tools = new LiveUpcomingRecurringsTools(live);
+
+    const result = await tools.getUpcomingRecurrings({});
+    expect(result._cache_oldest_fetched_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(result._cache_newest_fetched_at).toBe(result._cache_oldest_fetched_at);
+  });
+});
+
+describe('createLiveUpcomingRecurringsToolSchema', () => {
+  test('schema name is get_upcoming_recurrings_live', async () => {
+    const { createLiveUpcomingRecurringsToolSchema } = await import(
+      '../../../src/tools/live/upcoming-recurrings.js'
+    );
+    const schema = createLiveUpcomingRecurringsToolSchema();
+    expect(schema.name).toBe('get_upcoming_recurrings_live');
+  });
+
+  test('schema is read-only', async () => {
+    const { createLiveUpcomingRecurringsToolSchema } = await import(
+      '../../../src/tools/live/upcoming-recurrings.js'
+    );
+    const schema = createLiveUpcomingRecurringsToolSchema();
+    expect(schema.annotations.readOnlyHint).toBe(true);
+  });
+
+  test('description distinguishes about-to-bill vs configured/historical view', async () => {
+    const { createLiveUpcomingRecurringsToolSchema } = await import(
+      '../../../src/tools/live/upcoming-recurrings.js'
+    );
+    const schema = createLiveUpcomingRecurringsToolSchema();
+    expect(schema.description).toMatch(/get_recurring_live/);
+    expect(schema.description.toLowerCase()).toMatch(/about.to.bill|upcoming|next.due/);
+  });
+});

--- a/tests/tools/live/upcoming-recurrings.test.ts
+++ b/tests/tools/live/upcoming-recurrings.test.ts
@@ -55,9 +55,8 @@ describe('LiveUpcomingRecurringsTools.getUpcomingRecurrings', () => {
       mkUpcoming({ id: 'r2', name: 'Item Early', nextPaymentDate: '2026-05-05' }),
       mkUpcoming({ id: 'r3', name: 'Item Mid', nextPaymentDate: '2026-05-10' }),
     ]);
-    const { LiveUpcomingRecurringsTools } = await import(
-      '../../../src/tools/live/upcoming-recurrings.js'
-    );
+    const { LiveUpcomingRecurringsTools } =
+      await import('../../../src/tools/live/upcoming-recurrings.js');
     const tools = new LiveUpcomingRecurringsTools(live);
 
     const result = await tools.getUpcomingRecurrings({});
@@ -71,9 +70,8 @@ describe('LiveUpcomingRecurringsTools.getUpcomingRecurrings', () => {
     const { live, client } = mkLiveReturning([
       mkUpcoming({ id: 'r1', name: 'Item', nextPaymentDate: '2026-05-10' }),
     ]);
-    const { LiveUpcomingRecurringsTools } = await import(
-      '../../../src/tools/live/upcoming-recurrings.js'
-    );
+    const { LiveUpcomingRecurringsTools } =
+      await import('../../../src/tools/live/upcoming-recurrings.js');
     const tools = new LiveUpcomingRecurringsTools(live);
 
     await tools.getUpcomingRecurrings({});
@@ -85,9 +83,8 @@ describe('LiveUpcomingRecurringsTools.getUpcomingRecurrings', () => {
 
   test('returns empty list and count=0 when nothing is upcoming', async () => {
     const { live } = mkLiveReturning([]);
-    const { LiveUpcomingRecurringsTools } = await import(
-      '../../../src/tools/live/upcoming-recurrings.js'
-    );
+    const { LiveUpcomingRecurringsTools } =
+      await import('../../../src/tools/live/upcoming-recurrings.js');
     const tools = new LiveUpcomingRecurringsTools(live);
 
     const result = await tools.getUpcomingRecurrings({});
@@ -102,9 +99,8 @@ describe('LiveUpcomingRecurringsTools.getUpcomingRecurrings', () => {
       mkUpcoming({ id: 'r2', name: 'No date', nextPaymentDate: null }),
       mkUpcoming({ id: 'r3', name: 'Earliest', nextPaymentDate: '2026-05-01' }),
     ]);
-    const { LiveUpcomingRecurringsTools } = await import(
-      '../../../src/tools/live/upcoming-recurrings.js'
-    );
+    const { LiveUpcomingRecurringsTools } =
+      await import('../../../src/tools/live/upcoming-recurrings.js');
     const tools = new LiveUpcomingRecurringsTools(live);
 
     const result = await tools.getUpcomingRecurrings({});
@@ -126,9 +122,8 @@ describe('LiveUpcomingRecurringsTools.getUpcomingRecurrings', () => {
       .getCategoriesCache()
       .read(async () => [mkCat({ id: 'cat-utils', name: 'Utilities' })]);
 
-    const { LiveUpcomingRecurringsTools } = await import(
-      '../../../src/tools/live/upcoming-recurrings.js'
-    );
+    const { LiveUpcomingRecurringsTools } =
+      await import('../../../src/tools/live/upcoming-recurrings.js');
     const tools = new LiveUpcomingRecurringsTools(live);
     const result = await tools.getUpcomingRecurrings({});
 
@@ -148,9 +143,8 @@ describe('LiveUpcomingRecurringsTools.getUpcomingRecurrings', () => {
     ]);
     // Do NOT pre-warm categoriesCache.
 
-    const { LiveUpcomingRecurringsTools } = await import(
-      '../../../src/tools/live/upcoming-recurrings.js'
-    );
+    const { LiveUpcomingRecurringsTools } =
+      await import('../../../src/tools/live/upcoming-recurrings.js');
     const tools = new LiveUpcomingRecurringsTools(live);
     const result = await tools.getUpcomingRecurrings({});
 
@@ -170,9 +164,8 @@ describe('LiveUpcomingRecurringsTools.getUpcomingRecurrings', () => {
     ]);
     await live.getCategoriesCache().read(async () => [mkCat({ id: 'cat-other', name: 'Other' })]);
 
-    const { LiveUpcomingRecurringsTools } = await import(
-      '../../../src/tools/live/upcoming-recurrings.js'
-    );
+    const { LiveUpcomingRecurringsTools } =
+      await import('../../../src/tools/live/upcoming-recurrings.js');
     const tools = new LiveUpcomingRecurringsTools(live);
     const result = await tools.getUpcomingRecurrings({});
 
@@ -184,9 +177,8 @@ describe('LiveUpcomingRecurringsTools.getUpcomingRecurrings', () => {
     const { live } = mkLiveReturning([
       mkUpcoming({ id: 'r1', name: 'Item', nextPaymentDate: '2026-05-10' }),
     ]);
-    const { LiveUpcomingRecurringsTools } = await import(
-      '../../../src/tools/live/upcoming-recurrings.js'
-    );
+    const { LiveUpcomingRecurringsTools } =
+      await import('../../../src/tools/live/upcoming-recurrings.js');
     const tools = new LiveUpcomingRecurringsTools(live);
 
     const result = await tools.getUpcomingRecurrings({});
@@ -197,25 +189,22 @@ describe('LiveUpcomingRecurringsTools.getUpcomingRecurrings', () => {
 
 describe('createLiveUpcomingRecurringsToolSchema', () => {
   test('schema name is get_upcoming_recurrings_live', async () => {
-    const { createLiveUpcomingRecurringsToolSchema } = await import(
-      '../../../src/tools/live/upcoming-recurrings.js'
-    );
+    const { createLiveUpcomingRecurringsToolSchema } =
+      await import('../../../src/tools/live/upcoming-recurrings.js');
     const schema = createLiveUpcomingRecurringsToolSchema();
     expect(schema.name).toBe('get_upcoming_recurrings_live');
   });
 
   test('schema is read-only', async () => {
-    const { createLiveUpcomingRecurringsToolSchema } = await import(
-      '../../../src/tools/live/upcoming-recurrings.js'
-    );
+    const { createLiveUpcomingRecurringsToolSchema } =
+      await import('../../../src/tools/live/upcoming-recurrings.js');
     const schema = createLiveUpcomingRecurringsToolSchema();
     expect(schema.annotations.readOnlyHint).toBe(true);
   });
 
   test('description distinguishes about-to-bill vs configured/historical view', async () => {
-    const { createLiveUpcomingRecurringsToolSchema } = await import(
-      '../../../src/tools/live/upcoming-recurrings.js'
-    );
+    const { createLiveUpcomingRecurringsToolSchema } =
+      await import('../../../src/tools/live/upcoming-recurrings.js');
     const schema = createLiveUpcomingRecurringsToolSchema();
     expect(schema.description).toMatch(/get_recurring_live/);
     expect(schema.description.toLowerCase()).toMatch(/about.to.bill|upcoming|next.due/);


### PR DESCRIPTION
## Summary

Adds a net-new live-mode tool `get_upcoming_recurrings_live` that wraps the GraphQL `UpcomingRecurrings` query (returns `unpaidUpcomingRecurrings`). This is the "what's about to bill" view, distinct from `get_recurring_live` which is the configured/historical view of all user-confirmed recurrings.

- New `fetchUpcomingRecurrings(client)` query wrapper (no variables) reusing the `RecurringNode` shape via a `UpcomingRecurringNode` alias.
- New `upcomingRecurringsCache: SnapshotCache<UpcomingRecurringNode>` on `LiveCopilotDatabase` with a 1h TTL (shorter than `recurringCache`'s 6h because items move out of this view as bills get paid intra-day).
- New `LiveUpcomingRecurringsTools` with projection that sorts soonest-due first (rows with null `nextPaymentDate` sort to the end) and joins `category_name` from `categoriesCache.peek()` with the same cold-cache fallback used by `get_recurring_live`.
- Wired into `src/server.ts` (live-mode guard + handler case + schema registration).
- Added `'upcoming_recurrings'` scope to `refresh_cache` (and included in `'all'` cascade).

Result shape:
```
{
  count: number,
  upcoming: [{ ...UpcomingRecurringNode, category_name: string | null }],
  _cache_oldest_fetched_at: string,  // ISO
  _cache_newest_fetched_at: string,  // ISO
  _cache_hit: boolean
}
```

## Test plan

- [x] `bun test tests/core/graphql/queries/upcoming-recurrings.test.ts` — query wrapper (3 tests)
- [x] `bun test tests/core/live-database.test.ts` — cache accessor + TTL (49 tests)
- [x] `bun test tests/tools/live/upcoming-recurrings.test.ts` — projection, sort order, category_name join warm/cold/missing, schema (11 tests)
- [x] `bun test tests/tools/live/refresh-cache.test.ts` — scope wiring (20 tests)
- [x] `bun test tests/e2e/server.test.ts` — server wiring under --live-reads on/off
- [x] `bun run check` — typecheck + lint + format + full suite (1845 pass, 0 fail)
- [ ] Manual smoke via MCP host (deferred — host is on pre-merge code; tool will appear after merge + reload)