### PR TITLE
docs+codegen: capture 10 investments GraphQL queries

### DIFF
--- a/docs/graphql-capture/operations/queries/Account.md
+++ b/docs/graphql-capture/operations/queries/Account.md
@@ -1,0 +1,87 @@
+# Account
+
+- **Type:** query
+- **Endpoint:** https://app.copilot.money/api/graphql
+- **Fires on:** Clicking into a single account from the accounts list.
+- **Observations:** 1
+
+## Query
+
+```graphql
+query Account($itemId: ID!, $id: ID!, $accountLink: Boolean = false) {
+  account(itemId: $itemId, id: $id) {
+    ...AccountFields
+    accountLink @include(if: $accountLink) {
+      type
+      account { ...AccountFields __typename }
+      __typename
+    }
+    __typename
+  }
+}
+
+fragment AccountFields on Account {
+  hasHistoricalUpdates
+  latestBalanceUpdate
+  hasLiveBalance
+  institutionId
+  isUserHidden
+  isUserClosed
+  liveBalance
+  isManual
+  balance
+  subType
+  itemId
+  limit
+  color
+  name
+  type
+  mask
+  id
+  __typename
+}
+```
+
+## Variables
+
+| Name | Type | Required | Example |
+|------|------|----------|---------|
+| itemId | ID! | true | `"<id>"` |
+| id | ID! | true | `"<id>"` |
+| accountLink | Boolean | false | `true` |
+
+## Example request
+
+```json
+{"operationName":"Account","query":"query Account($itemId: ID!, $id: ID!, $accountLink: Boolean = false) {\n  account(itemId: $itemId, id: $id) {\n    ...AccountFields\n    accountLink @include(if: $accountLink) {\n      type\n      account { ...AccountFields __typename }\n      __typename\n    }\n    __typename\n  }\n}\n\nfragment AccountFields on Account {\n  hasHistoricalUpdates\n  latestBalanceUpdate\n  hasLiveBalance\n  institutionId\n  isUserHidden\n  isUserClosed\n  liveBalance\n  isManual\n  balance\n  subType\n  itemId\n  limit\n  color\n  name\n  type\n  mask\n  id\n  __typename\n}","variables":{"accountLink":true,"itemId":"<id>","id":"<id>"}}
+```
+
+## Example response
+
+```json
+{
+  "data": {
+    "account": {
+      "__typename": "Account",
+      "id": "<id>",
+      "itemId": "<id>",
+      "institutionId": "<id>",
+      "name": "<name>",
+      "mask": "<placeholder>",
+      "type": "<placeholder>",
+      "subType": "<placeholder>",
+      "color": "<placeholder>",
+      "balance": "<amount>",
+      "liveBalance": "<amount>",
+      "limit": null,
+      "isManual": false,
+      "isUserHidden": false,
+      "isUserClosed": false,
+      "hasHistoricalUpdates": true,
+      "hasLiveBalance": true,
+      "latestBalanceUpdate": "<timestamp>",
+      "accountLink": null
+    }
+  }
+}
+```

--- a/docs/graphql-capture/operations/queries/AggregatedHoldings.md
+++ b/docs/graphql-capture/operations/queries/AggregatedHoldings.md
@@ -44,6 +44,8 @@ query AggregatedHoldings($timeFrame: TimeFrame, $filter: AggregatedHoldingsFilte
 
 `AggregatedHoldingsFilter` is an array; concrete enum members are not yet enumerated from captures.
 
+The inline security selection here omits `currentPrice` (which the `SecurityFields` fragment in `Holdings.md` / `TopMovers.md` does include). This matches the captured web traffic — the aggregated view renders `change` + `value` only and does not need the spot price. Future implementors should match the web app's selection here rather than reaching for `SecurityFields`.
+
 ## Example request
 
 ```json

--- a/docs/graphql-capture/operations/queries/AggregatedHoldings.md
+++ b/docs/graphql-capture/operations/queries/AggregatedHoldings.md
@@ -1,0 +1,80 @@
+# AggregatedHoldings
+
+- **Type:** query
+- **Endpoint:** https://app.copilot.money/api/graphql
+- **Fires on:** Investment overview chart time-range buttons (1W/1M/3M/YTD/1Y/ALL); also fires when entering an account-level holdings view.
+- **Observations:** 1
+
+## Query
+
+```graphql
+query AggregatedHoldings($timeFrame: TimeFrame, $filter: AggregatedHoldingsFilter, $accountId: ID, $itemId: ID) {
+  aggregatedHoldings(
+    timeFrame: $timeFrame
+    filter: $filter
+    accountId: $accountId
+    itemId: $itemId
+  ) {
+    security {
+      marketInfo { closeTime openTime __typename }
+      lastUpdate
+      symbol
+      name
+      type
+      id
+      __typename
+    }
+    change
+    value
+    __typename
+  }
+}
+```
+
+## Variables
+
+| Name | Type | Required | Example |
+|------|------|----------|---------|
+| timeFrame | TimeFrame | false | `"ONE_MONTH"` |
+| filter | AggregatedHoldingsFilter | false | `[]` |
+| accountId | ID | false | `"<id>"` |
+| itemId | ID | false | `"<id>"` |
+
+`TimeFrame` enum values observed: `ONE_DAY`, `ONE_WEEK`, `ONE_MONTH`, `THREE_MONTHS`, `YTD`, `ONE_YEAR`, `ALL`.
+
+`AggregatedHoldingsFilter` is an array; concrete enum members are not yet enumerated from captures.
+
+## Example request
+
+```json
+{"operationName":"AggregatedHoldings","query":"query AggregatedHoldings($timeFrame: TimeFrame, $filter: AggregatedHoldingsFilter, $accountId: ID, $itemId: ID) {\n  aggregatedHoldings(\n    timeFrame: $timeFrame\n    filter: $filter\n    accountId: $accountId\n    itemId: $itemId\n  ) {\n    security {\n      marketInfo { closeTime openTime __typename }\n      lastUpdate\n      symbol\n      name\n      type\n      id\n      __typename\n    }\n    change\n    value\n    __typename\n  }\n}","variables":{"timeFrame":"ONE_MONTH"}}
+```
+
+## Example response
+
+```json
+{
+  "data": {
+    "aggregatedHoldings": [
+      {
+        "__typename": "AggregatedHolding",
+        "change": "<amount>",
+        "value": "<amount>",
+        "security": {
+          "__typename": "Security",
+          "id": "<id>",
+          "name": "<name>",
+          "symbol": "<symbol>",
+          "type": "EQUITY",
+          "lastUpdate": "<timestamp>",
+          "marketInfo": {
+            "__typename": "MarketInfo",
+            "closeTime": "<epoch-ms>",
+            "openTime": "<epoch-ms>"
+          }
+        }
+      }
+    ]
+  }
+}
+```

--- a/docs/graphql-capture/operations/queries/BalanceHistory.md
+++ b/docs/graphql-capture/operations/queries/BalanceHistory.md
@@ -1,0 +1,58 @@
+# BalanceHistory
+
+- **Type:** query
+- **Endpoint:** https://app.copilot.money/api/graphql
+- **Fires on:** Clicking a time-range button (1W / 1M / 3M / YTD / 1Y / ALL) on an account detail page.
+- **Observations:** 1
+
+## Query
+
+```graphql
+query BalanceHistory($itemId: ID!, $accountId: ID!, $timeFrame: TimeFrame) {
+  accountBalanceHistory(itemId: $itemId, accountId: $accountId, timeFrame: $timeFrame) {
+    ...BalanceFields
+    __typename
+  }
+}
+
+fragment BalanceFields on AccountBalanceHistory {
+  balance
+  date
+  __typename
+}
+```
+
+## Variables
+
+| Name | Type | Required | Example |
+|------|------|----------|---------|
+| itemId | ID! | true | `"<id>"` |
+| accountId | ID! | true | `"<id>"` |
+| timeFrame | TimeFrame | false | `"ONE_MONTH"` |
+
+## Example request
+
+```json
+{"operationName":"BalanceHistory","query":"query BalanceHistory($itemId: ID!, $accountId: ID!, $timeFrame: TimeFrame) {\n  accountBalanceHistory(itemId: $itemId, accountId: $accountId, timeFrame: $timeFrame) {\n    ...BalanceFields\n    __typename\n  }\n}\n\nfragment BalanceFields on AccountBalanceHistory {\n  balance\n  date\n  __typename\n}","variables":{"itemId":"<id>","accountId":"<id>","timeFrame":"ONE_MONTH"}}
+```
+
+## Example response
+
+```json
+{
+  "data": {
+    "accountBalanceHistory": [
+      {
+        "__typename": "AccountBalanceHistory",
+        "date": "<YYYY-MM-DD>",
+        "balance": "<amount>"
+      },
+      {
+        "__typename": "AccountBalanceHistory",
+        "date": "<YYYY-MM-DD>",
+        "balance": "<amount>"
+      }
+    ]
+  }
+}
+```

--- a/docs/graphql-capture/operations/queries/Holdings.md
+++ b/docs/graphql-capture/operations/queries/Holdings.md
@@ -1,0 +1,113 @@
+# Holdings
+
+- **Type:** query
+- **Endpoint:** https://app.copilot.money/api/graphql
+- **Fires on:** Initial page load of /investments
+- **Observations:** 1
+
+## Query
+
+```graphql
+query Holdings {
+  holdings {
+    security {
+      ...SecurityFields
+      __typename
+    }
+    metrics {
+      averageCost
+      totalReturn
+      costBasis
+      __typename
+    }
+    accountId
+    quantity
+    itemId
+    id
+    __typename
+  }
+}
+
+fragment SecurityFields on Security {
+  marketInfo { closeTime openTime __typename }
+  currentPrice
+  lastUpdate
+  symbol
+  name
+  type
+  id
+  __typename
+}
+```
+
+## Variables
+
+_(no variables)_
+
+## Example request
+
+```json
+{"operationName":"Holdings","query":"query Holdings {\n  holdings {\n    security {\n      ...SecurityFields\n      __typename\n    }\n    metrics {\n      averageCost\n      totalReturn\n      costBasis\n      __typename\n    }\n    accountId\n    quantity\n    itemId\n    id\n    __typename\n  }\n}\n\nfragment SecurityFields on Security {\n  marketInfo { closeTime openTime __typename }\n  currentPrice\n  lastUpdate\n  symbol\n  name\n  type\n  id\n  __typename\n}","variables":{}}
+```
+
+## Example response
+
+> Note: `metrics` is `null` for some holdings (e.g. CASH positions where average cost / cost basis / total return are not meaningful).
+
+```json
+{
+  "data": {
+    "holdings": [
+      {
+        "__typename": "Holding",
+        "id": "<id>",
+        "accountId": "<id>",
+        "itemId": "<id>",
+        "quantity": "<amount>",
+        "security": {
+          "__typename": "Security",
+          "id": "<id>",
+          "name": "<name>",
+          "symbol": "<symbol>",
+          "type": "EQUITY",
+          "currentPrice": "<amount>",
+          "lastUpdate": "<timestamp>",
+          "marketInfo": {
+            "__typename": "MarketInfo",
+            "closeTime": "<epoch-ms>",
+            "openTime": "<epoch-ms>"
+          }
+        },
+        "metrics": {
+          "__typename": "HoldingMetric",
+          "averageCost": "<amount>",
+          "costBasis": "<amount>",
+          "totalReturn": "<amount>"
+        }
+      },
+      {
+        "__typename": "Holding",
+        "id": "<id>",
+        "accountId": "<id>",
+        "itemId": "<id>",
+        "quantity": "<amount>",
+        "security": {
+          "__typename": "Security",
+          "id": "<id>",
+          "name": "<name>",
+          "symbol": "<symbol>",
+          "type": "CASH",
+          "currentPrice": "<amount>",
+          "lastUpdate": "<timestamp>",
+          "marketInfo": {
+            "__typename": "MarketInfo",
+            "closeTime": "<epoch-ms>",
+            "openTime": "<epoch-ms>"
+          }
+        },
+        "metrics": null
+      }
+    ]
+  }
+}
+```

--- a/docs/graphql-capture/operations/queries/InvestmentAllocation.md
+++ b/docs/graphql-capture/operations/queries/InvestmentAllocation.md
@@ -1,0 +1,64 @@
+# InvestmentAllocation
+
+- **Type:** query
+- **Endpoint:** https://app.copilot.money/api/graphql
+- **Fires on:** Clicking into an investment account (drives the allocation breakdown UI).
+- **Observations:** 1
+
+## Query
+
+```graphql
+query InvestmentAllocation($filter: AllocationFilter) {
+  investmentAllocation(filter: $filter) {
+    ...AllocationFields
+    __typename
+  }
+}
+
+fragment AllocationFields on Allocation {
+  percentage
+  amount
+  type
+  id
+  __typename
+}
+```
+
+## Variables
+
+| Name | Type | Required | Example |
+|------|------|----------|---------|
+| filter | AllocationFilter | false | `{"accountId":"<id>","itemId":"<id>"}` |
+
+`AllocationFilter` is an input object with `accountId` and `itemId` fields.
+
+## Example request
+
+```json
+{"operationName":"InvestmentAllocation","query":"query InvestmentAllocation($filter: AllocationFilter) {\n  investmentAllocation(filter: $filter) {\n    ...AllocationFields\n    __typename\n  }\n}\n\nfragment AllocationFields on Allocation {\n  percentage\n  amount\n  type\n  id\n  __typename\n}","variables":{"filter":{"accountId":"<id>","itemId":"<id>"}}}
+```
+
+## Example response
+
+```json
+{
+  "data": {
+    "investmentAllocation": [
+      {
+        "__typename": "Allocation",
+        "id": "<id>",
+        "type": "<placeholder>",
+        "amount": "<amount>",
+        "percentage": "<placeholder>"
+      },
+      {
+        "__typename": "Allocation",
+        "id": "<id>",
+        "type": "<placeholder>",
+        "amount": "<amount>",
+        "percentage": "<placeholder>"
+      }
+    ]
+  }
+}
+```

--- a/docs/graphql-capture/operations/queries/InvestmentAllocation.md
+++ b/docs/graphql-capture/operations/queries/InvestmentAllocation.md
@@ -47,16 +47,16 @@ fragment AllocationFields on Allocation {
       {
         "__typename": "Allocation",
         "id": "<id>",
-        "type": "<placeholder>",
+        "type": "<allocation-type>",
         "amount": "<amount>",
-        "percentage": "<placeholder>"
+        "percentage": "<amount>"
       },
       {
         "__typename": "Allocation",
         "id": "<id>",
-        "type": "<placeholder>",
+        "type": "<allocation-type>",
         "amount": "<amount>",
-        "percentage": "<placeholder>"
+        "percentage": "<amount>"
       }
     ]
   }

--- a/docs/graphql-capture/operations/queries/InvestmentBalance.md
+++ b/docs/graphql-capture/operations/queries/InvestmentBalance.md
@@ -1,0 +1,54 @@
+# InvestmentBalance
+
+- **Type:** query
+- **Endpoint:** https://app.copilot.money/api/graphql
+- **Fires on:** Investment overview chart initial load.
+- **Observations:** 1
+
+## Query
+
+```graphql
+query InvestmentBalance($timeFrame: TimeFrame) {
+  investmentBalance(timeFrame: $timeFrame) {
+    id
+    date
+    balance
+    __typename
+  }
+}
+```
+
+## Variables
+
+| Name | Type | Required | Example |
+|------|------|----------|---------|
+| timeFrame | TimeFrame | false | `"ALL"` |
+
+## Example request
+
+```json
+{"operationName":"InvestmentBalance","query":"query InvestmentBalance($timeFrame: TimeFrame) {\n  investmentBalance(timeFrame: $timeFrame) {\n    id\n    date\n    balance\n    __typename\n  }\n}","variables":{"timeFrame":"ALL"}}
+```
+
+## Example response
+
+```json
+{
+  "data": {
+    "investmentBalance": [
+      {
+        "__typename": "InvestmentBalance",
+        "id": "<id>",
+        "date": "<YYYY-MM-DD>",
+        "balance": "<amount>"
+      },
+      {
+        "__typename": "InvestmentBalance",
+        "id": "<id>",
+        "date": "<YYYY-MM-DD>",
+        "balance": "<amount>"
+      }
+    ]
+  }
+}
+```

--- a/docs/graphql-capture/operations/queries/InvestmentLiveBalance.md
+++ b/docs/graphql-capture/operations/queries/InvestmentLiveBalance.md
@@ -1,0 +1,44 @@
+# InvestmentLiveBalance
+
+- **Type:** query
+- **Endpoint:** https://app.copilot.money/api/graphql
+- **Fires on:** Initial /investments page load (live balance estimate dot on the chart).
+- **Observations:** 1
+
+## Query
+
+```graphql
+query InvestmentLiveBalance {
+  investmentLiveBalance {
+    id
+    date
+    balance
+    __typename
+  }
+}
+```
+
+## Variables
+
+_(no variables)_
+
+## Example request
+
+```json
+{"operationName":"InvestmentLiveBalance","query":"query InvestmentLiveBalance {\n  investmentLiveBalance {\n    id\n    date\n    balance\n    __typename\n  }\n}","variables":{}}
+```
+
+## Example response
+
+```json
+{
+  "data": {
+    "investmentLiveBalance": {
+      "__typename": "InvestmentBalance",
+      "id": "<id>",
+      "date": "<YYYY-MM-DD>",
+      "balance": "<amount>"
+    }
+  }
+}
+```

--- a/docs/graphql-capture/operations/queries/SecurityPrices.md
+++ b/docs/graphql-capture/operations/queries/SecurityPrices.md
@@ -1,0 +1,57 @@
+# SecurityPrices
+
+- **Type:** query
+- **Endpoint:** https://app.copilot.money/api/graphql
+- **Fires on:** Tapping a security and clicking 1M / 3M / YTD / 1Y / ALL on the chart (longer ranges, daily granularity).
+- **Observations:** 1
+
+## Query
+
+```graphql
+query SecurityPrices($id: ID!, $timeFrame: TimeFrame) {
+  securityPrices(securityId: $id, timeFrame: $timeFrame) {
+    price
+    date
+    id
+    __typename
+  }
+}
+```
+
+## Variables
+
+| Name | Type | Required | Example |
+|------|------|----------|---------|
+| id | ID! | true | `"<id>"` |
+| timeFrame | TimeFrame | false | `"ONE_MONTH"` |
+
+Observed `timeFrame` values: `ONE_MONTH`, `THREE_MONTHS`, `YTD`, `ONE_YEAR`, `ALL`.
+
+## Example request
+
+```json
+{"operationName":"SecurityPrices","query":"query SecurityPrices($id: ID!, $timeFrame: TimeFrame) {\n  securityPrices(securityId: $id, timeFrame: $timeFrame) {\n    price\n    date\n    id\n    __typename\n  }\n}","variables":{"id":"<id>","timeFrame":"ONE_MONTH"}}
+```
+
+## Example response
+
+```json
+{
+  "data": {
+    "securityPrices": [
+      {
+        "__typename": "SecurityPrice",
+        "id": "<id>",
+        "date": "<YYYY-MM-DD>",
+        "price": "<amount>"
+      },
+      {
+        "__typename": "SecurityPrice",
+        "id": "<id>",
+        "date": "<YYYY-MM-DD>",
+        "price": "<amount>"
+      }
+    ]
+  }
+}
+```

--- a/docs/graphql-capture/operations/queries/SecurityPricesHighFrequency.md
+++ b/docs/graphql-capture/operations/queries/SecurityPricesHighFrequency.md
@@ -1,0 +1,57 @@
+# SecurityPricesHighFrequency
+
+- **Type:** query
+- **Endpoint:** https://app.copilot.money/api/graphql
+- **Fires on:** Tapping a security on /investments and clicking 1D or 1W on the chart (intraday / short-range price data).
+- **Observations:** 1
+
+## Query
+
+```graphql
+query SecurityPricesHighFrequency($id: ID!, $timeFrame: TimeFrame) {
+  securityPricesHighFrequency(securityId: $id, timeFrame: $timeFrame) {
+    timestamp
+    price
+    id
+    __typename
+  }
+}
+```
+
+## Variables
+
+| Name | Type | Required | Example |
+|------|------|----------|---------|
+| id | ID! | true | `"<id>"` |
+| timeFrame | TimeFrame | false | `"ONE_DAY"` |
+
+Observed `timeFrame` values: `ONE_DAY`, `ONE_WEEK`.
+
+## Example request
+
+```json
+{"operationName":"SecurityPricesHighFrequency","query":"query SecurityPricesHighFrequency($id: ID!, $timeFrame: TimeFrame) {\n  securityPricesHighFrequency(securityId: $id, timeFrame: $timeFrame) {\n    timestamp\n    price\n    id\n    __typename\n  }\n}","variables":{"id":"<id>","timeFrame":"ONE_DAY"}}
+```
+
+## Example response
+
+```json
+{
+  "data": {
+    "securityPricesHighFrequency": [
+      {
+        "__typename": "SecurityPrice",
+        "id": "<id>",
+        "timestamp": "<epoch-ms>",
+        "price": "<amount>"
+      },
+      {
+        "__typename": "SecurityPrice",
+        "id": "<id>",
+        "timestamp": "<epoch-ms>",
+        "price": "<amount>"
+      }
+    ]
+  }
+}
+```

--- a/docs/graphql-capture/operations/queries/TopMovers.md
+++ b/docs/graphql-capture/operations/queries/TopMovers.md
@@ -1,0 +1,81 @@
+# TopMovers
+
+- **Type:** query
+- **Endpoint:** https://app.copilot.money/api/graphql
+- **Fires on:** Initial /investments page load (powers the "Your top movers" cards). Fires twice — once with `PRICE_CHANGE`, once with `MY_EQUITY_CHANGE`.
+- **Observations:** 1
+
+## Query
+
+```graphql
+query TopMovers($filter: TopMoversFilter) {
+  topMovers(filter: $filter) {
+    security { ...SecurityFields __typename }
+    values { timestamp price id __typename }
+    change
+    __typename
+  }
+}
+
+fragment SecurityFields on Security {
+  marketInfo { closeTime openTime __typename }
+  currentPrice
+  lastUpdate
+  symbol
+  name
+  type
+  id
+  __typename
+}
+```
+
+## Variables
+
+| Name | Type | Required | Example |
+|------|------|----------|---------|
+| filter | TopMoversFilter | false | `"PRICE_CHANGE"` |
+
+Observed `filter` values: `PRICE_CHANGE`, `MY_EQUITY_CHANGE`.
+
+## Example request
+
+```json
+{"operationName":"TopMovers","query":"query TopMovers($filter: TopMoversFilter) {\n  topMovers(filter: $filter) {\n    security { ...SecurityFields __typename }\n    values { timestamp price id __typename }\n    change\n    __typename\n  }\n}\n\nfragment SecurityFields on Security {\n  marketInfo { closeTime openTime __typename }\n  currentPrice\n  lastUpdate\n  symbol\n  name\n  type\n  id\n  __typename\n}","variables":{"filter":"PRICE_CHANGE"}}
+```
+
+## Example response
+
+```json
+{
+  "data": {
+    "topMovers": [
+      {
+        "__typename": "TopMover",
+        "change": "<amount>",
+        "security": {
+          "__typename": "Security",
+          "id": "<id>",
+          "name": "<name>",
+          "symbol": "<symbol>",
+          "type": "EQUITY",
+          "currentPrice": "<amount>",
+          "lastUpdate": "<timestamp>",
+          "marketInfo": {
+            "__typename": "MarketInfo",
+            "closeTime": "<epoch-ms>",
+            "openTime": "<epoch-ms>"
+          }
+        },
+        "values": [
+          {
+            "__typename": "SecurityPrice",
+            "id": "<id>",
+            "timestamp": "<epoch-ms>",
+            "price": "<amount>"
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/scripts/generate-graphql-operations.ts
+++ b/scripts/generate-graphql-operations.ts
@@ -42,6 +42,17 @@ const IN_SCOPE_QUERIES = [
   'Networth',
   'UpcomingRecurrings',
   'MonthlySpend',
+  // Phase 3 investments:
+  'Holdings',
+  'TopMovers',
+  'AggregatedHoldings',
+  'SecurityPrices',
+  'SecurityPricesHighFrequency',
+  'InvestmentBalance',
+  'InvestmentLiveBalance',
+  'InvestmentAllocation',
+  'Account',
+  'BalanceHistory',
 ] as const;
 
 const CAPTURE_DIR = 'docs/graphql-capture/operations/mutations';

--- a/scripts/generate-graphql-operations.ts
+++ b/scripts/generate-graphql-operations.ts
@@ -1,8 +1,8 @@
 /**
  * Generate src/core/graphql/operations.generated.ts from the captured
- * mutation docs in docs/graphql-capture/operations/mutations/.
+ * operation docs in docs/graphql-capture/operations/{mutations,queries}/.
  *
- * Parses each in-scope mutation's query string, injects __typename into
+ * Parses each in-scope mutation and query string, injects __typename into
  * every selection set (matching Apollo's documentTransform behavior
  * required by Copilot's GraphQL server), and emits typed string constants.
  */

--- a/src/core/graphql/operations.generated.ts
+++ b/src/core/graphql/operations.generated.ts
@@ -55,3 +55,23 @@ export const NETWORTH = "query Networth($timeFrame: TimeFrame) {\n  networthHist
 export const UPCOMING_RECURRINGS = "query UpcomingRecurrings {\n  unpaidUpcomingRecurrings {\n    ...RecurringFields\n    rule {\n      ...RecurringRuleFields\n      __typename\n    }\n    payments @connection(key: \"upcoming\") {\n      ...RecurringPaymentFields\n      __typename\n    }\n    __typename\n  }\n}\n\nfragment RecurringFields on Recurring {\n  nextPaymentAmount\n  nextPaymentDate\n  categoryId\n  frequency\n  emoji\n  icon {\n    ... on EmojiUnicode {\n      unicode\n      __typename\n    }\n    ... on Genmoji {\n      id\n      src\n      __typename\n    }\n    __typename\n  }\n  state\n  name\n  id\n  __typename\n}\n\nfragment RecurringRuleFields on RecurringRule {\n  nameContains\n  minAmount\n  maxAmount\n  days\n  __typename\n}\n\nfragment RecurringPaymentFields on RecurringPayment {\n  amount\n  isPaid\n  date\n  __typename\n}";
 
 export const MONTHLY_SPEND = "query MonthlySpend {\n  monthlySpending {\n    comparisonAmount\n    totalAmount\n    date\n    id\n    __typename\n  }\n}";
+
+export const HOLDINGS = "query Holdings {\n  holdings {\n    security {\n      ...SecurityFields\n      __typename\n    }\n    metrics {\n      averageCost\n      totalReturn\n      costBasis\n      __typename\n    }\n    accountId\n    quantity\n    itemId\n    id\n    __typename\n  }\n}\n\nfragment SecurityFields on Security {\n  marketInfo {\n    closeTime\n    openTime\n    __typename\n  }\n  currentPrice\n  lastUpdate\n  symbol\n  name\n  type\n  id\n  __typename\n}";
+
+export const TOP_MOVERS = "query TopMovers($filter: TopMoversFilter) {\n  topMovers(filter: $filter) {\n    security {\n      ...SecurityFields\n      __typename\n    }\n    values {\n      timestamp\n      price\n      id\n      __typename\n    }\n    change\n    __typename\n  }\n}\n\nfragment SecurityFields on Security {\n  marketInfo {\n    closeTime\n    openTime\n    __typename\n  }\n  currentPrice\n  lastUpdate\n  symbol\n  name\n  type\n  id\n  __typename\n}";
+
+export const AGGREGATED_HOLDINGS = "query AggregatedHoldings($timeFrame: TimeFrame, $filter: AggregatedHoldingsFilter, $accountId: ID, $itemId: ID) {\n  aggregatedHoldings(\n    timeFrame: $timeFrame\n    filter: $filter\n    accountId: $accountId\n    itemId: $itemId\n  ) {\n    security {\n      marketInfo {\n        closeTime\n        openTime\n        __typename\n      }\n      lastUpdate\n      symbol\n      name\n      type\n      id\n      __typename\n    }\n    change\n    value\n    __typename\n  }\n}";
+
+export const SECURITY_PRICES = "query SecurityPrices($id: ID!, $timeFrame: TimeFrame) {\n  securityPrices(securityId: $id, timeFrame: $timeFrame) {\n    price\n    date\n    id\n    __typename\n  }\n}";
+
+export const SECURITY_PRICES_HIGH_FREQUENCY = "query SecurityPricesHighFrequency($id: ID!, $timeFrame: TimeFrame) {\n  securityPricesHighFrequency(securityId: $id, timeFrame: $timeFrame) {\n    timestamp\n    price\n    id\n    __typename\n  }\n}";
+
+export const INVESTMENT_BALANCE = "query InvestmentBalance($timeFrame: TimeFrame) {\n  investmentBalance(timeFrame: $timeFrame) {\n    id\n    date\n    balance\n    __typename\n  }\n}";
+
+export const INVESTMENT_LIVE_BALANCE = "query InvestmentLiveBalance {\n  investmentLiveBalance {\n    id\n    date\n    balance\n    __typename\n  }\n}";
+
+export const INVESTMENT_ALLOCATION = "query InvestmentAllocation($filter: AllocationFilter) {\n  investmentAllocation(filter: $filter) {\n    ...AllocationFields\n    __typename\n  }\n}\n\nfragment AllocationFields on Allocation {\n  percentage\n  amount\n  type\n  id\n  __typename\n}";
+
+export const ACCOUNT = "query Account($itemId: ID!, $id: ID!, $accountLink: Boolean = false) {\n  account(itemId: $itemId, id: $id) {\n    ...AccountFields\n    accountLink @include(if: $accountLink) {\n      type\n      account {\n        ...AccountFields\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n}\n\nfragment AccountFields on Account {\n  hasHistoricalUpdates\n  latestBalanceUpdate\n  hasLiveBalance\n  institutionId\n  isUserHidden\n  isUserClosed\n  liveBalance\n  isManual\n  balance\n  subType\n  itemId\n  limit\n  color\n  name\n  type\n  mask\n  id\n  __typename\n}";
+
+export const BALANCE_HISTORY = "query BalanceHistory($itemId: ID!, $accountId: ID!, $timeFrame: TimeFrame) {\n  accountBalanceHistory(\n    itemId: $itemId\n    accountId: $accountId\n    timeFrame: $timeFrame\n  ) {\n    ...BalanceFields\n    __typename\n  }\n}\n\nfragment BalanceFields on AccountBalanceHistory {\n  balance\n  date\n  __typename\n}";


### PR DESCRIPTION
## Summary

PR 1 of a multi-PR Phase 3 roadmap that brings live (GraphQL-backed) investment tools to the Copilot Money MCP server. **Documentation and codegen only — no MCP tools, no client wiring, no behavior change.**

- Adds 10 new query captures under `docs/graphql-capture/operations/queries/` covering the /investments page and account-detail surfaces, recorded via the Chrome Apollo-interceptor capture extension:
  - `Holdings`, `TopMovers`, `AggregatedHoldings`, `SecurityPrices`, `SecurityPricesHighFrequency`, `InvestmentBalance`, `InvestmentLiveBalance`, `InvestmentAllocation`, `Account`, `BalanceHistory`.
- Adds the 10 names to `IN_SCOPE_QUERIES` in `scripts/generate-graphql-operations.ts` so codegen picks them up.
- Regenerates `src/core/graphql/operations.generated.ts` — adds 10 new typed string constants (`HOLDINGS`, `TOP_MOVERS`, etc.) — also no behavior change since nothing imports them yet.

All response examples are PII-redacted: real ids, names, balances, and prices are replaced with `<id>`, `<name>`, `<symbol>`, `<amount>`, `<epoch-ms>`, `<timestamp>`, `<YYYY-MM-DD>`, or `<placeholder>` markers.

## Roadmap

This is the first of ~5 PRs landing live investment tools:

- **PR 1 (this PR):** GraphQL capture files + codegen wiring.
- **PR 2:** GraphQL helper modules under `src/core/graphql/queries/` for the new operations.
- **PR 3:** `get_holdings_live` MCP tool.
- **PR 4:** `get_balance_history_live` MCP tool.
- **PR 5:** Cleanup, smoke tests, docs.

## Test plan

- [x] `bun run check` passes (typecheck + lint + format:check + 1890 tests).
- [x] `bun run generate:graphql` produces a clean diff with the 10 new constants.
- [x] No real PII in any new file.
- [ ] Reviewer: confirm capture file structure matches existing `Networth.md` / `MonthlySpend.md` layout.