### PR TITLE
chore(tools): clarify cache-only nature of get_goals + get_goal_history

### DIFF
--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -4050,7 +4050,10 @@ export function createToolSchemas(): ToolSchema[] {
         "Get financial goals from Copilot's native goal tracking. " +
         'Retrieves user-defined savings goals, debt payoff targets, and investment goals. ' +
         'Returns goal details including target amounts, monthly contributions, status (active/paused), ' +
-        'start dates, and tracking configuration. Calculates total target amount across all goals.',
+        'start dates, and tracking configuration. Calculates total target amount across all goals. ' +
+        "Cache-only: no live-mode (`--live-reads`) counterpart exists because Copilot's GraphQL endpoint " +
+        'does not expose goal data, so this tool always returns cached LevelDB data regardless of the ' +
+        '`--live-reads` flag.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -4186,7 +4189,10 @@ export function createToolSchemas(): ToolSchema[] {
       description:
         'Get monthly progress snapshots for financial goals. Returns current_amount, ' +
         'target_amount, daily data points, and contribution records per month. ' +
-        'Filter by goal_id or month range (YYYY-MM).',
+        'Filter by goal_id or month range (YYYY-MM). ' +
+        "Cache-only: no live-mode (`--live-reads`) counterpart exists because Copilot's GraphQL endpoint " +
+        'does not expose goal data, so this tool always returns cached LevelDB data regardless of the ' +
+        '`--live-reads` flag.',
       inputSchema: {
         type: 'object',
         properties: {


### PR DESCRIPTION
## Summary

- Tool-description-only update for `get_goals` and `get_goal_history` in `src/tools/tools.ts`.
- Three rounds of GraphQL introspection (a focused 277-candidate name sweep, documented in `docs/graphql-capture/hidden-mutations.md`) confirmed that Copilot's GraphQL endpoint does not expose goal data anywhere (`goals` / `financialGoals` / `savingsGoals` / `userGoals` are all absent, as are any goal mutations).
- These two tools will remain cache-only for the foreseeable future; the updated descriptions make that explicit so users understand why no `--live-reads` counterpart exists.

No behavior change. No GraphQL changes, so no smoke test required.

## Test plan

- [x] `bun run check` passes (1832 pass, 0 fail).
- [x] No tests assert the exact description strings; no test updates needed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>