### PR TITLE
feat(graphql): add investments query wrappers (PR 2 of 5)

### DIFF
--- a/src/core/graphql/queries/_shared.ts
+++ b/src/core/graphql/queries/_shared.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared types used across multiple investments query wrappers.
+ *
+ * Kept in a single module to avoid duplicating the TimeFrame string union
+ * across the five wrappers that take it. SecurityNode and MarketInfoNode
+ * are also shared between holdings.ts and top-movers.ts (aggregated-holdings.ts
+ * uses a slimmer variant that omits `currentPrice` — see its JSDoc).
+ */
+
+/**
+ * Server-recognized timeframe enum values for investments queries.
+ *
+ * Not all values are accepted by every query — for example, the
+ * high-frequency security-prices endpoint only accepts `ONE_DAY` and
+ * `ONE_WEEK`. The server validates per-operation; we keep the union open
+ * here so callers can pass any captured value without per-wrapper unions.
+ */
+export type TimeFrame =
+  | 'ONE_DAY'
+  | 'ONE_WEEK'
+  | 'ONE_MONTH'
+  | 'THREE_MONTHS'
+  | 'YTD'
+  | 'ONE_YEAR'
+  | 'ALL';
+
+/**
+ * Market hours metadata attached to each Security.
+ *
+ * Both fields are epoch milliseconds and may be `null` (e.g. for CASH
+ * positions or securities the server cannot resolve a market calendar for).
+ */
+export interface MarketInfoNode {
+  closeTime: number | null;
+  openTime: number | null;
+}
+
+/**
+ * Canonical SecurityFields fragment shape (per
+ * `docs/graphql-capture/operations/queries/Holdings.md`).
+ *
+ * Used by holdings.ts and top-movers.ts. `aggregated-holdings.ts` uses a
+ * slimmer variant (AggregatedSecurityNode) that omits `currentPrice`.
+ */
+export interface SecurityNode {
+  id: string;
+  name: string;
+  symbol: string;
+  type: string;
+  currentPrice: number;
+  lastUpdate: string;
+  marketInfo: MarketInfoNode;
+}

--- a/src/core/graphql/queries/aggregated-holdings.ts
+++ b/src/core/graphql/queries/aggregated-holdings.ts
@@ -49,7 +49,7 @@ export interface AggregatedHoldingNode {
 
 export interface FetchAggregatedHoldingsOpts {
   timeFrame?: TimeFrame;
-  filter?: unknown[];
+  filter?: Record<string, unknown>[];
   accountId?: string;
   itemId?: string;
 }
@@ -65,7 +65,7 @@ export async function fetchAggregatedHoldings(
   const data = await client.query<
     {
       timeFrame?: TimeFrame;
-      filter?: unknown[];
+      filter?: Record<string, unknown>[];
       accountId?: string;
       itemId?: string;
     },

--- a/src/core/graphql/queries/aggregated-holdings.ts
+++ b/src/core/graphql/queries/aggregated-holdings.ts
@@ -9,7 +9,7 @@
  * The captured query at docs/graphql-capture/operations/queries/AggregatedHoldings.md
  * accepts an optional `timeFrame`, an opaque `filter` input object (the
  * server schema is `AggregatedHoldingsFilter`; structure not captured —
- * accept as `unknown[]` for now), plus optional `accountId` / `itemId`
+ * accept as `Record<string, unknown>[]` for now), plus optional `accountId` / `itemId`
  * scope filters.
  *
  * NOTE: the embedded `security` block in this query intentionally omits

--- a/src/core/graphql/queries/aggregated-holdings.ts
+++ b/src/core/graphql/queries/aggregated-holdings.ts
@@ -1,0 +1,80 @@
+/**
+ * GraphQL query wrapper for AggregatedHoldings.
+ *
+ * Returns one row per security with aggregated `value` (current market
+ * value of the user's position) and `change` (period-over-period delta
+ * scoped by `timeFrame`). Useful for an investments overview table that
+ * collapses per-account rows into per-security totals.
+ *
+ * The captured query at docs/graphql-capture/operations/queries/AggregatedHoldings.md
+ * accepts an optional `timeFrame`, an opaque `filter` input object (the
+ * server schema is `AggregatedHoldingsFilter`; structure not captured —
+ * accept as `unknown[]` for now), plus optional `accountId` / `itemId`
+ * scope filters.
+ *
+ * NOTE: the embedded `security` block in this query intentionally omits
+ * `currentPrice` — the aggregated view exposes `value` (already
+ * quantity-weighted) instead. See the capture doc for the exact selected
+ * fields. We declare a slimmer `AggregatedSecurityNode` rather than reuse
+ * `SecurityNode` from `_shared.ts` to keep the type honest.
+ */
+
+import type { GraphQLClient } from '../client.js';
+import { AGGREGATED_HOLDINGS } from '../operations.generated.js';
+import type { MarketInfoNode, TimeFrame } from './_shared.js';
+
+/**
+ * Slimmer Security shape used by AggregatedHoldings only.
+ *
+ * Distinct from `SecurityNode` because the captured AggregatedHoldings
+ * query does NOT select `currentPrice` — the aggregated row carries
+ * `value` (quantity * currentPrice) instead, so `currentPrice` would be
+ * redundant. Keeping the missing field out of the type prevents callers
+ * from reaching for an undefined property at runtime.
+ */
+export interface AggregatedSecurityNode {
+  id: string;
+  name: string;
+  symbol: string;
+  type: string;
+  lastUpdate: string;
+  marketInfo: MarketInfoNode;
+}
+
+export interface AggregatedHoldingNode {
+  security: AggregatedSecurityNode;
+  change: number;
+  value: number;
+}
+
+export interface FetchAggregatedHoldingsOpts {
+  timeFrame?: TimeFrame;
+  filter?: unknown[];
+  accountId?: string;
+  itemId?: string;
+}
+
+interface AggregatedHoldingsResponse {
+  aggregatedHoldings: AggregatedHoldingNode[];
+}
+
+export async function fetchAggregatedHoldings(
+  client: GraphQLClient,
+  opts: FetchAggregatedHoldingsOpts = {}
+): Promise<AggregatedHoldingNode[]> {
+  const data = await client.query<
+    {
+      timeFrame?: TimeFrame;
+      filter?: unknown[];
+      accountId?: string;
+      itemId?: string;
+    },
+    AggregatedHoldingsResponse
+  >('AggregatedHoldings', AGGREGATED_HOLDINGS, {
+    timeFrame: opts.timeFrame,
+    filter: opts.filter,
+    accountId: opts.accountId,
+    itemId: opts.itemId,
+  });
+  return data.aggregatedHoldings;
+}

--- a/src/core/graphql/queries/balance-history.ts
+++ b/src/core/graphql/queries/balance-history.ts
@@ -1,0 +1,51 @@
+/**
+ * GraphQL query wrapper for BalanceHistory.
+ *
+ * Returns a date-sorted balance timeseries for a single account. One row
+ * per day in the requested `timeFrame`. The web app fires this query when
+ * the user clicks a time-range button (1W / 1M / 3M / YTD / 1Y / ALL) on
+ * an account detail page.
+ *
+ * The operation is named `BalanceHistory`, but the resolver returns the
+ * data under the `accountBalanceHistory` field — that's what the wrapper
+ * reads. Verified against
+ * docs/graphql-capture/operations/queries/BalanceHistory.md.
+ *
+ * Both `itemId` and `accountId` are required (the server enforces the
+ * non-null `ID!` annotation).
+ */
+
+import type { GraphQLClient } from '../client.js';
+import { BALANCE_HISTORY } from '../operations.generated.js';
+import type { TimeFrame } from './_shared.js';
+
+export interface BalanceHistoryPointNode {
+  /** ISO YYYY-MM-DD; one row per day in the requested range. */
+  date: string;
+  balance: number;
+}
+
+export interface FetchAccountBalanceHistoryOpts {
+  itemId: string;
+  accountId: string;
+  timeFrame?: TimeFrame;
+}
+
+interface BalanceHistoryResponse {
+  accountBalanceHistory: BalanceHistoryPointNode[];
+}
+
+export async function fetchAccountBalanceHistory(
+  client: GraphQLClient,
+  opts: FetchAccountBalanceHistoryOpts
+): Promise<BalanceHistoryPointNode[]> {
+  const data = await client.query<
+    { itemId: string; accountId: string; timeFrame?: TimeFrame },
+    BalanceHistoryResponse
+  >('BalanceHistory', BALANCE_HISTORY, {
+    itemId: opts.itemId,
+    accountId: opts.accountId,
+    timeFrame: opts.timeFrame,
+  });
+  return data.accountBalanceHistory;
+}

--- a/src/core/graphql/queries/holdings.ts
+++ b/src/core/graphql/queries/holdings.ts
@@ -1,0 +1,50 @@
+/**
+ * GraphQL query wrapper for Holdings.
+ *
+ * Returns the user's investment positions — one row per (account, security)
+ * pair. Each row carries the security definition, the held quantity, and a
+ * `metrics` block with cost-basis / return numbers.
+ *
+ * `metrics` is `null` for non-investable positions — most commonly CASH
+ * sleeves inside investment accounts, where average cost / cost basis /
+ * total return are not meaningful. Callers must null-check before using.
+ *
+ * `costBasis` is the absolute total cost (quantity-weighted), not per-share.
+ * `totalReturn` is a dollar amount and can be negative; the web UI derives
+ * the displayed percentage as `totalReturn / costBasis`.
+ *
+ * The captured query at docs/graphql-capture/operations/queries/Holdings.md
+ * takes no variables. One round-trip per call.
+ */
+
+import type { GraphQLClient } from '../client.js';
+import { HOLDINGS } from '../operations.generated.js';
+import type { SecurityNode } from './_shared.js';
+
+export interface HoldingMetricNode {
+  averageCost: number;
+  costBasis: number;
+  totalReturn: number;
+}
+
+export interface HoldingNode {
+  id: string;
+  accountId: string;
+  itemId: string;
+  quantity: number;
+  security: SecurityNode;
+  metrics: HoldingMetricNode | null;
+}
+
+interface HoldingsResponse {
+  holdings: HoldingNode[];
+}
+
+export async function fetchHoldings(client: GraphQLClient): Promise<HoldingNode[]> {
+  const data = await client.query<Record<string, never>, HoldingsResponse>(
+    'Holdings',
+    HOLDINGS,
+    {}
+  );
+  return data.holdings;
+}

--- a/src/core/graphql/queries/investment-allocation.ts
+++ b/src/core/graphql/queries/investment-allocation.ts
@@ -1,0 +1,53 @@
+/**
+ * GraphQL query wrapper for InvestmentAllocation.
+ *
+ * Returns one row per asset class describing the user's portfolio mix —
+ * an `amount` (dollar value), a `percentage` (of total invested), and a
+ * categorical `type` string (e.g. `"EQUITY"`, `"CASH"`, `"FIXED_INCOME"`).
+ *
+ * The captured query at docs/graphql-capture/operations/queries/InvestmentAllocation.md
+ * accepts an optional `$filter: AllocationFilter` input object with
+ * `accountId` and `itemId` fields for scope filtering. When omitted, the
+ * server returns the allocation across all investment accounts.
+ */
+
+import type { GraphQLClient } from '../client.js';
+import { INVESTMENT_ALLOCATION } from '../operations.generated.js';
+
+export interface AllocationFilter {
+  accountId?: string;
+  itemId?: string;
+}
+
+export interface AllocationNode {
+  id: string;
+  /** Asset class label — e.g. "EQUITY", "CASH", "FIXED_INCOME". */
+  type: string;
+  amount: number;
+  /**
+   * Share of total invested. The captured payload does not disambiguate
+   * 0..1 vs 0..100; treat as whatever the server returns and verify against
+   * a live response before scaling for display.
+   */
+  percentage: number;
+}
+
+export interface FetchInvestmentAllocationOpts {
+  filter?: AllocationFilter;
+}
+
+interface InvestmentAllocationResponse {
+  investmentAllocation: AllocationNode[];
+}
+
+export async function fetchInvestmentAllocation(
+  client: GraphQLClient,
+  opts: FetchInvestmentAllocationOpts = {}
+): Promise<AllocationNode[]> {
+  const data = await client.query<{ filter?: AllocationFilter }, InvestmentAllocationResponse>(
+    'InvestmentAllocation',
+    INVESTMENT_ALLOCATION,
+    { filter: opts.filter }
+  );
+  return data.investmentAllocation;
+}

--- a/src/core/graphql/queries/investment-balance.ts
+++ b/src/core/graphql/queries/investment-balance.ts
@@ -1,0 +1,45 @@
+/**
+ * GraphQL query wrapper for InvestmentBalance.
+ *
+ * Returns a date-sorted balance timeseries across all investment accounts
+ * combined. One row per day in the requested `timeFrame`. Use for the
+ * investments-page top-of-page chart.
+ *
+ * For the current-moment value rather than the timeseries, use
+ * `fetchInvestmentLiveBalance` — same row shape, but a single point.
+ *
+ * The captured query at docs/graphql-capture/operations/queries/InvestmentBalance.md
+ * takes an optional `$timeFrame: TimeFrame`. When omitted, the server
+ * applies its own default range.
+ */
+
+import type { GraphQLClient } from '../client.js';
+import { INVESTMENT_BALANCE } from '../operations.generated.js';
+import type { TimeFrame } from './_shared.js';
+
+export interface InvestmentBalanceNode {
+  id: string;
+  /** ISO YYYY-MM-DD; one row per day in the requested range. */
+  date: string;
+  balance: number;
+}
+
+export interface FetchInvestmentBalanceOpts {
+  timeFrame?: TimeFrame;
+}
+
+interface InvestmentBalanceResponse {
+  investmentBalance: InvestmentBalanceNode[];
+}
+
+export async function fetchInvestmentBalance(
+  client: GraphQLClient,
+  opts: FetchInvestmentBalanceOpts = {}
+): Promise<InvestmentBalanceNode[]> {
+  const data = await client.query<{ timeFrame?: TimeFrame }, InvestmentBalanceResponse>(
+    'InvestmentBalance',
+    INVESTMENT_BALANCE,
+    { timeFrame: opts.timeFrame }
+  );
+  return data.investmentBalance;
+}

--- a/src/core/graphql/queries/investment-live-balance.ts
+++ b/src/core/graphql/queries/investment-live-balance.ts
@@ -1,0 +1,33 @@
+/**
+ * GraphQL query wrapper for InvestmentLiveBalance.
+ *
+ * Returns the current-moment combined investment balance — a single
+ * `{id, date, balance}` row. This is the "live dot" companion to the
+ * timeseries returned by `fetchInvestmentBalance`; the web app fires both
+ * on /investments load (one for the chart, one for the current value).
+ *
+ * The captured query at docs/graphql-capture/operations/queries/InvestmentLiveBalance.md
+ * takes no variables. One round-trip per call.
+ *
+ * The row shape is identical to `InvestmentBalanceNode`, so we reuse that
+ * type rather than declare a parallel one.
+ */
+
+import type { GraphQLClient } from '../client.js';
+import { INVESTMENT_LIVE_BALANCE } from '../operations.generated.js';
+import type { InvestmentBalanceNode } from './investment-balance.js';
+
+interface InvestmentLiveBalanceResponse {
+  investmentLiveBalance: InvestmentBalanceNode;
+}
+
+export async function fetchInvestmentLiveBalance(
+  client: GraphQLClient
+): Promise<InvestmentBalanceNode> {
+  const data = await client.query<Record<string, never>, InvestmentLiveBalanceResponse>(
+    'InvestmentLiveBalance',
+    INVESTMENT_LIVE_BALANCE,
+    {}
+  );
+  return data.investmentLiveBalance;
+}

--- a/src/core/graphql/queries/security-prices-high-frequency.ts
+++ b/src/core/graphql/queries/security-prices-high-frequency.ts
@@ -1,0 +1,56 @@
+/**
+ * GraphQL query wrapper for SecurityPricesHighFrequency.
+ *
+ * Returns an intraday price series for a single security. Use for short
+ * ranges only: `ONE_DAY` (minute-bar granularity) and `ONE_WEEK`
+ * (sub-hourly). Longer ranges should use `fetchSecurityPrices`, which
+ * returns one row per market day.
+ *
+ * The wrapper does not enforce the timeFrame restriction — the server
+ * validates and will reject other values. Documented here so callers don't
+ * waste a round-trip discovering it.
+ *
+ * The captured query at docs/graphql-capture/operations/queries/SecurityPricesHighFrequency.md
+ * declares its security argument as `$id: ID!` in the operation signature
+ * but passes it to the resolver as `securityId: $id`.
+ */
+
+import type { GraphQLClient } from '../client.js';
+import { SECURITY_PRICES_HIGH_FREQUENCY } from '../operations.generated.js';
+import type { TimeFrame } from './_shared.js';
+
+/**
+ * A single intraday price point.
+ *
+ * `timestamp` is whatever opaque numeric the server returns. The captured
+ * payload does not disambiguate epoch-millis vs epoch-seconds; treat as
+ * an ordered key for plotting.
+ */
+export interface HighFrequencyPricePointNode {
+  id: string;
+  timestamp: number;
+  price: number;
+}
+
+export interface FetchSecurityPricesHighFrequencyOpts {
+  id: string;
+  timeFrame?: TimeFrame;
+}
+
+interface SecurityPricesHighFrequencyResponse {
+  securityPricesHighFrequency: HighFrequencyPricePointNode[];
+}
+
+export async function fetchSecurityPricesHighFrequency(
+  client: GraphQLClient,
+  opts: FetchSecurityPricesHighFrequencyOpts
+): Promise<HighFrequencyPricePointNode[]> {
+  const data = await client.query<
+    { id: string; timeFrame?: TimeFrame },
+    SecurityPricesHighFrequencyResponse
+  >('SecurityPricesHighFrequency', SECURITY_PRICES_HIGH_FREQUENCY, {
+    id: opts.id,
+    timeFrame: opts.timeFrame,
+  });
+  return data.securityPricesHighFrequency;
+}

--- a/src/core/graphql/queries/security-prices.ts
+++ b/src/core/graphql/queries/security-prices.ts
@@ -1,0 +1,46 @@
+/**
+ * GraphQL query wrapper for SecurityPrices.
+ *
+ * Returns a date-sorted price series for a single security at daily
+ * granularity. Use for medium- to long-range views: `ONE_MONTH`,
+ * `THREE_MONTHS`, `YTD`, `ONE_YEAR`, `ALL`. For intraday ranges
+ * (`ONE_DAY`, `ONE_WEEK`), use `fetchSecurityPricesHighFrequency` instead
+ * — that variant returns intraday timestamps rather than per-day rows.
+ *
+ * The captured query at docs/graphql-capture/operations/queries/SecurityPrices.md
+ * declares its security argument as `$id: ID!` in the operation signature
+ * but passes it to the resolver as `securityId: $id`. The wrapper exposes
+ * the user-facing variable name `id` to match the operation signature.
+ */
+
+import type { GraphQLClient } from '../client.js';
+import { SECURITY_PRICES } from '../operations.generated.js';
+import type { TimeFrame } from './_shared.js';
+
+export interface SecurityPricePointNode {
+  id: string;
+  price: number;
+  /** ISO YYYY-MM-DD; one row per market day in the requested range. */
+  date: string;
+}
+
+export interface FetchSecurityPricesOpts {
+  id: string;
+  timeFrame?: TimeFrame;
+}
+
+interface SecurityPricesResponse {
+  securityPrices: SecurityPricePointNode[];
+}
+
+export async function fetchSecurityPrices(
+  client: GraphQLClient,
+  opts: FetchSecurityPricesOpts
+): Promise<SecurityPricePointNode[]> {
+  const data = await client.query<{ id: string; timeFrame?: TimeFrame }, SecurityPricesResponse>(
+    'SecurityPrices',
+    SECURITY_PRICES,
+    { id: opts.id, timeFrame: opts.timeFrame }
+  );
+  return data.securityPrices;
+}

--- a/src/core/graphql/queries/top-movers.ts
+++ b/src/core/graphql/queries/top-movers.ts
@@ -1,0 +1,62 @@
+/**
+ * GraphQL query wrapper for TopMovers.
+ *
+ * Returns the biggest movers across the user's holdings — one row per
+ * security with a recent-price series and a single aggregate `change`
+ * number. The web app fires this query twice on /investments load, once
+ * per `filter` value:
+ *
+ * - `PRICE_CHANGE`: ranks by raw security price change.
+ * - `MY_EQUITY_CHANGE`: ranks by the dollar impact on the user's position
+ *   (price change weighted by held quantity).
+ *
+ * The captured query at docs/graphql-capture/operations/queries/TopMovers.md
+ * takes an optional `$filter: TopMoversFilter`. When omitted, the server
+ * applies its own default; callers usually pass an explicit filter.
+ */
+
+import type { GraphQLClient } from '../client.js';
+import { TOP_MOVERS } from '../operations.generated.js';
+import type { SecurityNode } from './_shared.js';
+
+export type TopMoversFilter = 'PRICE_CHANGE' | 'MY_EQUITY_CHANGE';
+
+/**
+ * A single price point in a `TopMoverNode.values` series.
+ *
+ * `timestamp` is whatever opaque numeric the server returns. The captured
+ * payload does not disambiguate epoch-millis vs epoch-seconds, so consumers
+ * should treat it as an ordered key for plotting and not assume a unit
+ * without verifying against a live response.
+ */
+export interface PricePointNode {
+  id: string;
+  timestamp: number;
+  price: number;
+}
+
+export interface TopMoverNode {
+  security: SecurityNode;
+  values: PricePointNode[];
+  change: number;
+}
+
+export interface FetchTopMoversOpts {
+  filter?: TopMoversFilter;
+}
+
+interface TopMoversResponse {
+  topMovers: TopMoverNode[];
+}
+
+export async function fetchTopMovers(
+  client: GraphQLClient,
+  opts: FetchTopMoversOpts = {}
+): Promise<TopMoverNode[]> {
+  const data = await client.query<{ filter?: TopMoversFilter }, TopMoversResponse>(
+    'TopMovers',
+    TOP_MOVERS,
+    { filter: opts.filter }
+  );
+  return data.topMovers;
+}

--- a/tests/core/graphql/queries/aggregated-holdings.test.ts
+++ b/tests/core/graphql/queries/aggregated-holdings.test.ts
@@ -42,14 +42,14 @@ describe('fetchAggregatedHoldings', () => {
       await import('../../../../src/core/graphql/queries/aggregated-holdings.js');
     await fetchAggregatedHoldings(client, {
       timeFrame: 'YTD',
-      filter: [],
+      filter: [{ kind: 'assetClass', value: 'equity' }],
       accountId: 'a1',
       itemId: 'i1',
     });
 
     expect(client.query).toHaveBeenCalledWith('AggregatedHoldings', expect.any(String), {
       timeFrame: 'YTD',
-      filter: [],
+      filter: [{ kind: 'assetClass', value: 'equity' }],
       accountId: 'a1',
       itemId: 'i1',
     });

--- a/tests/core/graphql/queries/aggregated-holdings.test.ts
+++ b/tests/core/graphql/queries/aggregated-holdings.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../../src/core/graphql/client.js';
+
+describe('fetchAggregatedHoldings', () => {
+  test('returns the aggregatedHoldings array as-is from the GraphQL response', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          aggregatedHoldings: [
+            {
+              security: {
+                id: 's1',
+                name: 'Synthetic ETF',
+                symbol: 'SYN',
+                type: 'EQUITY',
+                lastUpdate: '2026-05-01T00:00:00Z',
+                marketInfo: { closeTime: 1700000000000, openTime: 1700000000000 },
+              },
+              change: 50,
+              value: 1000,
+            },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchAggregatedHoldings } =
+      await import('../../../../src/core/graphql/queries/aggregated-holdings.js');
+    const rows = await fetchAggregatedHoldings(client, { timeFrame: 'ONE_MONTH' });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.value).toBe(1000);
+    expect(rows[0]?.security.symbol).toBe('SYN');
+  });
+
+  test('passes timeFrame, filter, accountId, itemId through', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ aggregatedHoldings: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchAggregatedHoldings } =
+      await import('../../../../src/core/graphql/queries/aggregated-holdings.js');
+    await fetchAggregatedHoldings(client, {
+      timeFrame: 'YTD',
+      filter: [],
+      accountId: 'a1',
+      itemId: 'i1',
+    });
+
+    expect(client.query).toHaveBeenCalledWith('AggregatedHoldings', expect.any(String), {
+      timeFrame: 'YTD',
+      filter: [],
+      accountId: 'a1',
+      itemId: 'i1',
+    });
+  });
+
+  test('handles empty response with default opts', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ aggregatedHoldings: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchAggregatedHoldings } =
+      await import('../../../../src/core/graphql/queries/aggregated-holdings.js');
+    const rows = await fetchAggregatedHoldings(client);
+
+    expect(rows).toEqual([]);
+    expect(client.query).toHaveBeenCalledWith('AggregatedHoldings', expect.any(String), {
+      timeFrame: undefined,
+      filter: undefined,
+      accountId: undefined,
+      itemId: undefined,
+    });
+  });
+});

--- a/tests/core/graphql/queries/balance-history.test.ts
+++ b/tests/core/graphql/queries/balance-history.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../../src/core/graphql/client.js';
+
+describe('fetchAccountBalanceHistory', () => {
+  test('returns the accountBalanceHistory array as-is from the GraphQL response', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          accountBalanceHistory: [
+            { date: '2026-04-01', balance: 100 },
+            { date: '2026-04-02', balance: 200 },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchAccountBalanceHistory } =
+      await import('../../../../src/core/graphql/queries/balance-history.js');
+    const rows = await fetchAccountBalanceHistory(client, {
+      itemId: 'i1',
+      accountId: 'a1',
+      timeFrame: 'ONE_MONTH',
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.date).toBe('2026-04-01');
+    expect(rows[1]?.balance).toBe(200);
+  });
+
+  test('passes itemId, accountId, timeFrame through as variables', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ accountBalanceHistory: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchAccountBalanceHistory } =
+      await import('../../../../src/core/graphql/queries/balance-history.js');
+    await fetchAccountBalanceHistory(client, {
+      itemId: 'i1',
+      accountId: 'a1',
+      timeFrame: 'YTD',
+    });
+
+    expect(client.query).toHaveBeenCalledWith('BalanceHistory', expect.any(String), {
+      itemId: 'i1',
+      accountId: 'a1',
+      timeFrame: 'YTD',
+    });
+  });
+
+  test('handles empty response and omits timeFrame when not provided', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ accountBalanceHistory: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchAccountBalanceHistory } =
+      await import('../../../../src/core/graphql/queries/balance-history.js');
+    const rows = await fetchAccountBalanceHistory(client, { itemId: 'i1', accountId: 'a1' });
+
+    expect(rows).toEqual([]);
+    expect(client.query).toHaveBeenCalledWith('BalanceHistory', expect.any(String), {
+      itemId: 'i1',
+      accountId: 'a1',
+      timeFrame: undefined,
+    });
+  });
+});

--- a/tests/core/graphql/queries/holdings.test.ts
+++ b/tests/core/graphql/queries/holdings.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../../src/core/graphql/client.js';
+
+describe('fetchHoldings', () => {
+  test('returns the holdings array as-is from the GraphQL response', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          holdings: [
+            {
+              id: 'h1',
+              accountId: 'a1',
+              itemId: 'i1',
+              quantity: 10,
+              security: {
+                id: 's1',
+                name: 'Synthetic ETF',
+                symbol: 'SYN',
+                type: 'EQUITY',
+                currentPrice: 100,
+                lastUpdate: '2026-05-01T00:00:00Z',
+                marketInfo: { closeTime: 1700000000000, openTime: 1700000000000 },
+              },
+              metrics: { averageCost: 80, costBasis: 800, totalReturn: 200 },
+            },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchHoldings } = await import('../../../../src/core/graphql/queries/holdings.js');
+    const rows = await fetchHoldings(client);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe('h1');
+    expect(rows[0]?.security.symbol).toBe('SYN');
+    expect(rows[0]?.metrics?.costBasis).toBe(800);
+  });
+
+  test('passes no variables (Holdings query takes none)', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ holdings: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchHoldings } = await import('../../../../src/core/graphql/queries/holdings.js');
+    await fetchHoldings(client);
+
+    expect(client.query).toHaveBeenCalledWith('Holdings', expect.any(String), {});
+  });
+
+  test('preserves null metrics for CASH positions', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          holdings: [
+            {
+              id: 'h2',
+              accountId: 'a1',
+              itemId: 'i1',
+              quantity: 562.5,
+              security: {
+                id: 's-cash',
+                name: 'Cash',
+                symbol: 'CASH',
+                type: 'CASH',
+                currentPrice: 1,
+                lastUpdate: '2026-05-01T00:00:00Z',
+                marketInfo: { closeTime: null, openTime: null },
+              },
+              metrics: null,
+            },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchHoldings } = await import('../../../../src/core/graphql/queries/holdings.js');
+    const rows = await fetchHoldings(client);
+
+    expect(rows[0]?.metrics).toBeNull();
+    expect(rows[0]?.security.marketInfo.closeTime).toBeNull();
+  });
+});

--- a/tests/core/graphql/queries/investment-allocation.test.ts
+++ b/tests/core/graphql/queries/investment-allocation.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../../src/core/graphql/client.js';
+
+describe('fetchInvestmentAllocation', () => {
+  test('returns the investmentAllocation array as-is from the GraphQL response', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          investmentAllocation: [
+            { id: 'a1', type: 'EQUITY', amount: 800, percentage: 80 },
+            { id: 'a2', type: 'CASH', amount: 200, percentage: 20 },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchInvestmentAllocation } =
+      await import('../../../../src/core/graphql/queries/investment-allocation.js');
+    const rows = await fetchInvestmentAllocation(client);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.type).toBe('EQUITY');
+    expect(rows[1]?.amount).toBe(200);
+  });
+
+  test('passes filter through as a variable', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ investmentAllocation: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchInvestmentAllocation } =
+      await import('../../../../src/core/graphql/queries/investment-allocation.js');
+    await fetchInvestmentAllocation(client, { filter: { accountId: 'a1', itemId: 'i1' } });
+
+    expect(client.query).toHaveBeenCalledWith('InvestmentAllocation', expect.any(String), {
+      filter: { accountId: 'a1', itemId: 'i1' },
+    });
+  });
+
+  test('handles empty response with no filter', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ investmentAllocation: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchInvestmentAllocation } =
+      await import('../../../../src/core/graphql/queries/investment-allocation.js');
+    const rows = await fetchInvestmentAllocation(client);
+
+    expect(rows).toEqual([]);
+    expect(client.query).toHaveBeenCalledWith('InvestmentAllocation', expect.any(String), {
+      filter: undefined,
+    });
+  });
+});

--- a/tests/core/graphql/queries/investment-balance.test.ts
+++ b/tests/core/graphql/queries/investment-balance.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../../src/core/graphql/client.js';
+
+describe('fetchInvestmentBalance', () => {
+  test('returns the investmentBalance array as-is from the GraphQL response', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          investmentBalance: [
+            { id: 'd1', date: '2026-04-01', balance: 100 },
+            { id: 'd2', date: '2026-04-02', balance: 200 },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchInvestmentBalance } =
+      await import('../../../../src/core/graphql/queries/investment-balance.js');
+    const rows = await fetchInvestmentBalance(client, { timeFrame: 'ONE_MONTH' });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.balance).toBe(100);
+    expect(rows[1]?.date).toBe('2026-04-02');
+  });
+
+  test('passes timeFrame through as a variable', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ investmentBalance: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchInvestmentBalance } =
+      await import('../../../../src/core/graphql/queries/investment-balance.js');
+    await fetchInvestmentBalance(client, { timeFrame: 'ALL' });
+
+    expect(client.query).toHaveBeenCalledWith('InvestmentBalance', expect.any(String), {
+      timeFrame: 'ALL',
+    });
+  });
+
+  test('handles empty response with default opts', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ investmentBalance: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchInvestmentBalance } =
+      await import('../../../../src/core/graphql/queries/investment-balance.js');
+    const rows = await fetchInvestmentBalance(client);
+
+    expect(rows).toEqual([]);
+    expect(client.query).toHaveBeenCalledWith('InvestmentBalance', expect.any(String), {
+      timeFrame: undefined,
+    });
+  });
+});

--- a/tests/core/graphql/queries/investment-live-balance.test.ts
+++ b/tests/core/graphql/queries/investment-live-balance.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../../src/core/graphql/client.js';
+
+describe('fetchInvestmentLiveBalance', () => {
+  test('returns the single investmentLiveBalance row as-is', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          investmentLiveBalance: { id: 'live1', date: '2026-05-04', balance: 562.5 },
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchInvestmentLiveBalance } =
+      await import('../../../../src/core/graphql/queries/investment-live-balance.js');
+    const row = await fetchInvestmentLiveBalance(client);
+
+    expect(row.id).toBe('live1');
+    expect(row.balance).toBe(562.5);
+    expect(row.date).toBe('2026-05-04');
+  });
+
+  test('passes no variables (InvestmentLiveBalance query takes none)', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          investmentLiveBalance: { id: 'live1', date: '2026-05-04', balance: 100 },
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchInvestmentLiveBalance } =
+      await import('../../../../src/core/graphql/queries/investment-live-balance.js');
+    await fetchInvestmentLiveBalance(client);
+
+    expect(client.query).toHaveBeenCalledWith('InvestmentLiveBalance', expect.any(String), {});
+  });
+
+  test('preserves a zero balance faithfully', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          investmentLiveBalance: { id: 'live2', date: '2026-05-04', balance: 0 },
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchInvestmentLiveBalance } =
+      await import('../../../../src/core/graphql/queries/investment-live-balance.js');
+    const row = await fetchInvestmentLiveBalance(client);
+
+    expect(row.balance).toBe(0);
+  });
+});

--- a/tests/core/graphql/queries/security-prices-high-frequency.test.ts
+++ b/tests/core/graphql/queries/security-prices-high-frequency.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../../src/core/graphql/client.js';
+
+describe('fetchSecurityPricesHighFrequency', () => {
+  test('returns the securityPricesHighFrequency array as-is', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          securityPricesHighFrequency: [
+            { id: 'p1', timestamp: 1700000000000, price: 100 },
+            { id: 'p2', timestamp: 1700000060000, price: 200 },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchSecurityPricesHighFrequency } =
+      await import('../../../../src/core/graphql/queries/security-prices-high-frequency.js');
+    const rows = await fetchSecurityPricesHighFrequency(client, {
+      id: 's1',
+      timeFrame: 'ONE_DAY',
+    });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.timestamp).toBe(1700000000000);
+    expect(rows[1]?.price).toBe(200);
+  });
+
+  test('passes id and timeFrame through as variables', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ securityPricesHighFrequency: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchSecurityPricesHighFrequency } =
+      await import('../../../../src/core/graphql/queries/security-prices-high-frequency.js');
+    await fetchSecurityPricesHighFrequency(client, { id: 's1', timeFrame: 'ONE_WEEK' });
+
+    expect(client.query).toHaveBeenCalledWith('SecurityPricesHighFrequency', expect.any(String), {
+      id: 's1',
+      timeFrame: 'ONE_WEEK',
+    });
+  });
+
+  test('handles empty intraday response', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ securityPricesHighFrequency: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchSecurityPricesHighFrequency } =
+      await import('../../../../src/core/graphql/queries/security-prices-high-frequency.js');
+    const rows = await fetchSecurityPricesHighFrequency(client, { id: 's1' });
+
+    expect(rows).toEqual([]);
+  });
+});

--- a/tests/core/graphql/queries/security-prices-high-frequency.test.ts
+++ b/tests/core/graphql/queries/security-prices-high-frequency.test.ts
@@ -41,7 +41,7 @@ describe('fetchSecurityPricesHighFrequency', () => {
     });
   });
 
-  test('handles empty intraday response', async () => {
+  test('omits timeFrame when not provided', async () => {
     const client = {
       query: mock(() => Promise.resolve({ securityPricesHighFrequency: [] })),
     } as unknown as GraphQLClient;
@@ -51,5 +51,9 @@ describe('fetchSecurityPricesHighFrequency', () => {
     const rows = await fetchSecurityPricesHighFrequency(client, { id: 's1' });
 
     expect(rows).toEqual([]);
+    expect(client.query).toHaveBeenCalledWith('SecurityPricesHighFrequency', expect.any(String), {
+      id: 's1',
+      timeFrame: undefined,
+    });
   });
 });

--- a/tests/core/graphql/queries/security-prices.test.ts
+++ b/tests/core/graphql/queries/security-prices.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../../src/core/graphql/client.js';
+
+describe('fetchSecurityPrices', () => {
+  test('returns the securityPrices array as-is from the GraphQL response', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          securityPrices: [
+            { id: 'p1', date: '2026-04-01', price: 100 },
+            { id: 'p2', date: '2026-04-02', price: 200 },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchSecurityPrices } =
+      await import('../../../../src/core/graphql/queries/security-prices.js');
+    const rows = await fetchSecurityPrices(client, { id: 's1', timeFrame: 'ONE_MONTH' });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.date).toBe('2026-04-01');
+    expect(rows[0]?.price).toBe(100);
+  });
+
+  test('passes id and timeFrame through as variables', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ securityPrices: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchSecurityPrices } =
+      await import('../../../../src/core/graphql/queries/security-prices.js');
+    await fetchSecurityPrices(client, { id: 's1', timeFrame: 'YTD' });
+
+    expect(client.query).toHaveBeenCalledWith('SecurityPrices', expect.any(String), {
+      id: 's1',
+      timeFrame: 'YTD',
+    });
+  });
+
+  test('omits timeFrame when not provided', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ securityPrices: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchSecurityPrices } =
+      await import('../../../../src/core/graphql/queries/security-prices.js');
+    const rows = await fetchSecurityPrices(client, { id: 's1' });
+
+    expect(rows).toEqual([]);
+    expect(client.query).toHaveBeenCalledWith('SecurityPrices', expect.any(String), {
+      id: 's1',
+      timeFrame: undefined,
+    });
+  });
+});

--- a/tests/core/graphql/queries/top-movers.test.ts
+++ b/tests/core/graphql/queries/top-movers.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../../src/core/graphql/client.js';
+
+describe('fetchTopMovers', () => {
+  test('returns the topMovers array as-is from the GraphQL response', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          topMovers: [
+            {
+              security: {
+                id: 's1',
+                name: 'Synthetic ETF',
+                symbol: 'SYN',
+                type: 'EQUITY',
+                currentPrice: 100,
+                lastUpdate: '2026-05-01T00:00:00Z',
+                marketInfo: { closeTime: 1700000000000, openTime: 1700000000000 },
+              },
+              values: [
+                { id: 'p1', timestamp: 1700000000000, price: 95 },
+                { id: 'p2', timestamp: 1700003600000, price: 100 },
+              ],
+              change: 5,
+            },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchTopMovers } = await import('../../../../src/core/graphql/queries/top-movers.js');
+    const rows = await fetchTopMovers(client, { filter: 'PRICE_CHANGE' });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.change).toBe(5);
+    expect(rows[0]?.values).toHaveLength(2);
+  });
+
+  test('passes the filter variable through', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ topMovers: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchTopMovers } = await import('../../../../src/core/graphql/queries/top-movers.js');
+    await fetchTopMovers(client, { filter: 'MY_EQUITY_CHANGE' });
+
+    expect(client.query).toHaveBeenCalledWith('TopMovers', expect.any(String), {
+      filter: 'MY_EQUITY_CHANGE',
+    });
+  });
+
+  test('omits filter when no opts are passed', async () => {
+    const client = {
+      query: mock(() => Promise.resolve({ topMovers: [] })),
+    } as unknown as GraphQLClient;
+
+    const { fetchTopMovers } = await import('../../../../src/core/graphql/queries/top-movers.js');
+    const rows = await fetchTopMovers(client);
+
+    expect(rows).toEqual([]);
+    expect(client.query).toHaveBeenCalledWith('TopMovers', expect.any(String), {
+      filter: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PR 2 of the investments-surface roadmap. Adds nine type-safe GraphQL query wrappers plus a shared types module. **No MCP tools wired, no behavior change** — these helpers sit dormant until subsequent PRs invoke them.

Roadmap:
- **PR #372** (merged): captured operations + IN_SCOPE_QUERIES entries.
- **PR 2 (this PR)**: 9 query wrappers + tests.
- **PR 3**: `get_holdings_live` MCP tool on top of `fetchHoldings`.
- **PR 4**: `get_balance_history_live` MCP tool on top of `fetchAccountBalanceHistory`.
- **PR 5**: cleanup of dead cache-backed investment tools.

## New files

Wrappers in `src/core/graphql/queries/`:

- `_shared.ts` — `TimeFrame` union, `MarketInfoNode`, `SecurityNode` (shared by holdings + top-movers; aggregated-holdings uses a slimmer variant).
- `holdings.ts` — `fetchHoldings(client)`. Documents the `metrics: null` case for CASH positions and that `totalReturn` is dollars (web-app derives the percentage as `totalReturn / costBasis`).
- `top-movers.ts` — `fetchTopMovers(client, opts)`. Exports the `TopMoversFilter` union (`PRICE_CHANGE` / `MY_EQUITY_CHANGE`). `PricePointNode.timestamp` is documented as opaque numeric (capture did not disambiguate ms vs seconds).
- `aggregated-holdings.ts` — `fetchAggregatedHoldings(client, opts)`. Uses a slimmer `AggregatedSecurityNode` (omits `currentPrice`) because the captured query intentionally doesn't select it.
- `security-prices.ts` — `fetchSecurityPrices(client, opts)`. Daily granularity; documents which time frames are valid here vs the high-frequency variant.
- `security-prices-high-frequency.ts` — `fetchSecurityPricesHighFrequency(client, opts)`. Intraday only (ONE_DAY / ONE_WEEK).
- `investment-balance.ts` — `fetchInvestmentBalance(client, opts)`. Timeseries.
- `investment-live-balance.ts` — `fetchInvestmentLiveBalance(client)`. Single-point companion to investment-balance; reuses `InvestmentBalanceNode`.
- `investment-allocation.ts` — `fetchInvestmentAllocation(client, opts)`. Exports `AllocationFilter` (`accountId` / `itemId`).
- `balance-history.ts` — `fetchAccountBalanceHistory(client, opts)`. Operation is named `BalanceHistory` but the resolver returns under `accountBalanceHistory`; the wrapper does the unwrap.

Tests mirror the structure under `tests/core/graphql/queries/`, three to four cases per wrapper:
- Happy path (returns the unwrapped array/object faithfully).
- Variables passed to `client.query` correctly.
- Empty / null / default-opts edge case (e.g. `metrics: null` for CASH; `marketInfo` with null `closeTime` / `openTime`; absent `timeFrame`).

## Test plan

- [x] `bun run check` (typecheck + lint + format:check + tests) passes locally — 1917 pass / 0 fail.
- [x] Synthetic numbers only (100, 200, 562.5, 1000, opaque epoch ts) — no PII.
- [x] No MCP tool registration — verified `src/server.ts` and `src/tools/tools.ts` are untouched.