### PR TITLE
ci: publish to MCP registry after npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -117,8 +117,10 @@ jobs:
 
       - name: Install mcp-publisher
         if: inputs.dry_run != true && github.event.inputs.dry_run != 'true'
+        env:
+          MCP_PUBLISHER_VERSION: v1.7.8
         run: |
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          curl -fL "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
 
       - name: Authenticate to MCP Registry (GitHub OIDC)
         if: inputs.dry_run != true && github.event.inputs.dry_run != 'true'
@@ -126,4 +128,5 @@ jobs:
 
       - name: Publish to MCP Registry
         if: inputs.dry_run != true && github.event.inputs.dry_run != 'true'
+        continue-on-error: true
         run: ./mcp-publisher publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -117,6 +117,7 @@ jobs:
 
       - name: Install mcp-publisher
         if: inputs.dry_run != true && github.event.inputs.dry_run != 'true'
+        continue-on-error: true
         env:
           MCP_PUBLISHER_VERSION: v1.7.8
         run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -124,6 +124,7 @@ jobs:
 
       - name: Authenticate to MCP Registry (GitHub OIDC)
         if: inputs.dry_run != true && github.event.inputs.dry_run != 'true'
+        continue-on-error: true
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -114,3 +114,16 @@ jobs:
       - name: Publish to npm
         if: inputs.dry_run != true && github.event.inputs.dry_run != 'true'
         run: npm publish --provenance --access public --verbose
+
+      - name: Install mcp-publisher
+        if: inputs.dry_run != true && github.event.inputs.dry_run != 'true'
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        if: inputs.dry_run != true && github.event.inputs.dry_run != 'true'
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        if: inputs.dry_run != true && github.event.inputs.dry_run != 'true'
+        run: ./mcp-publisher publish


### PR DESCRIPTION
## Summary
- Chains MCP registry publishing onto the existing `auto-release.yml` → `npm-publish.yml` flow by appending three steps to `npm-publish.yml`: install `mcp-publisher`, authenticate via GitHub OIDC, then publish.
- Auth uses GitHub OIDC (`mcp-publisher login github-oidc`). No new secret is needed — `id-token: write` is already granted at the workflow level for npm provenance, and OIDC reuses it.
- Each new step carries the same `dry_run` guard as the npm publish step, so `workflow_dispatch` dry runs continue to short-circuit cleanly. No version bumps in this PR.

Per the [MCP registry GitHub Actions guide](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/github-actions.mdx), the registry validates ownership by reading the npm tarball's `mcpName` field. PR #374 added that field to `package.json`, but the currently published npm tarball at the current version predates it — so the first run of this workflow will need to follow a fresh `npm publish` (i.e. a version bump). Subsequent releases are fully automatic.

## Test plan
- [ ] Confirm YAML parses (verified locally).
- [ ] On the next release after this lands (whenever the version is bumped), watch the `Publish to npm` job and confirm the three new steps (`Install mcp-publisher`, `Authenticate to MCP Registry (GitHub OIDC)`, `Publish to MCP Registry`) run after `Publish to npm` and succeed.
- [ ] After that run, verify the server appears in the registry: `curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.ignaciohermosillacornejo/copilot-money-mcp"`.
- [ ] Smoke-test a `workflow_dispatch` dry run from the Actions UI — the three new steps should be skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)