### PR TITLE
feat(live): uniform pagination across time-series tools (issue #380)

### DIFF
--- a/src/tools/live/balance-history.ts
+++ b/src/tools/live/balance-history.ts
@@ -49,7 +49,7 @@ import {
   type BalanceHistoryPointNode,
 } from '../../core/graphql/queries/balance-history.js';
 import type { TimeFrame } from '../../core/graphql/queries/_shared.js';
-import { paginate, DEFAULT_MAX_ROWS, HARD_MAX_ROWS } from '../../utils/pagination.js';
+import { paginate, DEFAULT_MAX_ROWS } from '../../utils/pagination.js';
 
 const TIME_FRAMES: TimeFrame[] = [
   'ONE_DAY',
@@ -257,7 +257,3 @@ export function createLiveBalanceHistoryToolSchema() {
     },
   };
 }
-
-// Re-export pagination constants so callers/tests can pull the bounds from
-// one place if needed.
-export { DEFAULT_MAX_ROWS, HARD_MAX_ROWS };

--- a/src/tools/live/balance-history.ts
+++ b/src/tools/live/balance-history.ts
@@ -49,6 +49,7 @@ import {
   type BalanceHistoryPointNode,
 } from '../../core/graphql/queries/balance-history.js';
 import type { TimeFrame } from '../../core/graphql/queries/_shared.js';
+import { paginate, DEFAULT_MAX_ROWS, HARD_MAX_ROWS } from '../../utils/pagination.js';
 
 const TIME_FRAMES: TimeFrame[] = [
   'ONE_DAY',
@@ -78,6 +79,17 @@ export interface GetBalanceHistoryLiveArgs {
   account_id: string;
   /** Optional timeFrame. Omit to use the server's default range. */
   time_frame?: TimeFrame;
+  /**
+   * Cap on the number of rows returned. Clamped to [1, 5000]; default 500.
+   * Slices the most-recent rows of the ascending-by-date series.
+   */
+  max_rows?: number;
+  /**
+   * Number of rows to skip from the most-recent end (counts from the tail).
+   * Clamped to >= 0; default 0. `offset=max_rows` returns the
+   * next-most-recent batch.
+   */
+  offset?: number;
 }
 
 export interface GetBalanceHistoryLiveEntry {
@@ -86,7 +98,12 @@ export interface GetBalanceHistoryLiveEntry {
 }
 
 export interface GetBalanceHistoryLiveResult {
+  /** Number of rows in this page (= balance_history.length). */
   count: number;
+  /** Pre-pagination row count of the full series the server returned. */
+  total_rows: number;
+  /** True iff older rows beyond this page remain (caller can paginate further). */
+  truncated: boolean;
   balance_history: GetBalanceHistoryLiveEntry[];
   _cache_oldest_fetched_at: string;
   _cache_newest_fetched_at: string;
@@ -158,7 +175,10 @@ export class LiveBalanceHistoryTools {
     // safety net here makes the contract explicit. `.slice()` first so we
     // never mutate the cached array.
     const sorted = entry.rows.slice().sort((a, b) => a.date.localeCompare(b.date));
-    const projected: GetBalanceHistoryLiveEntry[] = sorted.map((r) => ({
+
+    // Apply uniform pagination AFTER sort so the "newest N" semantics hold.
+    const page = paginate(sorted, { max_rows: args.max_rows, offset: args.offset });
+    const projected: GetBalanceHistoryLiveEntry[] = page.rows.map((r) => ({
       date: r.date,
       balance: r.balance,
     }));
@@ -175,6 +195,8 @@ export class LiveBalanceHistoryTools {
     // Single-fetch shape — oldest and newest are identical.
     return {
       count: projected.length,
+      total_rows: page.total_rows,
+      truncated: page.truncated,
       balance_history: projected,
       _cache_oldest_fetched_at: fetchedAtIso,
       _cache_newest_fetched_at: fetchedAtIso,
@@ -192,7 +214,10 @@ export function createLiveBalanceHistoryToolSchema() {
       'Date range is selected by the time_frame enum; the server returns daily granularity ' +
       'and no name/limit enrichment. For cross-account history or weekly/monthly downsampling, ' +
       'use cache-mode `get_balance_history`. Use `get_accounts_live` to enumerate ' +
-      '(item_id, account_id) pairs. Available when --live-reads is on.',
+      '(item_id, account_id) pairs. ' +
+      'Long-range responses are paginated via `max_rows` (default 500, max 5000) and `offset` ' +
+      '(counts from the most-recent end); `total_rows` and `truncated` indicate whether ' +
+      'older rows remain. Available when --live-reads is on.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -209,6 +234,21 @@ export function createLiveBalanceHistoryToolSchema() {
           enum: TIME_FRAMES,
           description: "Date range preset. Optional — omit to use the server's default range.",
         },
+        max_rows: {
+          type: 'integer',
+          description:
+            'Cap response to the most recent N rows (default 500, max 5000). Helps avoid the ' +
+            'MCP single-tool-result token limit on long-range queries. If hit, response ' +
+            'includes `truncated: true`.',
+          default: DEFAULT_MAX_ROWS,
+        },
+        offset: {
+          type: 'integer',
+          description:
+            'Number of rows to skip from the most-recent end. Default 0. Set to `max_rows` to ' +
+            'fetch the next-most-recent batch (counts backwards through history).',
+          default: 0,
+        },
       },
       required: ['item_id', 'account_id'],
     },
@@ -217,3 +257,7 @@ export function createLiveBalanceHistoryToolSchema() {
     },
   };
 }
+
+// Re-export pagination constants so callers/tests can pull the bounds from
+// one place if needed.
+export { DEFAULT_MAX_ROWS, HARD_MAX_ROWS };

--- a/src/tools/live/investment-prices.ts
+++ b/src/tools/live/investment-prices.ts
@@ -81,6 +81,7 @@ import {
 } from '../../core/graphql/queries/security-prices-high-frequency.js';
 import type { TimeFrame } from '../../core/graphql/queries/_shared.js';
 import { GraphQLError } from '../../core/graphql/client.js';
+import { paginate, DEFAULT_MAX_ROWS } from '../../utils/pagination.js';
 
 const TIME_FRAMES: TimeFrame[] = [
   'ONE_DAY',
@@ -98,9 +99,6 @@ const FIVE_MIN_MS = 5 * 60 * 1000;
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
 const DEFAULT_TIME_FRAME: TimeFrame = 'ONE_MONTH';
-const DEFAULT_MAX_ROWS = 500;
-const MIN_MAX_ROWS = 1;
-const MAX_MAX_ROWS = 5000;
 
 /**
  * Sentinel key segment for "no timeFrame passed" so an explicit `'ALL'`
@@ -121,7 +119,16 @@ export type PriceGranularity = 'daily' | 'intraday';
 export interface GetInvestmentPricesLiveArgs {
   security_id: string;
   time_frame?: TimeFrame;
+  /**
+   * Cap on the number of rows returned. Clamped to [1, 5000]; default 500.
+   * Slices the most-recent rows of the ascending series.
+   */
   max_rows?: number;
+  /**
+   * Number of rows to skip from the most-recent end. Clamped to >= 0;
+   * default 0. Set to `max_rows` to fetch the next-most-recent batch.
+   */
+  offset?: number;
 }
 
 export interface GetInvestmentPricesLiveEntry {
@@ -161,12 +168,6 @@ function makeKey(securityId: string, timeFrame?: TimeFrame): string {
 
 function isIntraday(timeFrame: TimeFrame): boolean {
   return INTRADAY_TIME_FRAMES.has(timeFrame);
-}
-
-function clampMaxRows(n: number | undefined): number {
-  if (n === undefined) return DEFAULT_MAX_ROWS;
-  if (!Number.isFinite(n)) return DEFAULT_MAX_ROWS;
-  return Math.max(MIN_MAX_ROWS, Math.min(MAX_MAX_ROWS, Math.floor(n)));
 }
 
 /**
@@ -255,7 +256,6 @@ export class LiveInvestmentPricesTools {
     }
 
     const timeFrame: TimeFrame = args.time_frame ?? DEFAULT_TIME_FRAME;
-    const maxRows = clampMaxRows(args.max_rows);
     const intraday = isIntraday(timeFrame);
     const key = makeKey(args.security_id, args.time_frame);
     const startedAt = Date.now();
@@ -263,6 +263,7 @@ export class LiveInvestmentPricesTools {
     let granularity: PriceGranularity;
     let projected: GetInvestmentPricesLiveEntry[];
     let totalRows: number;
+    let truncated: boolean;
     let fetchedAt: number;
     let hit = false;
 
@@ -280,9 +281,10 @@ export class LiveInvestmentPricesTools {
         this.intradayCache.set(key, entry);
       }
       const sorted = entry.rows.slice().sort((a, b) => a.timestamp - b.timestamp);
-      totalRows = sorted.length;
-      const sliced = sorted.length > maxRows ? sorted.slice(sorted.length - maxRows) : sorted;
-      projected = sliced.map((r) => ({ price: r.price, timestamp: r.timestamp }));
+      const page = paginate(sorted, { max_rows: args.max_rows, offset: args.offset });
+      totalRows = page.total_rows;
+      truncated = page.truncated;
+      projected = page.rows.map((r) => ({ price: r.price, timestamp: r.timestamp }));
       fetchedAt = entry.fetched_at;
     } else {
       granularity = 'daily';
@@ -295,13 +297,12 @@ export class LiveInvestmentPricesTools {
         this.dailyCache.set(key, entry);
       }
       const sorted = entry.rows.slice().sort((a, b) => a.date.localeCompare(b.date));
-      totalRows = sorted.length;
-      const sliced = sorted.length > maxRows ? sorted.slice(sorted.length - maxRows) : sorted;
-      projected = sliced.map((r) => ({ price: r.price, date: r.date }));
+      const page = paginate(sorted, { max_rows: args.max_rows, offset: args.offset });
+      totalRows = page.total_rows;
+      truncated = page.truncated;
+      projected = page.rows.map((r) => ({ price: r.price, date: r.date }));
       fetchedAt = entry.fetched_at;
     }
-
-    const truncated = totalRows > projected.length;
 
     this.live.logReadCall({
       op: intraday ? 'SecurityPricesHighFrequency' : 'SecurityPrices',
@@ -365,6 +366,13 @@ export function createLiveInvestmentPricesToolSchema() {
             'MCP single-tool-result token limit on long-range queries. If hit, response ' +
             'includes `truncated: true`.',
           default: DEFAULT_MAX_ROWS,
+        },
+        offset: {
+          type: 'integer',
+          description:
+            'Number of rows to skip from the most-recent end. Default 0. Set to `max_rows` to ' +
+            'fetch the next-most-recent batch (counts backwards through history).',
+          default: 0,
         },
       },
       required: ['security_id'],

--- a/src/tools/live/investment-prices.ts
+++ b/src/tools/live/investment-prices.ts
@@ -187,7 +187,7 @@ function translateNotFound(err: unknown, securityId: string): never {
       `Price history for security ${securityId} is not available — the security is not currently in your linked accounts.`
     );
   }
-  throw err as Error;
+  throw err;
 }
 
 export class LiveInvestmentPricesTools {
@@ -344,7 +344,10 @@ export function createLiveInvestmentPricesToolSchema() {
       'IMPORTANT — server-side ownership gate: this query is restricted to securities you ' +
       'currently hold. For any security_id not in your linked-account positions, the tool ' +
       'returns a clean error ("not currently in your linked accounts"). Use `get_holdings_live` ' +
-      'to enumerate valid security_ids. Available when --live-reads is on.',
+      'to enumerate valid security_ids. Long-range responses are paginated via `max_rows` ' +
+      '(default 500, max 5000) and `offset` (counts from the most-recent row); the response ' +
+      'reports `total_rows` and `truncated` so callers can detect when older data was elided. ' +
+      'Available when --live-reads is on.',
     inputSchema: {
       type: 'object' as const,
       properties: {

--- a/src/tools/live/networth.ts
+++ b/src/tools/live/networth.ts
@@ -4,12 +4,17 @@
  * Fetches net-worth-over-time history via GraphQL through the
  * SnapshotCache<NetworthHistoryNode> exposed by LiveCopilotDatabase
  * (1h TTL). Output envelope mirrors the other live read tools (count,
- * networth_history) plus the freshness-envelope fields.
+ * networth_history) plus the freshness-envelope fields, plus the uniform
+ * pagination shape (total_rows, truncated; max_rows/offset args).
  *
  * The `total` field from the upstream NetworthHistory type is a client-side
  * (`@client`) projection stripped by the operations generator and is not
  * present on the wire. Consumers that want net worth at each point should
  * compute `assets - debt` per row.
+ *
+ * Default time_frame is `YTD` (tightened from `ALL` on 2026-05) so the
+ * default call stays well below the MCP single-tool-result token cap.
+ * Callers wanting the full history pass `time_frame: 'ALL'` explicitly.
  *
  * timeFrame caching: a single SnapshotCache holds the most-recently-requested
  * timeFrame's rows. Requests for a different timeFrame invalidate the cache
@@ -23,15 +28,31 @@ import {
   fetchNetworthHistory,
   type NetworthHistoryNode,
 } from '../../core/graphql/queries/networth.js';
+import { paginate, DEFAULT_MAX_ROWS } from '../../utils/pagination.js';
 
-const DEFAULT_TIME_FRAME = 'ALL';
+const DEFAULT_TIME_FRAME = 'YTD';
 
 export interface GetNetworthLiveArgs {
   time_frame?: string;
+  /**
+   * Cap on the number of rows returned. Clamped to [1, 5000]; default 500.
+   * Slices the most-recent rows of the ascending-by-date series.
+   */
+  max_rows?: number;
+  /**
+   * Number of rows to skip from the most-recent end (counts from the tail).
+   * Clamped to >= 0; default 0.
+   */
+  offset?: number;
 }
 
 export interface GetNetworthLiveResult {
+  /** Number of rows in this page (= networth_history.length). */
   count: number;
+  /** Pre-pagination row count of the full series the server returned. */
+  total_rows: number;
+  /** True iff older rows beyond this page remain. */
+  truncated: boolean;
   networth_history: NetworthHistoryNode[];
   _cache_oldest_fetched_at: string;
   _cache_newest_fetched_at: string;
@@ -69,14 +90,17 @@ export class LiveNetworthTools {
       hit,
     } = await cache.read(() => fetchNetworthHistory(this.live.getClient(), { timeFrame }));
 
-    const rows = [...cached].sort((a, b) => a.date.localeCompare(b.date));
+    const sorted = [...cached].sort((a, b) => a.date.localeCompare(b.date));
 
-    // Log after sort so `rows` reflects what's returned to the caller.
+    // Apply uniform pagination AFTER sort so the "newest N" semantics hold.
+    const page = paginate(sorted, { max_rows: args.max_rows, offset: args.offset });
+
+    // Log after pagination so `rows` reflects what's returned to the caller.
     this.live.logReadCall({
       op: 'Networth',
       pages: hit ? 0 : 1,
       latencyMs: Date.now() - startedAt,
-      rows: rows.length,
+      rows: page.rows.length,
       cache_hit: hit,
     });
 
@@ -85,8 +109,10 @@ export class LiveNetworthTools {
     // the same single-snapshot fetch time — unlike the windowed transaction
     // cache where they can differ across month windows.
     return {
-      count: rows.length,
-      networth_history: rows,
+      count: page.rows.length,
+      total_rows: page.total_rows,
+      truncated: page.truncated,
+      networth_history: page.rows,
       _cache_oldest_fetched_at: fetchedAtIso,
       _cache_newest_fetched_at: fetchedAtIso,
       _cache_hit: hit,
@@ -102,20 +128,38 @@ export function createLiveNetworthToolSchema() {
       'sorted oldest→newest by date; for each row, `assets - debt` gives the net worth ' +
       'at that point in time. Both `assets` and `debt` are nullable strings — early dates ' +
       "in the user's history may have `assets: null` until backfilled. Available when " +
-      '--live-reads is on. Optional `time_frame` arg (default "ALL"; other server-supported ' +
-      'values include "YEAR", "MONTH"). The cache holds the most-recently-requested ' +
-      'time_frame; requesting a different value triggers a fresh fetch.',
+      '--live-reads is on. Optional `time_frame` arg (default "YTD"; other server-supported ' +
+      'values include "ALL", "YEAR", "MONTH"). The cache holds the most-recently-requested ' +
+      'time_frame; requesting a different value triggers a fresh fetch. ' +
+      'Long-range responses are paginated via `max_rows` (default 500, max 5000) and ' +
+      '`offset`; `total_rows` and `truncated` indicate whether older rows remain.',
     inputSchema: {
       type: 'object' as const,
       properties: {
         time_frame: {
           type: 'string',
-          enum: ['ALL', 'YEAR', 'MONTH'],
+          enum: ['ALL', 'YEAR', 'MONTH', 'YTD'],
           description:
-            'TimeFrame enum passed through to the Networth query. Default "ALL". ' +
-            'Other values are passed through unchanged; the server is the source of truth ' +
-            'on which TimeFrame values it accepts.',
+            'TimeFrame enum passed through to the Networth query. Default "YTD" ' +
+            '(tightened on 2026-05 to fit the default response under the MCP token cap). ' +
+            'Pass "ALL" for full history. Other values are passed through unchanged; ' +
+            'the server is the source of truth on which TimeFrame values it accepts.',
           default: DEFAULT_TIME_FRAME,
+        },
+        max_rows: {
+          type: 'integer',
+          description:
+            'Cap response to the most recent N rows (default 500, max 5000). Helps avoid the ' +
+            'MCP single-tool-result token limit on long-range queries. If hit, response ' +
+            'includes `truncated: true`.',
+          default: DEFAULT_MAX_ROWS,
+        },
+        offset: {
+          type: 'integer',
+          description:
+            'Number of rows to skip from the most-recent end. Default 0. Set to `max_rows` to ' +
+            'fetch the next-most-recent batch.',
+          default: 0,
         },
       },
     },

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,101 @@
+/**
+ * Uniform pagination + truncation shape for time-series live tools.
+ *
+ * Live tools can return long row counts (multi-year daily balance / price
+ * history) that overflow the MCP single-tool-result token cap. This helper:
+ *
+ * 1. Clamps `max_rows` to [1, 5000] with a default of 500.
+ * 2. Clamps `offset` to >= 0.
+ * 3. Slices the most-recent rows (the tail of an ascending-by-time series).
+ * 4. Reports `total_rows` (pre-truncation) and `truncated` (whether the
+ *    response was capped — i.e., there are older rows the caller did not
+ *    receive in this response).
+ *
+ * Slice math (ascending series):
+ *   end   = total - offset
+ *   start = max(0, end - effective_max_rows)
+ *   rows  = series.slice(start, end)
+ *
+ * So `offset=0` returns the newest `max_rows` rows (the tail), `offset=500`
+ * returns the next-most-recent batch (the 500 rows older than the newest
+ * 500), and so on. `offset >= total` produces an empty result without
+ * throwing.
+ *
+ * `truncated` is `true` when there are MORE rows older than what was
+ * returned (i.e., `start > 0`, equivalently `total > offset + effective_max`).
+ * It is intentionally `false` when `offset + effective_max == total` exactly,
+ * because no older rows remain.
+ */
+
+/** Default number of rows returned when `max_rows` is not provided. */
+export const DEFAULT_MAX_ROWS = 500;
+/** Hard upper bound applied after `max_rows` is parsed. */
+export const HARD_MAX_ROWS = 5000;
+/** Hard lower bound applied after `max_rows` is parsed. */
+export const MIN_MAX_ROWS = 1;
+
+export interface PaginationOpts {
+  /**
+   * Cap on the number of rows returned. Clamped to [1, 5000]; non-finite
+   * values fall back to the default. Default: 500.
+   */
+  max_rows?: number;
+  /**
+   * Number of rows to skip from the most-recent end. Clamped to >= 0;
+   * non-finite values fall back to 0. Default: 0.
+   */
+  offset?: number;
+}
+
+export interface PaginationResult<T> {
+  /** The page of rows (sub-slice of the input). */
+  rows: T[];
+  /** Pre-truncation count of the input series. */
+  total_rows: number;
+  /** True iff there are older rows the caller did not receive. */
+  truncated: boolean;
+}
+
+/**
+ * Clamp `max_rows` to [MIN_MAX_ROWS, HARD_MAX_ROWS]. Non-finite or omitted
+ * values resolve to DEFAULT_MAX_ROWS. Fractional inputs are floored.
+ */
+export function clampMaxRows(n: number | undefined): number {
+  if (n === undefined) return DEFAULT_MAX_ROWS;
+  if (!Number.isFinite(n)) return DEFAULT_MAX_ROWS;
+  return Math.max(MIN_MAX_ROWS, Math.min(HARD_MAX_ROWS, Math.floor(n)));
+}
+
+/**
+ * Clamp `offset` to >= 0. Non-finite or omitted values resolve to 0.
+ * Fractional inputs are floored.
+ */
+export function clampOffset(n: number | undefined): number {
+  if (n === undefined) return 0;
+  if (!Number.isFinite(n)) return 0;
+  return Math.max(0, Math.floor(n));
+}
+
+/**
+ * Slice the most-recent rows of an ascending-by-time series, applying the
+ * shared pagination contract. See module JSDoc for the slice math.
+ *
+ * Important: the input series MUST already be sorted ascending by time
+ * (oldest → newest) for the "most-recent" semantics to hold. Callers should
+ * sort before calling.
+ */
+export function paginate<T>(series: readonly T[], opts: PaginationOpts = {}): PaginationResult<T> {
+  const effective_max = clampMaxRows(opts.max_rows);
+  const offset = clampOffset(opts.offset);
+  const total = series.length;
+  const end = Math.max(0, total - offset);
+  const start = Math.max(0, end - effective_max);
+  const rows = series.slice(start, end);
+  // `truncated` is strict — equal totals (offset + max == total) means no
+  // older rows remain to fetch.
+  return {
+    rows,
+    total_rows: total,
+    truncated: total > offset + effective_max,
+  };
+}

--- a/tests/tools/live/balance-history.test.ts
+++ b/tests/tools/live/balance-history.test.ts
@@ -40,6 +40,8 @@ describe('LiveBalanceHistoryTools.getBalanceHistory — happy path', () => {
     });
 
     expect(result.count).toBe(3);
+    expect(result.total_rows).toBe(3);
+    expect(result.truncated).toBe(false);
     expect(result.balance_history).toEqual([
       { date: '2026-01-01', balance: 1000 },
       { date: '2026-01-02', balance: 1050 },
@@ -63,6 +65,8 @@ describe('LiveBalanceHistoryTools.getBalanceHistory — happy path', () => {
     });
 
     expect(result.count).toBe(0);
+    expect(result.total_rows).toBe(0);
+    expect(result.truncated).toBe(false);
     expect(result.balance_history).toEqual([]);
     expect(result._cache_hit).toBe(false);
     expect(typeof result._cache_oldest_fetched_at).toBe('string');
@@ -246,6 +250,67 @@ describe('LiveBalanceHistoryTools — GraphQL wiring', () => {
   });
 });
 
+describe('LiveBalanceHistoryTools — pagination', () => {
+  // 1500-row synthetic series — well above the default 500-row cap so we can
+  // exercise truncation and offset pagination. Dates are synthetic
+  // (year-2025-padded month/day), values are 1000 + index.
+  const bigRows = Array.from({ length: 1500 }, (_, i) => ({
+    date: `2025-${String(Math.floor(i / 30) + 1).padStart(2, '0')}-${String((i % 30) + 1).padStart(2, '0')}`,
+    balance: 1000 + i,
+  }));
+
+  test('caps at default max_rows=500 and reports truncated=true', async () => {
+    const client = makeClient(bigRows);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    const result = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+    });
+
+    expect(result.total_rows).toBe(1500);
+    expect(result.count).toBe(500);
+    expect(result.truncated).toBe(true);
+    // Sliced to MOST RECENT (tail of ascending series).
+    expect(result.balance_history[0]!.balance).toBe(1000 + 1000);
+    expect(result.balance_history[499]!.balance).toBe(1000 + 1499);
+  });
+
+  test('offset=500 returns the next-most-recent batch', async () => {
+    const client = makeClient(bigRows);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    const result = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+      max_rows: 500,
+      offset: 500,
+    });
+
+    expect(result.count).toBe(500);
+    expect(result.total_rows).toBe(1500);
+    expect(result.truncated).toBe(true); // 500 older rows still remain
+    expect(result.balance_history[0]!.balance).toBe(1000 + 500);
+    expect(result.balance_history[499]!.balance).toBe(1000 + 999);
+  });
+
+  test('offset beyond total returns empty rows without throwing', async () => {
+    const client = makeClient(bigRows);
+    const tools = new LiveBalanceHistoryTools(makeLive(client));
+
+    const result = await tools.getBalanceHistory({
+      item_id: ITEM_ID,
+      account_id: ACCOUNT_ID,
+      max_rows: 100,
+      offset: 5000,
+    });
+
+    expect(result.count).toBe(0);
+    expect(result.total_rows).toBe(1500);
+    expect(result.balance_history).toEqual([]);
+  });
+});
+
 describe('createLiveBalanceHistoryToolSchema', () => {
   test('name is get_balance_history_live, readOnlyHint=true', () => {
     const schema = createLiveBalanceHistoryToolSchema();
@@ -257,7 +322,7 @@ describe('createLiveBalanceHistoryToolSchema', () => {
     const schema = createLiveBalanceHistoryToolSchema();
     const props = schema.inputSchema.properties as Record<
       string,
-      { type: string; enum?: string[] }
+      { type: string; enum?: string[]; default?: number }
     >;
     expect(props.item_id?.type).toBe('string');
     expect(props.account_id?.type).toBe('string');
@@ -275,5 +340,17 @@ describe('createLiveBalanceHistoryToolSchema', () => {
       'item_id',
       'account_id',
     ]);
+  });
+
+  test('exposes max_rows and offset pagination args', () => {
+    const schema = createLiveBalanceHistoryToolSchema();
+    const props = schema.inputSchema.properties as Record<
+      string,
+      { type: string; default?: number }
+    >;
+    expect(props.max_rows?.type).toBe('integer');
+    expect(props.max_rows?.default).toBe(500);
+    expect(props.offset?.type).toBe('integer');
+    expect(props.offset?.default).toBe(0);
   });
 });

--- a/tests/tools/live/investment-prices.test.ts
+++ b/tests/tools/live/investment-prices.test.ts
@@ -308,7 +308,7 @@ describe('LiveInvestmentPricesTools — cache behavior', () => {
     expect(client.query).toHaveBeenCalledTimes(4);
   });
 
-  test('omitted vs explicit ONE_MONTH share a key but distinct from DEFAULT', async () => {
+  test('omitted time_frame uses DEFAULT sentinel key, distinct from explicit ONE_MONTH', async () => {
     // Both default to ONE_MONTH semantics, but they use different cache keys:
     // explicit ONE_MONTH uses the enum value; omitted uses the DEFAULT sentinel.
     const client = makeClient({ daily: dailyRows });

--- a/tests/tools/live/investment-prices.test.ts
+++ b/tests/tools/live/investment-prices.test.ts
@@ -415,6 +415,46 @@ describe('LiveInvestmentPricesTools — max_rows truncation', () => {
     expect(result.total_rows).toBe(5);
     expect(result.truncated).toBe(false);
   });
+
+  test('offset=max_rows returns the next-most-recent batch', async () => {
+    const bigDaily = Array.from({ length: 1500 }, (_, i) => ({
+      id: SECURITY_ID,
+      price: 100 + i,
+      date: `2025-${String(Math.floor(i / 30) + 1).padStart(2, '0')}-${String((i % 30) + 1).padStart(2, '0')}`,
+    }));
+    const client = makeClient({ daily: bigDaily });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_YEAR',
+      max_rows: 500,
+      offset: 500,
+    });
+
+    expect(result.count).toBe(500);
+    expect(result.total_rows).toBe(1500);
+    expect(result.truncated).toBe(true);
+    expect(result.prices[0]!.price).toBe(100 + 500);
+    expect(result.prices[499]!.price).toBe(100 + 999);
+  });
+
+  test('offset beyond total returns empty rows without throwing', async () => {
+    const client = makeClient({ daily: dailyRows });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+      max_rows: 100,
+      offset: 5000,
+    });
+
+    expect(result.count).toBe(0);
+    expect(result.total_rows).toBe(5);
+    expect(result.prices).toEqual([]);
+    expect(result.truncated).toBe(false);
+  });
 });
 
 describe('LiveInvestmentPricesTools — sorting', () => {
@@ -550,6 +590,16 @@ describe('createLiveInvestmentPricesToolSchema', () => {
     expect(props.max_rows?.type).toBe('integer');
     expect(props.max_rows?.default).toBe(500);
     expect((schema.inputSchema as { required?: string[] }).required ?? []).toEqual(['security_id']);
+  });
+
+  test('exposes offset pagination arg matching the shared shape', () => {
+    const schema = createLiveInvestmentPricesToolSchema();
+    const props = schema.inputSchema.properties as Record<
+      string,
+      { type: string; default?: number }
+    >;
+    expect(props.offset?.type).toBe('integer');
+    expect(props.offset?.default).toBe(0);
   });
 
   test('description mentions the ownership gate', () => {

--- a/tests/tools/live/networth.test.ts
+++ b/tests/tools/live/networth.test.ts
@@ -24,6 +24,8 @@ describe('LiveNetworthTools.getNetworth', () => {
     const result = await tools.getNetworth({});
 
     expect(result.count).toBe(1);
+    expect(result.total_rows).toBe(1);
+    expect(result.truncated).toBe(false);
     expect(result.networth_history[0]?.date).toBe('2026-01-01');
     expect(result.networth_history[0]?.assets).toBe('100000');
     expect(result.networth_history[0]?.debt).toBe('5000');
@@ -70,11 +72,25 @@ describe('LiveNetworthTools.getNetworth', () => {
     ]);
   });
 
-  test('default timeFrame is "ALL" when not provided', async () => {
+  test('default timeFrame is "YTD" when not provided', async () => {
+    // Tightened on 2026-05 from ALL → YTD so the default response stays
+    // under the MCP single-tool-result token cap (issue #380). Callers
+    // wanting full history must pass time_frame: 'ALL' explicitly.
     const client = makeClient([]);
     const tools = new LiveNetworthTools(makeLive(client));
 
     await tools.getNetworth({});
+
+    expect(client.query).toHaveBeenCalledWith('Networth', expect.any(String), {
+      timeFrame: 'YTD',
+    });
+  });
+
+  test('explicit time_frame=ALL still works (opt-in to full history)', async () => {
+    const client = makeClient([]);
+    const tools = new LiveNetworthTools(makeLive(client));
+
+    await tools.getNetworth({ time_frame: 'ALL' });
 
     expect(client.query).toHaveBeenCalledWith('Networth', expect.any(String), {
       timeFrame: 'ALL',
@@ -103,6 +119,57 @@ describe('LiveNetworthTools.getNetworth', () => {
     expect(second._cache_hit).toBe(false);
   });
 
+  test('caps at default max_rows=500 and reports truncated=true', async () => {
+    const bigRows = Array.from({ length: 1500 }, (_, i) => ({
+      date: `2025-${String(Math.floor(i / 30) + 1).padStart(2, '0')}-${String((i % 30) + 1).padStart(2, '0')}`,
+      assets: String(100 + i),
+      debt: String(10 + i),
+    }));
+    const client = makeClient(bigRows);
+    const tools = new LiveNetworthTools(makeLive(client));
+
+    const result = await tools.getNetworth({ time_frame: 'ALL' });
+
+    expect(result.total_rows).toBe(1500);
+    expect(result.count).toBe(500);
+    expect(result.truncated).toBe(true);
+    // Sliced to MOST RECENT (tail of ascending series).
+    expect(result.networth_history[0]?.assets).toBe(String(100 + 1000));
+    expect(result.networth_history[499]?.assets).toBe(String(100 + 1499));
+  });
+
+  test('offset=500 returns the next-most-recent batch', async () => {
+    const bigRows = Array.from({ length: 1500 }, (_, i) => ({
+      date: `2025-${String(Math.floor(i / 30) + 1).padStart(2, '0')}-${String((i % 30) + 1).padStart(2, '0')}`,
+      assets: String(100 + i),
+      debt: String(10 + i),
+    }));
+    const client = makeClient(bigRows);
+    const tools = new LiveNetworthTools(makeLive(client));
+
+    const result = await tools.getNetworth({
+      time_frame: 'ALL',
+      max_rows: 500,
+      offset: 500,
+    });
+
+    expect(result.count).toBe(500);
+    expect(result.total_rows).toBe(1500);
+    expect(result.truncated).toBe(true);
+    expect(result.networth_history[0]?.assets).toBe(String(100 + 500));
+  });
+
+  test('offset beyond total returns empty rows without throwing', async () => {
+    const client = makeClient([sampleRow]);
+    const tools = new LiveNetworthTools(makeLive(client));
+
+    const result = await tools.getNetworth({ max_rows: 100, offset: 5000 });
+
+    expect(result.count).toBe(0);
+    expect(result.networth_history).toEqual([]);
+    expect(result.total_rows).toBe(1);
+  });
+
   test('preserves null assets/debt in passthrough (early dates)', async () => {
     const client = makeClient([{ date: '2022-09-13', assets: null, debt: '500' }]);
     const tools = new LiveNetworthTools(makeLive(client));
@@ -121,5 +188,30 @@ describe('createLiveNetworthToolSchema', () => {
     expect(schema.name).toBe('get_networth_live');
     expect(schema.annotations?.readOnlyHint).toBe(true);
     expect(schema.inputSchema.properties).toHaveProperty('time_frame');
+  });
+
+  test('time_frame default is "YTD" (tightened from ALL on 2026-05)', async () => {
+    const { createLiveNetworthToolSchema } = await import('../../../src/tools/live/networth.js');
+    const schema = createLiveNetworthToolSchema();
+    const props = schema.inputSchema.properties as Record<
+      string,
+      { type: string; default?: string | number; enum?: string[] }
+    >;
+    expect(props.time_frame?.default).toBe('YTD');
+    // Description should explain the change so callers can find context.
+    expect(schema.description).toMatch(/YTD/);
+  });
+
+  test('exposes max_rows and offset pagination args', async () => {
+    const { createLiveNetworthToolSchema } = await import('../../../src/tools/live/networth.js');
+    const schema = createLiveNetworthToolSchema();
+    const props = schema.inputSchema.properties as Record<
+      string,
+      { type: string; default?: number }
+    >;
+    expect(props.max_rows?.type).toBe('integer');
+    expect(props.max_rows?.default).toBe(500);
+    expect(props.offset?.type).toBe('integer');
+    expect(props.offset?.default).toBe(0);
   });
 });

--- a/tests/utils/pagination.test.ts
+++ b/tests/utils/pagination.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  paginate,
+  clampMaxRows,
+  clampOffset,
+  DEFAULT_MAX_ROWS,
+  HARD_MAX_ROWS,
+  MIN_MAX_ROWS,
+} from '../../src/utils/pagination.js';
+
+// 10-row ascending series; the "newest" rows are at the tail.
+const small = Array.from({ length: 10 }, (_, i) => i);
+
+// 1500-row ascending series; long enough to exercise default/cap behavior.
+const big = Array.from({ length: 1500 }, (_, i) => i);
+
+describe('paginate — default behavior', () => {
+  test('omitting both args returns newest DEFAULT_MAX_ROWS rows', () => {
+    const r = paginate(big);
+    expect(r.rows.length).toBe(DEFAULT_MAX_ROWS);
+    expect(r.total_rows).toBe(1500);
+    expect(r.truncated).toBe(true);
+    // tail of ascending series — newest rows
+    expect(r.rows[0]).toBe(1500 - DEFAULT_MAX_ROWS);
+    expect(r.rows[r.rows.length - 1]).toBe(1499);
+  });
+
+  test('series smaller than max_rows returns all rows, truncated=false', () => {
+    const r = paginate(small);
+    expect(r.rows).toEqual(small);
+    expect(r.total_rows).toBe(10);
+    expect(r.truncated).toBe(false);
+  });
+
+  test('empty input series → empty rows, total=0, truncated=false', () => {
+    const r = paginate<number>([]);
+    expect(r.rows).toEqual([]);
+    expect(r.total_rows).toBe(0);
+    expect(r.truncated).toBe(false);
+  });
+});
+
+describe('paginate — truncation flag', () => {
+  test('total > max_rows → truncated=true', () => {
+    const r = paginate(big, { max_rows: 500 });
+    expect(r.truncated).toBe(true);
+  });
+
+  test('total <= max_rows → truncated=false', () => {
+    const r = paginate(small, { max_rows: 50 });
+    expect(r.truncated).toBe(false);
+  });
+
+  test('boundary: total == max_rows exactly → truncated=false', () => {
+    const r = paginate(small, { max_rows: 10 });
+    expect(r.rows).toEqual(small);
+    expect(r.truncated).toBe(false);
+  });
+
+  test('boundary: offset + max_rows == total exactly → truncated=false (no older rows remain)', () => {
+    // 10 rows, max=5, offset=5 → returns rows[0..5) (the older half).
+    // total > offset + max  →  10 > 5 + 5  →  false.
+    const r = paginate(small, { max_rows: 5, offset: 5 });
+    expect(r.rows).toEqual([0, 1, 2, 3, 4]);
+    expect(r.truncated).toBe(false);
+  });
+});
+
+describe('paginate — clamping', () => {
+  test('max_rows above HARD_MAX_ROWS is clamped down', () => {
+    const r = paginate(big, { max_rows: 100_000 });
+    expect(r.rows.length).toBe(Math.min(big.length, HARD_MAX_ROWS));
+  });
+
+  test('max_rows below MIN_MAX_ROWS is clamped up to 1', () => {
+    const r = paginate(small, { max_rows: 0 });
+    expect(r.rows.length).toBe(MIN_MAX_ROWS);
+    expect(r.rows[0]).toBe(9); // most-recent
+    expect(r.truncated).toBe(true);
+  });
+
+  test('negative max_rows is clamped up to 1', () => {
+    const r = paginate(small, { max_rows: -100 });
+    expect(r.rows.length).toBe(MIN_MAX_ROWS);
+  });
+
+  test('negative offset is clamped to 0', () => {
+    const r = paginate(small, { max_rows: 3, offset: -50 });
+    // offset 0 means newest-3 — i.e., [7, 8, 9]
+    expect(r.rows).toEqual([7, 8, 9]);
+  });
+
+  test('non-finite max_rows falls back to default', () => {
+    const r = paginate(big, { max_rows: Number.NaN });
+    expect(r.rows.length).toBe(DEFAULT_MAX_ROWS);
+  });
+
+  test('non-finite offset falls back to 0', () => {
+    const r = paginate(small, { max_rows: 3, offset: Number.NaN });
+    expect(r.rows).toEqual([7, 8, 9]);
+  });
+
+  test('fractional max_rows is floored', () => {
+    expect(clampMaxRows(3.9)).toBe(3);
+  });
+
+  test('fractional offset is floored', () => {
+    expect(clampOffset(2.9)).toBe(2);
+  });
+});
+
+describe('paginate — offset semantics (counts from the end)', () => {
+  test('offset=0 returns the newest max_rows rows', () => {
+    const r = paginate(small, { max_rows: 3, offset: 0 });
+    expect(r.rows).toEqual([7, 8, 9]);
+  });
+
+  test('offset=max_rows returns the next-most-recent batch', () => {
+    const r = paginate(small, { max_rows: 3, offset: 3 });
+    expect(r.rows).toEqual([4, 5, 6]);
+    // total > offset + max  →  10 > 3 + 3  →  truncated=true (older rows remain)
+    expect(r.truncated).toBe(true);
+  });
+
+  test('walking offset eventually drains the series', () => {
+    const page1 = paginate(small, { max_rows: 3, offset: 0 });
+    const page2 = paginate(small, { max_rows: 3, offset: 3 });
+    const page3 = paginate(small, { max_rows: 3, offset: 6 });
+    // last page: 10 - 6 = 4 rows remain at the head (indices 0..3)
+    // start = max(0, 4 - 3) = 1, end = 4 → rows[1..4) = [1, 2, 3]
+    expect(page1.rows).toEqual([7, 8, 9]);
+    expect(page2.rows).toEqual([4, 5, 6]);
+    expect(page3.rows).toEqual([1, 2, 3]);
+    expect(page3.truncated).toBe(true);
+  });
+
+  test('offset beyond total returns empty rows, truncated=false', () => {
+    const r = paginate(small, { max_rows: 3, offset: 100 });
+    expect(r.rows).toEqual([]);
+    expect(r.total_rows).toBe(10);
+    expect(r.truncated).toBe(false);
+  });
+
+  test('offset exactly at total returns empty rows', () => {
+    const r = paginate(small, { max_rows: 3, offset: 10 });
+    expect(r.rows).toEqual([]);
+    expect(r.total_rows).toBe(10);
+  });
+});
+
+describe('paginate — slicing math', () => {
+  test('big series, max=500, offset=0 → tail (indices 1000..1499)', () => {
+    const r = paginate(big, { max_rows: 500, offset: 0 });
+    expect(r.rows[0]).toBe(1000);
+    expect(r.rows[499]).toBe(1499);
+  });
+
+  test('big series, max=500, offset=500 → indices 500..999', () => {
+    const r = paginate(big, { max_rows: 500, offset: 500 });
+    expect(r.rows[0]).toBe(500);
+    expect(r.rows[499]).toBe(999);
+  });
+
+  test('partial last page: 10 rows, max=4, offset=8 → only 2 rows remain at head', () => {
+    // end = 10 - 8 = 2, start = max(0, 2 - 4) = 0 → rows[0..2)
+    const r = paginate(small, { max_rows: 4, offset: 8 });
+    expect(r.rows).toEqual([0, 1]);
+    expect(r.truncated).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Retrofits three live time-series tools with a uniform pagination shape so their default responses fit under the MCP single-tool-result token cap (issue #380):

- `get_balance_history_live`
- `get_networth_live`
- `get_investment_prices_live`

All three now share a new `src/utils/pagination.ts` helper, exposing identical `max_rows` + `offset` input args and `total_rows` + `truncated` output fields. Design doc kept locally as `docs/superpowers/specs/2026-05-11-live-tools-pagination-design.md` (gitignored — not in this diff).

## Decisions locked in

| Decision | Value |
| --- | --- |
| `max_rows` default | 500 |
| `max_rows` clamp | [1, 5000] (lower bound clamps up, upper clamps down) |
| `offset` default | 0 |
| `offset` clamp | >= 0 |
| Truncation slice direction | last-N (most-recent, tail of ascending series) |
| `offset` semantics | counts from the most-recent end |
| `truncated` flag | strict — `total > offset + max_rows`; equal totals → `false` |
| `get_networth_live` default `time_frame` | **changed from `ALL` to `YTD`** |
| Summary mode | deferred to follow-up PR |

## Breaking-ish change

`get_networth_live` default `time_frame` is now `YTD` (was `ALL`). Agents that explicitly pass `time_frame: 'ALL'` continue to work; agents that relied on the default now get a narrower range. Description and JSDoc updated to mention the change.

## Smoke output

`bun run scripts/smoke-graphql.ts --section balance-history`:

```
Copilot GraphQL E2E smoke test
flags: quick=false skipDestructive=false skipErrors=false skipEdgeCases=false skipConsistency=false skipMcpE2e=false includeStateGated=false section=balance-history

━━ Balance history — happy path ━━
  Account: cash management
  Balance history rows: 30
  ✓ fetchAccountBalanceHistory returns well-shaped, date-sorted rows (380ms)

════════════════════════════════════════════════════════════════════════
SUMMARY
════════════════════════════════════════════════════════════════════════
Section               Pass  Fail      Time
------------------------------------------
balance-history          1     0    0.38s
------------------------------------------
TOTAL                    1     0    3.79s

Latency (successful ops): median=380ms max=380ms

✓ no cleanup stragglers
```

`bun run scripts/smoke-graphql.ts --section investment-prices`:

```
Copilot GraphQL E2E smoke test
flags: quick=false skipDestructive=false skipErrors=false skipEdgeCases=false skipConsistency=false skipMcpE2e=false includeStateGated=false section=investment-prices

━━ Investment prices — happy path ━━
  Security type: EQUITY
  Daily prices: 29
  ✓ fetchSecurityPrices (daily, ONE_MONTH) returns well-shaped, date-sorted rows (420ms)
  Intraday prices: 79
  ✓ fetchSecurityPricesHighFrequency (intraday, ONE_DAY) returns well-shaped, timestamp-sorted rows (382ms)

════════════════════════════════════════════════════════════════════════
SUMMARY
════════════════════════════════════════════════════════════════════════
Section               Pass  Fail      Time
------------------------------------------
investment-prices        2     0    0.80s
------------------------------------------
TOTAL                    2     0    1.62s

Latency (successful ops): median=420ms max=420ms

✓ no cleanup stragglers
```

`networth-live` does not have a dedicated smoke section; no networth section was added in this PR.

## Test plan

- [x] New `tests/utils/pagination.test.ts` — 23 cases covering defaults, clamping, offset walking, truncation flag, boundary (`offset + max_rows == total`), empty input
- [x] `balance-history.test.ts` — added pagination cases (default cap, offset paging, offset beyond total) + schema asserts new fields
- [x] `networth.test.ts` — updated to assert `YTD` default, added pagination cases + schema asserts new fields + explicit `ALL` opt-in still works
- [x] `investment-prices.test.ts` — added offset cases; existing truncation cases now route through the shared helper
- [x] `bun run check` clean (typecheck + lint + format + 1921 tests, 0 fail)
- [x] Live smoke `--section balance-history` (1/1 pass)
- [x] Live smoke `--section investment-prices` (2/2 pass)

Closes the immediate-overflow part of issue #380.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>