### PR TITLE
docs: add MCP Registry badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Tests](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/ignaciohermosillacornejo/copilot-money-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/ignaciohermosillacornejo/copilot-money-mcp)
 [![copilot-money-mcp MCP server](https://glama.ai/mcp/servers/ignaciohermosillacornejo/copilot-money-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ignaciohermosillacornejo/copilot-money-mcp)
-[![MCP Registry](https://img.shields.io/badge/MCP_Registry-copilot--money-blue)](https://registry.modelcontextprotocol.io/?q=copilot-money-mcp)
+[![MCP Registry](https://img.shields.io/badge/MCP_Registry-copilot--money--mcp-blue)](https://registry.modelcontextprotocol.io/?q=copilot-money-mcp)
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Tests](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/ignaciohermosillacornejo/copilot-money-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/ignaciohermosillacornejo/copilot-money-mcp)
 [![copilot-money-mcp MCP server](https://glama.ai/mcp/servers/ignaciohermosillacornejo/copilot-money-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ignaciohermosillacornejo/copilot-money-mcp)
+[![MCP Registry](https://img.shields.io/badge/MCP_Registry-copilot--money-blue)](https://registry.modelcontextprotocol.io/?q=copilot-money-mcp)
 
 ## Disclaimer
 


### PR DESCRIPTION
## Summary
- Add MCP Registry badge to README badge row, linking to the registry listing now that the server is published there.

## Test plan
- [x] `bun run lint` and `bun run typecheck` pass (warnings only, pre-existing)
- [x] Pre-push hook (`bun run check` + full test suite) passes
- [ ] Badge renders correctly on GitHub and links to https://registry.modelcontextprotocol.io/?q=copilot-money-mcp

https://claude.ai/code/session_01Rou6YkhrA7HE7P8YWwUrRx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rou6YkhrA7HE7P8YWwUrRx)_