### PR TITLE
feat(live): add get_balance_history_live MCP tool (PR 4 of 5)

### DIFF
--- a/scripts/smoke-graphql.ts
+++ b/scripts/smoke-graphql.ts
@@ -19,8 +19,8 @@
  *   bun run scripts/smoke-graphql.ts --section transactions-write
  *
  * Sections: tags, categories, transactions, transactions-write, recurrings,
- *           budgets, accounts, holdings, bulk, errors, edge, consistency,
- *           mcp-e2e, state-gated
+ *           budgets, accounts, holdings, balance-history, bulk, errors, edge,
+ *           consistency, mcp-e2e, state-gated
  *
  * State-gated tests are opt-in because they require the user to toggle UI
  * state manually in the Copilot desktop app between prompts.
@@ -59,6 +59,7 @@ import {
 import { setBudget } from '../src/core/graphql/budgets.js';
 import { editAccount } from '../src/core/graphql/accounts.js';
 import { fetchHoldings } from '../src/core/graphql/queries/holdings.js';
+import { fetchAccountBalanceHistory } from '../src/core/graphql/queries/balance-history.js';
 
 // -----------------------------------------------------------------------------
 // Polling helper — wait for a local-cache read to reflect a GraphQL write
@@ -131,6 +132,7 @@ const VALID_SECTIONS = [
   'budgets',
   'accounts',
   'holdings',
+  'balance-history',
   'bulk',
   'errors',
   'edge',
@@ -1565,6 +1567,65 @@ async function smokeHoldingsHappyPath(client: GraphQLClient): Promise<void> {
   });
 }
 
+/**
+ * Balance history — read-only smoke. Picks the first usable account
+ * (account_id + item_id present), fetches ONE_MONTH of daily balance
+ * history, and verifies the payload shape. Row count is printed; account
+ * sub-type is printed but balances/IDs are not (PII).
+ */
+async function smokeBalanceHistoryHappyPath(
+  client: GraphQLClient,
+  db: CopilotDatabase
+): Promise<void> {
+  logSection('Balance history — happy path');
+
+  const accounts = await db.getAccounts();
+  const a = accounts.find((x) => x.account_id && x.item_id);
+  if (!a || !a.item_id) {
+    console.warn('  no usable account; skipping');
+    return;
+  }
+  const accountId = a.account_id;
+  const itemId = a.item_id;
+  console.log(`  Account: ${a.subtype ?? a.account_type ?? 'unknown'}`);
+
+  await step(
+    'balance-history',
+    'fetchAccountBalanceHistory returns well-shaped, date-sorted rows',
+    async () => {
+      const rows = await fetchAccountBalanceHistory(client, {
+        itemId,
+        accountId,
+        timeFrame: 'ONE_MONTH',
+      });
+      console.log(`  Balance history rows: ${rows.length}`);
+      if (!Array.isArray(rows)) {
+        throw new Error(`expected array, got ${typeof rows}`);
+      }
+      if (rows.length === 0) return;
+
+      for (const r of rows) {
+        if (typeof r.date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(r.date)) {
+          throw new Error(`row.date not YYYY-MM-DD: ${String(r.date)}`);
+        }
+        if (typeof r.balance !== 'number') {
+          throw new Error(`row.balance not numeric: ${typeof r.balance}`);
+        }
+      }
+
+      if (rows.length > 1) {
+        for (let i = 1; i < rows.length; i += 1) {
+          if (rows[i]!.date < rows[i - 1]!.date) {
+            throw new Error(
+              `rows not sorted ascending at index ${i} (${rows[i - 1]!.date} → ${rows[i]!.date})`
+            );
+          }
+        }
+      }
+    }
+  );
+}
+
 // -----------------------------------------------------------------------------
 // Section 2 — Bulk operations
 // -----------------------------------------------------------------------------
@@ -2780,6 +2841,7 @@ async function main(): Promise<void> {
   if (sectionEnabled('budgets')) await smokeBudgetsHappyPath(client, db);
   if (sectionEnabled('accounts')) await smokeAccountsHappyPath(client, db);
   if (sectionEnabled('holdings')) await smokeHoldingsHappyPath(client);
+  if (sectionEnabled('balance-history')) await smokeBalanceHistoryHappyPath(client, db);
 
   // Section 2 — bulk
   if (sectionEnabled('bulk')) await smokeBulkReviewTransactions(client, db);

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,10 @@ import {
   createLiveMonthlySpendToolSchema,
 } from './tools/live/monthly-spend.js';
 import { LiveHoldingsTools, createLiveHoldingsToolSchema } from './tools/live/holdings.js';
+import {
+  LiveBalanceHistoryTools,
+  createLiveBalanceHistoryToolSchema,
+} from './tools/live/balance-history.js';
 import { RefreshCacheTool, createRefreshCacheToolSchema } from './tools/live/refresh-cache.js';
 
 // Read version from package.json
@@ -60,6 +64,7 @@ export class CopilotMoneyServer {
   private liveUpcomingRecurringsTools?: LiveUpcomingRecurringsTools;
   private liveMonthlySpendTools?: LiveMonthlySpendTools;
   private liveHoldingsTools?: LiveHoldingsTools;
+  private liveBalanceHistoryTools?: LiveBalanceHistoryTools;
   private refreshCacheTool?: RefreshCacheTool;
 
   /**
@@ -100,7 +105,8 @@ export class CopilotMoneyServer {
       this.liveUpcomingRecurringsTools = new LiveUpcomingRecurringsTools(liveDb);
       this.liveMonthlySpendTools = new LiveMonthlySpendTools(liveDb);
       this.liveHoldingsTools = new LiveHoldingsTools(liveDb);
-      this.refreshCacheTool = new RefreshCacheTool(liveDb);
+      this.liveBalanceHistoryTools = new LiveBalanceHistoryTools(liveDb);
+      this.refreshCacheTool = new RefreshCacheTool(liveDb, this.liveBalanceHistoryTools);
     }
 
     this.tools = new CopilotMoneyTools(this.db, graphqlClient, liveDb);
@@ -130,6 +136,11 @@ export class CopilotMoneyServer {
     // liveSchemas array — for every name removed here there must be a live
     // schema added below (and vice versa) so users see exactly one tool per
     // semantic read.
+    // Note: `get_balance_history` is deliberately NOT swapped out for
+    // `get_balance_history_live`. The live tool's GraphQL backing is
+    // strictly narrower than cache mode — single-account, timeFrame-enum
+    // only, no weekly/monthly downsampling, no name/limit enrichment. Both
+    // tools coexist so callers can pick the right shape per use case.
     const filteredReads = this.liveReadsEnabled
       ? readSchemas.filter(
           (s) =>
@@ -153,6 +164,7 @@ export class CopilotMoneyServer {
           createLiveUpcomingRecurringsToolSchema(),
           createLiveMonthlySpendToolSchema(),
           createLiveHoldingsToolSchema(),
+          createLiveBalanceHistoryToolSchema(),
           createRefreshCacheToolSchema(),
         ]
       : [];
@@ -335,6 +347,18 @@ export class CopilotMoneyServer {
       };
     }
 
+    if (name === 'get_balance_history_live' && !this.liveBalanceHistoryTools) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'get_balance_history_live is only available when the server runs with --live-reads.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
     if (name === 'refresh_cache' && !this.refreshCacheTool) {
       return {
         content: [
@@ -451,6 +475,18 @@ export class CopilotMoneyServer {
             (typedArgs as Parameters<
               NonNullable<typeof this.liveHoldingsTools>['getHoldings']
             >[0]) ?? {}
+          );
+          break;
+
+        case 'get_balance_history_live':
+          // liveBalanceHistoryTools non-null invariant enforced by the early guard above.
+          // item_id and account_id are required by the schema; the runtime
+          // validation (in getBalanceHistory) surfaces a clean error if a
+          // caller bypasses the schema.
+          result = await this.liveBalanceHistoryTools!.getBalanceHistory(
+            (typedArgs ?? {}) as unknown as Parameters<
+              NonNullable<typeof this.liveBalanceHistoryTools>['getBalanceHistory']
+            >[0]
           );
           break;
 

--- a/src/tools/live/balance-history.ts
+++ b/src/tools/live/balance-history.ts
@@ -99,7 +99,11 @@ interface CacheEntry {
 }
 
 function makeKey(itemId: string, accountId: string, timeFrame?: TimeFrame): string {
-  return `${itemId}:${accountId}:${timeFrame ?? DEFAULT_TIME_FRAME_KEY}`;
+  // Use \0 (null byte) as the separator — Plaid IDs today are alphanumeric +
+  // hyphen, but the colon variant of this function would have aliased
+  // (itemId="foo:bar", accountId="baz") with (itemId="foo", accountId="bar:baz").
+  // \0 cannot appear in either field so the join is injectively reversible.
+  return `${itemId}\0${accountId}\0${timeFrame ?? DEFAULT_TIME_FRAME_KEY}`;
 }
 
 export class LiveBalanceHistoryTools {
@@ -133,11 +137,10 @@ export class LiveBalanceHistoryTools {
 
     const startedAt = Date.now();
     const key = makeKey(args.item_id, args.account_id, args.time_frame);
-    const now = Date.now();
 
     let entry = this.cache.get(key);
     let hit = false;
-    if (entry !== undefined && now - entry.fetched_at < this.ttlMs) {
+    if (entry !== undefined && startedAt - entry.fetched_at < this.ttlMs) {
       hit = true;
     } else {
       const rows = await this.live.withRetry(() =>

--- a/src/tools/live/balance-history.ts
+++ b/src/tools/live/balance-history.ts
@@ -1,0 +1,216 @@
+/**
+ * Live-mode get_balance_history_live tool.
+ *
+ * Wraps the GraphQL `BalanceHistory` query, projecting each row onto the
+ * minimal `{ date, balance }` shape the server returns, plus the standard
+ * `_cache_*` metadata envelope shared with the other live tools.
+ *
+ * Schema asymmetry vs cache-mode `get_balance_history`
+ * ----------------------------------------------------
+ * Unlike the other Phase 3 live tools, this one does NOT supersede its
+ * cache-mode counterpart — both coexist in the tool list. Server
+ * constraints make the GraphQL query strictly narrower than cache mode:
+ *
+ *   Capability        | Cache mode              | Live mode
+ *   ──────────────────┼─────────────────────────┼──────────────────────────
+ *   Account scope     | optional account_id     | itemId + accountId required
+ *                     |   (all accounts in one) |   (one account per call)
+ *   Date filter       | free-form start/end     | timeFrame enum only
+ *   Granularity       | daily/weekly/monthly    | server returns daily
+ *   Account enrichment| name/balance/limit      | none
+ *
+ * Callers needing cross-account history or downsampling stay on
+ * `get_balance_history`. Callers wanting fresh server-side numbers without
+ * a LevelDB refresh use this tool.
+ *
+ * Cache strategy
+ * --------------
+ * Each `(itemId, accountId, timeFrame)` tuple is a distinct snapshot —
+ * `SnapshotCache<T>` (single-snapshot per entity) doesn't fit. We use a
+ * bespoke per-instance `Map` keyed on the tuple string. The cache lives
+ * on this class (not `LiveCopilotDatabase`) because it is local to one
+ * tool and tightly coupled to the call shape. `refresh_cache --scope
+ * balance_history` clears the map.
+ *
+ * Memory bound: ~10s of (itemId, accountId) pairs × 7 timeFrame values
+ * (incl. omitted) ≈ ≤80 entries per process, each holding at most ~365
+ * `{date, balance}` rows. Not a leak. TTL still applies — stale entries
+ * are refetched on access, not actively evicted.
+ *
+ * Sort: the server returns rows already sorted ascending by date. We
+ * pass through verbatim. A defensive ascending sort is applied here so
+ * any future server-side reordering does not silently change output
+ * order (cost is negligible — at most ~365 rows per response).
+ */
+
+import type { LiveCopilotDatabase } from '../../core/live-database.js';
+import {
+  fetchAccountBalanceHistory,
+  type BalanceHistoryPointNode,
+} from '../../core/graphql/queries/balance-history.js';
+import type { TimeFrame } from '../../core/graphql/queries/_shared.js';
+
+const TIME_FRAMES: TimeFrame[] = [
+  'ONE_DAY',
+  'ONE_WEEK',
+  'ONE_MONTH',
+  'THREE_MONTHS',
+  'YTD',
+  'ONE_YEAR',
+  'ALL',
+];
+
+/** 1 hour. Balance history is daily-granular and rarely updates intraday. */
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+/**
+ * Sentinel key segment for "no timeFrame passed" so an explicit `'ALL'`
+ * never collides with an omitted argument. The two are semantically
+ * different (server default vs explicit ALL) — keep their cache entries
+ * separate to honor that distinction.
+ */
+const DEFAULT_TIME_FRAME_KEY = 'DEFAULT';
+
+export interface GetBalanceHistoryLiveArgs {
+  /** Plaid item ID. Required by the server. */
+  item_id: string;
+  /** Account ID. Required by the server. */
+  account_id: string;
+  /** Optional timeFrame. Omit to use the server's default range. */
+  time_frame?: TimeFrame;
+}
+
+export interface GetBalanceHistoryLiveEntry {
+  date: string;
+  balance: number;
+}
+
+export interface GetBalanceHistoryLiveResult {
+  count: number;
+  balance_history: GetBalanceHistoryLiveEntry[];
+  _cache_oldest_fetched_at: string;
+  _cache_newest_fetched_at: string;
+  _cache_hit: boolean;
+}
+
+interface CacheEntry {
+  rows: BalanceHistoryPointNode[];
+  fetched_at: number;
+}
+
+function makeKey(itemId: string, accountId: string, timeFrame?: TimeFrame): string {
+  return `${itemId}:${accountId}:${timeFrame ?? DEFAULT_TIME_FRAME_KEY}`;
+}
+
+export class LiveBalanceHistoryTools {
+  /**
+   * Per-(itemId, accountId, timeFrame) cache. Bounded by the small product
+   * of accounts × timeFrames (see class JSDoc). Cleared by
+   * `clearCache()` on refresh_cache.
+   */
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly ttlMs: number;
+
+  constructor(
+    private readonly live: LiveCopilotDatabase,
+    opts: { ttlMs?: number } = {}
+  ) {
+    this.ttlMs = opts.ttlMs ?? ONE_HOUR_MS;
+  }
+
+  /** Public for refresh_cache. Drops every cached tuple. */
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  async getBalanceHistory(args: GetBalanceHistoryLiveArgs): Promise<GetBalanceHistoryLiveResult> {
+    if (!args.item_id) {
+      throw new Error("get_balance_history_live: 'item_id' is required.");
+    }
+    if (!args.account_id) {
+      throw new Error("get_balance_history_live: 'account_id' is required.");
+    }
+
+    const startedAt = Date.now();
+    const key = makeKey(args.item_id, args.account_id, args.time_frame);
+    const now = Date.now();
+
+    let entry = this.cache.get(key);
+    let hit = false;
+    if (entry !== undefined && now - entry.fetched_at < this.ttlMs) {
+      hit = true;
+    } else {
+      const rows = await this.live.withRetry(() =>
+        fetchAccountBalanceHistory(this.live.getClient(), {
+          itemId: args.item_id,
+          accountId: args.account_id,
+          timeFrame: args.time_frame,
+        })
+      );
+      entry = { rows, fetched_at: Date.now() };
+      this.cache.set(key, entry);
+    }
+
+    // Defensive ascending sort — server currently pre-sorts, but a small
+    // safety net here makes the contract explicit. `.slice()` first so we
+    // never mutate the cached array.
+    const sorted = entry.rows.slice().sort((a, b) => a.date.localeCompare(b.date));
+    const projected: GetBalanceHistoryLiveEntry[] = sorted.map((r) => ({
+      date: r.date,
+      balance: r.balance,
+    }));
+
+    this.live.logReadCall({
+      op: 'BalanceHistory',
+      pages: hit ? 0 : 1,
+      latencyMs: Date.now() - startedAt,
+      rows: projected.length,
+      cache_hit: hit,
+    });
+
+    const fetchedAtIso = new Date(entry.fetched_at).toISOString();
+    // Single-fetch shape — oldest and newest are identical.
+    return {
+      count: projected.length,
+      balance_history: projected,
+      _cache_oldest_fetched_at: fetchedAtIso,
+      _cache_newest_fetched_at: fetchedAtIso,
+      _cache_hit: hit,
+    };
+  }
+}
+
+export function createLiveBalanceHistoryToolSchema() {
+  return {
+    name: 'get_balance_history_live',
+    description:
+      'Get daily balance history for a single account (live, GraphQL-backed). ' +
+      'Requires both item_id and account_id (server constraint — one account per call). ' +
+      'Date range is selected by the time_frame enum; the server returns daily granularity ' +
+      'and no name/limit enrichment. For cross-account history or weekly/monthly downsampling, ' +
+      'use cache-mode `get_balance_history`. Use `get_accounts_live` to enumerate ' +
+      '(item_id, account_id) pairs. Available when --live-reads is on.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        item_id: {
+          type: 'string',
+          description: 'Plaid item ID (from get_accounts_live).',
+        },
+        account_id: {
+          type: 'string',
+          description: 'Account ID (from get_accounts_live).',
+        },
+        time_frame: {
+          type: 'string',
+          enum: TIME_FRAMES,
+          description: "Date range preset. Optional — omit to use the server's default range.",
+        },
+      },
+      required: ['item_id', 'account_id'],
+    },
+    annotations: {
+      readOnlyHint: true,
+    },
+  };
+}

--- a/src/tools/live/refresh-cache.ts
+++ b/src/tools/live/refresh-cache.ts
@@ -57,8 +57,9 @@ export class RefreshCacheTool {
   /**
    * `balanceHistory` is optional so existing call sites and tests don't
    * have to wire the tool instance — when omitted, the `balance_history`
-   * scope is a no-op (but still surfaces `flushed.balance_history: true`
-   * for output parity). The live server path passes a real tool.
+   * scope is a no-op AND `flushed.balance_history` is omitted from the
+   * response (the flag only appears when a real flush happened). The
+   * live server path always passes a real tool.
    */
   constructor(
     private readonly live: LiveCopilotDatabase,
@@ -106,8 +107,10 @@ export class RefreshCacheTool {
       flushed.monthly_spend = true;
       this.live.getHoldingsCache().invalidate();
       flushed.holdings = true;
-      this.balanceHistory?.clearCache();
-      flushed.balance_history = true;
+      if (this.balanceHistory) {
+        this.balanceHistory.clearCache();
+        flushed.balance_history = true;
+      }
     };
 
     const flushTransactions = () => {
@@ -177,8 +180,12 @@ export class RefreshCacheTool {
         // The cache lives on LiveBalanceHistoryTools (Map<tuple, snapshot>),
         // not on LiveCopilotDatabase — the keying is tightly coupled to the
         // tool's call shape. clearCache() drops every cached tuple at once.
-        this.balanceHistory?.clearCache();
-        flushed.balance_history = true;
+        // Only set flushed.balance_history when the tool was actually wired
+        // (no-op semantics: "was flushed" not "operation acknowledged").
+        if (this.balanceHistory) {
+          this.balanceHistory.clearCache();
+          flushed.balance_history = true;
+        }
         break;
     }
 

--- a/src/tools/live/refresh-cache.ts
+++ b/src/tools/live/refresh-cache.ts
@@ -9,6 +9,7 @@
  */
 
 import type { LiveCopilotDatabase } from '../../core/live-database.js';
+import type { LiveBalanceHistoryTools } from './balance-history.js';
 
 const VALID_SCOPES = [
   'all',
@@ -23,6 +24,7 @@ const VALID_SCOPES = [
   'networth',
   'monthly_spend',
   'holdings',
+  'balance_history',
 ] as const;
 
 const YEAR_MONTH_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
@@ -46,12 +48,22 @@ export interface RefreshCacheResult {
     networth?: boolean;
     monthly_spend?: boolean;
     holdings?: boolean;
+    balance_history?: boolean;
     transactions_months?: string[] | 'all';
   };
 }
 
 export class RefreshCacheTool {
-  constructor(private readonly live: LiveCopilotDatabase) {}
+  /**
+   * `balanceHistory` is optional so existing call sites and tests don't
+   * have to wire the tool instance — when omitted, the `balance_history`
+   * scope is a no-op (but still surfaces `flushed.balance_history: true`
+   * for output parity). The live server path passes a real tool.
+   */
+  constructor(
+    private readonly live: LiveCopilotDatabase,
+    private readonly balanceHistory?: LiveBalanceHistoryTools
+  ) {}
 
   refresh(args: RefreshCacheArgs): Promise<RefreshCacheResult> {
     const scope: Scope = args.scope ?? 'all';
@@ -94,6 +106,8 @@ export class RefreshCacheTool {
       flushed.monthly_spend = true;
       this.live.getHoldingsCache().invalidate();
       flushed.holdings = true;
+      this.balanceHistory?.clearCache();
+      flushed.balance_history = true;
     };
 
     const flushTransactions = () => {
@@ -158,6 +172,13 @@ export class RefreshCacheTool {
       case 'holdings':
         this.live.getHoldingsCache().invalidate();
         flushed.holdings = true;
+        break;
+      case 'balance_history':
+        // The cache lives on LiveBalanceHistoryTools (Map<tuple, snapshot>),
+        // not on LiveCopilotDatabase — the keying is tightly coupled to the
+        // tool's call shape. clearCache() drops every cached tuple at once.
+        this.balanceHistory?.clearCache();
+        flushed.balance_history = true;
         break;
     }
 

--- a/tests/tools/live/balance-history.test.ts
+++ b/tests/tools/live/balance-history.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../src/core/graphql/client.js';
+import { CopilotDatabase } from '../../../src/core/database.js';
+import { LiveCopilotDatabase } from '../../../src/core/live-database.js';
+import {
+  LiveBalanceHistoryTools,
+  createLiveBalanceHistoryToolSchema,
+} from '../../../src/tools/live/balance-history.js';
+
+const ITEM_ID = 'item-A';
+const ACCOUNT_ID = 'acct-A';
+
+const sampleRows = [
+  { date: '2026-01-01', balance: 1000 },
+  { date: '2026-01-02', balance: 1050 },
+  { date: '2026-01-03', balance: 1100 },
+];
+
+function makeClient(rowsOrFn: unknown[] | (() => unknown[])): GraphQLClient {
+  return {
+    query: mock(() => {
+      const rows = typeof rowsOrFn === 'function' ? rowsOrFn() : rowsOrFn;
+      return Promise.resolve({ accountBalanceHistory: rows });
+    }),
+  } as unknown as GraphQLClient;
+}
+
+function makeLive(client: GraphQLClient): LiveCopilotDatabase {
+  return new LiveCopilotDatabase(client, new CopilotDatabase('/tmp/no-such-db'));
+}
+
+describe('LiveBalanceHistoryTools.getBalanceHistory — happy path', () => {
+  test('projects rows and emits standard cache metadata', async () => {
+    const client = makeClient(sampleRows);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    const result = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+    });
+
+    expect(result.count).toBe(3);
+    expect(result.balance_history).toEqual([
+      { date: '2026-01-01', balance: 1000 },
+      { date: '2026-01-02', balance: 1050 },
+      { date: '2026-01-03', balance: 1100 },
+    ]);
+    expect(result._cache_hit).toBe(false);
+    expect(typeof result._cache_oldest_fetched_at).toBe('string');
+    expect(typeof result._cache_newest_fetched_at).toBe('string');
+    // Single-fetch — oldest === newest.
+    expect(result._cache_oldest_fetched_at).toBe(result._cache_newest_fetched_at);
+    expect(result._cache_oldest_fetched_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test('empty response returns count=0 with metadata intact', async () => {
+    const client = makeClient([]);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    const result = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+    });
+
+    expect(result.count).toBe(0);
+    expect(result.balance_history).toEqual([]);
+    expect(result._cache_hit).toBe(false);
+    expect(typeof result._cache_oldest_fetched_at).toBe('string');
+  });
+
+  test('out-of-order server rows are sorted ascending defensively', async () => {
+    const client = makeClient([
+      { date: '2026-01-03', balance: 1100 },
+      { date: '2026-01-01', balance: 1000 },
+      { date: '2026-01-02', balance: 1050 },
+    ]);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    const result = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+    });
+
+    expect(result.balance_history.map((r) => r.date)).toEqual([
+      '2026-01-01',
+      '2026-01-02',
+      '2026-01-03',
+    ]);
+  });
+});
+
+describe('LiveBalanceHistoryTools — cache behavior', () => {
+  test('second call with same tuple is a cache hit and skips the network', async () => {
+    const client = makeClient(sampleRows);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    const first = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+      time_frame: 'ONE_MONTH',
+    });
+    const second = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+      time_frame: 'ONE_MONTH',
+    });
+
+    expect(first._cache_hit).toBe(false);
+    expect(second._cache_hit).toBe(true);
+    expect(second.balance_history).toEqual(first.balance_history);
+    expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  test('different time_frame for the same account bypasses the cache', async () => {
+    const client = makeClient(sampleRows);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+      time_frame: 'ONE_MONTH',
+    });
+    await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+      time_frame: 'ONE_YEAR',
+    });
+
+    expect(client.query).toHaveBeenCalledTimes(2);
+  });
+
+  test('omitted time_frame uses DEFAULT key — two omitted calls share the cache', async () => {
+    const client = makeClient(sampleRows);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    const first = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+    });
+    const second = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+    });
+
+    expect(first._cache_hit).toBe(false);
+    expect(second._cache_hit).toBe(true);
+    expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  test('omitted vs explicit time_frame are distinct keys (server-default ≠ explicit ALL)', async () => {
+    const client = makeClient(sampleRows);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+    });
+    const explicit = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+      time_frame: 'ALL',
+    });
+
+    expect(explicit._cache_hit).toBe(false);
+    expect(client.query).toHaveBeenCalledTimes(2);
+  });
+
+  test('TTL expiry triggers refetch', async () => {
+    const client = makeClient(sampleRows);
+    // Tiny TTL: the synthetic delay below clears it.
+    const tools = new LiveBalanceHistoryTools(makeLive(client), { ttlMs: 5 });
+
+    const first = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+    });
+    expect(first._cache_hit).toBe(false);
+
+    await new Promise((r) => setTimeout(r, 15));
+
+    const second = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+    });
+    expect(second._cache_hit).toBe(false);
+    expect(client.query).toHaveBeenCalledTimes(2);
+  });
+
+  test('clearCache() drops every entry — next call refetches', async () => {
+    const client = makeClient(sampleRows);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    await tools.getBalanceHistory({ item_id: ITEM_ID, account_id: ACCOUNT_ID });
+    tools.clearCache();
+    const after = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+    });
+
+    expect(after._cache_hit).toBe(false);
+    expect(client.query).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('LiveBalanceHistoryTools — GraphQL wiring', () => {
+  test('passes (operation name, query string, variables) verbatim', async () => {
+    const client = makeClient(sampleRows);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+      time_frame: 'ONE_MONTH',
+    });
+
+    expect(client.query).toHaveBeenCalledTimes(1);
+    const queryMock = client.query as ReturnType<typeof mock>;
+    const callArgs = queryMock.mock.calls[0] as unknown[];
+    expect(callArgs[0]).toBe('BalanceHistory');
+    expect(typeof callArgs[1]).toBe('string');
+    expect(callArgs[2]).toEqual({
+      itemId: ITEM_ID,
+      accountId: ACCOUNT_ID,
+      timeFrame: 'ONE_MONTH',
+    });
+  });
+
+  test('throws when item_id is missing', async () => {
+    const client = makeClient(sampleRows);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    await expect(
+      // @ts-expect-error intentional violation for runtime check
+      tools.getBalanceHistory({ account_id: ACCOUNT_ID })
+    ).rejects.toThrow(/item_id/);
+  });
+
+  test('throws when account_id is missing', async () => {
+    const client = makeClient(sampleRows);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    await expect(
+      // @ts-expect-error intentional violation for runtime check
+      tools.getBalanceHistory({ item_id: ITEM_ID })
+    ).rejects.toThrow(/account_id/);
+  });
+});
+
+describe('createLiveBalanceHistoryToolSchema', () => {
+  test('name is get_balance_history_live, readOnlyHint=true', () => {
+    const schema = createLiveBalanceHistoryToolSchema();
+    expect(schema.name).toBe('get_balance_history_live');
+    expect(schema.annotations?.readOnlyHint).toBe(true);
+  });
+
+  test('item_id and account_id are required; time_frame is an enum', () => {
+    const schema = createLiveBalanceHistoryToolSchema();
+    const props = schema.inputSchema.properties as Record<
+      string,
+      { type: string; enum?: string[] }
+    >;
+    expect(props.item_id?.type).toBe('string');
+    expect(props.account_id?.type).toBe('string');
+    expect(props.time_frame?.type).toBe('string');
+    expect(props.time_frame?.enum).toEqual([
+      'ONE_DAY',
+      'ONE_WEEK',
+      'ONE_MONTH',
+      'THREE_MONTHS',
+      'YTD',
+      'ONE_YEAR',
+      'ALL',
+    ]);
+    expect((schema.inputSchema as { required?: string[] }).required ?? []).toEqual([
+      'item_id',
+      'account_id',
+    ]);
+  });
+});

--- a/tests/tools/live/refresh-cache.test.ts
+++ b/tests/tools/live/refresh-cache.test.ts
@@ -308,13 +308,15 @@ describe('RefreshCacheTool — scope: balance_history', () => {
     expect(result.flushed.accounts).toBeUndefined();
   });
 
-  test('no-op (but still reports flushed) when balanceHistory tool is not wired', async () => {
+  test('no-op when balanceHistory tool is not wired — omits balance_history from flushed', async () => {
     const { live } = makeMockLive();
     const tool = new RefreshCacheTool(live); // no balance-history tool passed
 
     const result = await tool.refresh({ scope: 'balance_history' });
 
-    expect(result.flushed.balance_history).toBe(true);
+    // Flag only appears when a real flush happened; unwired path returns
+    // an empty flushed map.
+    expect(result.flushed.balance_history).toBeUndefined();
   });
 });
 

--- a/tests/tools/live/refresh-cache.test.ts
+++ b/tests/tools/live/refresh-cache.test.ts
@@ -4,9 +4,19 @@ import {
   createRefreshCacheToolSchema,
 } from '../../../src/tools/live/refresh-cache.js';
 import type { LiveCopilotDatabase } from '../../../src/core/live-database.js';
+import type { LiveBalanceHistoryTools } from '../../../src/tools/live/balance-history.js';
 
 function makeInvalidateCache() {
   return { invalidate: mock(() => {}) };
+}
+
+function makeBalanceHistoryMock(): {
+  tool: LiveBalanceHistoryTools;
+  clearCache: ReturnType<typeof mock>;
+} {
+  const clearCache = mock(() => {});
+  const tool = { clearCache } as unknown as LiveBalanceHistoryTools;
+  return { tool, clearCache };
 }
 
 function makeMockLive(): {
@@ -68,7 +78,8 @@ function makeMockLive(): {
 describe('RefreshCacheTool — scope: all', () => {
   test('flushes all snapshot caches and transactions', async () => {
     const { live, mocks } = makeMockLive();
-    const tool = new RefreshCacheTool(live);
+    const bh = makeBalanceHistoryMock();
+    const tool = new RefreshCacheTool(live, bh.tool);
 
     const result = await tool.refresh({ scope: 'all' });
 
@@ -82,6 +93,7 @@ describe('RefreshCacheTool — scope: all', () => {
     expect(mocks.monthlySpend.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.holdings.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.transactions.invalidate).toHaveBeenCalledTimes(1);
+    expect(bh.clearCache).toHaveBeenCalledTimes(1);
     expect(result.flushed.accounts).toBe(true);
     expect(result.flushed.categories).toBe(true);
     expect(result.flushed.tags).toBe(true);
@@ -92,6 +104,7 @@ describe('RefreshCacheTool — scope: all', () => {
     expect(result.flushed.networth).toBe(true);
     expect(result.flushed.monthly_spend).toBe(true);
     expect(result.flushed.holdings).toBe(true);
+    expect(result.flushed.balance_history).toBe(true);
     expect(result.flushed.transactions_months).toBe('all');
   });
 
@@ -277,6 +290,34 @@ describe('RefreshCacheTool — scope: holdings', () => {
   });
 });
 
+describe('RefreshCacheTool — scope: balance_history', () => {
+  test('clears the balance-history tool cache and nothing else', async () => {
+    const { live, mocks } = makeMockLive();
+    const bh = makeBalanceHistoryMock();
+    const tool = new RefreshCacheTool(live, bh.tool);
+
+    const result = await tool.refresh({ scope: 'balance_history' });
+
+    expect(bh.clearCache).toHaveBeenCalledTimes(1);
+    expect(mocks.accounts.invalidate).not.toHaveBeenCalled();
+    expect(mocks.categories.invalidate).not.toHaveBeenCalled();
+    expect(mocks.holdings.invalidate).not.toHaveBeenCalled();
+    expect(mocks.transactions.invalidate).not.toHaveBeenCalled();
+    expect(result.flushed.balance_history).toBe(true);
+    expect(result.flushed.holdings).toBeUndefined();
+    expect(result.flushed.accounts).toBeUndefined();
+  });
+
+  test('no-op (but still reports flushed) when balanceHistory tool is not wired', async () => {
+    const { live } = makeMockLive();
+    const tool = new RefreshCacheTool(live); // no balance-history tool passed
+
+    const result = await tool.refresh({ scope: 'balance_history' });
+
+    expect(result.flushed.balance_history).toBe(true);
+  });
+});
+
 describe('RefreshCacheTool — scope: transactions', () => {
   test('flushes all transaction months by default', async () => {
     const { live, mocks } = makeMockLive();
@@ -363,6 +404,12 @@ describe('createRefreshCacheToolSchema', () => {
     const schema = createRefreshCacheToolSchema();
     const scopeProp = schema.inputSchema.properties.scope as { enum: string[] };
     expect(scopeProp.enum).toContain('holdings');
+  });
+
+  test('balance_history scope is listed in enum', () => {
+    const schema = createRefreshCacheToolSchema();
+    const scopeProp = schema.inputSchema.properties.scope as { enum: string[] };
+    expect(scopeProp.enum).toContain('balance_history');
   });
 
   test('schema description mentions budgets piggyback on categories', () => {


### PR DESCRIPTION
## Summary

Phase 3, PR 4 of 5. Adds `get_balance_history_live`, backed by the
`fetchAccountBalanceHistory` wrapper from PR #373. PR 5 is dead-tool
cleanup.

- New `LiveBalanceHistoryTools` with a bespoke per-instance `Map` cache
  keyed on `(itemId, accountId, timeFrame)`. `SnapshotCache` doesn't
  fit — each tuple is a distinct snapshot.
- `refresh_cache --scope balance_history` clears the map.
- `get_balance_history_live` registered **additively** alongside
  cache-mode `get_balance_history` — both coexist.

## Schema asymmetry vs cache mode

The live tool is strictly narrower than cache mode, so unlike PR #375
(which swapped out `get_holdings`), this PR keeps both tools:

| Capability        | Cache `get_balance_history`     | Live `get_balance_history_live` |
| ----------------- | ------------------------------- | ------------------------------- |
| Account scope     | optional `account_id`, all accts | `item_id` + `account_id` required (one per call) |
| Date filter       | free-form `start_date` / `end_date` | `time_frame` enum only        |
| Granularity       | daily / weekly / monthly        | server returns daily            |
| Account enrichment| name, available_balance, limit  | none                            |

Cross-account queries and downsampling stay on cache mode. The asymmetry
is documented in the tool's JSDoc and in a comment in `handleListTools`
so future maintainers don't filter out the cache tool.

## Cache design

- Map<string, {rows, fetched_at}> on the tool instance (not
  `LiveCopilotDatabase`) — the keying is tightly coupled to this tool's
  call shape.
- TTL: 1 hour. Balance history is daily-granular and rarely updates
  intraday.
- Bound: ~accounts × 7 time_frames ≤ ~80 entries × ~365 rows max each.
  Not a leak; documented in class JSDoc.
- Omitted `time_frame` cached under a `DEFAULT` sentinel so explicit
  `'ALL'` and omitted (server-default) stay distinct.
- `clearCache()` is public for refresh_cache wiring.

## Smoke

Ran against the real GraphQL endpoint:

```
━━ Balance history — happy path ━━
  Account: cash management
  Balance history rows: 30
  ✓ fetchAccountBalanceHistory returns well-shaped, date-sorted rows (1174ms)

────────── SUMMARY ──────────
TOTAL  1 pass  0 fail
Latency: median=1174ms max=1174ms
```

## Test plan

- [x] `bun test tests/tools/live/balance-history.test.ts` — 14 unit tests covering projection, cache hit/miss, TTL expiry, DEFAULT-key keying, GraphQL wiring, required args, schema.
- [x] `bun test tests/tools/live/refresh-cache.test.ts` — extended for balance_history scope (wired + unwired) and `scope: all`.
- [x] `bun run check` — typecheck + lint + format + 1973 tests, all green.
- [x] `bun run scripts/smoke-graphql.ts --section balance-history` against real endpoint — 1 pass / 0 fail / 30 rows / 1174ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)