### PR TITLE
feat(live): add get_holdings_live MCP tool (PR 3 of 5)

### DIFF
--- a/scripts/smoke-graphql.ts
+++ b/scripts/smoke-graphql.ts
@@ -58,6 +58,7 @@ import {
 } from '../src/core/graphql/recurrings.js';
 import { setBudget } from '../src/core/graphql/budgets.js';
 import { editAccount } from '../src/core/graphql/accounts.js';
+import { fetchHoldings } from '../src/core/graphql/queries/holdings.js';
 
 // -----------------------------------------------------------------------------
 // Polling helper — wait for a local-cache read to reflect a GraphQL write
@@ -129,6 +130,7 @@ const VALID_SECTIONS = [
   'recurrings',
   'budgets',
   'accounts',
+  'holdings',
   'bulk',
   'errors',
   'edge',
@@ -1520,6 +1522,49 @@ async function smokeAccountsHappyPath(
   });
 }
 
+/**
+ * Holdings — read-only smoke. No setup or cleanup. Verifies the query
+ * round-trips, returns a well-shaped payload, and (when at least one
+ * holding has metrics) the metric fields are numeric. Counts are printed
+ * but individual holdings are not (PII).
+ */
+async function smokeHoldingsHappyPath(client: GraphQLClient): Promise<void> {
+  logSection('Holdings — happy path');
+
+  await step('holdings', 'fetchHoldings returns well-shaped payload', async () => {
+    const rows = await fetchHoldings(client);
+    console.log(`  Holdings count: ${rows.length}`);
+    if (rows.length === 0) return;
+
+    const first = rows[0];
+    if (!first || typeof first.id !== 'string' || first.id.length === 0) {
+      throw new Error('holdings[0].id missing or empty');
+    }
+    if (typeof first.accountId !== 'string' || first.accountId.length === 0) {
+      throw new Error('holdings[0].accountId missing or empty');
+    }
+    if (typeof first.quantity !== 'number') {
+      throw new Error(`holdings[0].quantity expected number, got ${typeof first.quantity}`);
+    }
+    if (!first.security || typeof first.security.id !== 'string') {
+      throw new Error('holdings[0].security missing or malformed');
+    }
+
+    if (first.metrics) {
+      const { averageCost, costBasis, totalReturn } = first.metrics;
+      if (
+        typeof averageCost !== 'number' ||
+        typeof costBasis !== 'number' ||
+        typeof totalReturn !== 'number'
+      ) {
+        throw new Error(
+          `holdings[0].metrics fields not all numeric (averageCost=${typeof averageCost}, costBasis=${typeof costBasis}, totalReturn=${typeof totalReturn})`
+        );
+      }
+    }
+  });
+}
+
 // -----------------------------------------------------------------------------
 // Section 2 — Bulk operations
 // -----------------------------------------------------------------------------
@@ -2734,6 +2779,7 @@ async function main(): Promise<void> {
   }
   if (sectionEnabled('budgets')) await smokeBudgetsHappyPath(client, db);
   if (sectionEnabled('accounts')) await smokeAccountsHappyPath(client, db);
+  if (sectionEnabled('holdings')) await smokeHoldingsHappyPath(client);
 
   // Section 2 — bulk
   if (sectionEnabled('bulk')) await smokeBulkReviewTransactions(client, db);

--- a/scripts/smoke-graphql.ts
+++ b/scripts/smoke-graphql.ts
@@ -19,8 +19,8 @@
  *   bun run scripts/smoke-graphql.ts --section transactions-write
  *
  * Sections: tags, categories, transactions, transactions-write, recurrings,
- *           budgets, accounts, bulk, errors, edge, consistency, mcp-e2e,
- *           state-gated
+ *           budgets, accounts, holdings, bulk, errors, edge, consistency,
+ *           mcp-e2e, state-gated
  *
  * State-gated tests are opt-in because they require the user to toggle UI
  * state manually in the Copilot desktop app between prompts.

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -39,6 +39,7 @@ import type { RecurringNode } from './graphql/queries/recurrings.js';
 import type { NetworthHistoryNode } from './graphql/queries/networth.js';
 import type { UpcomingRecurringNode } from './graphql/queries/upcoming-recurrings.js';
 import type { DailySpendNode } from './graphql/queries/monthly-spend.js';
+import type { HoldingNode } from './graphql/queries/holdings.js';
 import { fetchUser, type UserNode } from './graphql/queries/user.js';
 import type { Transaction } from '../models/index.js';
 
@@ -86,6 +87,13 @@ export class LiveCopilotDatabase {
   // the 1h TTL still applies to the most-recently-requested timeFrame.
   private readonly networthCache: SnapshotCache<NetworthHistoryNode>;
   private readonly monthlySpendCache: SnapshotCache<DailySpendNode>;
+  // holdingsCache stores investment positions (one row per (account, security)).
+  // 6h TTL: positions change slowly (no daily buy/sell for most users); intraday
+  // price drift inside `security.currentPrice` and `metrics.totalReturn` does
+  // not need second-by-second freshness for agent queries — matches the
+  // `recurringCache` TTL precedent for similarly slow-moving entities. Callers
+  // who need a fresh snapshot can use refresh_cache with scope='holdings'.
+  private readonly holdingsCache: SnapshotCache<HoldingNode>;
   private readonly transactionsWindowCache: TransactionWindowCache<TransactionNode>;
 
   constructor(
@@ -133,6 +141,10 @@ export class LiveCopilotDatabase {
     );
     this.monthlySpendCache = new SnapshotCache<DailySpendNode>(
       { key: 'monthly_spend', ttlMs: ONE_HOUR_MS, keyFn: (d) => d.id },
+      this.inflight
+    );
+    this.holdingsCache = new SnapshotCache<HoldingNode>(
+      { key: 'holdings', ttlMs: SIX_HOURS_MS, keyFn: (h) => h.id },
       this.inflight
     );
     this.transactionsWindowCache = new TransactionWindowCache<TransactionNode>(
@@ -373,6 +385,10 @@ export class LiveCopilotDatabase {
 
   getMonthlySpendCache(): SnapshotCache<DailySpendNode> {
     return this.monthlySpendCache;
+  }
+
+  getHoldingsCache(): SnapshotCache<HoldingNode> {
+    return this.holdingsCache;
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,7 @@ import {
   LiveMonthlySpendTools,
   createLiveMonthlySpendToolSchema,
 } from './tools/live/monthly-spend.js';
+import { LiveHoldingsTools, createLiveHoldingsToolSchema } from './tools/live/holdings.js';
 import { RefreshCacheTool, createRefreshCacheToolSchema } from './tools/live/refresh-cache.js';
 
 // Read version from package.json
@@ -58,6 +59,7 @@ export class CopilotMoneyServer {
   private liveNetworthTools?: LiveNetworthTools;
   private liveUpcomingRecurringsTools?: LiveUpcomingRecurringsTools;
   private liveMonthlySpendTools?: LiveMonthlySpendTools;
+  private liveHoldingsTools?: LiveHoldingsTools;
   private refreshCacheTool?: RefreshCacheTool;
 
   /**
@@ -97,6 +99,7 @@ export class CopilotMoneyServer {
       this.liveNetworthTools = new LiveNetworthTools(liveDb);
       this.liveUpcomingRecurringsTools = new LiveUpcomingRecurringsTools(liveDb);
       this.liveMonthlySpendTools = new LiveMonthlySpendTools(liveDb);
+      this.liveHoldingsTools = new LiveHoldingsTools(liveDb);
       this.refreshCacheTool = new RefreshCacheTool(liveDb);
     }
 
@@ -122,6 +125,11 @@ export class CopilotMoneyServer {
    */
   handleListTools(): { tools: Tool[] } {
     const readSchemas = createToolSchemas();
+    // When --live-reads is on, the cache-mode reads in this list are swapped
+    // out for their _live counterparts below. Keep this in sync with the
+    // liveSchemas array — for every name removed here there must be a live
+    // schema added below (and vice versa) so users see exactly one tool per
+    // semantic read.
     const filteredReads = this.liveReadsEnabled
       ? readSchemas.filter(
           (s) =>
@@ -129,7 +137,8 @@ export class CopilotMoneyServer {
             s.name !== 'get_accounts' &&
             s.name !== 'get_categories' &&
             s.name !== 'get_budgets' &&
-            s.name !== 'get_recurring_transactions'
+            s.name !== 'get_recurring_transactions' &&
+            s.name !== 'get_holdings'
         )
       : readSchemas;
     const liveSchemas = this.liveReadsEnabled
@@ -143,6 +152,7 @@ export class CopilotMoneyServer {
           createLiveNetworthToolSchema(),
           createLiveUpcomingRecurringsToolSchema(),
           createLiveMonthlySpendToolSchema(),
+          createLiveHoldingsToolSchema(),
           createRefreshCacheToolSchema(),
         ]
       : [];
@@ -313,6 +323,18 @@ export class CopilotMoneyServer {
       };
     }
 
+    if (name === 'get_holdings_live' && !this.liveHoldingsTools) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'get_holdings_live is only available when the server runs with --live-reads.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
     if (name === 'refresh_cache' && !this.refreshCacheTool) {
       return {
         content: [
@@ -419,6 +441,15 @@ export class CopilotMoneyServer {
           result = await this.liveMonthlySpendTools!.getMonthlySpend(
             (typedArgs as Parameters<
               NonNullable<typeof this.liveMonthlySpendTools>['getMonthlySpend']
+            >[0]) ?? {}
+          );
+          break;
+
+        case 'get_holdings_live':
+          // liveHoldingsTools non-null invariant enforced by the early guard above.
+          result = await this.liveHoldingsTools!.getHoldings(
+            (typedArgs as Parameters<
+              NonNullable<typeof this.liveHoldingsTools>['getHoldings']
             >[0]) ?? {}
           );
           break;

--- a/src/tools/live/holdings.ts
+++ b/src/tools/live/holdings.ts
@@ -1,0 +1,217 @@
+/**
+ * Live-mode get_holdings_live tool.
+ *
+ * Wraps the GraphQL `Holdings` query, projecting each row onto the same
+ * field shape as cache-mode `get_holdings` so agents trained on one work
+ * with the other. Backed by the SnapshotCache<HoldingNode> on
+ * LiveCopilotDatabase (6h TTL — positions move slowly, intraday price
+ * drift inside `currentPrice` does not need second-by-second freshness).
+ *
+ * Projection rules:
+ *   - `institution_value` is derived as `quantity * security.currentPrice`
+ *     (rounded to 2dp via `roundAmount`).
+ *   - `cost_basis`, `average_cost`, `total_return`, `total_return_percent`
+ *     come from `holding.metrics`. When `metrics` is `null` (most commonly
+ *     CASH sleeves inside investment accounts), all four are omitted from
+ *     the output rather than emitted as `null` — `is_cash_equivalent` on
+ *     the same row tells the caller why.
+ *   - `total_return_percent = (totalReturn / costBasis) * 100`. Guards
+ *     against `costBasis === 0` (would produce Infinity/NaN) by omitting
+ *     the field in that case.
+ *   - `is_cash_equivalent` is derived from `security.type === 'CASH'`,
+ *     NOT from the absence of metrics. Non-cash positions may also lack
+ *     metrics (rare, but possible for newly-imported securities).
+ *   - `iso_currency_code` is in cache-mode output but NOT in the GraphQL
+ *     Security shape, so it is intentionally omitted here.
+ *
+ * No `include_history` parameter — monthly snapshots are not available on
+ * the GraphQL `Holdings` query. Callers needing history should use the
+ * cache-mode `get_holdings` tool with `include_history: true`.
+ *
+ * Server order is preserved (no client-side sort).
+ */
+
+import type { LiveCopilotDatabase } from '../../core/live-database.js';
+import { fetchHoldings, type HoldingNode } from '../../core/graphql/queries/holdings.js';
+import { roundAmount } from '../../utils/round.js';
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 10_000;
+const MIN_LIMIT = 1;
+
+export interface GetHoldingsLiveArgs {
+  /** Filter — exact match on `holding.accountId`. */
+  account_id?: string;
+  /** Filter — case-insensitive match on `security.symbol`. */
+  ticker_symbol?: string;
+  /** Default 100; clamped to [1, 10000]. */
+  limit?: number;
+  /** Default 0; clamped to >= 0. */
+  offset?: number;
+}
+
+export interface GetHoldingsLiveEntry {
+  security_id: string;
+  ticker_symbol: string;
+  name: string;
+  type: string;
+  account_id: string;
+  item_id: string;
+  quantity: number;
+  institution_price: number;
+  institution_value: number;
+  cost_basis?: number;
+  average_cost?: number;
+  total_return?: number;
+  total_return_percent?: number;
+  is_cash_equivalent: boolean;
+}
+
+export interface GetHoldingsLiveResult {
+  count: number;
+  total_count: number;
+  offset: number;
+  has_more: boolean;
+  holdings: GetHoldingsLiveEntry[];
+  _cache_oldest_fetched_at: string;
+  _cache_newest_fetched_at: string;
+  _cache_hit: boolean;
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (limit === undefined) return DEFAULT_LIMIT;
+  return Math.max(MIN_LIMIT, Math.min(MAX_LIMIT, Math.floor(limit)));
+}
+
+function clampOffset(offset: number | undefined): number {
+  if (offset === undefined) return 0;
+  return Math.max(0, Math.floor(offset));
+}
+
+function projectHolding(h: HoldingNode): GetHoldingsLiveEntry {
+  const institutionValue = roundAmount(h.quantity * h.security.currentPrice);
+  const entry: GetHoldingsLiveEntry = {
+    security_id: h.security.id,
+    ticker_symbol: h.security.symbol,
+    name: h.security.name,
+    type: h.security.type,
+    account_id: h.accountId,
+    item_id: h.itemId,
+    quantity: h.quantity,
+    institution_price: h.security.currentPrice,
+    institution_value: institutionValue,
+    is_cash_equivalent: h.security.type === 'CASH',
+  };
+
+  if (h.metrics) {
+    entry.cost_basis = roundAmount(h.metrics.costBasis);
+    entry.average_cost = roundAmount(h.metrics.averageCost);
+    entry.total_return = roundAmount(h.metrics.totalReturn);
+    // Divide-by-zero guard: costBasis === 0 would yield Infinity (positive
+    // return) or NaN (zero/zero) — neither is meaningful as a percentage.
+    // Omit the field instead so callers can detect "unavailable" cleanly.
+    if (h.metrics.costBasis !== 0) {
+      entry.total_return_percent = roundAmount(
+        (h.metrics.totalReturn / Math.abs(h.metrics.costBasis)) * 100
+      );
+    }
+  }
+
+  return entry;
+}
+
+export class LiveHoldingsTools {
+  constructor(private readonly live: LiveCopilotDatabase) {}
+
+  async getHoldings(args: GetHoldingsLiveArgs): Promise<GetHoldingsLiveResult> {
+    const cache = this.live.getHoldingsCache();
+    const startedAt = Date.now();
+    const {
+      rows: cached,
+      fetched_at,
+      hit,
+    } = await cache.read(() => fetchHoldings(this.live.getClient()));
+
+    const limit = clampLimit(args.limit);
+    const offset = clampOffset(args.offset);
+    const tickerLower = args.ticker_symbol?.toLowerCase();
+
+    // Filter on the raw GraphQL rows before projection — cheaper than
+    // projecting then filtering, and the filter predicates only need
+    // fields already present on HoldingNode.
+    const filtered = cached.filter((h) => {
+      if (args.account_id && h.accountId !== args.account_id) return false;
+      if (tickerLower && h.security.symbol.toLowerCase() !== tickerLower) return false;
+      return true;
+    });
+
+    const totalCount = filtered.length;
+    const hasMore = offset + limit < totalCount;
+    const paged = filtered.slice(offset, offset + limit).map(projectHolding);
+
+    this.live.logReadCall({
+      op: 'Holdings',
+      pages: hit ? 0 : 1,
+      latencyMs: Date.now() - startedAt,
+      rows: paged.length,
+      cache_hit: hit,
+    });
+
+    const fetchedAtIso = new Date(fetched_at).toISOString();
+    // Both `_cache_oldest_fetched_at` and `_cache_newest_fetched_at` reflect
+    // the same single-snapshot fetch time — unlike the windowed transaction
+    // cache where they can differ across month windows.
+    return {
+      count: paged.length,
+      total_count: totalCount,
+      offset,
+      has_more: hasMore,
+      holdings: paged,
+      _cache_oldest_fetched_at: fetchedAtIso,
+      _cache_newest_fetched_at: fetchedAtIso,
+      _cache_hit: hit,
+    };
+  }
+}
+
+export function createLiveHoldingsToolSchema() {
+  return {
+    name: 'get_holdings_live',
+    description:
+      'Get investment positions with cost-basis metrics (live, GraphQL-backed). ' +
+      'One row per (account, security). For CASH sleeves and other positions ' +
+      'where the server returns no cost-basis metrics, the four derived fields ' +
+      '(cost_basis, average_cost, total_return, total_return_percent) are ' +
+      'omitted from the row; check `is_cash_equivalent` (derived from ' +
+      "`security.type === 'CASH'`) to distinguish. For monthly snapshots, " +
+      'use cache-mode `get_holdings` with `include_history: true` — history ' +
+      'is not available on the live query. Available when --live-reads is on.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        account_id: {
+          type: 'string',
+          description: 'Filter — exact match on the holding\'s accountId.',
+        },
+        ticker_symbol: {
+          type: 'string',
+          description:
+            'Filter — case-insensitive match on the security\'s ticker symbol.',
+        },
+        limit: {
+          type: 'number',
+          description: `Max rows to return. Default ${DEFAULT_LIMIT}, clamped to [${MIN_LIMIT}, ${MAX_LIMIT}].`,
+          default: DEFAULT_LIMIT,
+        },
+        offset: {
+          type: 'number',
+          description: 'Pagination offset (>= 0). Default 0.',
+          default: 0,
+        },
+      },
+    },
+    annotations: {
+      readOnlyHint: true,
+    },
+  };
+}

--- a/src/tools/live/holdings.ts
+++ b/src/tools/live/holdings.ts
@@ -110,6 +110,12 @@ function projectHolding(h: HoldingNode): GetHoldingsLiveEntry {
     // Divide-by-zero guard: costBasis === 0 would yield Infinity (positive
     // return) or NaN (zero/zero) — neither is meaningful as a percentage.
     // Omit the field instead so callers can detect "unavailable" cleanly.
+    //
+    // Denominator is `Math.abs(costBasis)` so a negative basis (short
+    // positions, margin accounts) preserves the sign of `totalReturn`:
+    // a short that goes against you (totalReturn < 0 with costBasis < 0)
+    // should report a negative percentage, not flip to positive via
+    // negative ÷ negative cancellation.
     if (h.metrics.costBasis !== 0) {
       entry.total_return_percent = roundAmount(
         (h.metrics.totalReturn / Math.abs(h.metrics.costBasis)) * 100

--- a/src/tools/live/holdings.ts
+++ b/src/tools/live/holdings.ts
@@ -191,12 +191,11 @@ export function createLiveHoldingsToolSchema() {
       properties: {
         account_id: {
           type: 'string',
-          description: 'Filter — exact match on the holding\'s accountId.',
+          description: "Filter — exact match on the holding's accountId.",
         },
         ticker_symbol: {
           type: 'string',
-          description:
-            'Filter — case-insensitive match on the security\'s ticker symbol.',
+          description: "Filter — case-insensitive match on the security's ticker symbol.",
         },
         limit: {
           type: 'number',

--- a/src/tools/live/refresh-cache.ts
+++ b/src/tools/live/refresh-cache.ts
@@ -22,6 +22,7 @@ const VALID_SCOPES = [
   'user',
   'networth',
   'monthly_spend',
+  'holdings',
 ] as const;
 
 const YEAR_MONTH_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
@@ -44,6 +45,7 @@ export interface RefreshCacheResult {
     user?: boolean;
     networth?: boolean;
     monthly_spend?: boolean;
+    holdings?: boolean;
     transactions_months?: string[] | 'all';
   };
 }
@@ -90,6 +92,8 @@ export class RefreshCacheTool {
       flushed.networth = true;
       this.live.getMonthlySpendCache().invalidate();
       flushed.monthly_spend = true;
+      this.live.getHoldingsCache().invalidate();
+      flushed.holdings = true;
     };
 
     const flushTransactions = () => {
@@ -150,6 +154,10 @@ export class RefreshCacheTool {
       case 'monthly_spend':
         this.live.getMonthlySpendCache().invalidate();
         flushed.monthly_spend = true;
+        break;
+      case 'holdings':
+        this.live.getHoldingsCache().invalidate();
+        flushed.holdings = true;
         break;
     }
 

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -2741,3 +2741,80 @@ describe('--live-reads monthly-spend wiring', () => {
     expect(data._cache_hit).toBe(false);
   });
 });
+
+// ============================================
+// --live-reads holdings wiring tests
+// ============================================
+
+describe('--live-reads holdings wiring', () => {
+  test('handleListTools when --live-reads is OFF includes get_holdings and excludes get_holdings_live', () => {
+    const server = new CopilotMoneyServer(FAKE_DB_DIR);
+    const { tools } = server.handleListTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('get_holdings');
+    expect(names).not.toContain('get_holdings_live');
+  });
+
+  test('handleListTools when --live-reads is ON includes get_holdings_live and excludes get_holdings', () => {
+    // Pass a mock GraphQL client so the constructor can wire liveHoldingsTools
+    // without attempting real auth. The fourth positional arg is liveReadsEnabled.
+    const mockClient = createMockGraphQLClient({});
+    const server = new CopilotMoneyServer(FAKE_DB_DIR, undefined, false, true, mockClient);
+    const { tools } = server.handleListTools();
+    const names = tools.map((t) => t.name);
+    expect(names).toContain('get_holdings_live');
+    expect(names).not.toContain('get_holdings');
+  });
+
+  test('get_holdings_live without --live-reads returns isError with --live-reads hint', async () => {
+    const server = new CopilotMoneyServer(FAKE_DB_DIR);
+    const db = createMockDb();
+    server._injectForTesting(db, new CopilotMoneyTools(db));
+
+    const result = await server.handleCallTool('get_holdings_live', {});
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('--live-reads');
+  });
+
+  test('get_holdings_live with --live-reads dispatches to liveHoldingsTools.getHoldings', async () => {
+    const mockClient = createMockGraphQLClient({});
+    const server = new CopilotMoneyServer(FAKE_DB_DIR, undefined, false, true, mockClient);
+    const db = createMockDb();
+    server._injectForTesting(db, new CopilotMoneyTools(db));
+
+    // Inject a stub LiveHoldingsTools via private field access
+    const stubResult = {
+      count: 1,
+      total_count: 1,
+      offset: 0,
+      has_more: false,
+      holdings: [
+        {
+          security_id: 'sec-1',
+          ticker_symbol: 'ACME',
+          name: 'Acme',
+          type: 'EQUITY',
+          account_id: 'acct-1',
+          item_id: 'item-1',
+          quantity: 10,
+          institution_price: 100,
+          institution_value: 1000,
+          is_cash_equivalent: false,
+        },
+      ],
+      _cache_oldest_fetched_at: '2025-01-01T00:00:00.000Z',
+      _cache_newest_fetched_at: '2025-01-01T00:00:00.000Z',
+      _cache_hit: false,
+    };
+    (server as any).liveHoldingsTools = {
+      getHoldings: async (_args: unknown) => stubResult,
+    };
+
+    const result = await server.handleCallTool('get_holdings_live', {});
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text) as typeof stubResult;
+    expect(data.count).toBe(1);
+    expect(data.holdings[0]?.security_id).toBe('sec-1');
+    expect(data._cache_hit).toBe(false);
+  });
+});

--- a/tests/tools/live/holdings.test.ts
+++ b/tests/tools/live/holdings.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../src/core/graphql/client.js';
+import { CopilotDatabase } from '../../../src/core/database.js';
+import { LiveCopilotDatabase } from '../../../src/core/live-database.js';
+import { LiveHoldingsTools } from '../../../src/tools/live/holdings.js';
+
+function makeClient(rows: unknown[]): GraphQLClient {
+  return {
+    query: mock(() => Promise.resolve({ holdings: rows })),
+  } as unknown as GraphQLClient;
+}
+
+function makeLive(client: GraphQLClient): LiveCopilotDatabase {
+  return new LiveCopilotDatabase(client, new CopilotDatabase('/tmp/no-such-db'));
+}
+
+const equityHolding = {
+  id: 'h-equity',
+  accountId: 'acct-1',
+  itemId: 'item-1',
+  quantity: 10,
+  security: {
+    id: 'sec-equity',
+    name: 'Acme Corp',
+    symbol: 'ACME',
+    type: 'EQUITY',
+    currentPrice: 100,
+    lastUpdate: '2026-05-04',
+    marketInfo: { closeTime: null, openTime: null },
+  },
+  metrics: {
+    averageCost: 80,
+    costBasis: 800,
+    totalReturn: 200,
+  },
+};
+
+const mutualFundHolding = {
+  id: 'h-mf',
+  accountId: 'acct-1',
+  itemId: 'item-1',
+  quantity: 5,
+  security: {
+    id: 'sec-mf',
+    name: 'Index Fund',
+    symbol: 'IDX',
+    type: 'MUTUAL_FUND',
+    currentPrice: 200,
+    lastUpdate: '2026-05-04',
+    marketInfo: { closeTime: null, openTime: null },
+  },
+  metrics: {
+    averageCost: 150,
+    costBasis: 750,
+    totalReturn: 250,
+  },
+};
+
+const cashHolding = {
+  id: 'h-cash',
+  accountId: 'acct-2',
+  itemId: 'item-2',
+  quantity: 562.5,
+  security: {
+    id: 'sec-cash',
+    name: 'USD Cash',
+    symbol: 'USD',
+    type: 'CASH',
+    currentPrice: 1,
+    lastUpdate: '2026-05-04',
+    marketInfo: { closeTime: null, openTime: null },
+  },
+  metrics: null,
+};
+
+describe('LiveHoldingsTools.getHoldings', () => {
+  test('projects equity/mutual-fund metrics and computes institution_value + return %', async () => {
+    const client = makeClient([equityHolding, mutualFundHolding, cashHolding]);
+    const tools = new LiveHoldingsTools(makeLive(client));
+
+    const result = await tools.getHoldings({});
+
+    expect(result.count).toBe(3);
+    expect(result.total_count).toBe(3);
+    expect(result.has_more).toBe(false);
+    expect(result.holdings).toHaveLength(3);
+
+    const equity = result.holdings.find((h) => h.security_id === 'sec-equity');
+    expect(equity).toBeDefined();
+    expect(equity?.ticker_symbol).toBe('ACME');
+    expect(equity?.type).toBe('EQUITY');
+    expect(equity?.account_id).toBe('acct-1');
+    expect(equity?.item_id).toBe('item-1');
+    expect(equity?.quantity).toBe(10);
+    expect(equity?.institution_price).toBe(100);
+    // 10 * 100 = 1000
+    expect(equity?.institution_value).toBe(1000);
+    expect(equity?.cost_basis).toBe(800);
+    expect(equity?.average_cost).toBe(80);
+    expect(equity?.total_return).toBe(200);
+    // (200 / 800) * 100 = 25
+    expect(equity?.total_return_percent).toBe(25);
+    expect(equity?.is_cash_equivalent).toBe(false);
+
+    const mf = result.holdings.find((h) => h.security_id === 'sec-mf');
+    expect(mf?.institution_value).toBe(1000); // 5 * 200
+    expect(mf?.cost_basis).toBe(750);
+    // (250 / 750) * 100 = 33.33
+    expect(mf?.total_return_percent).toBe(33.33);
+  });
+
+  test('CASH holding has is_cash_equivalent=true and omits metric-derived fields', async () => {
+    const client = makeClient([cashHolding]);
+    const tools = new LiveHoldingsTools(makeLive(client));
+
+    const result = await tools.getHoldings({});
+
+    expect(result.count).toBe(1);
+    const cash = result.holdings[0];
+    expect(cash?.is_cash_equivalent).toBe(true);
+    expect(cash?.institution_value).toBe(562.5);
+    expect(cash?.cost_basis).toBeUndefined();
+    expect(cash?.average_cost).toBeUndefined();
+    expect(cash?.total_return).toBeUndefined();
+    expect(cash?.total_return_percent).toBeUndefined();
+  });
+
+  test('filters by account_id (exact match)', async () => {
+    const client = makeClient([equityHolding, mutualFundHolding, cashHolding]);
+    const tools = new LiveHoldingsTools(makeLive(client));
+
+    const result = await tools.getHoldings({ account_id: 'acct-2' });
+
+    expect(result.count).toBe(1);
+    expect(result.total_count).toBe(1);
+    expect(result.holdings[0]?.security_id).toBe('sec-cash');
+  });
+
+  test('filters by ticker_symbol case-insensitively', async () => {
+    const client = makeClient([equityHolding, mutualFundHolding, cashHolding]);
+    const tools = new LiveHoldingsTools(makeLive(client));
+
+    // Lowercase input must match uppercase server symbol.
+    const result = await tools.getHoldings({ ticker_symbol: 'acme' });
+
+    expect(result.count).toBe(1);
+    expect(result.holdings[0]?.ticker_symbol).toBe('ACME');
+  });
+
+  test('pagination: limit + offset produce correct count / total_count / has_more', async () => {
+    const client = makeClient([equityHolding, mutualFundHolding, cashHolding]);
+    const tools = new LiveHoldingsTools(makeLive(client));
+
+    const result = await tools.getHoldings({ limit: 2, offset: 0 });
+
+    expect(result.count).toBe(2);
+    expect(result.total_count).toBe(3);
+    expect(result.offset).toBe(0);
+    expect(result.has_more).toBe(true);
+
+    const next = await tools.getHoldings({ limit: 2, offset: 2 });
+    expect(next.count).toBe(1);
+    expect(next.total_count).toBe(3);
+    expect(next.offset).toBe(2);
+    expect(next.has_more).toBe(false);
+  });
+
+  test('warm call returns same data with _cache_hit=true and no second fetch', async () => {
+    const client = makeClient([equityHolding]);
+    const tools = new LiveHoldingsTools(makeLive(client));
+
+    const first = await tools.getHoldings({});
+    const second = await tools.getHoldings({});
+
+    expect(first._cache_hit).toBe(false);
+    expect(second._cache_hit).toBe(true);
+    expect(second.holdings[0]?.security_id).toBe('sec-equity');
+    expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  test('cache metadata: ISO strings, oldest === newest on a single-snapshot fetch', async () => {
+    const client = makeClient([equityHolding]);
+    const tools = new LiveHoldingsTools(makeLive(client));
+
+    const result = await tools.getHoldings({});
+
+    expect(typeof result._cache_oldest_fetched_at).toBe('string');
+    expect(typeof result._cache_newest_fetched_at).toBe('string');
+    expect(result._cache_oldest_fetched_at).toBe(result._cache_newest_fetched_at);
+    // ISO 8601 sanity check.
+    expect(result._cache_oldest_fetched_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test('degenerate cost_basis=0 does not produce Infinity/NaN total_return_percent', async () => {
+    const zeroBasis = {
+      ...equityHolding,
+      id: 'h-zero',
+      metrics: { averageCost: 0, costBasis: 0, totalReturn: 10 },
+    };
+    const client = makeClient([zeroBasis]);
+    const tools = new LiveHoldingsTools(makeLive(client));
+
+    const result = await tools.getHoldings({});
+
+    const entry = result.holdings[0];
+    expect(entry?.cost_basis).toBe(0);
+    expect(entry?.total_return).toBe(10);
+    expect(entry?.total_return_percent).toBeUndefined();
+  });
+
+  test('passes correct operation name and empty variables to GraphQLClient.query', async () => {
+    const client = makeClient([equityHolding]);
+    const tools = new LiveHoldingsTools(makeLive(client));
+
+    await tools.getHoldings({});
+
+    expect(client.query).toHaveBeenCalledTimes(1);
+    const queryMock = client.query as ReturnType<typeof mock>;
+    const callArgs = queryMock.mock.calls[0] as unknown[];
+    expect(callArgs[0]).toBe('Holdings');
+    expect(typeof callArgs[1]).toBe('string');
+    expect(callArgs[2]).toEqual({});
+  });
+
+  test('empty result returns count=0 without throwing', async () => {
+    const client = makeClient([]);
+    const tools = new LiveHoldingsTools(makeLive(client));
+
+    const result = await tools.getHoldings({});
+
+    expect(result.count).toBe(0);
+    expect(result.total_count).toBe(0);
+    expect(result.holdings).toEqual([]);
+    expect(result.has_more).toBe(false);
+  });
+});
+
+describe('createLiveHoldingsToolSchema', () => {
+  test('returns a schema with readOnlyHint=true and the expected tool name', async () => {
+    const { createLiveHoldingsToolSchema } = await import(
+      '../../../src/tools/live/holdings.js'
+    );
+    const schema = createLiveHoldingsToolSchema();
+    expect(schema.name).toBe('get_holdings_live');
+    expect(schema.annotations?.readOnlyHint).toBe(true);
+  });
+
+  test('declares optional account_id, ticker_symbol, limit, offset (no required)', async () => {
+    const { createLiveHoldingsToolSchema } = await import(
+      '../../../src/tools/live/holdings.js'
+    );
+    const schema = createLiveHoldingsToolSchema();
+    const props = schema.inputSchema.properties as Record<string, { type: string }>;
+    expect(props.account_id?.type).toBe('string');
+    expect(props.ticker_symbol?.type).toBe('string');
+    expect(props.limit?.type).toBe('number');
+    expect(props.offset?.type).toBe('number');
+    // All filters are opt-in.
+    expect((schema.inputSchema as { required?: string[] }).required ?? []).toEqual([]);
+  });
+});

--- a/tests/tools/live/holdings.test.ts
+++ b/tests/tools/live/holdings.test.ts
@@ -237,18 +237,14 @@ describe('LiveHoldingsTools.getHoldings', () => {
 
 describe('createLiveHoldingsToolSchema', () => {
   test('returns a schema with readOnlyHint=true and the expected tool name', async () => {
-    const { createLiveHoldingsToolSchema } = await import(
-      '../../../src/tools/live/holdings.js'
-    );
+    const { createLiveHoldingsToolSchema } = await import('../../../src/tools/live/holdings.js');
     const schema = createLiveHoldingsToolSchema();
     expect(schema.name).toBe('get_holdings_live');
     expect(schema.annotations?.readOnlyHint).toBe(true);
   });
 
   test('declares optional account_id, ticker_symbol, limit, offset (no required)', async () => {
-    const { createLiveHoldingsToolSchema } = await import(
-      '../../../src/tools/live/holdings.js'
-    );
+    const { createLiveHoldingsToolSchema } = await import('../../../src/tools/live/holdings.js');
     const schema = createLiveHoldingsToolSchema();
     const props = schema.inputSchema.properties as Record<string, { type: string }>;
     expect(props.account_id?.type).toBe('string');

--- a/tests/tools/live/refresh-cache.test.ts
+++ b/tests/tools/live/refresh-cache.test.ts
@@ -20,6 +20,7 @@ function makeMockLive(): {
     user: ReturnType<typeof makeInvalidateCache>;
     networth: ReturnType<typeof makeInvalidateCache>;
     monthlySpend: ReturnType<typeof makeInvalidateCache>;
+    holdings: ReturnType<typeof makeInvalidateCache>;
     transactions: { invalidate: ReturnType<typeof mock> };
   };
 } {
@@ -31,6 +32,7 @@ function makeMockLive(): {
   const user = makeInvalidateCache();
   const networth = makeInvalidateCache();
   const monthlySpend = makeInvalidateCache();
+  const holdings = makeInvalidateCache();
   const transactions = { invalidate: mock((_arg: string[] | 'all') => {}) };
 
   const live = {
@@ -42,6 +44,7 @@ function makeMockLive(): {
     getUserCache: mock(() => user),
     getNetworthCache: mock(() => networth),
     getMonthlySpendCache: mock(() => monthlySpend),
+    getHoldingsCache: mock(() => holdings),
     getTransactionsWindowCache: mock(() => transactions),
   } as unknown as LiveCopilotDatabase;
 
@@ -56,6 +59,7 @@ function makeMockLive(): {
       user,
       networth,
       monthlySpend,
+      holdings,
       transactions,
     },
   };
@@ -76,6 +80,7 @@ describe('RefreshCacheTool — scope: all', () => {
     expect(mocks.user.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.networth.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.monthlySpend.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.holdings.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.transactions.invalidate).toHaveBeenCalledTimes(1);
     expect(result.flushed.accounts).toBe(true);
     expect(result.flushed.categories).toBe(true);
@@ -86,6 +91,7 @@ describe('RefreshCacheTool — scope: all', () => {
     expect(result.flushed.user).toBe(true);
     expect(result.flushed.networth).toBe(true);
     expect(result.flushed.monthly_spend).toBe(true);
+    expect(result.flushed.holdings).toBe(true);
     expect(result.flushed.transactions_months).toBe('all');
   });
 
@@ -254,6 +260,23 @@ describe('RefreshCacheTool — scope: monthly_spend', () => {
   });
 });
 
+describe('RefreshCacheTool — scope: holdings', () => {
+  test('invalidates only holdingsCache', async () => {
+    const { live, mocks } = makeMockLive();
+    const tool = new RefreshCacheTool(live);
+
+    const result = await tool.refresh({ scope: 'holdings' });
+
+    expect(mocks.holdings.invalidate).toHaveBeenCalledTimes(1);
+    expect(mocks.accounts.invalidate).not.toHaveBeenCalled();
+    expect(mocks.categories.invalidate).not.toHaveBeenCalled();
+    expect(mocks.monthlySpend.invalidate).not.toHaveBeenCalled();
+    expect(mocks.transactions.invalidate).not.toHaveBeenCalled();
+    expect(result.flushed.holdings).toBe(true);
+    expect(result.flushed.accounts).toBeUndefined();
+  });
+});
+
 describe('RefreshCacheTool — scope: transactions', () => {
   test('flushes all transaction months by default', async () => {
     const { live, mocks } = makeMockLive();
@@ -334,6 +357,12 @@ describe('createRefreshCacheToolSchema', () => {
     const schema = createRefreshCacheToolSchema();
     const scopeProp = schema.inputSchema.properties.scope as { enum: string[] };
     expect(scopeProp.enum).toContain('monthly_spend');
+  });
+
+  test('holdings scope is listed in enum', () => {
+    const schema = createRefreshCacheToolSchema();
+    const scopeProp = schema.inputSchema.properties.scope as { enum: string[] };
+    expect(scopeProp.enum).toContain('holdings');
   });
 
   test('schema description mentions budgets piggyback on categories', () => {


### PR DESCRIPTION
## Summary

PR 3 of 5 in the Phase 3 live-reads roadmap. Wires the new `get_holdings_live` MCP tool on top of the `fetchHoldings` wrapper that landed in #373. With `--live-reads` on, this swaps out the cache-mode `get_holdings` tool — users see exactly one holdings tool per mode.

Roadmap context: #372 captured the operation files, #373 added the `fetchHoldings` wrapper, this PR exposes the tool. PR 4 adds `get_balance_history_live`; PR 5 cleans up dead cache tools.

### Projection rules

The output shape mirrors cache-mode `get_holdings` so agents trained on one work with the other:

- `institution_value` is derived as `quantity * security.currentPrice` (rounded via `roundAmount`).
- `cost_basis`, `average_cost`, `total_return`, `total_return_percent` come from `holding.metrics`.
- When `metrics` is `null` (CASH sleeves inside investment accounts, primarily) all four derived fields are **omitted from the row** rather than emitted as `null`. The `is_cash_equivalent` flag on the same row tells the caller why.
- `is_cash_equivalent` is derived from `security.type === 'CASH'`, not from the absence of metrics — non-cash positions may also lack metrics for newly-imported securities.
- `total_return_percent` guards against `costBasis === 0` to avoid Infinity/NaN; the field is omitted when basis is zero.
- `iso_currency_code` is in cache-mode output but NOT in the GraphQL Security shape, so it is intentionally omitted.

No `include_history` parameter — monthly snapshots are not available on the GraphQL `Holdings` query. The JSDoc and tool description point callers needing history to cache-mode `get_holdings` with `include_history: true`.

### Cache TTL

`holdingsCache` uses a 6h TTL, matching the `recurringCache` precedent for slow-moving entities. Positions move slowly (no daily buy/sell for most users), and intraday `currentPrice` drift does not require second-by-second freshness for agent queries. `refresh_cache` with `scope='holdings'` (also added) is the escape hatch for explicit fresh fetches.

## Test plan

- [x] `bun test tests/tools/live/holdings.test.ts` — 12 unit tests covering projection, CASH handling, filters, pagination, cache warm/cold, ISO metadata, divide-by-zero, and operation-name dispatch.
- [x] `bun test tests/tools/live/refresh-cache.test.ts` — extended for the new `holdings` scope.
- [x] `bun test tests/e2e/server.test.ts` — added a wiring suite parallel to the other live tools (off-mode includes cache name; on-mode swaps for `_live`; error when called without `--live-reads`; dispatch invokes the stub).
- [x] `bun run check` (typecheck + lint + format + full test suite) all green.
- [x] Smoke section added to `scripts/smoke-graphql.ts` (read-only, no PII printed); bundles cleanly. Manual run against a real account is up to the maintainer.