### PR TITLE
docs: point users at official Copilot Money MCP (waitlist, read-only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 **This is an independent, community-driven project and is not affiliated with, endorsed by, or associated with Copilot Money or its parent company in any way.** This tool was created by an independent developer to enable AI-powered queries of locally cached data. "Copilot Money" is a trademark of its respective owner.
 
 > [!NOTE]
-> **Copilot Money has announced an official MCP server (currently in waitlist, read-only).** If a first-party, read-only integration suits your needs, you should strongly consider using it instead of this community project. Learn more and join the waitlist at [agent.copilot.money](https://agent.copilot.money/?utm_source=reddit&utm_medium=social&utm_campaign=reddit_mcp-launch_051426#mcp).
+> **Copilot Money has announced an official MCP server (currently in waitlist, read-only).** If a first-party, read-only integration suits your needs, you should strongly consider using it instead of this community project. Learn more and join the waitlist at [agent.copilot.money](https://agent.copilot.money/#mcp).
 >
 > This project remains useful if you need write tools (categorize transactions, manage budgets, edit recurrings, etc.), fully offline cache-mode reads with zero network requests, or simply want access today without waiting for the official rollout.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@
 
 **This is an independent, community-driven project and is not affiliated with, endorsed by, or associated with Copilot Money or its parent company in any way.** This tool was created by an independent developer to enable AI-powered queries of locally cached data. "Copilot Money" is a trademark of its respective owner.
 
+> [!NOTE]
+> **Copilot Money has announced an official MCP server (currently in waitlist, read-only).** If a first-party, read-only integration suits your needs, you should strongly consider using it instead of this community project. Learn more and join the waitlist at [agent.copilot.money](https://agent.copilot.money/?utm_source=reddit&utm_medium=social&utm_campaign=reddit_mcp-launch_051426#mcp).
+>
+> This project remains useful if you need write tools (categorize transactions, manage budgets, edit recurrings, etc.), fully offline cache-mode reads with zero network requests, or simply want access today without waiting for the official rollout.
+
 ## Overview
 
 An [MCP](https://modelcontextprotocol.io/) server that gives AI assistants access to your Copilot Money personal finance data. It reads from the locally cached Firestore database (LevelDB + Protocol Buffers) on your Mac. **Reads are 100% local with zero network requests.**

--- a/tests/core/cache/transaction-window-cache.test.ts
+++ b/tests/core/cache/transaction-window-cache.test.ts
@@ -80,7 +80,7 @@ describe('TransactionWindowCache.plan', () => {
   test('stale cold-tier month is in toFetch', () => {
     const cache = makeCache();
     // Cold TTL is 1w; ingest a month with fetched_at 8 days ago → stale.
-    const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
+    const eightDaysAgo = today.getTime() - 8 * 24 * 60 * 60 * 1000;
     cache.ingestMonth('2026-02', [mkTx('a', '2026-02-10')], eightDaysAgo);
 
     const result = cache.plan({ from: '2026-02-01', to: '2026-02-28' }, today);


### PR DESCRIPTION
## Summary
- Add a NOTE callout under the existing Disclaimer in `README.md` flagging that Copilot Money has announced an official MCP server (currently waitlist, read-only) and asking users to consider it first if it fits their needs.
- Clarify when this community project still helps: writes (categorize, budgets, recurrings, splits, etc.), fully offline cache-mode reads, or access today without waiting for the official rollout.
- Drive-by: fix a date-dependent test in `tests/core/cache/transaction-window-cache.test.ts` that derived `eightDaysAgo` from `Date.now()` while passing a frozen `today=2026-05-15` to `cache.plan`. As wall-clock drifted past that date the eight-day gap shrank below the cold TTL and the month stopped counting as stale; deriving the timestamp from `today.getTime()` makes the test deterministic. The pre-push hook surfaced this on the doc commit.

Waitlist link in the README: https://agent.copilot.money/?utm_source=reddit&utm_medium=social&utm_campaign=reddit_mcp-launch_051426#mcp

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test tests/core/cache/transaction-window-cache.test.ts` (25 pass)
- [x] Full `bun run check` via pre-push hook (1918 pass / 0 fail)
- [ ] Visually confirm the new NOTE renders on GitHub


---
_Generated by [Claude Code](https://claude.ai/code/session_01QCwFF8YwtrXu6NLCj4N4Yr)_