### PR TITLE
chore: address audit follow-ups from PRs #387 #389 #390

### DIFF
--- a/docs/graphql-live-reads.md
+++ b/docs/graphql-live-reads.md
@@ -77,7 +77,7 @@ All errors surface as `isError: true` tool results.
 
 All migration phases are complete — every cache-mode read that has a GraphQL counterpart now ships a `_live` variant. Future work focuses on measurement (latency, cache-hit rates) ahead of any decision to flip `--live-reads` on by default. See [`docs/tools-by-mode.md`](./tools-by-mode.md) for the current inventory.
 
-## Cache architecture (Phase 2+)
+## Cache architecture (live-reads mode)
 
 When `--live-reads` is on, reads are served through an in-memory tiered cache:
 

--- a/src/tools/live/tags.ts
+++ b/src/tools/live/tags.ts
@@ -62,7 +62,7 @@ export function createLiveTagsToolSchema() {
     name: 'get_tags_live',
     description:
       'Get all user tags (live, GraphQL-backed). Each row carries `id`, `name`, and `color`. ' +
-      'No cache-mode counterpart exists — tags are additive in live mode. ' +
+      'No cache-mode counterpart exists — this tool is the only way to enumerate tags. ' +
       'Use this to enumerate tag IDs before calling `get_transactions_live` with a tag filter, ' +
       'or to enrich transaction-tag references with human-readable names. ' +
       'Available when --live-reads is on.',

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2153,12 +2153,11 @@ export class CopilotMoneyTools {
       ratio_description: string;
     }>;
   }> {
-    const { ticker_symbol, start_date, end_date } = options;
+    const { ticker_symbol } = options;
     const validatedLimit = validateLimit(options.limit, DEFAULT_QUERY_LIMIT);
     const validatedOffset = validateOffset(options.offset);
-
-    if (start_date) validateDate(start_date, 'start_date');
-    if (end_date) validateDate(end_date, 'end_date');
+    const start_date = validateDate(options.start_date, 'start_date');
+    const end_date = validateDate(options.end_date, 'end_date');
 
     // Load splits (applies ticker filter at the doc level).
     const docs = await this.db.getInvestmentSplits({ tickerSymbol: ticker_symbol });


### PR DESCRIPTION
## Summary

Batched LOW-severity audit follow-ups from three recent PRs into a single cleanup, per the project's audit-nit batching convention.

- **#393** (`src/tools/live/tags.ts`): reword the ambiguous phrase "tags are additive in live mode" — could be read as "tags are append-only" — to "this tool is the only way to enumerate tags." Tool-description copy only.
- **#392** (`docs/graphql-live-reads.md`): rename the section heading `## Cache architecture (Phase 2+)` → `## Cache architecture (live-reads mode)`. The "Phase 2+" label was stale now that all migration phases are complete (see preceding paragraph at L78).
- **#388** (`src/tools/tools.ts`, `getInvestmentSplits`): capture `validateDate`'s return value into `const start_date` / `const end_date` instead of destructuring then calling `validateDate` with the result discarded. Aligns with the captured-value pattern used by `getTransactions`/`getRecurring` (the broader codebase pattern). Cosmetic only — `validateDate` returns its input unchanged on success.

## Test plan

- [x] `bun run check` — typecheck, lint, format, tests (1919 pass / 0 fail) all green
- [x] grep confirms no remaining occurrences of "tags are additive" / "Phase 2+" in tracked sources (the two remaining "Phase 2+" hits are in `docs/superpowers/specs/` historical design docs, intentionally untouched)
- [x] `getInvestmentSplits` behavior unchanged: `validateDate` still throws on bad format, returns its input on success

Closes #393
Closes #392
Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)