### PR TITLE
feat(live): add get_monthly_spend_live

### DIFF
--- a/src/core/graphql/queries/monthly-spend.ts
+++ b/src/core/graphql/queries/monthly-spend.ts
@@ -1,0 +1,41 @@
+/**
+ * GraphQL query wrapper for MonthlySpend.
+ *
+ * Despite the operation name, the response is a daily series for the
+ * current month (or comparison period). Each row carries `totalAmount`
+ * (this period's spend on `date`) and `comparisonAmount` (same-day-of
+ * prior-period spend, used by the web app for "vs last month" deltas).
+ *
+ * For dates beyond today, both `totalAmount` and `comparisonAmount` are
+ * `null` — the response pads the full month with placeholder rows.
+ * Filtering those out is the projection layer's job; this wrapper preserves
+ * them verbatim so the cache can serve a faithful copy of the response.
+ *
+ * The captured query at docs/graphql-capture/operations/queries/MonthlySpend.md
+ * exposes only `id`, `date`, `totalAmount`, `comparisonAmount` per row and
+ * takes no variables. One round-trip per call; the SnapshotCache caches the
+ * full set with a 1h TTL.
+ */
+
+import type { GraphQLClient } from '../client.js';
+import { MONTHLY_SPEND } from '../operations.generated.js';
+
+export interface DailySpendNode {
+  id: string;
+  date: string;
+  totalAmount: string | null;
+  comparisonAmount: string | null;
+}
+
+interface MonthlySpendResponse {
+  monthlySpending: DailySpendNode[];
+}
+
+export async function fetchMonthlySpend(client: GraphQLClient): Promise<DailySpendNode[]> {
+  const data = await client.query<Record<string, never>, MonthlySpendResponse>(
+    'MonthlySpend',
+    MONTHLY_SPEND,
+    {}
+  );
+  return data.monthlySpending;
+}

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -38,6 +38,7 @@ import type { TagNode } from './graphql/queries/tags.js';
 import type { RecurringNode } from './graphql/queries/recurrings.js';
 import type { NetworthHistoryNode } from './graphql/queries/networth.js';
 import type { UpcomingRecurringNode } from './graphql/queries/upcoming-recurrings.js';
+import type { DailySpendNode } from './graphql/queries/monthly-spend.js';
 import { fetchUser, type UserNode } from './graphql/queries/user.js';
 import type { Transaction } from '../models/index.js';
 
@@ -84,6 +85,7 @@ export class LiveCopilotDatabase {
   // not partitioned by timeFrame to keep the SnapshotCache primitive simple);
   // the 1h TTL still applies to the most-recently-requested timeFrame.
   private readonly networthCache: SnapshotCache<NetworthHistoryNode>;
+  private readonly monthlySpendCache: SnapshotCache<DailySpendNode>;
   private readonly transactionsWindowCache: TransactionWindowCache<TransactionNode>;
 
   constructor(
@@ -127,6 +129,10 @@ export class LiveCopilotDatabase {
     // assumption here for future maintainers.
     this.networthCache = new SnapshotCache<NetworthHistoryNode>(
       { key: 'networth', ttlMs: ONE_HOUR_MS, keyFn: (n) => n.date },
+      this.inflight
+    );
+    this.monthlySpendCache = new SnapshotCache<DailySpendNode>(
+      { key: 'monthly_spend', ttlMs: ONE_HOUR_MS, keyFn: (d) => d.id },
       this.inflight
     );
     this.transactionsWindowCache = new TransactionWindowCache<TransactionNode>(
@@ -363,6 +369,10 @@ export class LiveCopilotDatabase {
 
   getNetworthCache(): SnapshotCache<NetworthHistoryNode> {
     return this.networthCache;
+  }
+
+  getMonthlySpendCache(): SnapshotCache<DailySpendNode> {
+    return this.monthlySpendCache;
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,10 @@ import {
   LiveUpcomingRecurringsTools,
   createLiveUpcomingRecurringsToolSchema,
 } from './tools/live/upcoming-recurrings.js';
+import {
+  LiveMonthlySpendTools,
+  createLiveMonthlySpendToolSchema,
+} from './tools/live/monthly-spend.js';
 import { RefreshCacheTool, createRefreshCacheToolSchema } from './tools/live/refresh-cache.js';
 
 // Read version from package.json
@@ -53,6 +57,7 @@ export class CopilotMoneyServer {
   private liveRecurringTools?: LiveRecurringTools;
   private liveNetworthTools?: LiveNetworthTools;
   private liveUpcomingRecurringsTools?: LiveUpcomingRecurringsTools;
+  private liveMonthlySpendTools?: LiveMonthlySpendTools;
   private refreshCacheTool?: RefreshCacheTool;
 
   /**
@@ -91,6 +96,7 @@ export class CopilotMoneyServer {
       this.liveRecurringTools = new LiveRecurringTools(liveDb);
       this.liveNetworthTools = new LiveNetworthTools(liveDb);
       this.liveUpcomingRecurringsTools = new LiveUpcomingRecurringsTools(liveDb);
+      this.liveMonthlySpendTools = new LiveMonthlySpendTools(liveDb);
       this.refreshCacheTool = new RefreshCacheTool(liveDb);
     }
 
@@ -136,6 +142,7 @@ export class CopilotMoneyServer {
           createLiveRecurringToolSchema(),
           createLiveNetworthToolSchema(),
           createLiveUpcomingRecurringsToolSchema(),
+          createLiveMonthlySpendToolSchema(),
           createRefreshCacheToolSchema(),
         ]
       : [];
@@ -294,6 +301,18 @@ export class CopilotMoneyServer {
       };
     }
 
+    if (name === 'get_monthly_spend_live' && !this.liveMonthlySpendTools) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'get_monthly_spend_live is only available when the server runs with --live-reads.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
     if (name === 'refresh_cache' && !this.refreshCacheTool) {
       return {
         content: [
@@ -391,6 +410,15 @@ export class CopilotMoneyServer {
           result = await this.liveUpcomingRecurringsTools!.getUpcomingRecurrings(
             (typedArgs as Parameters<
               NonNullable<typeof this.liveUpcomingRecurringsTools>['getUpcomingRecurrings']
+            >[0]) ?? {}
+          );
+          break;
+
+        case 'get_monthly_spend_live':
+          // liveMonthlySpendTools non-null invariant enforced by the early guard above.
+          result = await this.liveMonthlySpendTools!.getMonthlySpend(
+            (typedArgs as Parameters<
+              NonNullable<typeof this.liveMonthlySpendTools>['getMonthlySpend']
             >[0]) ?? {}
           );
           break;

--- a/src/tools/live/monthly-spend.ts
+++ b/src/tools/live/monthly-spend.ts
@@ -110,7 +110,7 @@ export function createLiveMonthlySpendToolSchema() {
     name: 'get_monthly_spend_live',
     description:
       "Get the current month's daily spending series (live, GraphQL-backed). " +
-      'Each row carries `total_amount` (this period\'s spend on `date`) and ' +
+      "Each row carries `total_amount` (this period's spend on `date`) and " +
       '`comparison_amount` (same-day-of-prior-period spend, used by the web app ' +
       'for "vs last month" deltas). Future-dated placeholder rows (where both ' +
       'amounts are null) are filtered out by default; pass `include_future: true` ' +

--- a/src/tools/live/monthly-spend.ts
+++ b/src/tools/live/monthly-spend.ts
@@ -95,6 +95,9 @@ export class LiveMonthlySpendTools {
     });
 
     const fetchedAtIso = new Date(fetched_at).toISOString();
+    // Both `_cache_oldest_fetched_at` and `_cache_newest_fetched_at` reflect
+    // the same single-snapshot fetch time — unlike the windowed transaction
+    // cache where they can differ across month windows.
     return {
       count: rows.length,
       daily_spending: rows,

--- a/src/tools/live/monthly-spend.ts
+++ b/src/tools/live/monthly-spend.ts
@@ -1,0 +1,134 @@
+/**
+ * Live-mode get_monthly_spend_live tool.
+ *
+ * Wraps the GraphQL `MonthlySpend` query — which, despite the name,
+ * returns a DAILY series of {date, totalAmount, comparisonAmount, id}
+ * rows for the current month/period. Backed by the SnapshotCache
+ * <DailySpendNode> on LiveCopilotDatabase (1h TTL).
+ *
+ * `total_amount` is the day's actual spend; `comparison_amount` is the
+ * same-day-of-prior-period spend (used by the web app for "vs last
+ * month" comparisons).
+ *
+ * The response includes future-dated placeholder rows where both amount
+ * fields are `null` (the server pads the full month). By default the
+ * projection drops those rows. Pass `include_future: true` to receive
+ * the full padded series (e.g., for callers that want a complete date
+ * axis with explicit nulls).
+ */
+
+import type { LiveCopilotDatabase } from '../../core/live-database.js';
+import {
+  fetchMonthlySpend,
+  type DailySpendNode,
+} from '../../core/graphql/queries/monthly-spend.js';
+
+export interface GetMonthlySpendLiveArgs {
+  /**
+   * Include future-dated placeholder rows (both totalAmount and
+   * comparisonAmount are null). Default: false — only days with at
+   * least one amount value are returned.
+   */
+  include_future?: boolean;
+}
+
+export interface GetMonthlySpendLiveDay {
+  id: string;
+  date: string;
+  total_amount: number | null;
+  comparison_amount: number | null;
+}
+
+export interface GetMonthlySpendLiveResult {
+  count: number;
+  daily_spending: GetMonthlySpendLiveDay[];
+  _cache_oldest_fetched_at: string;
+  _cache_newest_fetched_at: string;
+  _cache_hit: boolean;
+}
+
+function parseAmount(value: string | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function projectRow(row: DailySpendNode): GetMonthlySpendLiveDay {
+  return {
+    id: row.id,
+    date: row.date,
+    total_amount: parseAmount(row.totalAmount),
+    comparison_amount: parseAmount(row.comparisonAmount),
+  };
+}
+
+export class LiveMonthlySpendTools {
+  constructor(private readonly live: LiveCopilotDatabase) {}
+
+  async getMonthlySpend(args: GetMonthlySpendLiveArgs): Promise<GetMonthlySpendLiveResult> {
+    const cache = this.live.getMonthlySpendCache();
+    const startedAt = Date.now();
+    const {
+      rows: cached,
+      fetched_at,
+      hit,
+    } = await cache.read(() => fetchMonthlySpend(this.live.getClient()));
+
+    const projected = cached.map(projectRow);
+    const includeFuture = args.include_future ?? false;
+    // Default: drop any row where either amount is null (placeholder rows
+    // for future dates). The captured response always pairs both nulls
+    // together, but treat a single null as a placeholder too — emitting
+    // half-populated rows would be more confusing than dropping them.
+    const filtered = includeFuture
+      ? projected
+      : projected.filter((r) => r.total_amount !== null && r.comparison_amount !== null);
+
+    const rows = [...filtered].sort((a, b) => a.date.localeCompare(b.date));
+
+    this.live.logReadCall({
+      op: 'MonthlySpend',
+      pages: hit ? 0 : 1,
+      latencyMs: Date.now() - startedAt,
+      rows: rows.length,
+      cache_hit: hit,
+    });
+
+    const fetchedAtIso = new Date(fetched_at).toISOString();
+    return {
+      count: rows.length,
+      daily_spending: rows,
+      _cache_oldest_fetched_at: fetchedAtIso,
+      _cache_newest_fetched_at: fetchedAtIso,
+      _cache_hit: hit,
+    };
+  }
+}
+
+export function createLiveMonthlySpendToolSchema() {
+  return {
+    name: 'get_monthly_spend_live',
+    description:
+      "Get the current month's daily spending series (live, GraphQL-backed). " +
+      'Each row carries `total_amount` (this period\'s spend on `date`) and ' +
+      '`comparison_amount` (same-day-of-prior-period spend, used by the web app ' +
+      'for "vs last month" deltas). Future-dated placeholder rows (where both ' +
+      'amounts are null) are filtered out by default; pass `include_future: true` ' +
+      'to opt in to the full padded series. Available when --live-reads is on.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        include_future: {
+          type: 'boolean',
+          description:
+            'If true, include future-dated placeholder rows (both amounts null) ' +
+            'in the response. Default: false.',
+          default: false,
+        },
+      },
+    },
+    annotations: {
+      readOnlyHint: true,
+    },
+  };
+}

--- a/src/tools/live/refresh-cache.ts
+++ b/src/tools/live/refresh-cache.ts
@@ -21,6 +21,7 @@ const VALID_SCOPES = [
   'upcoming_recurrings',
   'user',
   'networth',
+  'monthly_spend',
 ] as const;
 
 const YEAR_MONTH_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
@@ -42,6 +43,7 @@ export interface RefreshCacheResult {
     upcoming_recurrings?: boolean;
     user?: boolean;
     networth?: boolean;
+    monthly_spend?: boolean;
     transactions_months?: string[] | 'all';
   };
 }
@@ -86,6 +88,8 @@ export class RefreshCacheTool {
       flushed.user = true;
       this.live.getNetworthCache().invalidate();
       flushed.networth = true;
+      this.live.getMonthlySpendCache().invalidate();
+      flushed.monthly_spend = true;
     };
 
     const flushTransactions = () => {
@@ -142,6 +146,10 @@ export class RefreshCacheTool {
       case 'networth':
         this.live.getNetworthCache().invalidate();
         flushed.networth = true;
+        break;
+      case 'monthly_spend':
+        this.live.getMonthlySpendCache().invalidate();
+        flushed.monthly_spend = true;
         break;
     }
 

--- a/tests/core/graphql/queries/monthly-spend.test.ts
+++ b/tests/core/graphql/queries/monthly-spend.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../../src/core/graphql/client.js';
+
+describe('fetchMonthlySpend', () => {
+  test('returns the daily spending list as-is from the GraphQL response', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          monthlySpending: [
+            { id: 'd1', date: '2026-04-01', totalAmount: '100', comparisonAmount: '90' },
+            { id: 'd2', date: '2026-04-02', totalAmount: '200', comparisonAmount: '180' },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchMonthlySpend } = await import(
+      '../../../../src/core/graphql/queries/monthly-spend.js'
+    );
+    const rows = await fetchMonthlySpend(client);
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.id)).toEqual(['d1', 'd2']);
+    expect(rows[0]?.date).toBe('2026-04-01');
+    expect(rows[0]?.totalAmount).toBe('100');
+    expect(rows[0]?.comparisonAmount).toBe('90');
+  });
+
+  test('passes no variables (MonthlySpend query takes none)', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ monthlySpending: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchMonthlySpend } = await import(
+      '../../../../src/core/graphql/queries/monthly-spend.js'
+    );
+    await fetchMonthlySpend(client);
+
+    expect(client.query).toHaveBeenCalledWith('MonthlySpend', expect.any(String), {});
+  });
+
+  test('handles empty response without throwing', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ monthlySpending: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchMonthlySpend } = await import(
+      '../../../../src/core/graphql/queries/monthly-spend.js'
+    );
+    const rows = await fetchMonthlySpend(client);
+    expect(rows).toEqual([]);
+  });
+
+  test('preserves null amount fields (future-dated rows)', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          monthlySpending: [
+            { id: 'd1', date: '2026-04-01', totalAmount: '100', comparisonAmount: '90' },
+            { id: 'd2', date: '2026-04-30', totalAmount: null, comparisonAmount: null },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchMonthlySpend } = await import(
+      '../../../../src/core/graphql/queries/monthly-spend.js'
+    );
+    const rows = await fetchMonthlySpend(client);
+
+    expect(rows[1]?.totalAmount).toBeNull();
+    expect(rows[1]?.comparisonAmount).toBeNull();
+  });
+});

--- a/tests/core/graphql/queries/monthly-spend.test.ts
+++ b/tests/core/graphql/queries/monthly-spend.test.ts
@@ -14,9 +14,8 @@ describe('fetchMonthlySpend', () => {
       ),
     } as unknown as GraphQLClient;
 
-    const { fetchMonthlySpend } = await import(
-      '../../../../src/core/graphql/queries/monthly-spend.js'
-    );
+    const { fetchMonthlySpend } =
+      await import('../../../../src/core/graphql/queries/monthly-spend.js');
     const rows = await fetchMonthlySpend(client);
 
     expect(rows).toHaveLength(2);
@@ -31,9 +30,8 @@ describe('fetchMonthlySpend', () => {
       query: mock(() => Promise.resolve({ monthlySpending: [] })),
     } as unknown as GraphQLClient;
 
-    const { fetchMonthlySpend } = await import(
-      '../../../../src/core/graphql/queries/monthly-spend.js'
-    );
+    const { fetchMonthlySpend } =
+      await import('../../../../src/core/graphql/queries/monthly-spend.js');
     await fetchMonthlySpend(client);
 
     expect(client.query).toHaveBeenCalledWith('MonthlySpend', expect.any(String), {});
@@ -44,9 +42,8 @@ describe('fetchMonthlySpend', () => {
       query: mock(() => Promise.resolve({ monthlySpending: [] })),
     } as unknown as GraphQLClient;
 
-    const { fetchMonthlySpend } = await import(
-      '../../../../src/core/graphql/queries/monthly-spend.js'
-    );
+    const { fetchMonthlySpend } =
+      await import('../../../../src/core/graphql/queries/monthly-spend.js');
     const rows = await fetchMonthlySpend(client);
     expect(rows).toEqual([]);
   });
@@ -63,9 +60,8 @@ describe('fetchMonthlySpend', () => {
       ),
     } as unknown as GraphQLClient;
 
-    const { fetchMonthlySpend } = await import(
-      '../../../../src/core/graphql/queries/monthly-spend.js'
-    );
+    const { fetchMonthlySpend } =
+      await import('../../../../src/core/graphql/queries/monthly-spend.js');
     const rows = await fetchMonthlySpend(client);
 
     expect(rows[1]?.totalAmount).toBeNull();

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -404,12 +404,17 @@ describe('LiveCopilotDatabase — cache accessors', () => {
     expect(mkLive().getNetworthCache()).toBeInstanceOf(SnapshotCache);
   });
 
+  test('getMonthlySpendCache returns a SnapshotCache instance', () => {
+    expect(mkLive().getMonthlySpendCache()).toBeInstanceOf(SnapshotCache);
+  });
+
   test('each call returns the same instance (not a new one)', () => {
     const live = mkLive();
     expect(live.getTagsCache()).toBe(live.getTagsCache());
     expect(live.getTransactionsWindowCache()).toBe(live.getTransactionsWindowCache());
     expect(live.getUserCache()).toBe(live.getUserCache());
     expect(live.getNetworthCache()).toBe(live.getNetworthCache());
+    expect(live.getMonthlySpendCache()).toBe(live.getMonthlySpendCache());
   });
 });
 

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -2724,9 +2724,7 @@ describe('--live-reads monthly-spend wiring', () => {
     // Inject a stub LiveMonthlySpendTools via private field access
     const stubResult = {
       count: 1,
-      daily_spending: [
-        { id: 'd1', date: '2026-04-01', total_amount: 100, comparison_amount: 90 },
-      ],
+      daily_spending: [{ id: 'd1', date: '2026-04-01', total_amount: 100, comparison_amount: 90 }],
       _cache_oldest_fetched_at: '2025-01-01T00:00:00.000Z',
       _cache_newest_fetched_at: '2025-01-01T00:00:00.000Z',
       _cache_hit: false,

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -2682,3 +2682,64 @@ describe('--live-reads upcoming-recurrings wiring', () => {
     expect(data._cache_hit).toBe(false);
   });
 });
+
+// ============================================
+// --live-reads monthly-spend wiring tests
+// ============================================
+
+describe('--live-reads monthly-spend wiring', () => {
+  test('handleListTools when --live-reads is OFF excludes get_monthly_spend_live', () => {
+    const server = new CopilotMoneyServer(FAKE_DB_DIR);
+    const { tools } = server.handleListTools();
+    const names = tools.map((t) => t.name);
+    expect(names).not.toContain('get_monthly_spend_live');
+  });
+
+  test('handleListTools when --live-reads is ON includes get_monthly_spend_live', () => {
+    // Pass a mock GraphQL client so the constructor can wire liveMonthlySpendTools
+    // without attempting real auth. The fourth positional arg is liveReadsEnabled.
+    const mockClient = createMockGraphQLClient({});
+    const server = new CopilotMoneyServer(FAKE_DB_DIR, undefined, false, true, mockClient);
+    const { tools } = server.handleListTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('get_monthly_spend_live');
+  });
+
+  test('get_monthly_spend_live without --live-reads returns isError with --live-reads hint', async () => {
+    const server = new CopilotMoneyServer(FAKE_DB_DIR);
+    const db = createMockDb();
+    server._injectForTesting(db, new CopilotMoneyTools(db));
+
+    const result = await server.handleCallTool('get_monthly_spend_live', {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('--live-reads');
+  });
+
+  test('get_monthly_spend_live with --live-reads dispatches to liveMonthlySpendTools.getMonthlySpend', async () => {
+    const mockClient = createMockGraphQLClient({});
+    const server = new CopilotMoneyServer(FAKE_DB_DIR, undefined, false, true, mockClient);
+    const db = createMockDb();
+    server._injectForTesting(db, new CopilotMoneyTools(db));
+
+    // Inject a stub LiveMonthlySpendTools via private field access
+    const stubResult = {
+      count: 1,
+      daily_spending: [
+        { id: 'd1', date: '2026-04-01', total_amount: 100, comparison_amount: 90 },
+      ],
+      _cache_oldest_fetched_at: '2025-01-01T00:00:00.000Z',
+      _cache_newest_fetched_at: '2025-01-01T00:00:00.000Z',
+      _cache_hit: false,
+    };
+    (server as any).liveMonthlySpendTools = {
+      getMonthlySpend: async (_args: unknown) => stubResult,
+    };
+
+    const result = await server.handleCallTool('get_monthly_spend_live', {});
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text) as typeof stubResult;
+    expect(data.count).toBe(1);
+    expect(data.daily_spending[0]?.id).toBe('d1');
+    expect(data._cache_hit).toBe(false);
+  });
+});

--- a/tests/tools/live/monthly-spend.test.ts
+++ b/tests/tools/live/monthly-spend.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../src/core/graphql/client.js';
+import { CopilotDatabase } from '../../../src/core/database.js';
+import { LiveCopilotDatabase } from '../../../src/core/live-database.js';
+import { LiveMonthlySpendTools } from '../../../src/tools/live/monthly-spend.js';
+
+function makeClient(rows: unknown[]): GraphQLClient {
+  return {
+    query: mock(() => Promise.resolve({ monthlySpending: rows })),
+  } as unknown as GraphQLClient;
+}
+
+function makeLive(client: GraphQLClient): LiveCopilotDatabase {
+  return new LiveCopilotDatabase(client, new CopilotDatabase('/tmp/no-such-db'));
+}
+
+const pastRow = { id: 'd1', date: '2026-04-01', totalAmount: '100', comparisonAmount: '90' };
+const todayRow = { id: 'd2', date: '2026-04-15', totalAmount: '50', comparisonAmount: '40' };
+const futureRow = { id: 'd3', date: '2026-04-20', totalAmount: null, comparisonAmount: null };
+
+describe('LiveMonthlySpendTools.getMonthlySpend', () => {
+  test('cold call: fetches and returns rows with cache_hit=false', async () => {
+    const client = makeClient([pastRow]);
+    const tools = new LiveMonthlySpendTools(makeLive(client));
+
+    const result = await tools.getMonthlySpend({});
+
+    expect(result.count).toBe(1);
+    expect(result.daily_spending[0]?.id).toBe('d1');
+    expect(result._cache_hit).toBe(false);
+    expect(typeof result._cache_oldest_fetched_at).toBe('string');
+    expect(typeof result._cache_newest_fetched_at).toBe('string');
+  });
+
+  test('warm call: cache hit, no second fetch', async () => {
+    const client = makeClient([pastRow]);
+    const tools = new LiveMonthlySpendTools(makeLive(client));
+
+    await tools.getMonthlySpend({});
+    const second = await tools.getMonthlySpend({});
+
+    expect(second._cache_hit).toBe(true);
+    expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  test('default: filters out future-dated rows where both amounts are null', async () => {
+    const client = makeClient([pastRow, todayRow, futureRow]);
+    const tools = new LiveMonthlySpendTools(makeLive(client));
+
+    const result = await tools.getMonthlySpend({});
+
+    expect(result.count).toBe(2);
+    expect(result.daily_spending.map((r) => r.id)).toEqual(['d1', 'd2']);
+  });
+
+  test('include_future=true: returns the placeholder rows verbatim', async () => {
+    const client = makeClient([pastRow, todayRow, futureRow]);
+    const tools = new LiveMonthlySpendTools(makeLive(client));
+
+    const result = await tools.getMonthlySpend({ include_future: true });
+
+    expect(result.count).toBe(3);
+    expect(result.daily_spending.map((r) => r.id)).toEqual(['d1', 'd2', 'd3']);
+    // Future row preserves null amounts when included.
+    const future = result.daily_spending.find((r) => r.id === 'd3');
+    expect(future?.total_amount).toBeNull();
+    expect(future?.comparison_amount).toBeNull();
+  });
+
+  test('output sorted by date ascending', async () => {
+    const client = makeClient([
+      { id: 'b', date: '2026-04-15', totalAmount: '200', comparisonAmount: '150' },
+      { id: 'a', date: '2026-04-01', totalAmount: '100', comparisonAmount: '90' },
+      { id: 'c', date: '2026-04-30', totalAmount: '300', comparisonAmount: '250' },
+    ]);
+    const tools = new LiveMonthlySpendTools(makeLive(client));
+
+    const result = await tools.getMonthlySpend({});
+
+    expect(result.daily_spending.map((r) => r.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  test('parses string amounts into numbers', async () => {
+    const client = makeClient([pastRow]);
+    const tools = new LiveMonthlySpendTools(makeLive(client));
+
+    const result = await tools.getMonthlySpend({});
+
+    expect(result.daily_spending[0]?.total_amount).toBe(100);
+    expect(result.daily_spending[0]?.comparison_amount).toBe(90);
+    expect(typeof result.daily_spending[0]?.total_amount).toBe('number');
+  });
+
+  test('empty result returns count 0, no throw', async () => {
+    const client = makeClient([]);
+    const tools = new LiveMonthlySpendTools(makeLive(client));
+
+    const result = await tools.getMonthlySpend({});
+
+    expect(result.count).toBe(0);
+    expect(result.daily_spending).toEqual([]);
+  });
+
+  test('default filters when only future rows exist (count=0)', async () => {
+    const client = makeClient([futureRow, { ...futureRow, id: 'd4', date: '2026-04-21' }]);
+    const tools = new LiveMonthlySpendTools(makeLive(client));
+
+    const result = await tools.getMonthlySpend({});
+
+    expect(result.count).toBe(0);
+    expect(result.daily_spending).toEqual([]);
+  });
+
+  test('row with one null amount is treated as future and filtered by default', async () => {
+    // Defensive: spec says "both amounts are null" is the placeholder shape,
+    // but if only one is null we still drop the row by default rather than
+    // emit a partial number.
+    const halfNull = {
+      id: 'd-half',
+      date: '2026-04-19',
+      totalAmount: null,
+      comparisonAmount: '90',
+    };
+    const client = makeClient([pastRow, halfNull]);
+    const tools = new LiveMonthlySpendTools(makeLive(client));
+
+    const result = await tools.getMonthlySpend({});
+
+    expect(result.daily_spending.map((r) => r.id)).toEqual(['d1']);
+  });
+});
+
+describe('createLiveMonthlySpendToolSchema', () => {
+  test('returns a schema with readOnlyHint=true', async () => {
+    const { createLiveMonthlySpendToolSchema } = await import(
+      '../../../src/tools/live/monthly-spend.js'
+    );
+    const schema = createLiveMonthlySpendToolSchema();
+    expect(schema.name).toBe('get_monthly_spend_live');
+    expect(schema.annotations?.readOnlyHint).toBe(true);
+  });
+
+  test('declares an optional include_future boolean property', async () => {
+    const { createLiveMonthlySpendToolSchema } = await import(
+      '../../../src/tools/live/monthly-spend.js'
+    );
+    const schema = createLiveMonthlySpendToolSchema();
+    const props = schema.inputSchema.properties as Record<string, { type: string }>;
+    expect(props.include_future?.type).toBe('boolean');
+    // include_future is opt-in, so it must not appear in `required`.
+    expect((schema.inputSchema as { required?: string[] }).required ?? []).not.toContain(
+      'include_future'
+    );
+  });
+});

--- a/tests/tools/live/monthly-spend.test.ts
+++ b/tests/tools/live/monthly-spend.test.ts
@@ -132,18 +132,16 @@ describe('LiveMonthlySpendTools.getMonthlySpend', () => {
 
 describe('createLiveMonthlySpendToolSchema', () => {
   test('returns a schema with readOnlyHint=true', async () => {
-    const { createLiveMonthlySpendToolSchema } = await import(
-      '../../../src/tools/live/monthly-spend.js'
-    );
+    const { createLiveMonthlySpendToolSchema } =
+      await import('../../../src/tools/live/monthly-spend.js');
     const schema = createLiveMonthlySpendToolSchema();
     expect(schema.name).toBe('get_monthly_spend_live');
     expect(schema.annotations?.readOnlyHint).toBe(true);
   });
 
   test('declares an optional include_future boolean property', async () => {
-    const { createLiveMonthlySpendToolSchema } = await import(
-      '../../../src/tools/live/monthly-spend.js'
-    );
+    const { createLiveMonthlySpendToolSchema } =
+      await import('../../../src/tools/live/monthly-spend.js');
     const schema = createLiveMonthlySpendToolSchema();
     const props = schema.inputSchema.properties as Record<string, { type: string }>;
     expect(props.include_future?.type).toBe('boolean');

--- a/tests/tools/live/refresh-cache.test.ts
+++ b/tests/tools/live/refresh-cache.test.ts
@@ -19,6 +19,7 @@ function makeMockLive(): {
     upcomingRecurrings: ReturnType<typeof makeInvalidateCache>;
     user: ReturnType<typeof makeInvalidateCache>;
     networth: ReturnType<typeof makeInvalidateCache>;
+    monthlySpend: ReturnType<typeof makeInvalidateCache>;
     transactions: { invalidate: ReturnType<typeof mock> };
   };
 } {
@@ -29,6 +30,7 @@ function makeMockLive(): {
   const upcomingRecurrings = makeInvalidateCache();
   const user = makeInvalidateCache();
   const networth = makeInvalidateCache();
+  const monthlySpend = makeInvalidateCache();
   const transactions = { invalidate: mock((_arg: string[] | 'all') => {}) };
 
   const live = {
@@ -39,6 +41,7 @@ function makeMockLive(): {
     getUpcomingRecurringsCache: mock(() => upcomingRecurrings),
     getUserCache: mock(() => user),
     getNetworthCache: mock(() => networth),
+    getMonthlySpendCache: mock(() => monthlySpend),
     getTransactionsWindowCache: mock(() => transactions),
   } as unknown as LiveCopilotDatabase;
 
@@ -52,6 +55,7 @@ function makeMockLive(): {
       upcomingRecurrings,
       user,
       networth,
+      monthlySpend,
       transactions,
     },
   };
@@ -71,6 +75,7 @@ describe('RefreshCacheTool — scope: all', () => {
     expect(mocks.upcomingRecurrings.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.user.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.networth.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.monthlySpend.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.transactions.invalidate).toHaveBeenCalledTimes(1);
     expect(result.flushed.accounts).toBe(true);
     expect(result.flushed.categories).toBe(true);
@@ -80,6 +85,7 @@ describe('RefreshCacheTool — scope: all', () => {
     expect(result.flushed.upcoming_recurrings).toBe(true);
     expect(result.flushed.user).toBe(true);
     expect(result.flushed.networth).toBe(true);
+    expect(result.flushed.monthly_spend).toBe(true);
     expect(result.flushed.transactions_months).toBe('all');
   });
 
@@ -230,6 +236,24 @@ describe('RefreshCacheTool — scope: user (audit C6)', () => {
   });
 });
 
+describe('RefreshCacheTool — scope: monthly_spend', () => {
+  test('invalidates only monthlySpendCache', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'monthly_spend' });
+
+    expect(mocks.monthlySpend.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.accounts.invalidate).not.toHaveBeenCalled();
+    expect(mocks.categories.invalidate).not.toHaveBeenCalled();
+    expect(mocks.tags.invalidate).not.toHaveBeenCalled();
+    expect(mocks.recurring.invalidate).not.toHaveBeenCalled();
+    expect(mocks.transactions.invalidate).not.toHaveBeenCalled();
+    expect(result.flushed.monthly_spend).toBe(true);
+    expect(result.flushed.accounts).toBeUndefined();
+  });
+});
+
 describe('RefreshCacheTool — scope: transactions', () => {
   test('flushes all transaction months by default', async () => {
     const { live, mocks } = makeMockLive();
@@ -304,6 +328,12 @@ describe('createRefreshCacheToolSchema', () => {
     const schema = createRefreshCacheToolSchema();
     const scopeProp = schema.inputSchema.properties.scope as { enum: string[] };
     expect(scopeProp.enum).toContain('upcoming_recurrings');
+  });
+
+  test('monthly_spend scope is listed in enum', () => {
+    const schema = createRefreshCacheToolSchema();
+    const scopeProp = schema.inputSchema.properties.scope as { enum: string[] };
+    expect(scopeProp.enum).toContain('monthly_spend');
   });
 
   test('schema description mentions budgets piggyback on categories', () => {

--- a/tests/tools/live/refresh-cache.test.ts
+++ b/tests/tools/live/refresh-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, mock, beforeEach } from 'bun:test';
+import { describe, expect, test, mock } from 'bun:test';
 import {
   RefreshCacheTool,
   createRefreshCacheToolSchema,


### PR DESCRIPTION
## Summary

- New `get_monthly_spend_live` MCP tool wrapping the GraphQL `MonthlySpend` query (no variables).
- Despite the operation name, the response is a DAILY series for the current month — internal type is `DailySpendNode`. External tool name keeps the GraphQL operation spelling.
- Each row: `total_amount` (this period's spend on `date`), `comparison_amount` (same-day-of-prior-period spend, used by the web app for "vs last month" deltas).
- Backed by a new `SnapshotCache<DailySpendNode>` on `LiveCopilotDatabase` with 1h TTL. New `monthly_spend` scope on `refresh_cache`.
- Future-dated placeholder rows (where either amount is null) are filtered out by default; pass `include_future: true` to receive the full padded series.
- Live tools are not part of `manifest.json` by design (sync-manifest only tracks default-mode tools), so no manifest update.

## Result shape

```json
{
  "count": 14,
  "daily_spending": [
    { "id": "...", "date": "YYYY-MM-DD", "total_amount": 100, "comparison_amount": 90 }
  ],
  "_cache_oldest_fetched_at": "...",
  "_cache_newest_fetched_at": "...",
  "_cache_hit": false
}
```

Sorted by `date` ascending. String amounts parsed via the same `parseAmount` pattern used in `budgets.ts`.

## Test plan

- [x] `bun test tests/core/graphql/queries/monthly-spend.test.ts` — fetch wrapper unit tests
- [x] `bun test tests/core/live-database.test.ts` — cache accessor tests
- [x] `bun test tests/tools/live/monthly-spend.test.ts` — projection, filtering, sort, cache hit/miss
- [x] `bun test tests/tools/live/refresh-cache.test.ts` — scope: monthly_spend + cascade in scope: all
- [x] `bun test tests/e2e/server.test.ts` — handler wiring, `--live-reads` guard
- [x] `bun run check` — typecheck + lint + format + 1844 tests pass

Generated with Claude Code