### PR TITLE
chore(tools): tool-definition review follow-up (descriptions + hints)

### DIFF
--- a/src/tools/live/budgets.ts
+++ b/src/tools/live/budgets.ts
@@ -161,7 +161,10 @@ export function createLiveBudgetsToolSchema() {
     description:
       "Get budgets from Copilot's native budget tracking (live, GraphQL-backed). " +
       'Projects per-category budgets from the categories cache — the same fetch that ' +
-      'powers get_categories_live populates this. Replaces get_budgets when --live-reads is on.',
+      'powers get_categories_live populates this. Replaces get_budgets when --live-reads is on. ' +
+      'Note: live mode does not include `name`, `period`, `start_date`, `end_date`, `is_active`, ' +
+      "or `iso_currency_code` per budget — those fields aren't exposed on Copilot's GraphQL endpoint. " +
+      'Use cache-mode `get_budgets` if you need them.',
     inputSchema: {
       type: 'object' as const,
       properties: {

--- a/src/tools/live/holdings.ts
+++ b/src/tools/live/holdings.ts
@@ -211,12 +211,12 @@ export function createLiveHoldingsToolSchema() {
           description: "Filter — case-insensitive match on the security's ticker symbol.",
         },
         limit: {
-          type: 'number',
+          type: 'integer',
           description: `Max rows to return. Default ${DEFAULT_LIMIT}, clamped to [${MIN_LIMIT}, ${MAX_LIMIT}].`,
           default: DEFAULT_LIMIT,
         },
         offset: {
-          type: 'number',
+          type: 'integer',
           description: 'Pagination offset (>= 0). Default 0.',
           default: 0,
         },

--- a/src/tools/live/monthly-spend.ts
+++ b/src/tools/live/monthly-spend.ts
@@ -117,7 +117,10 @@ export function createLiveMonthlySpendToolSchema() {
       '`comparison_amount` (same-day-of-prior-period spend, used by the web app ' +
       'for "vs last month" deltas). Future-dated placeholder rows (where both ' +
       'amounts are null) are filtered out by default; pass `include_future: true` ' +
-      'to opt in to the full padded series. Available when --live-reads is on.',
+      'to opt in to the full padded series. Available when --live-reads is on. ' +
+      'No pagination — the response is always ≤31 daily rows (one month). ' +
+      'The other time-series live tools expose `max_rows`/`offset`/`total_rows`/`truncated` ' +
+      "for capping long histories; this tool doesn't need them at this scale.",
     inputSchema: {
       type: 'object' as const,
       properties: {

--- a/src/tools/live/networth.ts
+++ b/src/tools/live/networth.ts
@@ -140,10 +140,10 @@ export function createLiveNetworthToolSchema() {
           type: 'string',
           enum: ['ALL', 'YEAR', 'MONTH', 'YTD'],
           description:
-            'TimeFrame enum passed through to the Networth query. Default "YTD" ' +
-            '(tightened on 2026-05 to fit the default response under the MCP token cap). ' +
-            'Pass "ALL" for full history. Other values are passed through unchanged; ' +
-            'the server is the source of truth on which TimeFrame values it accepts.',
+            "TimeFrame enum passed through to the Networth query. Default 'YTD' " +
+            "(tightened from 'ALL' on 2026-05). Note: this enum is smaller than the canonical " +
+            'TimeFrame used by other live time-series tools (no ONE_DAY/ONE_WEEK/ONE_MONTH/' +
+            'THREE_MONTHS/ONE_YEAR). The Networth GraphQL endpoint accepts only these four values.',
           default: DEFAULT_TIME_FRAME,
         },
         max_rows: {

--- a/src/tools/live/refresh-cache.ts
+++ b/src/tools/live/refresh-cache.ts
@@ -236,7 +236,8 @@ export function createRefreshCacheToolSchema() {
       },
     },
     annotations: {
-      readOnlyHint: false,
+      // Like refresh_database, this only flushes in-memory state — no user data is mutated.
+      readOnlyHint: true,
     },
   };
 }

--- a/src/tools/live/tags.ts
+++ b/src/tools/live/tags.ts
@@ -60,7 +60,12 @@ export class LiveTagsTools {
 export function createLiveTagsToolSchema() {
   return {
     name: 'get_tags_live',
-    description: 'Get user tags (live, GraphQL-backed). Available when --live-reads is on.',
+    description:
+      'Get all user tags (live, GraphQL-backed). Each row carries `id`, `name`, and `color`. ' +
+      'No cache-mode counterpart exists — tags are additive in live mode. ' +
+      'Use this to enumerate tag IDs before calling `get_transactions_live` with a tag filter, ' +
+      'or to enrich transaction-tag references with human-readable names. ' +
+      'Available when --live-reads is on.',
     inputSchema: {
       type: 'object' as const,
       properties: {},

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3782,6 +3782,8 @@ export function createToolSchemas(): ToolSchema[] {
     {
       name: 'get_transactions',
       description:
+        "Reads from the local LevelDB cache, which may lag behind Copilot's server if the macOS app hasn't synced recently. " +
+        'For real-time data use --live-reads with `get_transactions_live`. ' +
         'Unified transaction retrieval tool. Supports multiple modes: ' +
         '(1) Filter-based: Use period, date range, category, merchant, amount filters. ' +
         '(2) Single lookup: Provide transaction_id to get one transaction. ' +

--- a/tests/tools/live/holdings.test.ts
+++ b/tests/tools/live/holdings.test.ts
@@ -285,8 +285,8 @@ describe('createLiveHoldingsToolSchema', () => {
     const props = schema.inputSchema.properties as Record<string, { type: string }>;
     expect(props.account_id?.type).toBe('string');
     expect(props.ticker_symbol?.type).toBe('string');
-    expect(props.limit?.type).toBe('number');
-    expect(props.offset?.type).toBe('number');
+    expect(props.limit?.type).toBe('integer');
+    expect(props.offset?.type).toBe('integer');
     // All filters are opt-in.
     expect((schema.inputSchema as { required?: string[] }).required ?? []).toEqual([]);
   });


### PR DESCRIPTION
## Summary

Small follow-up PR addressing findings from the `/simplify`-style tool-definition review skill. **Description and annotation tweaks only** — no behavior changes, no API surface changes, no GraphQL changes.

## Fixes

1. **`refresh_cache` `readOnlyHint`** → `true`. Aligns with `refresh_database` — both flush in-memory state, neither mutates user data.
2. **`get_budgets_live` description** — call out the five fields that live mode does not expose (`name`, `period`, `start_date`, `end_date`, `is_active`, `iso_currency_code`) so agents switching modes aren't surprised.
3. **`get_transactions` description** — lead with the stale-cache warning and point at `--live-reads` / `get_transactions_live`. The most agent-relevant fact was buried.
4. **`get_tags_live` description** — expand from one sentence to cover fields (`id`, `name`, `color`), the absence of a cache-mode counterpart, and the cross-tool composition with `get_transactions_live`'s tag filter.
5. **`get_networth_live` `time_frame`** — explicitly document that this enum is smaller than the canonical 7-value `TimeFrame` used by sibling time-series tools.
6. **`get_monthly_spend_live`** — document why no pagination metadata: the response is always ≤31 daily rows (one month).
7. **`get_holdings_live` `limit`/`offset` type** — `number` → `integer`, matching sibling live tools and all cache-mode tools.

## Deliberate non-fixes (deferred)

- **`get_budgets_live` field-set drop documented but NOT closed by restoring fields** — would be a behavior change.
- **Pagination envelope unification** (`total_count`/`has_more` vs `total_rows`/`truncated`) — defer to a separate refactor.
- **Spread-NodeType opaque schemas** (`get_accounts_live`, `get_recurring_live`, `get_tags_live`, `get_upcoming_recurrings_live`) — defer; would require duplicating Node-type field lists in schemas, which has its own maintenance cost.
- **Decimal-as-string vs number drift** across write tools (`set_budget` vs `create_transaction`) — defer.

## Test plan

- [x] `bun run check` (typecheck + lint + format + 1910 tests) passes locally.
- [x] One test asserting `limit?.type === 'number'` on `get_holdings_live` updated to `'integer'`.
- [x] `bun run sync-manifest` reports no manifest drift.
- No GraphQL surface changed → no smoke test required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)