### PR TITLE
fix(tools): cache-mode get_transactions tag filter resolves name → tag id

### DIFF
--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -606,10 +606,7 @@ export class CopilotMoneyTools {
     // ============================================
     if (tag) {
       const normalizedTag = (tag.startsWith('#') ? tag.substring(1) : tag).toLowerCase();
-      // Resolve the input tag name to one or more tag IDs (case-insensitive match
-      // against Tag.name). The transaction's tag_ids array holds opaque Firestore
-      // IDs, so we have to look up the IDs that correspond to the user's input
-      // name before filtering.
+      // tag_ids holds opaque Firestore IDs; resolve name → IDs before filtering.
       const tags = await this.db.getTags();
       const matchingTagIds = new Set(
         tags

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -605,11 +605,19 @@ export class CopilotMoneyTools {
     // MODE 4: Tag filter
     // ============================================
     if (tag) {
-      const normalizedTag = tag.startsWith('#')
-        ? tag.substring(1).toLowerCase()
-        : tag.toLowerCase();
+      const normalizedTag = (tag.startsWith('#') ? tag.substring(1) : tag).toLowerCase();
+      // Resolve the input tag name to one or more tag IDs (case-insensitive match
+      // against Tag.name). The transaction's tag_ids array holds opaque Firestore
+      // IDs, so we have to look up the IDs that correspond to the user's input
+      // name before filtering.
+      const tags = await this.db.getTags();
+      const matchingTagIds = new Set(
+        tags
+          .filter((t) => (t.name ?? t.tag_id).toLowerCase() === normalizedTag)
+          .map((t) => t.tag_id)
+      );
       transactions = transactions.filter((txn) =>
-        txn.tag_ids?.some((id) => id.toLowerCase() === normalizedTag)
+        txn.tag_ids?.some((id) => matchingTagIds.has(id))
       );
     }
 

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -342,6 +342,9 @@ describe('CopilotMoneyTools', () => {
         current_balance: 5000,
       },
     ];
+    (db as any)._tags = [];
+    (db as any)._allCollectionsLoaded = true;
+    (db as any)._cacheLoadedAt = Date.now();
 
     tools = new CopilotMoneyTools(db);
   });
@@ -509,69 +512,122 @@ describe('CopilotMoneyTools', () => {
       expect(result.transactions[0].name).toBe('Grocery Store');
     });
 
-    test('filters by tag', async () => {
+    test('filters by tag name and matches transaction with corresponding opaque tag id', async () => {
+      // Transactions store opaque Firestore-generated tag IDs in tag_ids,
+      // not the human-readable name. The filter must resolve name -> id.
       const taggedTxn: Transaction = {
         transaction_id: 'txn_tagged',
         amount: 55.0,
         date: '2024-01-30',
-        name: 'Business Lunch',
+        name: 'Lunch Out',
         category_id: 'food_dining',
         account_id: 'acc1',
-        tag_ids: ['work', 'expense'],
+        tag_ids: ['9qyEMnfMXknwvx9OnYhk'],
       };
       (db as any)._transactions = [...mockTransactions, taggedTxn];
+      (db as any)._tags = [{ tag_id: '9qyEMnfMXknwvx9OnYhk', name: 'Tahiti' }];
 
-      const result = await tools.getTransactions({ tag: 'work' });
+      const result = await tools.getTransactions({ tag: 'Tahiti' });
       expect(result.count).toBe(1);
-      expect(result.transactions[0].tag_ids).toContain('work');
+      expect(result.transactions[0].transaction_id).toBe('txn_tagged');
+    });
+
+    test('filters by tag is case-insensitive on name', async () => {
+      const taggedTxn: Transaction = {
+        transaction_id: 'txn_tagged_case',
+        amount: 200.0,
+        date: '2024-01-30',
+        name: 'Hotel Stay',
+        category_id: 'travel',
+        account_id: 'acc1',
+        tag_ids: ['9qyEMnfMXknwvx9OnYhk'],
+      };
+      (db as any)._transactions = [...mockTransactions, taggedTxn];
+      (db as any)._tags = [{ tag_id: '9qyEMnfMXknwvx9OnYhk', name: 'Tahiti' }];
+
+      const result = await tools.getTransactions({ tag: 'TAHITI' });
+      expect(result.count).toBe(1);
+      expect(result.transactions[0].transaction_id).toBe('txn_tagged_case');
     });
 
     test('filters by tag with # prefix strips the #', async () => {
       const taggedTxn: Transaction = {
-        transaction_id: 'txn_tagged2',
+        transaction_id: 'txn_tagged_hash',
         amount: 65.0,
         date: '2024-01-30',
-        name: 'Office Supplies',
+        name: 'Souvenirs',
         category_id: 'shopping',
         account_id: 'acc1',
-        tag_ids: ['business'],
+        tag_ids: ['9qyEMnfMXknwvx9OnYhk'],
       };
       (db as any)._transactions = [...mockTransactions, taggedTxn];
+      (db as any)._tags = [{ tag_id: '9qyEMnfMXknwvx9OnYhk', name: 'Tahiti' }];
 
-      const result = await tools.getTransactions({ tag: '#business' });
+      const result = await tools.getTransactions({ tag: '#Tahiti' });
       expect(result.count).toBe(1);
-      expect(result.transactions[0].tag_ids).toContain('business');
+      expect(result.transactions[0].transaction_id).toBe('txn_tagged_hash');
     });
 
-    test('filters by tag is case-insensitive', async () => {
+    test('filters by unknown tag name returns no rows', async () => {
       const taggedTxn: Transaction = {
-        transaction_id: 'txn_tag_case',
-        amount: 200.0,
-        date: '2024-01-30',
-        name: 'Hotel Bora Bora',
-        category_id: 'travel',
-        account_id: 'acc1',
-        tag_ids: ['FrenchPolynesia'],
-      };
-      (db as any)._transactions = [...mockTransactions, taggedTxn];
-
-      const result = await tools.getTransactions({ tag: 'frenchpolynesia' });
-      expect(result.count).toBe(1);
-    });
-
-    test('filters by tag excludes transactions without tag_ids', async () => {
-      const untaggedTxn: Transaction = {
-        transaction_id: 'txn_no_tags',
+        transaction_id: 'txn_tagged_other',
         amount: 50.0,
         date: '2024-01-30',
         name: 'Dinner',
         category_id: 'food_dining',
         account_id: 'acc1',
+        tag_ids: ['9qyEMnfMXknwvx9OnYhk'],
       };
-      (db as any)._transactions = [...mockTransactions, untaggedTxn];
+      (db as any)._transactions = [...mockTransactions, taggedTxn];
+      (db as any)._tags = [{ tag_id: '9qyEMnfMXknwvx9OnYhk', name: 'Tahiti' }];
 
-      const result = await tools.getTransactions({ tag: 'vacation' });
+      const result = await tools.getTransactions({ tag: 'no-such-tag' });
       expect(result.count).toBe(0);
+    });
+
+    test('filters by tag name resolves to any tag id that shares the name', async () => {
+      // If two tag docs share the same name, a transaction tagged with either
+      // ID should match when filtering by that name.
+      const taggedTxn: Transaction = {
+        transaction_id: 'txn_tagged_dup',
+        amount: 80.0,
+        date: '2024-01-30',
+        name: 'Excursion',
+        category_id: 'travel',
+        account_id: 'acc1',
+        tag_ids: ['B'],
+      };
+      (db as any)._transactions = [...mockTransactions, taggedTxn];
+      (db as any)._tags = [
+        { tag_id: 'A', name: 'Tahiti' },
+        { tag_id: 'B', name: 'Tahiti' },
+      ];
+
+      const result = await tools.getTransactions({ tag: 'Tahiti' });
+      expect(result.count).toBe(1);
+      expect(result.transactions[0].transaction_id).toBe('txn_tagged_dup');
+    });
+
+    test('filters by tag still matches legacy id-equals-name tags', async () => {
+      // Older tags can have an ID that happens to equal their name. The filter
+      // must still resolve the input name to that ID so transactions referencing
+      // the legacy ID continue to match. This pins the behavior that masked the
+      // original bug.
+      const taggedTxn: Transaction = {
+        transaction_id: 'txn_legacy_tag',
+        amount: 75.0,
+        date: '2024-01-30',
+        name: 'Legacy Tagged',
+        category_id: 'travel',
+        account_id: 'acc1',
+        tag_ids: ['frenchpolynesia'],
+      };
+      (db as any)._transactions = [...mockTransactions, taggedTxn];
+      (db as any)._tags = [{ tag_id: 'frenchpolynesia', name: 'frenchpolynesia' }];
+
+      const result = await tools.getTransactions({ tag: 'frenchpolynesia' });
+      expect(result.count).toBe(1);
+      expect(result.transactions[0].transaction_id).toBe('txn_legacy_tag');
     });
 
     test('filters by transaction_type hsa_eligible', async () => {

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -585,6 +585,13 @@ describe('CopilotMoneyTools', () => {
       expect(result.count).toBe(0);
     });
 
+    test('filters by tag excludes transactions without tag_ids', async () => {
+      (db as any)._tags = [{ tag_id: '9qyEMnfMXknwvx9OnYhk', name: 'Tahiti' }];
+      // mockTransactions have no tag_ids — none should match the filter.
+      const result = await tools.getTransactions({ tag: 'Tahiti' });
+      expect(result.count).toBe(0);
+    });
+
     test('filters by tag name resolves to any tag id that shares the name', async () => {
       // If two tag docs share the same name, a transaction tagged with either
       // ID should match when filtering by that name.

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -593,8 +593,7 @@ describe('CopilotMoneyTools', () => {
     });
 
     test('filters by tag name resolves to any tag id that shares the name', async () => {
-      // If two tag docs share the same name, a transaction tagged with either
-      // ID should match when filtering by that name.
+      // Two tag docs sharing a name: a transaction tagged with either ID should match.
       const taggedTxn: Transaction = {
         transaction_id: 'txn_tagged_dup',
         amount: 80.0,


### PR DESCRIPTION
## Summary

The cache-mode `get_transactions` `tag` filter compared the user's input tag NAME against `txn.tag_ids`, which holds opaque Firestore-generated IDs (e.g. `9qyEMnfMXknwvx9OnYhk`). The two never match, so the filter always returned zero results — UNLESS the tag had a legacy id-equals-name shape, which was the case for the single tag exercised by the existing fixtures and masked the bug for over a month.

The fix resolves the input name to one or more tag IDs via the cached `tags` collection before filtering. `Tag.name` is optional in the schema, so we fall back to `tag_id` when name is absent, preserving the legacy id-equals-name behavior.

## Empirical verification

1. Wrote a tag to a transaction via `update_transaction`.
2. Confirmed the cache populated `tag_ids` correctly with the opaque Firestore ID.
3. Confirmed the buggy code returned zero results when filtering by the tag's name.
4. Confirmed the fixed code returns the transaction.

## Tests

The existing tag-filter tests used id-equals-name fixtures (`tag_ids: ['work']` for a tag named `work`), which is precisely what masked the original bug. Replaced with six tests that use realistic Firestore-style opaque IDs:

1. Name resolves to opaque ID and matches a tagged transaction.
2. Name match is case-insensitive.
3. `#` prefix is stripped.
4. Unknown name returns zero rows.
5. Multiple tag docs sharing a name: any matching ID matches.
6. Legacy id-equals-name tags still match (pins the behavior that masked the original bug).

The fixtures now make the original regression impossible to re-mask the same way.

## Memory

`project_tag_filter_bug.md` will be flipped from open → RESOLVED.

## Test plan

- [x] `bun run check` passes locally (1918 pass / 0 fail)
- [x] New tag-filter tests cover opaque-ID, hash-strip, case-insensitive, unknown, duplicate-name, and legacy id-equals-name shapes
- [x] Empirically reproduced with a real cached tag against `update_transaction` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)