### PR TITLE
feat(holdings): match Copilot UI rounding for total_return_percent

### DIFF
--- a/src/tools/live/holdings.ts
+++ b/src/tools/live/holdings.ts
@@ -15,9 +15,10 @@
  *     CASH sleeves inside investment accounts), all four are omitted from
  *     the output rather than emitted as `null` — `is_cash_equivalent` on
  *     the same row tells the caller why.
- *   - `total_return_percent = (totalReturn / costBasis) * 100`. Guards
- *     against `costBasis === 0` (would produce Infinity/NaN) by omitting
- *     the field in that case.
+ *   - `total_return_percent = (totalReturn / costBasis) * 100`, floored at
+ *     the 2-decimal-place position to mirror Copilot's web UI display
+ *     convention. Guards against `costBasis === 0` (would produce
+ *     Infinity/NaN) by omitting the field in that case.
  *   - `is_cash_equivalent` is derived from `security.type === 'CASH'`,
  *     NOT from the absence of metrics. Non-cash positions may also lack
  *     metrics (rare, but possible for newly-imported securities).
@@ -116,10 +117,16 @@ function projectHolding(h: HoldingNode): GetHoldingsLiveEntry {
     // a short that goes against you (totalReturn < 0 with costBasis < 0)
     // should report a negative percentage, not flip to positive via
     // negative ÷ negative cancellation.
+    //
+    // Rounding: `Math.floor(... * 100) / 100` floors at the 2-decimal-place
+    // position of the percent (toward negative infinity). This mirrors
+    // Copilot's web UI display convention, verified by direct comparison
+    // of two holdings against the UI's "Total return" field. Note this
+    // differs from the `roundAmount` (round-half-up) used for the other
+    // three derived fields above.
     if (h.metrics.costBasis !== 0) {
-      entry.total_return_percent = roundAmount(
-        (h.metrics.totalReturn / Math.abs(h.metrics.costBasis)) * 100
-      );
+      entry.total_return_percent =
+        Math.floor((h.metrics.totalReturn / Math.abs(h.metrics.costBasis)) * 10000) / 100;
     }
   }
 

--- a/src/tools/live/holdings.ts
+++ b/src/tools/live/holdings.ts
@@ -118,15 +118,15 @@ function projectHolding(h: HoldingNode): GetHoldingsLiveEntry {
     // should report a negative percentage, not flip to positive via
     // negative ÷ negative cancellation.
     //
-    // Rounding: `Math.floor(... * 100) / 100` floors at the 2-decimal-place
-    // position of the percent (toward negative infinity). This mirrors
-    // Copilot's web UI display convention, verified by direct comparison
-    // of two holdings against the UI's "Total return" field. Note this
-    // differs from the `roundAmount` (round-half-up) used for the other
-    // three derived fields above.
+    // Rounding: `Math.floor(percent * 100) / 100` floors at the
+    // 2-decimal-place position of the percent (toward negative infinity).
+    // This mirrors Copilot's web UI display convention, verified by direct
+    // comparison of two holdings against the UI's "Total return" field.
+    // Note this differs from the `roundAmount` (round-half-up) used for the
+    // other three derived fields above.
     if (h.metrics.costBasis !== 0) {
-      entry.total_return_percent =
-        Math.floor((h.metrics.totalReturn / Math.abs(h.metrics.costBasis)) * 10000) / 100;
+      const percent = (h.metrics.totalReturn / Math.abs(h.metrics.costBasis)) * 100;
+      entry.total_return_percent = Math.floor(percent * 100) / 100;
     }
   }
 

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2192,18 +2192,18 @@ export class CopilotMoneyTools {
         };
 
         // Compute cost basis derived fields.
-        // `total_return_percent` uses `Math.floor(... * 100) / 100` to floor
-        // at the 2-decimal-place position of the percent (toward negative
-        // infinity). This mirrors Copilot's web UI display convention,
-        // verified by direct comparison against the UI's "Total return"
-        // field. The other three fields use `roundAmount` (round-half-up).
+        // `total_return_percent` uses `Math.floor(percent * 100) / 100` to
+        // floor at the 2-decimal-place position of the percent (toward
+        // negative infinity). This mirrors Copilot's web UI display
+        // convention, verified by direct comparison against the UI's
+        // "Total return" field. The other three fields use `roundAmount`
+        // (round-half-up).
         if (h.cost_basis != null && h.cost_basis !== 0 && h.quantity !== 0) {
           entry.cost_basis = roundAmount(h.cost_basis);
           entry.average_cost = roundAmount(h.cost_basis / h.quantity);
           entry.total_return = roundAmount(h.institution_value - h.cost_basis);
-          entry.total_return_percent =
-            Math.floor(((h.institution_value - h.cost_basis) / Math.abs(h.cost_basis)) * 10000) /
-            100;
+          const percent = ((h.institution_value - h.cost_basis) / Math.abs(h.cost_basis)) * 100;
+          entry.total_return_percent = Math.floor(percent * 100) / 100;
         }
 
         holdings.push(entry);

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2191,14 +2191,19 @@ export class CopilotMoneyTools {
           iso_currency_code: h.iso_currency_code ?? sec?.iso_currency_code,
         };
 
-        // Compute cost basis derived fields
+        // Compute cost basis derived fields.
+        // `total_return_percent` uses `Math.floor(... * 100) / 100` to floor
+        // at the 2-decimal-place position of the percent (toward negative
+        // infinity). This mirrors Copilot's web UI display convention,
+        // verified by direct comparison against the UI's "Total return"
+        // field. The other three fields use `roundAmount` (round-half-up).
         if (h.cost_basis != null && h.cost_basis !== 0 && h.quantity !== 0) {
           entry.cost_basis = roundAmount(h.cost_basis);
           entry.average_cost = roundAmount(h.cost_basis / h.quantity);
           entry.total_return = roundAmount(h.institution_value - h.cost_basis);
-          entry.total_return_percent = roundAmount(
-            ((h.institution_value - h.cost_basis) / Math.abs(h.cost_basis)) * 100
-          );
+          entry.total_return_percent =
+            Math.floor(((h.institution_value - h.cost_basis) / Math.abs(h.cost_basis)) * 10000) /
+            100;
         }
 
         holdings.push(entry);

--- a/tests/tools/live/holdings.test.ts
+++ b/tests/tools/live/holdings.test.ts
@@ -191,6 +191,42 @@ describe('LiveHoldingsTools.getHoldings', () => {
     expect(result._cache_oldest_fetched_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
+  test('total_return_percent floors at the 2-decimal-place position (positive case)', async () => {
+    // 100 / 1191 * 100 = 8.3963...
+    //   Math.floor → 8.39 (locked in by this test)
+    //   Math.round → 8.40 (would fail under the previous round-half-up rule)
+    // This mirrors Copilot's web UI rounding convention.
+    const flooredPositive = {
+      ...equityHolding,
+      id: 'h-floor-pos',
+      metrics: { averageCost: 119.1, costBasis: 1191, totalReturn: 100 },
+    };
+    const client = makeClient([flooredPositive]);
+    const tools = new LiveHoldingsTools(makeLive(client));
+
+    const result = await tools.getHoldings({});
+
+    expect(result.holdings[0]?.total_return_percent).toBe(8.39);
+  });
+
+  test('total_return_percent floors toward negative infinity (negative case)', async () => {
+    // -100 / 437 * 100 = -22.8833...
+    //   Math.floor → -22.89 (further from zero, locked in by this test)
+    //   Math.round → -22.88 (would fail under round-half-up)
+    // Confirms floor toward negative infinity, not toward zero.
+    const flooredNegative = {
+      ...equityHolding,
+      id: 'h-floor-neg',
+      metrics: { averageCost: 43.7, costBasis: 437, totalReturn: -100 },
+    };
+    const client = makeClient([flooredNegative]);
+    const tools = new LiveHoldingsTools(makeLive(client));
+
+    const result = await tools.getHoldings({});
+
+    expect(result.holdings[0]?.total_return_percent).toBe(-22.89);
+  });
+
   test('degenerate cost_basis=0 does not produce Infinity/NaN total_return_percent', async () => {
     const zeroBasis = {
       ...equityHolding,

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -2383,7 +2383,9 @@ describe('getHoldings', () => {
     expect(aapl!.cost_basis).toBe(15000);
     expect(aapl!.average_cost).toBe(150);
     expect(aapl!.total_return).toBe(4000);
-    expect(aapl!.total_return_percent).toBeCloseTo(26.67, 1);
+    // (4000 / 15000) * 100 = 26.6666...
+    //   Math.floor → 26.66 (mirrors Copilot web UI display convention)
+    expect(aapl!.total_return_percent).toBe(26.66);
   });
 
   test('omits average_cost and total_return when cost_basis is null', async () => {
@@ -2468,6 +2470,55 @@ describe('getHoldings', () => {
     for (const h of result.holdings) {
       expect(h.ticker_symbol).toBe('SCHX');
     }
+  });
+
+  test('total_return_percent floors at the 2-decimal-place position (positive + negative)', async () => {
+    // Verifies the floor-toward-negative-infinity rounding convention that
+    // mirrors Copilot's web UI display of "Total return" percent.
+    //   Positive: (100 / 1191) * 100 = 8.3963... → floor = 8.39 (round → 8.40)
+    //   Negative: (-100 / 437) * 100 = -22.8833... → floor = -22.89 (round → -22.88)
+    (db as any)._accounts = [
+      {
+        account_id: 'inv_floor_pos',
+        current_balance: 1291,
+        name: 'Floor Positive',
+        account_type: 'investment',
+        holdings: [
+          {
+            security_id: 'sec_aapl',
+            account_id: 'inv_floor_pos',
+            cost_basis: 1191,
+            institution_price: 12.91,
+            institution_value: 1291,
+            quantity: 100,
+            iso_currency_code: 'USD',
+          },
+        ],
+      },
+      {
+        account_id: 'inv_floor_neg',
+        current_balance: 337,
+        name: 'Floor Negative',
+        account_type: 'investment',
+        holdings: [
+          {
+            security_id: 'sec_schx',
+            account_id: 'inv_floor_neg',
+            cost_basis: 437,
+            institution_price: 3.37,
+            institution_value: 337,
+            quantity: 100,
+            iso_currency_code: 'USD',
+          },
+        ],
+      },
+    ];
+
+    const result = await tools.getHoldings({});
+    const pos = result.holdings.find((h) => h.account_id === 'inv_floor_pos');
+    const neg = result.holdings.find((h) => h.account_id === 'inv_floor_neg');
+    expect(pos?.total_return_percent).toBe(8.39);
+    expect(neg?.total_return_percent).toBe(-22.89);
   });
 });
 


### PR DESCRIPTION
## Summary

- Switch `total_return_percent` rounding in both `get_holdings_live` and cache-mode `get_holdings` from `roundAmount` (round-half-up) to `Math.floor(... * 10000) / 100` (floor at the 2-decimal-place position of the percent, toward negative infinity).
- This mirrors Copilot's web UI display convention for the "Total return" field. Verified by direct side-by-side comparison of two holdings against what the UI shows.
- The user audited the two new live tools (`get_holdings_live`, `get_balance_history_live`) against the web UI; this rounding direction was the only correctness delta found.

## Why

Two-call-site fix to keep MCP output identical to what the user sees in the app — matters for percent rendering on holdings whose math lands above the half-cent threshold.

## What

- `src/tools/live/holdings.ts` — `projectHolding()`: replace `roundAmount(...)` with `Math.floor(... * 10000) / 100` plus an explanatory comment block (sits alongside the existing `Math.abs(costBasis)` short-position rationale and the divide-by-zero guard).
- `src/tools/tools.ts` — `CopilotMoneyTools.getHoldings()`: same change for the cache-mode path, plus a 5-line comment summarizing the rule.
- JSDoc summary at the top of `holdings.ts` updated to mention the floor convention.
- Tests:
  - New positive case in `tests/tools/live/holdings.test.ts` (`100 / 1191 * 100 = 8.3963...` → floor 8.39, would round to 8.40).
  - New negative case in same file (`-100 / 437 * 100 = -22.8833...` → floor -22.89, confirms floor-toward-negative-infinity, not toward-zero).
  - New combined positive + negative case in `tests/tools/tools.test.ts` for the cache-mode path.
  - Tightened the existing AAPL assertion from `toBeCloseTo(26.67, 1)` to the exact floored value `26.66`.

## Scope note

Other percent fields elsewhere in the codebase are NOT in scope for this PR — this matches the two specifically-observed cases from the UI audit. If a broader sweep is needed it should be its own PR.

## Test plan

- [x] `bun test tests/tools/live/holdings.test.ts tests/tools/tools.test.ts` — 166 pass
- [x] `bun run check` — 1832 pass / 20 skip / 0 fail
- No smoke test required (no GraphQL touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)