### PR TITLE
feat(tools): restore get_investment_splits with accurate adjustment-factor model

### DIFF
--- a/docs/firestore-collections.md
+++ b/docs/firestore-collections.md
@@ -4,7 +4,7 @@ Complete documentation of all Firestore collections cached locally by Copilot Mo
 
 **Last verified:** 2026-04-05 | **App version:** macOS (App Store) | **Total documents:** ~55,953 across ~35 unique collection patterns
 
-**Decode coverage:** 32 of 35 collection paths decoded — `investment_splits`, `investment_performance`, and `investment_performance/{hash}/twr_holding` were dropped after the underlying cache data proved either empty or non-analytical (see changelog for rationale)
+**Decode coverage:** 33 of 35 collection paths decoded — `investment_performance` and `investment_performance/{hash}/twr_holding` remain undecoded (cache data is non-analytical). `investment_splits` was restored 2026-05-11 after re-inspection revealed real date-keyed adjustment multipliers in docs for securities that have actually split (the original drop in 2026-05-10 was a false negative — none of the then-held securities had splits in their history).
 
 ## Database Location
 

--- a/manifest.json
+++ b/manifest.json
@@ -70,6 +70,10 @@
       "description": "Get investment price history for portfolio tracking. Returns daily and high-frequency price data for stocks, ETFs, mutual funds, and crypto."
     },
     {
+      "name": "get_investment_splits",
+      "description": "Get stock split events from the local Firestore cache."
+    },
+    {
       "name": "get_holdings",
       "description": "Get current investment holdings with position-level detail including ticker, quantity, price, average cost, and total return per holding."
     },

--- a/scripts/decode-coverage.ts
+++ b/scripts/decode-coverage.ts
@@ -102,6 +102,7 @@ function isDecoded(rawCollection: string): boolean {
     rawCollection.includes('investment_prices/')
   )
     return true;
+  if (collectionMatches(rawCollection, 'investment_splits')) return true;
   if (collectionMatches(rawCollection, 'items') || /^items\/[^/]+$/.test(rawCollection))
     return true;
   if (collectionMatches(rawCollection, 'tags')) return true;

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -36,7 +36,7 @@ import {
   Item,
   getTransactionDisplayName,
 } from '../models/index.js';
-import type { Security, HoldingsHistory, Tag } from '../models/index.js';
+import type { Security, HoldingsHistory, Tag, InvestmentSplit } from '../models/index.js';
 import type { BalanceHistory } from '../models/balance-history.js';
 import { getCategoryName } from '../utils/categories.js';
 
@@ -150,6 +150,7 @@ export class CopilotDatabase {
   private _goals: Goal[] | null = null;
   private _goalHistory: GoalHistory[] | null = null;
   private _investmentPrices: InvestmentPrice[] | null = null;
+  private _investmentSplits: InvestmentSplit[] | null = null;
   private _items: Item[] | null = null;
   private _userCategories: Category[] | null = null;
   private _categoryNameMap: Map<string, string> | null = null;
@@ -267,6 +268,7 @@ export class CopilotDatabase {
     this._goals = null;
     this._goalHistory = null;
     this._investmentPrices = null;
+    this._investmentSplits = null;
     this._items = null;
     this._userCategories = null;
     this._categoryNameMap = null;
@@ -320,6 +322,7 @@ export class CopilotDatabase {
     goals?: Goal[];
     goalHistory?: GoalHistory[];
     investmentPrices?: InvestmentPrice[];
+    investmentSplits?: InvestmentSplit[];
     items?: Item[];
     userCategories?: Category[];
     userAccounts?: UserAccountCustomization[];
@@ -337,6 +340,7 @@ export class CopilotDatabase {
     if (data.goals !== undefined) this._goals = data.goals;
     if (data.goalHistory !== undefined) this._goalHistory = data.goalHistory;
     if (data.investmentPrices !== undefined) this._investmentPrices = data.investmentPrices;
+    if (data.investmentSplits !== undefined) this._investmentSplits = data.investmentSplits;
     if (data.items !== undefined) this._items = data.items;
     if (data.userCategories !== undefined) this._userCategories = data.userCategories;
     if (data.userAccounts !== undefined) this._userAccounts = data.userAccounts;
@@ -559,6 +563,7 @@ export class CopilotDatabase {
       this._goals = result.goals;
       this._goalHistory = result.goalHistory;
       this._investmentPrices = result.investmentPrices;
+      this._investmentSplits = result.investmentSplits;
       this._items = result.items;
       this._userCategories = result.categories;
       this._userAccounts = result.userAccounts;
@@ -860,6 +865,26 @@ export class CopilotDatabase {
       return this._securities ?? [];
     }
     return this._securities ?? [];
+  }
+
+  /**
+   * Load investment splits with caching.
+   * Uses batch loading for optimal performance on first access.
+   *
+   * Cache shape: one InvestmentSplit per security (keyed by `security_id`)
+   * with a sparse `adjustments` map of YYYY-MM-DD → multiplier. Securities
+   * that have never split are omitted at decode time (placeholder docs are
+   * skipped) — so the returned array only contains entries with ≥1 split.
+   */
+  private async loadInvestmentSplits(): Promise<InvestmentSplit[]> {
+    if (this._investmentSplits !== null) {
+      return this._investmentSplits;
+    }
+    if (!this._allCollectionsLoaded) {
+      await this.loadAllCollections();
+      return this._investmentSplits ?? [];
+    }
+    return this._investmentSplits ?? [];
   }
 
   /**
@@ -1377,6 +1402,56 @@ export class CopilotDatabase {
       map.set(s.security_id, s);
     }
     return map;
+  }
+
+  /**
+   * Get investment splits (one entry per security that has had ≥1 split).
+   *
+   * Each entry has a sparse `adjustments` map of YYYY-MM-DD → multiplier.
+   * Securities with no splits are omitted entirely at decode time.
+   *
+   * Filters operate at the document level:
+   * - `tickerSymbol`: case-insensitive match via the securityMap join.
+   * - `startDate` / `endDate`: a doc is included if ≥1 of its `adjustments`
+   *   keys falls within the [startDate, endDate] window (inclusive). The
+   *   per-(date, multiplier) row-level filter happens at the tool/projection
+   *   layer — that's where each tuple is emitted as its own output row.
+   *
+   * @returns Array of InvestmentSplit objects
+   */
+  async getInvestmentSplits(
+    options: {
+      tickerSymbol?: string;
+      startDate?: string;
+      endDate?: string;
+    } = {}
+  ): Promise<InvestmentSplit[]> {
+    const { tickerSymbol, startDate, endDate } = options;
+    const allSplits = await this.loadInvestmentSplits();
+    let result = [...allSplits];
+
+    if (tickerSymbol) {
+      const securityMap = await this.getSecurityMap();
+      const lower = tickerSymbol.toLowerCase();
+      const matchingIds = new Set<string>();
+      for (const [id, sec] of securityMap) {
+        if (sec.ticker_symbol?.toLowerCase() === lower) matchingIds.add(id);
+      }
+      result = result.filter((s) => matchingIds.has(s.security_id));
+    }
+
+    if (startDate || endDate) {
+      result = result.filter((s) => {
+        for (const date of Object.keys(s.adjustments)) {
+          if (startDate && date < startDate) continue;
+          if (endDate && date > endDate) continue;
+          return true;
+        }
+        return false;
+      });
+    }
+
+    return result;
   }
 
   /**

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -22,7 +22,11 @@ import { Budget, BudgetSchema } from '../models/budget.js';
 import { Goal, GoalSchema } from '../models/goal.js';
 import { GoalHistory, GoalHistorySchema, DailySnapshot } from '../models/goal-history.js';
 import { InvestmentPrice, InvestmentPriceSchema } from '../models/investment-price.js';
-import { InvestmentSplit, InvestmentSplitSchema } from '../models/investment-split.js';
+import {
+  InvestmentSplit,
+  InvestmentSplitSchema,
+  DATE_KEY_REGEX,
+} from '../models/investment-split.js';
 import { Item, ItemSchema, IGNORED_ITEM_FIELDS } from '../models/item.js';
 import { Category, CategorySchema } from '../models/category.js';
 import { PlaidAccount, PlaidAccountSchema } from '../models/plaid-account.js';
@@ -2261,9 +2265,8 @@ function processInvestmentSplit(
   docId: string
 ): InvestmentSplit | null {
   const adjustments: Record<string, number> = {};
-  const dateKey = /^\d{4}-\d{2}-\d{2}$/;
   for (const [key, value] of fields.entries()) {
-    if (!dateKey.test(key)) continue;
+    if (!DATE_KEY_REGEX.test(key)) continue;
     if (value.type !== 'double' && value.type !== 'integer') continue;
     adjustments[key] = value.value;
   }

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -22,6 +22,7 @@ import { Budget, BudgetSchema } from '../models/budget.js';
 import { Goal, GoalSchema } from '../models/goal.js';
 import { GoalHistory, GoalHistorySchema, DailySnapshot } from '../models/goal-history.js';
 import { InvestmentPrice, InvestmentPriceSchema } from '../models/investment-price.js';
+import { InvestmentSplit, InvestmentSplitSchema } from '../models/investment-split.js';
 import { Item, ItemSchema, IGNORED_ITEM_FIELDS } from '../models/item.js';
 import { Category, CategorySchema } from '../models/category.js';
 import { PlaidAccount, PlaidAccountSchema } from '../models/plaid-account.js';
@@ -640,6 +641,7 @@ export interface AllCollectionsResult {
   goals: Goal[];
   goalHistory: GoalHistory[];
   investmentPrices: InvestmentPrice[];
+  investmentSplits: InvestmentSplit[];
   items: Item[];
   categories: Category[];
   userAccounts: UserAccountCustomization[];
@@ -2247,6 +2249,47 @@ function processSecurity(fields: Map<string, FirestoreValue>, docId: string): Se
 }
 
 /**
+ * Internal helper to process an investment split document.
+ *
+ * Each doc lives at `investment_splits/{security_id}` and contains a
+ * sparse set of date-keyed double fields (YYYY-MM-DD → multiplier).
+ * Securities that have never split get an empty placeholder doc; we
+ * skip those by returning null rather than emitting a zero-row entry.
+ */
+function processInvestmentSplit(
+  fields: Map<string, FirestoreValue>,
+  docId: string
+): InvestmentSplit | null {
+  const adjustments: Record<string, number> = {};
+  const dateKey = /^\d{4}-\d{2}-\d{2}$/;
+  for (const [key, value] of fields.entries()) {
+    if (!dateKey.test(key)) continue;
+    if (value.type !== 'double' && value.type !== 'integer') continue;
+    adjustments[key] = value.value;
+  }
+
+  // Per warnUnreadFields convention: explicitly mark date-keyed
+  // adjustment fields as consumed so they don't trigger the unread-field
+  // warning. The `consumed` list grows dynamically based on which dates
+  // appeared in this particular doc.
+  warnUnreadFields(
+    fields,
+    { consumed: Object.keys(adjustments), ignored: [] },
+    { collection: 'investment_splits', docId }
+  );
+
+  // Skip the placeholder/empty docs — surfacing zero-split rows for
+  // every never-split security is just noise.
+  if (Object.keys(adjustments).length === 0) return null;
+
+  return validateOrWarn(
+    InvestmentSplitSchema,
+    { security_id: docId, adjustments },
+    { collection: 'investment_splits', docId }
+  );
+}
+
+/**
  * Internal helper to process a user profile document.
  */
 function processUserProfile(
@@ -2655,6 +2698,7 @@ export async function decodeAllCollections(dbPath: string): Promise<AllCollectio
   const rawGoals: Goal[] = [];
   const rawGoalHistory: GoalHistory[] = [];
   const rawInvestmentPrices: InvestmentPrice[] = [];
+  const rawInvestmentSplits: InvestmentSplit[] = [];
   const rawItems: Item[] = [];
   const rawCategories: Category[] = [];
   const rawUserAccounts: UserAccountCustomization[] = [];
@@ -2731,6 +2775,9 @@ export async function decodeAllCollections(dbPath: string): Promise<AllCollectio
     ) {
       const price = processInvestmentPrice(fields, documentId, key);
       if (price) rawInvestmentPrices.push(price);
+    } else if (collectionMatches(collection, 'investment_splits')) {
+      const split = processInvestmentSplit(fields, documentId);
+      if (split) rawInvestmentSplits.push(split);
     } else if (collectionMatches(collection, 'items') || /^items\/[^/]+$/.test(collection)) {
       // Match both top-level items and items/{item_id} parent-pointer docs.
       // Parent-pointer docs (items/{item_id}) have empty fields and processItem returns null.
@@ -2873,6 +2920,17 @@ export async function decodeAllCollections(dbPath: string): Promise<AllCollectio
     const dateB = b.date || b.month || '';
     return dateB.localeCompare(dateA);
   });
+
+  // Investment splits: dedupe by security_id (one doc per security)
+  const splitSeen = new Set<string>();
+  const investmentSplits: InvestmentSplit[] = [];
+  for (const split of rawInvestmentSplits) {
+    if (!splitSeen.has(split.security_id)) {
+      splitSeen.add(split.security_id);
+      investmentSplits.push(split);
+    }
+  }
+  investmentSplits.sort((a, b) => a.security_id.localeCompare(b.security_id));
 
   // Items: dedupe by item_id
   const itemSeen = new Set<string>();
@@ -3113,6 +3171,7 @@ export async function decodeAllCollections(dbPath: string): Promise<AllCollectio
     goals,
     goalHistory,
     investmentPrices,
+    investmentSplits,
     items,
     categories,
     userAccounts,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -69,6 +69,12 @@ export {
 } from './investment-price.js';
 
 export {
+  InvestmentSplitSchema,
+  type InvestmentSplit,
+  formatRatio as formatSplitRatio,
+} from './investment-split.js';
+
+export {
   ItemSchema,
   type Item,
   type ConnectionStatus,

--- a/src/models/investment-split.ts
+++ b/src/models/investment-split.ts
@@ -18,13 +18,17 @@
 
 import { z } from 'zod';
 
-const DATE_KEY = /^\d{4}-\d{2}-\d{2}$/;
+/**
+ * Exported so the decoder can reuse the same regex when scanning raw
+ * Firestore docs for date-keyed adjustment fields.
+ */
+export const DATE_KEY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 export const InvestmentSplitSchema = z
   .object({
     security_id: z.string(),
     // Map of YYYY-MM-DD → adjustment multiplier (e.g. "2024-06-10": 0.1)
-    adjustments: z.record(z.string().regex(DATE_KEY), z.number()).default({}),
+    adjustments: z.record(z.string().regex(DATE_KEY_REGEX), z.number()).default({}),
   })
   .passthrough();
 
@@ -37,7 +41,11 @@ export type InvestmentSplit = z.infer<typeof InvestmentSplitSchema>;
  */
 export function formatRatio(multiplier: number): string {
   if (!Number.isFinite(multiplier) || multiplier <= 0) return 'unknown ratio';
-  if (multiplier >= 1) {
+  // multiplier === 1 is a no-op (no split). Copilot almost certainly never
+  // writes one, but guard against the misleading "1-for-1 reverse split"
+  // label if it ever does.
+  if (multiplier === 1) return 'unknown ratio';
+  if (multiplier > 1) {
     // Reverse split: 1/M shares become 1. e.g. multiplier 2 → 1-for-2 reverse.
     const denom = Math.round(multiplier);
     if (Math.abs(multiplier - denom) < 0.01) return `1-for-${denom} reverse split`;

--- a/src/models/investment-split.ts
+++ b/src/models/investment-split.ts
@@ -1,0 +1,51 @@
+/**
+ * Investment Split model — restored 2026-05-11 with an accurate schema
+ * reflecting what's actually in Copilot's local Firestore cache.
+ *
+ * The cache stores one document per security under the
+ * `investment_splits/{security_id}` collection. Each document contains
+ * a sparse set of date-keyed double fields, where the key is the split's
+ * effective date (`YYYY-MM-DD`) and the value is the adjustment
+ * multiplier — what to multiply pre-split prices/quantities by to get
+ * the post-split equivalent.
+ *
+ * Securities that have never split get an empty-fields placeholder doc.
+ *
+ * NOTE: do NOT add speculative fields here (split_ratio, from_factor,
+ * to_factor, announcement_date, etc.). The v1.5.0 schema had them but the
+ * cache never populates them. Empirically verified 2026-05-11.
+ */
+
+import { z } from 'zod';
+
+const DATE_KEY = /^\d{4}-\d{2}-\d{2}$/;
+
+export const InvestmentSplitSchema = z
+  .object({
+    security_id: z.string(),
+    // Map of YYYY-MM-DD → adjustment multiplier (e.g. "2024-06-10": 0.1)
+    adjustments: z.record(z.string().regex(DATE_KEY), z.number()).default({}),
+  })
+  .passthrough();
+
+export type InvestmentSplit = z.infer<typeof InvestmentSplitSchema>;
+
+/**
+ * Convert an adjustment multiplier to a human-readable ratio string.
+ * 0.1 → "10-for-1", 0.25 → "4-for-1", 0.333... → "3-for-1", 2 → "1-for-2 reverse split".
+ * Returns "unknown ratio" if the multiplier doesn't reduce to a clean integer ratio.
+ */
+export function formatRatio(multiplier: number): string {
+  if (!Number.isFinite(multiplier) || multiplier <= 0) return 'unknown ratio';
+  if (multiplier >= 1) {
+    // Reverse split: 1/M shares become 1. e.g. multiplier 2 → 1-for-2 reverse.
+    const denom = Math.round(multiplier);
+    if (Math.abs(multiplier - denom) < 0.01) return `1-for-${denom} reverse split`;
+    return 'unknown ratio';
+  }
+  // Regular forward split: 1 share becomes 1/multiplier shares.
+  const numerator = 1 / multiplier;
+  const rounded = Math.round(numerator);
+  if (Math.abs(numerator - rounded) < 0.01) return `${rounded}-for-1`;
+  return 'unknown ratio';
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -576,6 +576,10 @@ export class CopilotMoneyServer {
           result = await this.tools.getInvestmentPrices(typedArgs || {});
           break;
 
+        case 'get_investment_splits':
+          result = await this.tools.getInvestmentSplits(typedArgs || {});
+          break;
+
         case 'get_holdings':
           result = await this.tools.getHoldings(typedArgs || {});
           break;

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -46,7 +46,11 @@ import {
   isKnownPlaidCategory,
 } from '../utils/categories.js';
 import type { Transaction, Account, InvestmentPrice, Tag, Recurring } from '../models/index.js';
-import { getTransactionDisplayName, getRecurringDisplayName } from '../models/index.js';
+import {
+  getTransactionDisplayName,
+  getRecurringDisplayName,
+  formatSplitRatio,
+} from '../models/index.js';
 import type { GoalHistory } from '../models/goal-history.js';
 import { isItemHealthy, itemNeedsAttention, getItemDisplayName } from '../models/item.js';
 import { type Category, getCategoryDisplayName } from '../models/category.js';
@@ -2112,9 +2116,88 @@ export class CopilotMoneyTools {
   /**
    * Get stock split history with optional filters.
    *
-   * @param options - Filter options
-   * @returns Object with split data and pagination info
+   * One output row per (security, effective_date) tuple. Securities that
+   * have never had a split are omitted entirely. The returned `multiplier`
+   * is what to multiply a pre-split price/quantity by to convert to the
+   * post-split equivalent (e.g. 0.1 for a 10-for-1 split).
+   *
+   * IMPORTANT: prices returned by `get_investment_prices` (and its live
+   * counterpart) are ALREADY split-adjusted by Copilot. This tool is for
+   * surfacing the split events themselves — narrative or historical
+   * analysis — NOT for back-correcting prices.
    */
+  async getInvestmentSplits(
+    options: {
+      ticker_symbol?: string;
+      start_date?: string;
+      end_date?: string;
+      limit?: number;
+      offset?: number;
+    } = {}
+  ): Promise<{
+    count: number;
+    total_count: number;
+    offset: number;
+    has_more: boolean;
+    splits: Array<{
+      security_id: string;
+      ticker_symbol?: string;
+      name?: string;
+      effective_date: string;
+      multiplier: number;
+      ratio_description: string;
+    }>;
+  }> {
+    const { ticker_symbol, start_date, end_date } = options;
+    const validatedLimit = validateLimit(options.limit, DEFAULT_QUERY_LIMIT);
+    const validatedOffset = validateOffset(options.offset);
+
+    if (start_date) validateDate(start_date, 'start_date');
+    if (end_date) validateDate(end_date, 'end_date');
+
+    // Load splits (applies ticker filter at the doc level).
+    const docs = await this.db.getInvestmentSplits({ tickerSymbol: ticker_symbol });
+    const securityMap = await this.db.getSecurityMap();
+
+    // Project each (security, date) tuple into its own output row.
+    const allRows: Array<{
+      security_id: string;
+      ticker_symbol?: string;
+      name?: string;
+      effective_date: string;
+      multiplier: number;
+      ratio_description: string;
+    }> = [];
+    for (const doc of docs) {
+      const sec = securityMap.get(doc.security_id);
+      for (const [date, multiplier] of Object.entries(doc.adjustments)) {
+        if (start_date && date < start_date) continue;
+        if (end_date && date > end_date) continue;
+        allRows.push({
+          security_id: doc.security_id,
+          ticker_symbol: sec?.ticker_symbol,
+          name: sec?.name,
+          effective_date: date,
+          multiplier,
+          ratio_description: formatSplitRatio(multiplier),
+        });
+      }
+    }
+
+    // Sort by date descending (most-recent first) — natural agent UX.
+    allRows.sort((a, b) => b.effective_date.localeCompare(a.effective_date));
+
+    const total = allRows.length;
+    const sliced = allRows.slice(validatedOffset, validatedOffset + validatedLimit);
+    return {
+      count: sliced.length,
+      total_count: total,
+      offset: validatedOffset,
+      has_more: validatedOffset + sliced.length < total,
+      splits: sliced,
+    };
+  }
+
   /**
    * Get current investment holdings with cost basis and returns.
    *
@@ -4097,6 +4180,51 @@ export function createToolSchemas(): ToolSchema[] {
           offset: {
             type: 'integer',
             description: 'Number of results to skip for pagination (default: 0)',
+            default: 0,
+          },
+        },
+      },
+      annotations: { readOnlyHint: true },
+    },
+    {
+      name: 'get_investment_splits',
+      description:
+        'Get stock split events from the local Firestore cache. Returns one row ' +
+        'per (security, effective_date) with the adjustment multiplier (e.g. 0.1 ' +
+        'for a 10-for-1 split — multiply pre-split prices/quantities by this value ' +
+        'to convert to the post-split equivalent). Joined with the securities ' +
+        'collection so each row includes ticker and name. ' +
+        'IMPORTANT: prices returned by `get_investment_prices` and ' +
+        '`get_investment_prices_live` are ALREADY split-adjusted by Copilot. ' +
+        'Use this tool only when you need the split events themselves (e.g., for ' +
+        'narrative or historical-analysis purposes) — you do NOT need to apply ' +
+        'these multipliers to the prices yourself. Securities that have never ' +
+        'split are not included in the output. Coverage is limited to securities ' +
+        'Copilot currently syncs in your local cache (typically currently-held ' +
+        'or recently-held).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          ticker_symbol: {
+            type: 'string',
+            description: 'Optional. Case-insensitive ticker filter (e.g. "NVDA").',
+          },
+          start_date: {
+            type: 'string',
+            description: 'Optional. Inclusive lower bound on effective_date (YYYY-MM-DD).',
+          },
+          end_date: {
+            type: 'string',
+            description: 'Optional. Inclusive upper bound on effective_date (YYYY-MM-DD).',
+          },
+          limit: {
+            type: 'integer',
+            description: 'Maximum number of rows. Default 100, max 10000.',
+            default: 100,
+          },
+          offset: {
+            type: 'integer',
+            description: 'Pagination offset, default 0.',
             default: 0,
           },
         },

--- a/tests/core/decoder-coverage.test.ts
+++ b/tests/core/decoder-coverage.test.ts
@@ -1226,6 +1226,7 @@ describe('decoder coverage', () => {
       expect(result.goals).toEqual([]);
       expect(result.goalHistory).toEqual([]);
       expect(result.investmentPrices).toEqual([]);
+      expect(result.investmentSplits).toEqual([]);
       expect(result.items).toEqual([]);
       expect(result.categories).toEqual([]);
       expect(result.userAccounts).toEqual([]);
@@ -1710,6 +1711,38 @@ describe('decoder coverage', () => {
       expect(result.investmentPrices[1]?.date).toBe('2024-01-10');
       // Then second investment
       expect(result.investmentPrices[2]?.investment_id).toBe('inv2');
+    });
+
+    test('decodes investment_splits docs with date-keyed adjustment factors', async () => {
+      const dbPath = path.join(FIXTURES_DIR, 'investment-splits-db');
+      await createTestDatabase(dbPath, [
+        // Doc with two real split events for a synthetic security
+        {
+          collection: 'investment_splits',
+          id: 'sec-A',
+          fields: {
+            '2021-07-20': 0.25,
+            '2024-06-10': 0.1,
+          },
+        },
+        // Placeholder doc with zero fields — must be skipped, not surfaced as
+        // a zero-row entry.
+        {
+          collection: 'investment_splits',
+          id: 'sec-empty',
+          fields: {},
+        },
+      ]);
+
+      const result = await decodeAllCollections(dbPath);
+
+      expect(result.investmentSplits.length).toBe(1);
+      const doc = result.investmentSplits[0]!;
+      expect(doc.security_id).toBe('sec-A');
+      expect(doc.adjustments).toEqual({
+        '2021-07-20': 0.25,
+        '2024-06-10': 0.1,
+      });
     });
 
     test('decodes plaid accounts via decodeAllCollections', async () => {

--- a/tests/integration/mcpb-bundle.test.ts
+++ b/tests/integration/mcpb-bundle.test.ts
@@ -175,7 +175,7 @@ describe('mcpb bundle', () => {
       const tools = (response.result as { tools: unknown[] }).tools;
       expect(Array.isArray(tools)).toBe(true);
       // Bundled CLI runs read-only; write tools are excluded.
-      expect(tools.length).toBe(13);
+      expect(tools.length).toBe(14);
     } finally {
       proc.kill('SIGTERM');
     }

--- a/tests/integration/tools.test.ts
+++ b/tests/integration/tools.test.ts
@@ -451,7 +451,7 @@ describe('CopilotMoneyTools Integration', () => {
   describe('tool schemas', () => {
     test('returns correct number of tool schemas', async () => {
       const schemas = createToolSchemas();
-      expect(schemas.length).toBe(13);
+      expect(schemas.length).toBe(14);
     });
 
     test('all tools have readOnlyHint annotation', async () => {
@@ -489,13 +489,14 @@ describe('CopilotMoneyTools Integration', () => {
       expect(names).toContain('get_budgets');
       expect(names).toContain('get_goals');
       expect(names).toContain('get_investment_prices');
+      expect(names).toContain('get_investment_splits');
       expect(names).toContain('get_holdings');
       // New tools
       expect(names).toContain('get_balance_history');
       expect(names).toContain('get_goal_history');
 
-      // Should have exactly 13 read tools
-      expect(names.length).toBe(13);
+      // Should have exactly 14 read tools
+      expect(names.length).toBe(14);
     });
   });
 

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -2601,7 +2601,7 @@ describe('getInvestmentSplits', () => {
     });
   });
 
-  test('ratio formatting covers forward, reverse, and unknown', async () => {
+  test('ratio formatting covers forward, reverse, no-op, and unknown', async () => {
     (db as any)._investmentSplits = [
       {
         security_id: 'sec-A',
@@ -2610,6 +2610,9 @@ describe('getInvestmentSplits', () => {
           '2020-02-01': 0.25, // 4-for-1
           '2020-03-01': 2.0, // 1-for-2 reverse
           '2020-04-01': 0.123, // not a clean ratio
+          // multiplier === 1.0 is a no-op (shouldn't exist in real data, but
+          // guard against the misleading "1-for-1 reverse split" label).
+          '2020-05-01': 1.0,
         },
       },
     ];
@@ -2621,6 +2624,7 @@ describe('getInvestmentSplits', () => {
     expect(byDate['2020-02-01']).toBe('4-for-1');
     expect(byDate['2020-03-01']).toBe('1-for-2 reverse split');
     expect(byDate['2020-04-01']).toBe('unknown ratio');
+    expect(byDate['2020-05-01']).toBe('unknown ratio');
   });
 
   test('start_date filter excludes earlier rows', async () => {

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -1761,9 +1761,9 @@ describe('refreshDatabase', () => {
 });
 
 describe('createToolSchemas', () => {
-  test('returns 13 tool schemas', async () => {
+  test('returns 14 tool schemas', async () => {
     const schemas = createToolSchemas();
-    expect(schemas).toHaveLength(13);
+    expect(schemas).toHaveLength(14);
   });
 
   test('all tools have readOnlyHint: true', async () => {
@@ -1801,13 +1801,14 @@ describe('createToolSchemas', () => {
     expect(names).toContain('get_budgets');
     expect(names).toContain('get_goals');
     expect(names).toContain('get_investment_prices');
+    expect(names).toContain('get_investment_splits');
     expect(names).toContain('get_holdings');
     // New tools
     expect(names).toContain('get_balance_history');
     expect(names).toContain('get_goal_history');
 
-    // Should have exactly 13 tools
-    expect(names.length).toBe(13);
+    // Should have exactly 14 tools
+    expect(names.length).toBe(14);
   });
 });
 
@@ -2519,6 +2520,155 @@ describe('getHoldings', () => {
     const neg = result.holdings.find((h) => h.account_id === 'inv_floor_neg');
     expect(pos?.total_return_percent).toBe(8.39);
     expect(neg?.total_return_percent).toBe(-22.89);
+  });
+});
+
+describe('getInvestmentSplits', () => {
+  // Synthetic security IDs only — no real Plaid SHA256 hashes, no real
+  // tickers. Reviewer asked for obviously-fake fixtures so nothing leaks.
+  const synthSecurities: Security[] = [
+    {
+      security_id: 'sec-A',
+      ticker_symbol: 'TEST-A',
+      name: 'Test Security A',
+      type: 'equity',
+      current_price: 100.0,
+      is_cash_equivalent: false,
+      iso_currency_code: 'USD',
+    },
+    {
+      security_id: 'sec-B',
+      ticker_symbol: 'TEST-B',
+      name: 'Test Security B',
+      type: 'equity',
+      current_price: 50.0,
+      is_cash_equivalent: false,
+      iso_currency_code: 'USD',
+    },
+  ];
+
+  let db: CopilotDatabase;
+  let tools: CopilotMoneyTools;
+
+  beforeEach(() => {
+    db = new CopilotDatabase('/fake/path');
+    (db as any)._allCollectionsLoaded = true;
+    (db as any)._transactions = [];
+    (db as any)._accounts = [];
+    (db as any)._recurring = [];
+    (db as any)._budgets = [];
+    (db as any)._goals = [];
+    (db as any)._goalHistory = [];
+    (db as any)._investmentPrices = [];
+    (db as any)._items = [];
+    (db as any)._userCategories = [];
+    (db as any)._userAccounts = [];
+    (db as any)._securities = [...synthSecurities];
+    (db as any)._investmentSplits = [
+      {
+        security_id: 'sec-A',
+        adjustments: {
+          '2021-07-20': 0.25, // 4-for-1
+          '2024-06-10': 0.1, // 10-for-1
+        },
+      },
+    ];
+    tools = new CopilotMoneyTools(db);
+  });
+
+  test('happy path: projects each adjustment into its own row with ticker/name', async () => {
+    const result = await tools.getInvestmentSplits({});
+    expect(result.count).toBe(2);
+    expect(result.total_count).toBe(2);
+    expect(result.has_more).toBe(false);
+
+    // Sorted by date descending — newest first.
+    expect(result.splits[0]).toEqual({
+      security_id: 'sec-A',
+      ticker_symbol: 'TEST-A',
+      name: 'Test Security A',
+      effective_date: '2024-06-10',
+      multiplier: 0.1,
+      ratio_description: '10-for-1',
+    });
+    expect(result.splits[1]).toEqual({
+      security_id: 'sec-A',
+      ticker_symbol: 'TEST-A',
+      name: 'Test Security A',
+      effective_date: '2021-07-20',
+      multiplier: 0.25,
+      ratio_description: '4-for-1',
+    });
+  });
+
+  test('ratio formatting covers forward, reverse, and unknown', async () => {
+    (db as any)._investmentSplits = [
+      {
+        security_id: 'sec-A',
+        adjustments: {
+          '2020-01-01': 0.1, // 10-for-1
+          '2020-02-01': 0.25, // 4-for-1
+          '2020-03-01': 2.0, // 1-for-2 reverse
+          '2020-04-01': 0.123, // not a clean ratio
+        },
+      },
+    ];
+    const result = await tools.getInvestmentSplits({});
+    const byDate = Object.fromEntries(
+      result.splits.map((s) => [s.effective_date, s.ratio_description])
+    );
+    expect(byDate['2020-01-01']).toBe('10-for-1');
+    expect(byDate['2020-02-01']).toBe('4-for-1');
+    expect(byDate['2020-03-01']).toBe('1-for-2 reverse split');
+    expect(byDate['2020-04-01']).toBe('unknown ratio');
+  });
+
+  test('start_date filter excludes earlier rows', async () => {
+    const result = await tools.getInvestmentSplits({ start_date: '2024-01-01' });
+    expect(result.count).toBe(1);
+    expect(result.splits[0].effective_date).toBe('2024-06-10');
+  });
+
+  test('end_date filter excludes later rows', async () => {
+    const result = await tools.getInvestmentSplits({ end_date: '2023-12-31' });
+    expect(result.count).toBe(1);
+    expect(result.splits[0].effective_date).toBe('2021-07-20');
+  });
+
+  test('ticker filter returns zero rows when ticker has no splits', async () => {
+    const result = await tools.getInvestmentSplits({ ticker_symbol: 'TEST-B' });
+    expect(result.count).toBe(0);
+    expect(result.total_count).toBe(0);
+  });
+
+  test('ticker filter is case-insensitive', async () => {
+    const result = await tools.getInvestmentSplits({ ticker_symbol: 'test-a' });
+    expect(result.count).toBe(2);
+    for (const r of result.splits) {
+      expect(r.ticker_symbol).toBe('TEST-A');
+    }
+  });
+
+  test('pagination: limit + offset + has_more', async () => {
+    const result = await tools.getInvestmentSplits({ limit: 1, offset: 0 });
+    expect(result.count).toBe(1);
+    expect(result.total_count).toBe(2);
+    expect(result.offset).toBe(0);
+    expect(result.has_more).toBe(true);
+
+    const page2 = await tools.getInvestmentSplits({ limit: 1, offset: 1 });
+    expect(page2.count).toBe(1);
+    expect(page2.has_more).toBe(false);
+    expect(page2.splits[0].effective_date).toBe('2021-07-20');
+  });
+
+  test('returns count 0 when cache has no splits', async () => {
+    (db as any)._investmentSplits = [];
+    const result = await tools.getInvestmentSplits({});
+    expect(result.count).toBe(0);
+    expect(result.total_count).toBe(0);
+    expect(result.has_more).toBe(false);
+    expect(result.splits).toEqual([]);
   });
 });
 

--- a/tests/unit/server-protocol.test.ts
+++ b/tests/unit/server-protocol.test.ts
@@ -149,7 +149,7 @@ describe('CopilotMoneyServer.handleListTools', () => {
     }
   });
 
-  test('returns all 17 tools', () => {
+  test('returns all 14 read tools', () => {
     const response = server.handleListTools();
 
     const expectedTools = [
@@ -163,6 +163,7 @@ describe('CopilotMoneyServer.handleListTools', () => {
       'get_budgets',
       'get_goals',
       'get_investment_prices',
+      'get_investment_splits',
       'get_holdings',
       'get_balance_history',
       'get_goal_history',
@@ -172,7 +173,7 @@ describe('CopilotMoneyServer.handleListTools', () => {
     for (const expected of expectedTools) {
       expect(actualNames).toContain(expected);
     }
-    expect(response.tools.length).toBe(13);
+    expect(response.tools.length).toBe(14);
   });
 
   test('tool schemas have valid JSON schema format', () => {


### PR DESCRIPTION
## Summary

PR #378 removed `get_investment_splits` under the (then-correct-looking) belief that the local Firestore cache was always empty for this collection. Empirical re-inspection on 2026-05-11 — see [#147 (comment) #issuecomment-4427115619](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/147#issuecomment-4427115619) — found the cache DOES populate real, date-keyed adjustment multipliers in `investment_splits/{security_id}` docs for securities that have actually had splits in their history. The original drop happened during a window when none of the test user's then-held securities had splits, so every doc looked like a placeholder.

This PR restores the tool with an honest schema that only includes fields the cache actually populates — not the speculative v1.5.0 fields (`split_ratio`, `from_factor`, `to_factor`, `announcement_date`, etc.) that the cache never wrote.

- New `src/models/investment-split.ts` with `security_id` + sparse `adjustments: Record<YYYY-MM-DD, number>` schema and a `formatRatio` helper
- `decoder.ts`: `processInvestmentSplit` skips empty placeholder docs
- `database.ts`: `getInvestmentSplits` exposes ticker + date filters
- `tools.ts`: each `(security, effective_date)` tuple becomes its own output row, joined with the securities collection so each row includes ticker + name + a human-readable `ratio_description` (e.g. `"10-for-1"`, `"4-for-1"`, `"1-for-2 reverse split"`, `"unknown ratio"`)
- Tool description explicitly calls out that `get_investment_prices` and `get_investment_prices_live` return **already-split-adjusted** values — this tool surfaces the split events themselves for narrative / historical analysis, **not** for back-correcting prices

Closes #147

## Test plan

- [x] `bun run check` (typecheck + lint + format + 1910 tests) passes
- [x] 8 new unit tests in `tests/tools/tools.test.ts` (happy path, ratio formatting, date filters, ticker filters, pagination, empty cache)
- [x] 1 new decoder test in `tests/core/decoder-coverage.test.ts` covering doc decode + empty placeholder skip
- [x] Synthetic fixtures only (`sec-A` / `TEST-A`) — no real Plaid hashes or tickers leak into tests
- [x] Manifest synced (13 → 14 read tools)
- [x] Cache-only tool — no GraphQL smoke test required

🤖 Generated with [Claude Code](https://claude.com/claude-code)