### PR TITLE
test(live): cover non-null parentId upsert and months_window schema

### DIFF
--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -600,11 +600,49 @@ describe('LiveCopilotDatabase.patchLiveCategoryUpsert (CategoryNode shape)', () 
     expect(after.rows.find((c) => c.id === 'cat-1')?.name).toBe('New Name');
   });
 
-  test('preserves non-null parentId on upsert', async () => {
+  test('preserves non-null parentId on upsert (insert path)', async () => {
     const live = new LiveCopilotDatabase(mkClient(), mkCache());
 
     const cache = live.getCategoriesCache();
     await cache.read(() => Promise.resolve([]));
+
+    live.patchLiveCategoryUpsert({
+      id: 'child-1',
+      parentId: 'parent-1',
+      name: 'Coffee',
+      templateId: 'Food',
+      colorName: 'ORANGE2',
+      icon: null,
+      isExcluded: false,
+      isRolloverDisabled: false,
+      canBeDeleted: true,
+      budget: null,
+    });
+
+    const after = await cache.read(() => Promise.resolve([]));
+    expect(after.rows.find((c) => c.id === 'child-1')?.parentId).toBe('parent-1');
+  });
+
+  test('overwrites parentId on upsert when row already exists (update path)', async () => {
+    const live = new LiveCopilotDatabase(mkClient(), mkCache());
+
+    const cache = live.getCategoriesCache();
+    await cache.read(() =>
+      Promise.resolve([
+        {
+          id: 'child-1',
+          parentId: null,
+          name: 'Coffee',
+          templateId: 'Food',
+          colorName: 'ORANGE2',
+          icon: null,
+          isExcluded: false,
+          isRolloverDisabled: false,
+          canBeDeleted: true,
+          budget: null,
+        },
+      ])
+    );
 
     live.patchLiveCategoryUpsert({
       id: 'child-1',

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -600,6 +600,29 @@ describe('LiveCopilotDatabase.patchLiveCategoryUpsert (CategoryNode shape)', () 
     expect(after.rows.find((c) => c.id === 'cat-1')?.name).toBe('New Name');
   });
 
+  test('preserves non-null parentId on upsert', async () => {
+    const live = new LiveCopilotDatabase(mkClient(), mkCache());
+
+    const cache = live.getCategoriesCache();
+    await cache.read(() => Promise.resolve([]));
+
+    live.patchLiveCategoryUpsert({
+      id: 'child-1',
+      parentId: 'parent-1',
+      name: 'Coffee',
+      templateId: 'Food',
+      colorName: 'ORANGE2',
+      icon: null,
+      isExcluded: false,
+      isRolloverDisabled: false,
+      canBeDeleted: true,
+      budget: null,
+    });
+
+    const after = await cache.read(() => Promise.resolve([]));
+    expect(after.rows.find((c) => c.id === 'child-1')?.parentId).toBe('parent-1');
+  });
+
   test('patchLiveCategoryDelete removes category by id', async () => {
     const live = new LiveCopilotDatabase(mkClient(), mkCache());
     const catNode1: CategoryNode = {

--- a/tests/tools/live/budgets.test.ts
+++ b/tests/tools/live/budgets.test.ts
@@ -436,4 +436,12 @@ describe('createLiveBudgetsToolSchema', () => {
     expect(schema.name).toBe('get_budgets_live');
     expect(schema.annotations?.readOnlyHint).toBe(true);
   });
+
+  test('declares months_window with minimum: 0', async () => {
+    const { createLiveBudgetsToolSchema } = await import('../../../src/tools/live/budgets.js');
+    const schema = createLiveBudgetsToolSchema();
+    const props = schema.inputSchema.properties as Record<string, { minimum?: number }>;
+    expect(props.months_window).toBeDefined();
+    expect(props.months_window?.minimum).toBe(0);
+  });
 });

--- a/tests/tools/live/budgets.test.ts
+++ b/tests/tools/live/budgets.test.ts
@@ -442,6 +442,6 @@ describe('createLiveBudgetsToolSchema', () => {
     const schema = createLiveBudgetsToolSchema();
     const props = schema.inputSchema.properties as Record<string, { minimum?: number }>;
     expect(props.months_window).toBeDefined();
-    expect(props.months_window?.minimum).toBe(0);
+    expect(props.months_window.minimum).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Bundled cleanup of two LOW-severity audit followups (per the "batch audit-followup nits into one PR" rule).

- **#358** (PR #357 followup) — adds a `patchLiveCategoryUpsert` fixture with `parentId: 'parent-1'` so the non-null path is covered. Pre-fix every fixture in `live-database.test.ts` set `parentId: null`.
- **#359** (PR #356 followup) — asserts `createLiveBudgetsToolSchema()` declares `months_window` with `minimum: 0`. Pre-fix only `name` + `readOnlyHint` were checked, so silent schema regressions could slip through.

## Audit issue #351 (statSync ENOENT guard) — already resolved

Re-verified before opening this PR. The guard the audit asks for landed in PR #352 (commit f50e8f6, "tolerate compaction TOCTOU in copy + fingerprint — closes #350"); regression tests live at `tests/core/leveldb-reader.test.ts:572,592,624`. I'll close #351 separately with a comment pointing at the landed fix.

## Test plan

- [x] `bun run check` (1889 pass / 0 fail)
- [x] New parentId test passes in isolation
- [x] New months_window schema assertion passes in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)