### PR TITLE
docs: catch up post-PR #387 splits restoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 An [MCP](https://modelcontextprotocol.io/) server that gives AI assistants access to your Copilot Money personal finance data. It reads from the locally cached Firestore database (LevelDB + Protocol Buffers) on your Mac. **Reads are 100% local with zero network requests.**
 
-**13 cache-mode read tools (or 20 in `--live-reads` mode: 7 surviving cache + 13 live), plus up to 17 write tools** — query and modify transactions, accounts, holdings, balances, categories, recurring charges, budgets, goals, and investment performance. See [Tools by Mode](#tools-by-mode) below.
+**14 cache-mode read tools (or 21 in `--live-reads` mode: 8 surviving cache + 13 live), plus up to 17 write tools** — query and modify transactions, accounts, holdings, balances, categories, recurring charges, budgets, goals, and investment performance. See [Tools by Mode](#tools-by-mode) below.
 
 ## Privacy First
 
@@ -38,8 +38,8 @@ This server exposes different tools depending on which CLI flags you enable.
 
 | Mode | Flag | What it does | Auth | Network | Tools available |
 |---|---|---|---|---|---|
-| 🟢 Default | _(none)_ | Reads from your local LevelDB cache | ❌ None | 🔌 Zero (offline) | 13 cache-mode read + utility tools |
-| 🌐 Live reads | `--live-reads` | Real-time reads via Copilot's GraphQL API; swaps out 6 cache tools and adds 7 live-only ones | 🔒 Browser session | 🌐 HTTPS per request | 20 read tools (7 cache + 13 live) |
+| 🟢 Default | _(none)_ | Reads from your local LevelDB cache | ❌ None | 🔌 Zero (offline) | 14 cache-mode read + utility tools |
+| 🌐 Live reads | `--live-reads` | Real-time reads via Copilot's GraphQL API; swaps out 6 cache tools and adds 7 live-only ones | 🔒 Browser session | 🌐 HTTPS per request | 21 read tools (8 cache + 13 live) |
 | ✍️ Writes | `--write` | Adds mutation tools (transactions, tags, categories, budgets, recurrings, splits) | 🔒 Browser session | 🌐 HTTPS per request | +17 write tools (additive to either read mode) |
 
 `--live-reads` and `--write` can be combined.

--- a/docs/graphql-live-reads.md
+++ b/docs/graphql-live-reads.md
@@ -1,8 +1,8 @@
 # GraphQL Live Reads
 
-The `--live-reads` CLI flag swaps the cache-backed `get_transactions` MCP tool for a GraphQL-backed `get_transactions_live` that reads directly from Copilot's web API. Use it when the local LevelDB cache is missing data for the window you need — most commonly for historical reconciliation like `/amazon-sync` on older years.
+The `--live-reads` CLI flag swaps cache-backed read tools for GraphQL-backed `_live` equivalents that read directly from Copilot's web API. Use it when the local LevelDB cache is missing data for the window you need — most commonly for historical reconciliation like `/amazon-sync` on older years — or whenever you want freshness guarantees the local cache can't give.
 
-This is Phase 1 of a progressive migration off LevelDB. See `docs/superpowers/specs/2026-04-23-graphql-live-reads-design.md` for the full roadmap.
+The progressive migration off LevelDB is now complete for every entity that has a usable GraphQL endpoint: 13 `_live` tools ship today, covering transactions, accounts, categories, budgets, recurring transactions, holdings, tags, net worth, upcoming recurrings, monthly spend, balance history, investment prices, plus a `refresh_cache` utility. See [`docs/tools-by-mode.md`](./tools-by-mode.md) for the full per-tool inventory and which cache-mode tools `--live-reads` swaps vs. adds alongside.
 
 ## Starting with live reads
 
@@ -75,7 +75,7 @@ All errors surface as `isError: true` tool results.
 
 `_live` suffix is transitional. When every cache-backed read tool has a GraphQL-backed equivalent and measurement shows live reads are fast enough, a future release will flip `--live-reads` on by default and rename `get_<entity>_live` → `get_<entity>`, retiring the flag.
 
-Current phase: **1** — only `get_transactions_live`. Phases 2..N will add `_live` variants for accounts, categories, budgets, recurring transactions, and tags.
+All migration phases are complete — every cache-mode read that has a GraphQL counterpart now ships a `_live` variant. Future work focuses on measurement (latency, cache-hit rates) ahead of any decision to flip `--live-reads` on by default. See [`docs/tools-by-mode.md`](./tools-by-mode.md) for the current inventory.
 
 ## Cache architecture (Phase 2+)
 

--- a/docs/tools-by-mode.md
+++ b/docs/tools-by-mode.md
@@ -14,6 +14,7 @@ This server exposes different tools depending on which CLI flags you enable. The
 | `get_holdings` | ✅ | Investment positions with cost basis (cached) |
 | `get_balance_history` | ✅ | Daily balance history; supports cross-account + daily/weekly/monthly granularity |
 | `get_investment_prices` | ✅ | Historical price data |
+| `get_investment_splits` | ⚠️ | Cache-only — returns stock-split events (date + multiplier) for held securities that have split. Empty for securities that never split. Note that prices from `get_investment_prices` are already split-adjusted; use this tool only for narrative/historical analysis. |
 | `get_goals` | ⚠️ | Cache-only — Copilot's GraphQL endpoint doesn't expose goals data, so no `--live-reads` counterpart exists |
 | `get_goal_history` | ⚠️ | Same — cache-only forever |
 | `get_cache_info` | ✅ | Local cache metadata (utility) |
@@ -62,6 +63,6 @@ When enabled, 6 cache-mode read tools are replaced with GraphQL-backed equivalen
 |---|---|
 | Goals (`get_goals`, `get_goal_history`) | ⚠️ Cache-only. Copilot's GraphQL endpoint doesn't expose goals. There is no live counterpart, and there are no goal write tools (goals are desktop-only in Copilot). |
 | Goal write tools (`create_goal` / `update_goal` / `delete_goal`) | ❌ Not implemented. Copilot doesn't expose goal mutations via GraphQL. |
-| Stock-split data | ⚠️ Copilot's local cache contains only empty placeholder records (no split dates / ratios), and there is no GraphQL endpoint for splits. The previous `get_investment_splits` cache-mode tool returned no useful data and was removed. |
+| Stock-split data | ⚠️ Available via `get_investment_splits` for currently-held securities that have split (one row per `(security_id, effective_date)` with adjustment multiplier). Empty for securities that never split. Securities a user no longer holds eventually fall out of the cache. There is no GraphQL endpoint for splits — this is the only way to get them, and only for held securities. |
 | Long time-series responses | ⚠️ The MCP single-tool-result token cap means very long histories (e.g., multi-year daily prices or balances) are capped at 500 rows by default. Use `max_rows` / `offset` parameters, or narrow `time_frame` to fetch more. |
 | 🔒 Browser authentication | Both `--live-reads` and `--write` require a logged-in browser session against `app.copilot.money` (the server uses the same Firebase refresh-token flow as the web app). Reads in default mode require nothing. |


### PR DESCRIPTION
## Summary

Three docs were stale after PR #387 restored `get_investment_splits` as a cache-mode tool:

- **README counts** — the headline tool count said "13 cache-mode read tools (or 20 in --live-reads mode: 7 surviving cache + 13 live)". After the restoration the cache-mode count is **14**, and re-checking what `--live-reads` actually swaps in `src/server.ts` confirms only 6 tools are removed (transactions, accounts, categories, budgets, recurring_transactions, holdings), so **8** cache tools survive, giving **21** total live-mode reads — not 20. Both the prose line and the comparison-table cell are corrected.
- **`docs/tools-by-mode.md` Default-mode table** — added a `get_investment_splits` row (marked ⚠️ because the data is only available for currently-held securities that have split; empty otherwise). The tool is genuinely useful but has narrower coverage than a typical cache-mode read.
- **`docs/tools-by-mode.md` Known caveats row** — the "Stock-split data" caveat still claimed Copilot's local cache contains "only empty placeholder records (no split dates / ratios)" and that the tool had been removed. Empirical re-inspection on 2026-05-11 (the basis for PR #387) found split data does exist for held-and-split securities. Rewrote the row to describe accurate coverage and call out that there is still no GraphQL endpoint for splits, so this cache-mode tool is the only path to that data.
- **`docs/graphql-live-reads.md`** — also flagged as stale on PR #383's review thread. The intro framed `--live-reads` as Phase 1 shipping only `get_transactions_live`; 13 `_live` tools have shipped since. Refreshed the intro and the migration-roadmap section to reflect that all entity-level phases are complete, with the per-tool inventory deferred to `docs/tools-by-mode.md`. Technical content (architecture, filter reference, freshness fields, `refresh_cache`) is preserved.

## Test plan
- [x] `grep -E "13 cache-mode" README.md docs/tools-by-mode.md` — zero matches
- [x] `grep "get_investment_splits" docs/tools-by-mode.md` — appears in Default-mode table and updated caveat
- [x] `grep "was removed" docs/tools-by-mode.md` — zero matches
- [x] `grep "Current phase.*1" docs/graphql-live-reads.md` — zero matches
- [x] `bun run check` — typecheck + lint + format + 1910 tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)