### PR TITLE
feat(live): add get_investment_prices_live MCP tool

### DIFF
--- a/scripts/smoke-graphql.ts
+++ b/scripts/smoke-graphql.ts
@@ -19,8 +19,8 @@
  *   bun run scripts/smoke-graphql.ts --section transactions-write
  *
  * Sections: tags, categories, transactions, transactions-write, recurrings,
- *           budgets, accounts, holdings, balance-history, bulk, errors, edge,
- *           consistency, mcp-e2e, state-gated
+ *           budgets, accounts, holdings, balance-history, investment-prices,
+ *           bulk, errors, edge, consistency, mcp-e2e, state-gated
  *
  * State-gated tests are opt-in because they require the user to toggle UI
  * state manually in the Copilot desktop app between prompts.
@@ -60,6 +60,8 @@ import { setBudget } from '../src/core/graphql/budgets.js';
 import { editAccount } from '../src/core/graphql/accounts.js';
 import { fetchHoldings } from '../src/core/graphql/queries/holdings.js';
 import { fetchAccountBalanceHistory } from '../src/core/graphql/queries/balance-history.js';
+import { fetchSecurityPrices } from '../src/core/graphql/queries/security-prices.js';
+import { fetchSecurityPricesHighFrequency } from '../src/core/graphql/queries/security-prices-high-frequency.js';
 
 // -----------------------------------------------------------------------------
 // Polling helper — wait for a local-cache read to reflect a GraphQL write
@@ -133,6 +135,7 @@ const VALID_SECTIONS = [
   'accounts',
   'holdings',
   'balance-history',
+  'investment-prices',
   'bulk',
   'errors',
   'edge',
@@ -1626,6 +1629,94 @@ async function smokeBalanceHistoryHappyPath(
   );
 }
 
+/**
+ * Investment prices — read-only smoke. Picks a security_id from the user's
+ * current Holdings (the server is ownership-gated), then exercises both the
+ * daily (SecurityPrices) and intraday (SecurityPricesHighFrequency) wrappers.
+ * Verifies row shape and ascending sort. No prices or dates are printed.
+ */
+async function smokeInvestmentPricesHappyPath(client: GraphQLClient): Promise<void> {
+  logSection('Investment prices — happy path');
+
+  const holdings = await fetchHoldings(client);
+  const usable = holdings.find(
+    (h) => h.security?.id && h.security.type !== 'CASH' && h.quantity > 0
+  );
+  if (!usable) {
+    console.warn('  no usable holding (non-cash, qty > 0); skipping');
+    return;
+  }
+  const securityId = usable.security.id;
+  console.log(`  Security type: ${usable.security.type}`);
+
+  await step(
+    'investment-prices',
+    'fetchSecurityPrices (daily, ONE_MONTH) returns well-shaped, date-sorted rows',
+    async () => {
+      const rows = await fetchSecurityPrices(client, { id: securityId, timeFrame: 'ONE_MONTH' });
+      console.log(`  Daily prices: ${rows.length}`);
+      if (!Array.isArray(rows)) {
+        throw new Error(`expected array, got ${typeof rows}`);
+      }
+      if (rows.length === 0) return;
+
+      for (const r of rows) {
+        if (typeof r.price !== 'number') {
+          throw new Error(`daily row.price not numeric: ${typeof r.price}`);
+        }
+        if (typeof r.date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(r.date)) {
+          throw new Error(`daily row.date not YYYY-MM-DD: ${String(r.date)}`);
+        }
+      }
+
+      if (rows.length > 1) {
+        for (let i = 1; i < rows.length; i += 1) {
+          if (rows[i]!.date < rows[i - 1]!.date) {
+            throw new Error(
+              `daily rows not sorted ascending at index ${i} (${rows[i - 1]!.date} → ${rows[i]!.date})`
+            );
+          }
+        }
+      }
+    }
+  );
+
+  await step(
+    'investment-prices',
+    'fetchSecurityPricesHighFrequency (intraday, ONE_DAY) returns well-shaped, timestamp-sorted rows',
+    async () => {
+      const rows = await fetchSecurityPricesHighFrequency(client, {
+        id: securityId,
+        timeFrame: 'ONE_DAY',
+      });
+      console.log(`  Intraday prices: ${rows.length}`);
+      if (!Array.isArray(rows)) {
+        throw new Error(`expected array, got ${typeof rows}`);
+      }
+      if (rows.length === 0) return;
+
+      for (const r of rows) {
+        if (typeof r.price !== 'number') {
+          throw new Error(`intraday row.price not numeric: ${typeof r.price}`);
+        }
+        if (typeof r.timestamp !== 'number') {
+          throw new Error(`intraday row.timestamp not numeric: ${typeof r.timestamp}`);
+        }
+      }
+
+      if (rows.length > 1) {
+        for (let i = 1; i < rows.length; i += 1) {
+          if (rows[i]!.timestamp < rows[i - 1]!.timestamp) {
+            throw new Error(
+              `intraday rows not sorted ascending at index ${i} (timestamps ${rows[i - 1]!.timestamp} → ${rows[i]!.timestamp})`
+            );
+          }
+        }
+      }
+    }
+  );
+}
+
 // -----------------------------------------------------------------------------
 // Section 2 — Bulk operations
 // -----------------------------------------------------------------------------
@@ -2842,6 +2933,7 @@ async function main(): Promise<void> {
   if (sectionEnabled('accounts')) await smokeAccountsHappyPath(client, db);
   if (sectionEnabled('holdings')) await smokeHoldingsHappyPath(client);
   if (sectionEnabled('balance-history')) await smokeBalanceHistoryHappyPath(client, db);
+  if (sectionEnabled('investment-prices')) await smokeInvestmentPricesHappyPath(client);
 
   // Section 2 — bulk
   if (sectionEnabled('bulk')) await smokeBulkReviewTransactions(client, db);

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,10 @@ import {
   LiveBalanceHistoryTools,
   createLiveBalanceHistoryToolSchema,
 } from './tools/live/balance-history.js';
+import {
+  LiveInvestmentPricesTools,
+  createLiveInvestmentPricesToolSchema,
+} from './tools/live/investment-prices.js';
 import { RefreshCacheTool, createRefreshCacheToolSchema } from './tools/live/refresh-cache.js';
 
 // Read version from package.json
@@ -65,6 +69,7 @@ export class CopilotMoneyServer {
   private liveMonthlySpendTools?: LiveMonthlySpendTools;
   private liveHoldingsTools?: LiveHoldingsTools;
   private liveBalanceHistoryTools?: LiveBalanceHistoryTools;
+  private liveInvestmentPricesTools?: LiveInvestmentPricesTools;
   private refreshCacheTool?: RefreshCacheTool;
 
   /**
@@ -106,7 +111,12 @@ export class CopilotMoneyServer {
       this.liveMonthlySpendTools = new LiveMonthlySpendTools(liveDb);
       this.liveHoldingsTools = new LiveHoldingsTools(liveDb);
       this.liveBalanceHistoryTools = new LiveBalanceHistoryTools(liveDb);
-      this.refreshCacheTool = new RefreshCacheTool(liveDb, this.liveBalanceHistoryTools);
+      this.liveInvestmentPricesTools = new LiveInvestmentPricesTools(liveDb);
+      this.refreshCacheTool = new RefreshCacheTool(
+        liveDb,
+        this.liveBalanceHistoryTools,
+        this.liveInvestmentPricesTools
+      );
     }
 
     this.tools = new CopilotMoneyTools(this.db, graphqlClient, liveDb);
@@ -165,6 +175,7 @@ export class CopilotMoneyServer {
           createLiveMonthlySpendToolSchema(),
           createLiveHoldingsToolSchema(),
           createLiveBalanceHistoryToolSchema(),
+          createLiveInvestmentPricesToolSchema(),
           createRefreshCacheToolSchema(),
         ]
       : [];
@@ -359,6 +370,18 @@ export class CopilotMoneyServer {
       };
     }
 
+    if (name === 'get_investment_prices_live' && !this.liveInvestmentPricesTools) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'get_investment_prices_live is only available when the server runs with --live-reads.',
+          },
+        ],
+        isError: true,
+      };
+    }
+
     if (name === 'refresh_cache' && !this.refreshCacheTool) {
       return {
         content: [
@@ -486,6 +509,18 @@ export class CopilotMoneyServer {
           result = await this.liveBalanceHistoryTools!.getBalanceHistory(
             (typedArgs ?? {}) as unknown as Parameters<
               NonNullable<typeof this.liveBalanceHistoryTools>['getBalanceHistory']
+            >[0]
+          );
+          break;
+
+        case 'get_investment_prices_live':
+          // liveInvestmentPricesTools non-null invariant enforced by the early guard above.
+          // security_id is required by the schema; the runtime validation
+          // (in getInvestmentPrices) surfaces a clean error if a caller
+          // bypasses the schema.
+          result = await this.liveInvestmentPricesTools!.getInvestmentPrices(
+            (typedArgs ?? {}) as unknown as Parameters<
+              NonNullable<typeof this.liveInvestmentPricesTools>['getInvestmentPrices']
             >[0]
           );
           break;

--- a/src/tools/live/investment-prices.ts
+++ b/src/tools/live/investment-prices.ts
@@ -1,0 +1,370 @@
+/**
+ * Live-mode get_investment_prices_live tool.
+ *
+ * Wraps the GraphQL `SecurityPrices` (daily) and `SecurityPricesHighFrequency`
+ * (intraday) queries behind a single MCP tool that auto-routes based on the
+ * caller's `time_frame`. The Copilot web app uses the two queries to back
+ * different time-range buttons (1D / 1W → intraday; 1M / 3M / YTD / 1Y / ALL
+ * → daily), and we mirror that split server-side so agents don't have to
+ * know about it.
+ *
+ * Routing rules
+ * -------------
+ *   - `ONE_DAY`, `ONE_WEEK` → SecurityPricesHighFrequency (intraday). The
+ *     row shape is `{ id, price, timestamp }` where `timestamp` is an opaque
+ *     numeric (treated as epoch ms based on the captured payload).
+ *   - All other values (`ONE_MONTH`, `THREE_MONTHS`, `YTD`, `ONE_YEAR`,
+ *     `ALL`) → SecurityPrices (daily closes). The row shape is
+ *     `{ id, price, date }` where `date` is `YYYY-MM-DD`.
+ *   - Omitted `time_frame` defaults to `ONE_MONTH` — the most common
+ *     "show me the recent trend" use case and the safer default for a
+ *     daily-granularity payload size.
+ *
+ * The output carries a `granularity` discriminator (`'daily' | 'intraday'`)
+ * so callers can branch on the right field (`date` vs `timestamp`). Each row
+ * carries EXACTLY ONE of `date` or `timestamp` — never both — matching the
+ * server payload's shape.
+ *
+ * Authorization caveat (documented from empirical testing)
+ * --------------------------------------------------------
+ * Both queries are ownership-gated server-side: the server returns a
+ * GraphQL error with message "No holdings found for this security" for any
+ * security the user does not currently hold. The tool detects that error
+ * message and re-throws with a clean, security_id-bearing message so agents
+ * can react gracefully instead of seeing the raw GraphQL error.
+ *
+ * Cache strategy
+ * --------------
+ * Two maps with different TTLs:
+ *   - `intradayCache` — 5 minutes. Intraday prices change throughout the
+ *     trading day, so a short TTL keeps the cache useful for repeated
+ *     within-minute requests without staling.
+ *   - `dailyCache` — 1 hour. Daily closes only update once per day at
+ *     market close, so a long TTL is safe; cache invalidation at market
+ *     close is the user's responsibility (refresh_cache --scope
+ *     investment_prices).
+ *
+ * Cache key for both maps: `${security_id}\0${time_frame ?? 'DEFAULT'}`.
+ * The null-byte separator avoids the colon-aliasing pitfall noted in the
+ * balance-history cache (see its JSDoc). A `'DEFAULT'` sentinel keeps the
+ * "omitted time_frame" entry distinct from any explicit enum value.
+ *
+ * The cache lives on this class (not `LiveCopilotDatabase`) because the
+ * keying is per-request and tightly coupled to the tool's call shape, the
+ * same as balance-history. `refresh_cache --scope investment_prices` clears
+ * both maps.
+ *
+ * Sort
+ * ----
+ * Server returns rows ascending (verified by the smoke test); we apply a
+ * defensive ascending sort by `date` for daily and by `timestamp` for
+ * intraday so any future server-side reordering doesn't silently change
+ * output order.
+ *
+ * Truncation
+ * ----------
+ * `max_rows` caps the response (default 500, clamped to [1, 5000]). When
+ * the server returns more than `max_rows`, we slice to the most-recent
+ * `max_rows` rows (the tail of the ascending series) and set
+ * `truncated: true`. `total_rows` exposes the pre-truncation count so the
+ * caller knows what was dropped.
+ */
+
+import type { LiveCopilotDatabase } from '../../core/live-database.js';
+import {
+  fetchSecurityPrices,
+  type SecurityPricePointNode,
+} from '../../core/graphql/queries/security-prices.js';
+import {
+  fetchSecurityPricesHighFrequency,
+  type HighFrequencyPricePointNode,
+} from '../../core/graphql/queries/security-prices-high-frequency.js';
+import type { TimeFrame } from '../../core/graphql/queries/_shared.js';
+import { GraphQLError } from '../../core/graphql/client.js';
+
+const TIME_FRAMES: TimeFrame[] = [
+  'ONE_DAY',
+  'ONE_WEEK',
+  'ONE_MONTH',
+  'THREE_MONTHS',
+  'YTD',
+  'ONE_YEAR',
+  'ALL',
+];
+
+/** Intraday TTL — 5 minutes. Prices change throughout the trading day. */
+const FIVE_MIN_MS = 5 * 60 * 1000;
+/** Daily TTL — 1 hour. Daily closes only update at end-of-day. */
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+const DEFAULT_TIME_FRAME: TimeFrame = 'ONE_MONTH';
+const DEFAULT_MAX_ROWS = 500;
+const MIN_MAX_ROWS = 1;
+const MAX_MAX_ROWS = 5000;
+
+/**
+ * Sentinel key segment for "no timeFrame passed" so an explicit `'ALL'`
+ * never collides with an omitted argument. The two are semantically
+ * different (server default vs explicit ALL) — keep their cache entries
+ * separate to honor that distinction.
+ */
+const DEFAULT_TIME_FRAME_KEY = 'DEFAULT';
+
+/**
+ * Time frames that route to the high-frequency (intraday) query. Anything
+ * not in this set routes to the daily SecurityPrices query.
+ */
+const INTRADAY_TIME_FRAMES = new Set<TimeFrame>(['ONE_DAY', 'ONE_WEEK']);
+
+export type PriceGranularity = 'daily' | 'intraday';
+
+export interface GetInvestmentPricesLiveArgs {
+  security_id: string;
+  time_frame?: TimeFrame;
+  max_rows?: number;
+}
+
+export interface GetInvestmentPricesLiveEntry {
+  price: number;
+  /** Present only when granularity === 'daily'. */
+  date?: string;
+  /** Present only when granularity === 'intraday'. */
+  timestamp?: number;
+}
+
+export interface GetInvestmentPricesLiveResult {
+  granularity: PriceGranularity;
+  count: number;
+  total_rows: number;
+  truncated: boolean;
+  prices: GetInvestmentPricesLiveEntry[];
+  _cache_oldest_fetched_at: string;
+  _cache_newest_fetched_at: string;
+  _cache_hit: boolean;
+}
+
+interface DailyCacheEntry {
+  rows: SecurityPricePointNode[];
+  fetched_at: number;
+}
+
+interface IntradayCacheEntry {
+  rows: HighFrequencyPricePointNode[];
+  fetched_at: number;
+}
+
+function makeKey(securityId: string, timeFrame?: TimeFrame): string {
+  // \0 (null byte) cannot appear in either field, so the join is injectively
+  // reversible. See balance-history.ts for the colon-aliasing rationale.
+  return `${securityId}\0${timeFrame ?? DEFAULT_TIME_FRAME_KEY}`;
+}
+
+function isIntraday(timeFrame: TimeFrame): boolean {
+  return INTRADAY_TIME_FRAMES.has(timeFrame);
+}
+
+function clampMaxRows(n: number | undefined): number {
+  if (n === undefined) return DEFAULT_MAX_ROWS;
+  if (!Number.isFinite(n)) return DEFAULT_MAX_ROWS;
+  return Math.max(MIN_MAX_ROWS, Math.min(MAX_MAX_ROWS, Math.floor(n)));
+}
+
+/**
+ * Translate the ownership-gated server error into a clean, security_id-
+ * bearing message. The GraphQL client classifies the server's error as
+ * `USER_ACTION_REQUIRED` (any errors[] in the response body falls into that
+ * bucket); we look at the message text since the server doesn't carry a
+ * structured error code.
+ */
+function translateNotFound(err: unknown, securityId: string): never {
+  if (
+    err instanceof GraphQLError &&
+    err.code === 'USER_ACTION_REQUIRED' &&
+    /no holdings found/i.test(err.message)
+  ) {
+    throw new Error(
+      `Price history for security ${securityId} is not available — the security is not currently in your linked accounts.`
+    );
+  }
+  throw err as Error;
+}
+
+export class LiveInvestmentPricesTools {
+  /**
+   * Intraday-only cache (1D / 1W). 5-minute TTL.
+   */
+  private readonly intradayCache = new Map<string, IntradayCacheEntry>();
+  /**
+   * Daily-only cache (1M / 3M / YTD / 1Y / ALL). 1-hour TTL.
+   */
+  private readonly dailyCache = new Map<string, DailyCacheEntry>();
+  private readonly intradayTtlMs: number;
+  private readonly dailyTtlMs: number;
+
+  constructor(
+    private readonly live: LiveCopilotDatabase,
+    opts: { intradayTtlMs?: number; dailyTtlMs?: number } = {}
+  ) {
+    this.intradayTtlMs = opts.intradayTtlMs ?? FIVE_MIN_MS;
+    this.dailyTtlMs = opts.dailyTtlMs ?? ONE_HOUR_MS;
+  }
+
+  /** Public for refresh_cache. Drops every cached entry across both maps. */
+  clearCache(): void {
+    this.intradayCache.clear();
+    this.dailyCache.clear();
+  }
+
+  private async fetchIntraday(
+    securityId: string,
+    timeFrame: TimeFrame
+  ): Promise<HighFrequencyPricePointNode[]> {
+    try {
+      return await this.live.withRetry(() =>
+        fetchSecurityPricesHighFrequency(this.live.getClient(), {
+          id: securityId,
+          timeFrame,
+        })
+      );
+    } catch (err) {
+      translateNotFound(err, securityId);
+    }
+  }
+
+  private async fetchDaily(
+    securityId: string,
+    timeFrame: TimeFrame
+  ): Promise<SecurityPricePointNode[]> {
+    try {
+      return await this.live.withRetry(() =>
+        fetchSecurityPrices(this.live.getClient(), {
+          id: securityId,
+          timeFrame,
+        })
+      );
+    } catch (err) {
+      translateNotFound(err, securityId);
+    }
+  }
+
+  async getInvestmentPrices(
+    args: GetInvestmentPricesLiveArgs
+  ): Promise<GetInvestmentPricesLiveResult> {
+    if (!args.security_id) {
+      throw new Error("get_investment_prices_live: 'security_id' is required.");
+    }
+
+    const timeFrame: TimeFrame = args.time_frame ?? DEFAULT_TIME_FRAME;
+    const maxRows = clampMaxRows(args.max_rows);
+    const intraday = isIntraday(timeFrame);
+    const key = makeKey(args.security_id, args.time_frame);
+    const startedAt = Date.now();
+
+    let granularity: PriceGranularity;
+    let projected: GetInvestmentPricesLiveEntry[];
+    let totalRows: number;
+    let fetchedAt: number;
+    let hit = false;
+
+    if (intraday) {
+      granularity = 'intraday';
+      let entry = this.intradayCache.get(key);
+      if (entry !== undefined && startedAt - entry.fetched_at < this.intradayTtlMs) {
+        hit = true;
+      } else {
+        // Translate the ownership-gated error OUTSIDE withRetry. Doing it
+        // inside would swallow the typed GraphQLError before withRetry can
+        // see (and retry) NETWORK errors.
+        const rows = await this.fetchIntraday(args.security_id, timeFrame);
+        entry = { rows, fetched_at: Date.now() };
+        this.intradayCache.set(key, entry);
+      }
+      const sorted = entry.rows.slice().sort((a, b) => a.timestamp - b.timestamp);
+      totalRows = sorted.length;
+      const sliced = sorted.length > maxRows ? sorted.slice(sorted.length - maxRows) : sorted;
+      projected = sliced.map((r) => ({ price: r.price, timestamp: r.timestamp }));
+      fetchedAt = entry.fetched_at;
+    } else {
+      granularity = 'daily';
+      let entry = this.dailyCache.get(key);
+      if (entry !== undefined && startedAt - entry.fetched_at < this.dailyTtlMs) {
+        hit = true;
+      } else {
+        const rows = await this.fetchDaily(args.security_id, timeFrame);
+        entry = { rows, fetched_at: Date.now() };
+        this.dailyCache.set(key, entry);
+      }
+      const sorted = entry.rows.slice().sort((a, b) => a.date.localeCompare(b.date));
+      totalRows = sorted.length;
+      const sliced = sorted.length > maxRows ? sorted.slice(sorted.length - maxRows) : sorted;
+      projected = sliced.map((r) => ({ price: r.price, date: r.date }));
+      fetchedAt = entry.fetched_at;
+    }
+
+    const truncated = totalRows > projected.length;
+
+    this.live.logReadCall({
+      op: intraday ? 'SecurityPricesHighFrequency' : 'SecurityPrices',
+      pages: hit ? 0 : 1,
+      latencyMs: Date.now() - startedAt,
+      rows: projected.length,
+      cache_hit: hit,
+    });
+
+    const fetchedAtIso = new Date(fetchedAt).toISOString();
+    return {
+      granularity,
+      count: projected.length,
+      total_rows: totalRows,
+      truncated,
+      prices: projected,
+      _cache_oldest_fetched_at: fetchedAtIso,
+      _cache_newest_fetched_at: fetchedAtIso,
+      _cache_hit: hit,
+    };
+  }
+}
+
+export function createLiveInvestmentPricesToolSchema() {
+  return {
+    name: 'get_investment_prices_live',
+    description:
+      'Get price history for a single security (live, GraphQL-backed). One MCP tool routes ' +
+      'to two underlying queries based on time_frame: ONE_DAY and ONE_WEEK return intraday ' +
+      'timestamps (5-minute cache TTL); ONE_MONTH / THREE_MONTHS / YTD / ONE_YEAR / ALL return ' +
+      'daily closes (1-hour cache TTL). The output `granularity` field tells callers which ' +
+      'row field to use (`date` for daily, `timestamp` for intraday). ' +
+      'IMPORTANT — server-side ownership gate: this query is restricted to securities you ' +
+      'currently hold. For any security_id not in your linked-account positions, the tool ' +
+      'returns a clean error ("not currently in your linked accounts"). Use `get_holdings_live` ' +
+      'to enumerate valid security_ids. Available when --live-reads is on.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        security_id: {
+          type: 'string',
+          description: 'The security id (from get_holdings_live).',
+        },
+        time_frame: {
+          type: 'string',
+          enum: TIME_FRAMES,
+          description:
+            'Date range. Default: ONE_MONTH. ONE_DAY and ONE_WEEK return intraday timestamps; ' +
+            'larger ranges return daily closes.',
+        },
+        max_rows: {
+          type: 'integer',
+          description:
+            'Cap response to the most recent N rows (default 500, max 5000). Helps avoid the ' +
+            'MCP single-tool-result token limit on long-range queries. If hit, response ' +
+            'includes `truncated: true`.',
+          default: DEFAULT_MAX_ROWS,
+        },
+      },
+      required: ['security_id'],
+    },
+    annotations: {
+      readOnlyHint: true,
+    },
+  };
+}

--- a/src/tools/live/investment-prices.ts
+++ b/src/tools/live/investment-prices.ts
@@ -312,6 +312,12 @@ export class LiveInvestmentPricesTools {
     });
 
     const fetchedAtIso = new Date(fetchedAt).toISOString();
+    // Single-fetch shape — each cache key maps to exactly one fetched-at
+    // timestamp, so `_cache_oldest_fetched_at` and `_cache_newest_fetched_at`
+    // are always identical here. The dual field mirrors the envelope shared
+    // with other live tools (notably the windowed transactions cache, where
+    // the two can differ across month windows). Keep both for cross-tool
+    // consistency.
     return {
       granularity,
       count: projected.length,

--- a/src/tools/live/refresh-cache.ts
+++ b/src/tools/live/refresh-cache.ts
@@ -10,6 +10,7 @@
 
 import type { LiveCopilotDatabase } from '../../core/live-database.js';
 import type { LiveBalanceHistoryTools } from './balance-history.js';
+import type { LiveInvestmentPricesTools } from './investment-prices.js';
 
 const VALID_SCOPES = [
   'all',
@@ -25,6 +26,7 @@ const VALID_SCOPES = [
   'monthly_spend',
   'holdings',
   'balance_history',
+  'investment_prices',
 ] as const;
 
 const YEAR_MONTH_RE = /^\d{4}-(0[1-9]|1[0-2])$/;
@@ -49,6 +51,7 @@ export interface RefreshCacheResult {
     monthly_spend?: boolean;
     holdings?: boolean;
     balance_history?: boolean;
+    investment_prices?: boolean;
     transactions_months?: string[] | 'all';
   };
 }
@@ -63,7 +66,8 @@ export class RefreshCacheTool {
    */
   constructor(
     private readonly live: LiveCopilotDatabase,
-    private readonly balanceHistory?: LiveBalanceHistoryTools
+    private readonly balanceHistory?: LiveBalanceHistoryTools,
+    private readonly investmentPrices?: LiveInvestmentPricesTools
   ) {}
 
   refresh(args: RefreshCacheArgs): Promise<RefreshCacheResult> {
@@ -110,6 +114,10 @@ export class RefreshCacheTool {
       if (this.balanceHistory) {
         this.balanceHistory.clearCache();
         flushed.balance_history = true;
+      }
+      if (this.investmentPrices) {
+        this.investmentPrices.clearCache();
+        flushed.investment_prices = true;
       }
     };
 
@@ -185,6 +193,18 @@ export class RefreshCacheTool {
         if (this.balanceHistory) {
           this.balanceHistory.clearCache();
           flushed.balance_history = true;
+        }
+        break;
+      case 'investment_prices':
+        // The cache lives on LiveInvestmentPricesTools (two Maps — intraday
+        // + daily), not on LiveCopilotDatabase, for the same reason as
+        // balance_history. clearCache() drops every cached entry across
+        // both maps. Only flag flushed.investment_prices when the tool was
+        // actually wired (no-op semantics: "was flushed" not "operation
+        // acknowledged").
+        if (this.investmentPrices) {
+          this.investmentPrices.clearCache();
+          flushed.investment_prices = true;
         }
         break;
     }

--- a/tests/tools/live/investment-prices.test.ts
+++ b/tests/tools/live/investment-prices.test.ts
@@ -381,6 +381,26 @@ describe('LiveInvestmentPricesTools — max_rows truncation', () => {
     expect(result.truncated).toBe(false);
   });
 
+  test('max_rows below MIN floor (0) is clamped up to 1', async () => {
+    // 5 daily rows on the server; max_rows=0 must clamp to MIN_MAX_ROWS (=1)
+    // rather than producing an empty/error response. The most-recent row
+    // (tail of ascending series) should be returned.
+    const client = makeClient({ daily: dailyRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+      max_rows: 0,
+    });
+
+    expect(result.count).toBe(1);
+    expect(result.total_rows).toBe(5);
+    expect(result.truncated).toBe(true);
+    // Tail of ascending series — most recent.
+    expect(result.prices[0]!.date).toBe('2026-01-05');
+  });
+
   test('no truncation when total_rows <= max_rows', async () => {
     const client = makeClient({ daily: dailyRows });
     const tools = new LiveInvestmentPricesTools(makeLive(client));

--- a/tests/tools/live/investment-prices.test.ts
+++ b/tests/tools/live/investment-prices.test.ts
@@ -1,0 +1,539 @@
+import { describe, expect, test, mock } from 'bun:test';
+import type { GraphQLClient } from '../../../src/core/graphql/client.js';
+import { GraphQLError } from '../../../src/core/graphql/client.js';
+import { CopilotDatabase } from '../../../src/core/database.js';
+import { LiveCopilotDatabase } from '../../../src/core/live-database.js';
+import {
+  LiveInvestmentPricesTools,
+  createLiveInvestmentPricesToolSchema,
+} from '../../../src/tools/live/investment-prices.js';
+
+const SECURITY_ID = 'sec-A';
+
+const dailyRows = [
+  { id: SECURITY_ID, price: 100, date: '2026-01-01' },
+  { id: SECURITY_ID, price: 101, date: '2026-01-02' },
+  { id: SECURITY_ID, price: 102, date: '2026-01-03' },
+  { id: SECURITY_ID, price: 103, date: '2026-01-04' },
+  { id: SECURITY_ID, price: 104, date: '2026-01-05' },
+];
+
+const intradayRows = [
+  { id: SECURITY_ID, price: 100, timestamp: 1_700_000_000_000 },
+  { id: SECURITY_ID, price: 101, timestamp: 1_700_000_060_000 },
+  { id: SECURITY_ID, price: 102, timestamp: 1_700_000_120_000 },
+];
+
+interface FakeQueryConfig {
+  daily?: unknown[];
+  intraday?: unknown[];
+  /** When set, the next call to either operation throws this error. */
+  throwOnce?: Error;
+}
+
+function makeClient(config: FakeQueryConfig): GraphQLClient {
+  let pending = config.throwOnce;
+  return {
+    query: mock((operationName: string) => {
+      if (pending) {
+        const e = pending;
+        pending = undefined;
+        return Promise.reject(e);
+      }
+      if (operationName === 'SecurityPrices') {
+        return Promise.resolve({ securityPrices: config.daily ?? [] });
+      }
+      if (operationName === 'SecurityPricesHighFrequency') {
+        return Promise.resolve({ securityPricesHighFrequency: config.intraday ?? [] });
+      }
+      return Promise.reject(new Error(`unexpected operation: ${operationName}`));
+    }),
+  } as unknown as GraphQLClient;
+}
+
+function makeLive(client: GraphQLClient): LiveCopilotDatabase {
+  return new LiveCopilotDatabase(client, new CopilotDatabase('/tmp/no-such-db'));
+}
+
+describe('LiveInvestmentPricesTools.getInvestmentPrices — happy daily path', () => {
+  test('returns granularity=daily with `date` populated and `timestamp` absent', async () => {
+    const client = makeClient({ daily: dailyRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+    });
+
+    expect(result.granularity).toBe('daily');
+    expect(result.count).toBe(5);
+    expect(result.total_rows).toBe(5);
+    expect(result.truncated).toBe(false);
+    expect(result.prices).toHaveLength(5);
+    for (const row of result.prices) {
+      expect(typeof row.price).toBe('number');
+      expect(typeof row.date).toBe('string');
+      expect(row.timestamp).toBeUndefined();
+    }
+    expect(result._cache_hit).toBe(false);
+    expect(result._cache_oldest_fetched_at).toBe(result._cache_newest_fetched_at);
+    expect(result._cache_oldest_fetched_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test('default time_frame routes to daily SecurityPrices', async () => {
+    const client = makeClient({ daily: dailyRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const result = await tools.getInvestmentPrices({ security_id: SECURITY_ID });
+
+    expect(result.granularity).toBe('daily');
+    const queryMock = client.query as ReturnType<typeof mock>;
+    expect(queryMock.mock.calls[0]?.[0]).toBe('SecurityPrices');
+  });
+});
+
+describe('LiveInvestmentPricesTools.getInvestmentPrices — happy intraday path', () => {
+  test('returns granularity=intraday with `timestamp` populated and `date` absent', async () => {
+    const client = makeClient({ intraday: intradayRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_DAY',
+    });
+
+    expect(result.granularity).toBe('intraday');
+    expect(result.count).toBe(3);
+    expect(result.total_rows).toBe(3);
+    expect(result.truncated).toBe(false);
+    for (const row of result.prices) {
+      expect(typeof row.price).toBe('number');
+      expect(typeof row.timestamp).toBe('number');
+      expect(row.date).toBeUndefined();
+    }
+  });
+
+  test('ONE_WEEK also routes to intraday', async () => {
+    const client = makeClient({ intraday: intradayRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_WEEK',
+    });
+
+    expect(result.granularity).toBe('intraday');
+    const queryMock = client.query as ReturnType<typeof mock>;
+    expect(queryMock.mock.calls[0]?.[0]).toBe('SecurityPricesHighFrequency');
+  });
+});
+
+describe('LiveInvestmentPricesTools — routing', () => {
+  test('ONE_MONTH routes to SecurityPrices (daily)', async () => {
+    const client = makeClient({ daily: dailyRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    await tools.getInvestmentPrices({ security_id: SECURITY_ID, time_frame: 'ONE_MONTH' });
+
+    const queryMock = client.query as ReturnType<typeof mock>;
+    expect(queryMock.mock.calls[0]?.[0]).toBe('SecurityPrices');
+  });
+
+  test('ONE_DAY routes to SecurityPricesHighFrequency (intraday)', async () => {
+    const client = makeClient({ intraday: intradayRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    await tools.getInvestmentPrices({ security_id: SECURITY_ID, time_frame: 'ONE_DAY' });
+
+    const queryMock = client.query as ReturnType<typeof mock>;
+    expect(queryMock.mock.calls[0]?.[0]).toBe('SecurityPricesHighFrequency');
+  });
+
+  test('THREE_MONTHS, YTD, ONE_YEAR, ALL all route to SecurityPrices', async () => {
+    for (const tf of ['THREE_MONTHS', 'YTD', 'ONE_YEAR', 'ALL'] as const) {
+      const client = makeClient({ daily: dailyRows });
+      const tools = new LiveInvestmentPricesTools(makeLive(client));
+      await tools.getInvestmentPrices({ security_id: SECURITY_ID, time_frame: tf });
+      const queryMock = client.query as ReturnType<typeof mock>;
+      expect(queryMock.mock.calls[0]?.[0]).toBe('SecurityPrices');
+    }
+  });
+});
+
+describe('LiveInvestmentPricesTools — NOT_FOUND error translation', () => {
+  test('translates the ownership-gated GraphQL error into a clean message (daily)', async () => {
+    const client = makeClient({
+      throwOnce: new GraphQLError(
+        'USER_ACTION_REQUIRED',
+        'No holdings found for this security',
+        'SecurityPrices',
+        200
+      ),
+    });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    await expect(
+      tools.getInvestmentPrices({ security_id: SECURITY_ID, time_frame: 'ONE_MONTH' })
+    ).rejects.toThrow(/sec-A.*not currently in your linked accounts/);
+  });
+
+  test('translates the ownership-gated GraphQL error into a clean message (intraday)', async () => {
+    const client = makeClient({
+      throwOnce: new GraphQLError(
+        'USER_ACTION_REQUIRED',
+        'No holdings found for this security',
+        'SecurityPricesHighFrequency',
+        200
+      ),
+    });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    await expect(
+      tools.getInvestmentPrices({ security_id: SECURITY_ID, time_frame: 'ONE_DAY' })
+    ).rejects.toThrow(/sec-A.*not currently in your linked accounts/);
+  });
+
+  test('non-matching GraphQL errors are NOT translated (pass through)', async () => {
+    const client = makeClient({
+      throwOnce: new GraphQLError(
+        'USER_ACTION_REQUIRED',
+        'Some other server-side error',
+        'SecurityPrices',
+        200
+      ),
+    });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    await expect(tools.getInvestmentPrices({ security_id: SECURITY_ID })).rejects.toThrow(
+      /Some other server-side error/
+    );
+  });
+});
+
+describe('LiveInvestmentPricesTools — cache behavior', () => {
+  test('second call with same (security_id, time_frame) is a cache hit', async () => {
+    const client = makeClient({ daily: dailyRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const first = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+    });
+    const second = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+    });
+
+    expect(first._cache_hit).toBe(false);
+    expect(second._cache_hit).toBe(true);
+    expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  test('different granularity bypasses the cache (intraday vs daily are separate maps)', async () => {
+    const client = makeClient({ daily: dailyRows, intraday: intradayRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    await tools.getInvestmentPrices({ security_id: SECURITY_ID, time_frame: 'ONE_DAY' });
+    await tools.getInvestmentPrices({ security_id: SECURITY_ID, time_frame: 'ONE_MONTH' });
+
+    expect(client.query).toHaveBeenCalledTimes(2);
+  });
+
+  test('different daily time_frames for the same security bypass each other', async () => {
+    const client = makeClient({ daily: dailyRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    await tools.getInvestmentPrices({ security_id: SECURITY_ID, time_frame: 'ONE_MONTH' });
+    await tools.getInvestmentPrices({ security_id: SECURITY_ID, time_frame: 'ONE_YEAR' });
+
+    expect(client.query).toHaveBeenCalledTimes(2);
+  });
+
+  test('intraday TTL expires faster than daily TTL', async () => {
+    const client = makeClient({ daily: dailyRows, intraday: intradayRows });
+    // intradayTtl=5ms (expires before second call), dailyTtl=1h (still warm).
+    const tools = new LiveInvestmentPricesTools(makeLive(client), {
+      intradayTtlMs: 5,
+      dailyTtlMs: 60 * 60 * 1000,
+    });
+
+    const firstIntra = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_DAY',
+    });
+    const firstDaily = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+    });
+
+    await new Promise((r) => setTimeout(r, 15));
+
+    const secondIntra = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_DAY',
+    });
+    const secondDaily = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+    });
+
+    expect(firstIntra._cache_hit).toBe(false);
+    expect(firstDaily._cache_hit).toBe(false);
+    // intraday expired → refetch (no cache hit).
+    expect(secondIntra._cache_hit).toBe(false);
+    // daily still warm → cache hit.
+    expect(secondDaily._cache_hit).toBe(true);
+  });
+
+  test('clearCache() drops every entry across both maps — next call refetches', async () => {
+    const client = makeClient({ daily: dailyRows, intraday: intradayRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    await tools.getInvestmentPrices({ security_id: SECURITY_ID, time_frame: 'ONE_MONTH' });
+    await tools.getInvestmentPrices({ security_id: SECURITY_ID, time_frame: 'ONE_DAY' });
+
+    tools.clearCache();
+
+    const refetchDaily = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+    });
+    const refetchIntra = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_DAY',
+    });
+
+    expect(refetchDaily._cache_hit).toBe(false);
+    expect(refetchIntra._cache_hit).toBe(false);
+    expect(client.query).toHaveBeenCalledTimes(4);
+  });
+
+  test('omitted vs explicit ONE_MONTH share a key but distinct from DEFAULT', async () => {
+    // Both default to ONE_MONTH semantics, but they use different cache keys:
+    // explicit ONE_MONTH uses the enum value; omitted uses the DEFAULT sentinel.
+    const client = makeClient({ daily: dailyRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    await tools.getInvestmentPrices({ security_id: SECURITY_ID });
+    const explicit = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+    });
+
+    expect(explicit._cache_hit).toBe(false);
+    expect(client.query).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('LiveInvestmentPricesTools — max_rows truncation', () => {
+  test('caps at max_rows and reports `truncated: true` with original total_rows', async () => {
+    const bigDaily = Array.from({ length: 1500 }, (_, i) => ({
+      id: SECURITY_ID,
+      price: 100 + i,
+      // generate ascending date-like strings; localeCompare keeps them ordered.
+      date: `2025-${String(Math.floor(i / 30) + 1).padStart(2, '0')}-${String((i % 30) + 1).padStart(2, '0')}`,
+    }));
+    const client = makeClient({ daily: bigDaily });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_YEAR',
+      max_rows: 500,
+    });
+
+    expect(result.total_rows).toBe(1500);
+    expect(result.count).toBe(500);
+    expect(result.truncated).toBe(true);
+    // Sliced to MOST RECENT (tail of ascending series).
+    expect(result.prices[0]!.price).toBe(100 + 1000);
+    expect(result.prices[499]!.price).toBe(100 + 1499);
+  });
+
+  test('default max_rows is 500', async () => {
+    const bigDaily = Array.from({ length: 600 }, (_, i) => ({
+      id: SECURITY_ID,
+      price: 100 + i,
+      date: `2025-${String(Math.floor(i / 30) + 1).padStart(2, '0')}-${String((i % 30) + 1).padStart(2, '0')}`,
+    }));
+    const client = makeClient({ daily: bigDaily });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_YEAR',
+    });
+
+    expect(result.count).toBe(500);
+    expect(result.truncated).toBe(true);
+  });
+
+  test('max_rows above MAX cap (5000) is clamped down', async () => {
+    const client = makeClient({ daily: dailyRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    // Should not throw — clamped to 5000 internally, well above our 5 rows.
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      max_rows: 50_000,
+    });
+    expect(result.count).toBe(5);
+    expect(result.truncated).toBe(false);
+  });
+
+  test('no truncation when total_rows <= max_rows', async () => {
+    const client = makeClient({ daily: dailyRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+      max_rows: 10,
+    });
+
+    expect(result.count).toBe(5);
+    expect(result.total_rows).toBe(5);
+    expect(result.truncated).toBe(false);
+  });
+});
+
+describe('LiveInvestmentPricesTools — sorting', () => {
+  test('out-of-order daily rows are sorted ascending defensively', async () => {
+    const client = makeClient({
+      daily: [
+        { id: SECURITY_ID, price: 103, date: '2026-01-04' },
+        { id: SECURITY_ID, price: 100, date: '2026-01-01' },
+        { id: SECURITY_ID, price: 102, date: '2026-01-03' },
+        { id: SECURITY_ID, price: 101, date: '2026-01-02' },
+      ],
+    });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+    });
+
+    expect(result.prices.map((r) => r.date)).toEqual([
+      '2026-01-01',
+      '2026-01-02',
+      '2026-01-03',
+      '2026-01-04',
+    ]);
+  });
+
+  test('out-of-order intraday rows are sorted ascending defensively', async () => {
+    const client = makeClient({
+      intraday: [
+        { id: SECURITY_ID, price: 102, timestamp: 3000 },
+        { id: SECURITY_ID, price: 100, timestamp: 1000 },
+        { id: SECURITY_ID, price: 101, timestamp: 2000 },
+      ],
+    });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_DAY',
+    });
+
+    expect(result.prices.map((r) => r.timestamp)).toEqual([1000, 2000, 3000]);
+  });
+});
+
+describe('LiveInvestmentPricesTools — empty + validation', () => {
+  test('empty server response: count=0, prices=[], metadata still populated', async () => {
+    const client = makeClient({ daily: [] });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+    });
+
+    expect(result.count).toBe(0);
+    expect(result.total_rows).toBe(0);
+    expect(result.truncated).toBe(false);
+    expect(result.prices).toEqual([]);
+    expect(typeof result._cache_oldest_fetched_at).toBe('string');
+  });
+
+  test('throws when security_id is missing', async () => {
+    const client = makeClient({ daily: dailyRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    await expect(
+      // @ts-expect-error intentional violation for runtime check
+      tools.getInvestmentPrices({ time_frame: 'ONE_MONTH' })
+    ).rejects.toThrow(/security_id/);
+  });
+});
+
+describe('LiveInvestmentPricesTools — GraphQL wiring', () => {
+  test('passes (operation name, query string, variables) verbatim for daily', async () => {
+    const client = makeClient({ daily: dailyRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+    });
+
+    const queryMock = client.query as ReturnType<typeof mock>;
+    const callArgs = queryMock.mock.calls[0] as unknown[];
+    expect(callArgs[0]).toBe('SecurityPrices');
+    expect(typeof callArgs[1]).toBe('string');
+    expect(callArgs[2]).toEqual({ id: SECURITY_ID, timeFrame: 'ONE_MONTH' });
+  });
+
+  test('passes (operation name, query string, variables) verbatim for intraday', async () => {
+    const client = makeClient({ intraday: intradayRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_DAY',
+    });
+
+    const queryMock = client.query as ReturnType<typeof mock>;
+    const callArgs = queryMock.mock.calls[0] as unknown[];
+    expect(callArgs[0]).toBe('SecurityPricesHighFrequency');
+    expect(typeof callArgs[1]).toBe('string');
+    expect(callArgs[2]).toEqual({ id: SECURITY_ID, timeFrame: 'ONE_DAY' });
+  });
+});
+
+describe('createLiveInvestmentPricesToolSchema', () => {
+  test('name is get_investment_prices_live, readOnlyHint=true', () => {
+    const schema = createLiveInvestmentPricesToolSchema();
+    expect(schema.name).toBe('get_investment_prices_live');
+    expect(schema.annotations?.readOnlyHint).toBe(true);
+  });
+
+  test('security_id is required; time_frame is an enum; max_rows is integer', () => {
+    const schema = createLiveInvestmentPricesToolSchema();
+    const props = schema.inputSchema.properties as Record<
+      string,
+      { type: string; enum?: string[]; default?: number }
+    >;
+    expect(props.security_id?.type).toBe('string');
+    expect(props.time_frame?.type).toBe('string');
+    expect(props.time_frame?.enum).toEqual([
+      'ONE_DAY',
+      'ONE_WEEK',
+      'ONE_MONTH',
+      'THREE_MONTHS',
+      'YTD',
+      'ONE_YEAR',
+      'ALL',
+    ]);
+    expect(props.max_rows?.type).toBe('integer');
+    expect(props.max_rows?.default).toBe(500);
+    expect((schema.inputSchema as { required?: string[] }).required ?? []).toEqual(['security_id']);
+  });
+
+  test('description mentions the ownership gate', () => {
+    const schema = createLiveInvestmentPricesToolSchema();
+    expect(schema.description.toLowerCase()).toMatch(/ownership|currently hold|linked account/);
+  });
+});

--- a/tests/tools/live/refresh-cache.test.ts
+++ b/tests/tools/live/refresh-cache.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../src/tools/live/refresh-cache.js';
 import type { LiveCopilotDatabase } from '../../../src/core/live-database.js';
 import type { LiveBalanceHistoryTools } from '../../../src/tools/live/balance-history.js';
+import type { LiveInvestmentPricesTools } from '../../../src/tools/live/investment-prices.js';
 
 function makeInvalidateCache() {
   return { invalidate: mock(() => {}) };
@@ -16,6 +17,15 @@ function makeBalanceHistoryMock(): {
 } {
   const clearCache = mock(() => {});
   const tool = { clearCache } as unknown as LiveBalanceHistoryTools;
+  return { tool, clearCache };
+}
+
+function makeInvestmentPricesMock(): {
+  tool: LiveInvestmentPricesTools;
+  clearCache: ReturnType<typeof mock>;
+} {
+  const clearCache = mock(() => {});
+  const tool = { clearCache } as unknown as LiveInvestmentPricesTools;
   return { tool, clearCache };
 }
 
@@ -79,7 +89,8 @@ describe('RefreshCacheTool — scope: all', () => {
   test('flushes all snapshot caches and transactions', async () => {
     const { live, mocks } = makeMockLive();
     const bh = makeBalanceHistoryMock();
-    const tool = new RefreshCacheTool(live, bh.tool);
+    const ip = makeInvestmentPricesMock();
+    const tool = new RefreshCacheTool(live, bh.tool, ip.tool);
 
     const result = await tool.refresh({ scope: 'all' });
 
@@ -94,6 +105,7 @@ describe('RefreshCacheTool — scope: all', () => {
     expect(mocks.holdings.invalidate).toHaveBeenCalledTimes(1);
     expect(mocks.transactions.invalidate).toHaveBeenCalledTimes(1);
     expect(bh.clearCache).toHaveBeenCalledTimes(1);
+    expect(ip.clearCache).toHaveBeenCalledTimes(1);
     expect(result.flushed.accounts).toBe(true);
     expect(result.flushed.categories).toBe(true);
     expect(result.flushed.tags).toBe(true);
@@ -105,6 +117,7 @@ describe('RefreshCacheTool — scope: all', () => {
     expect(result.flushed.monthly_spend).toBe(true);
     expect(result.flushed.holdings).toBe(true);
     expect(result.flushed.balance_history).toBe(true);
+    expect(result.flushed.investment_prices).toBe(true);
     expect(result.flushed.transactions_months).toBe('all');
   });
 
@@ -320,6 +333,35 @@ describe('RefreshCacheTool — scope: balance_history', () => {
   });
 });
 
+describe('RefreshCacheTool — scope: investment_prices', () => {
+  test('clears the investment-prices tool cache and nothing else', async () => {
+    const { live, mocks } = makeMockLive();
+    const ip = makeInvestmentPricesMock();
+    const tool = new RefreshCacheTool(live, undefined, ip.tool);
+
+    const result = await tool.refresh({ scope: 'investment_prices' });
+
+    expect(ip.clearCache).toHaveBeenCalledTimes(1);
+    expect(mocks.accounts.invalidate).not.toHaveBeenCalled();
+    expect(mocks.categories.invalidate).not.toHaveBeenCalled();
+    expect(mocks.holdings.invalidate).not.toHaveBeenCalled();
+    expect(mocks.transactions.invalidate).not.toHaveBeenCalled();
+    expect(result.flushed.investment_prices).toBe(true);
+    expect(result.flushed.holdings).toBeUndefined();
+    expect(result.flushed.accounts).toBeUndefined();
+  });
+
+  test('no-op when investmentPrices tool is not wired — omits investment_prices from flushed', async () => {
+    const { live } = makeMockLive();
+    const tool = new RefreshCacheTool(live); // no investment-prices tool passed
+
+    const result = await tool.refresh({ scope: 'investment_prices' });
+
+    // Flag only appears when a real flush happened.
+    expect(result.flushed.investment_prices).toBeUndefined();
+  });
+});
+
 describe('RefreshCacheTool — scope: transactions', () => {
   test('flushes all transaction months by default', async () => {
     const { live, mocks } = makeMockLive();
@@ -412,6 +454,12 @@ describe('createRefreshCacheToolSchema', () => {
     const schema = createRefreshCacheToolSchema();
     const scopeProp = schema.inputSchema.properties.scope as { enum: string[] };
     expect(scopeProp.enum).toContain('balance_history');
+  });
+
+  test('investment_prices scope is listed in enum', () => {
+    const schema = createRefreshCacheToolSchema();
+    const scopeProp = schema.inputSchema.properties.scope as { enum: string[] };
+    expect(scopeProp.enum).toContain('investment_prices');
   });
 
   test('schema description mentions budgets piggyback on categories', () => {


### PR DESCRIPTION
## Summary

Adds the third (and last reachable-via-GraphQL) live investment tool, closing the original Phase 3 inventory. The query wrappers landed in #373; this PR wires the MCP tool.

**Auto-routing design.** The Copilot web app fires two different queries depending on which time-range button is clicked. We expose them as ONE MCP tool that routes on `time_frame`, so agents don't need to know about the daily/intraday split:

- `ONE_DAY`, `ONE_WEEK` → `SecurityPricesHighFrequency` (intraday timestamps)
- `ONE_MONTH`, `THREE_MONTHS`, `YTD`, `ONE_YEAR`, `ALL` → `SecurityPrices` (daily closes)

The output carries a `granularity` discriminator (`'daily' | 'intraday'`) so callers branch on the right field (`date` vs `timestamp`).

**TTLs.** Two internal maps with different cadences:
- Intraday → 5 minutes (prices change throughout the trading day).
- Daily → 1 hour (daily closes only update at market close).

**Server ownership-gate (documented).** Empirical testing found that both queries return `"No holdings found for this security"` for any security the user does not currently hold. The tool detects that and re-throws with a clean, security_id-bearing message: _"Price history for security {securityId} is not available — the security is not currently in your linked accounts."_ Both the JSDoc and the MCP description surface this caveat.

**`max_rows` cap.** Default 500, clamped to [1, 5000]. Forward-looking nod to #380. When the server returns more than `max_rows`, the tool slices to the most-recent rows (the tail of the ascending series) and sets `truncated: true`. `total_rows` carries the pre-truncation count.

**Refresh-cache integration.** New `investment_prices` scope clears both internal maps. The `all` scope cascades to it as well.

## Roadmap context

Phase 3 closed with PRs #372 / #373 / #375 / #377 / #378. Two pending Phase 3 items (splits + goals) remain confirmed-blocked on iOS/desktop capture (mitmproxy ruled out). This PR ships the one Phase 3 tool that was ready to wire and slipped — see #147.

## Smoke output (verbatim)

```
━━ Investment prices — happy path ━━
  Security type: EQUITY
  Daily prices: 29
  ✓ fetchSecurityPrices (daily, ONE_MONTH) returns well-shaped, date-sorted rows (354ms)
  Intraday prices: 79
  ✓ fetchSecurityPricesHighFrequency (intraday, ONE_DAY) returns well-shaped, timestamp-sorted rows (324ms)

Section               Pass  Fail      Time
------------------------------------------
investment-prices        2     0    0.68s
------------------------------------------
TOTAL                    2     0    1.73s

Latency (successful ops): median=354ms max=354ms
```

Both paths exercised end-to-end against the live endpoint. Median latency in line with the existing holdings smoke (~350ms / call).

## Test plan

- [x] Unit tests (29 new): happy daily, happy intraday, routing per time_frame, NOT_FOUND translation (daily + intraday + pass-through for non-matching), cache hit, granularity bypasses cache, TTL difference, clearCache, max_rows truncation + default + clamp, sort, empty, validation, GraphQL wiring, schema.
- [x] refresh-cache unit tests extended for new `investment_prices` scope + `all`-scope cascade.
- [x] `bun run check` clean (typecheck + lint + format + 1864 tests pass).
- [x] Smoke test passes against live endpoint (output above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)