### PR TITLE
skills: pulse + cleanup targeted improvements

### DIFF
--- a/skills/finance-cleanup/SKILL.md
+++ b/skills/finance-cleanup/SKILL.md
@@ -134,7 +134,7 @@ Before flagging archive, for each overdue sub:
    - **Amount cap drift:** plan price increased (or rent has proration / annual increases) and blew past the old `max_amount`.
 4. **If a near-miss is found**, propose `update_recurring` to fix the rule — widen the amount range, correct the name substring, or both. Only propose `set_recurring_state` to archive if the sub is genuinely silent for **30+ days past the expected `next_date`** with zero near-miss matches in the last 90 days. (Phase 2.3 flags missed cycles at 7+ days, which is right for "might be cancelled" — but archiving is a heavier call and should wait for a full extra cycle to rule out delayed posting.)
 
-When a matcher is updated, write the new rule back to the user profile's "Recurring Matcher State" section (see Phase 5) so next session doesn't re-investigate the same sub from scratch.
+When a matcher is updated, write the new rule back to the user profile's "Recurring Matcher State" section (see Phase 4 step 2) so next session doesn't re-investigate the same sub from scratch.
 
 ### 2.5 Quick Wins
 

--- a/skills/finance-cleanup/SKILL.md
+++ b/skills/finance-cleanup/SKILL.md
@@ -169,18 +169,28 @@ Examples of good phrasing:
 
 **Never auto-approve. Never skip the presentation phase.**
 
-## Phase 4 — Apply Fixes
+## Phase 4 — Apply Fixes (loop)
 
-Only after the user approves a batch:
+Phase 2 built an in-memory list of all findings. Phase 3 presents a batch from that list and waits for user approval. Phase 4 then runs the loop below for each approved batch — and loops back to Phase 3 with the remaining findings until the list is empty or the user stops.
 
-- **Recategorize:** Use `update_transaction` for each transaction that needs a category change. Set the correct `categoryId`.
-- **New recurrings:** Use `create_recurring` for merchants the user confirms as recurring.
-- **Mark reviewed:** Use `review_transactions` to mark cleaned-up transactions as reviewed.
-- **Transfer fixes:** Use `update_transaction` to change category to/from Internal Transfer.
+**Per-batch loop:**
 
-After each batch of writes:
-- Confirm what was changed: "Done — recategorized 3 Uber Eats transactions to Dining, marked 5 old transactions as reviewed."
-- If any write fails, report the error and move on. Do not retry silently.
+1. **Apply MCP writes.**
+   - Recategorize: `update_transaction` per transaction (set `categoryId` to the user-created category).
+   - New recurrings: `create_recurring` for merchants the user confirms as recurring.
+   - Mark reviewed: `review_transactions` for cleaned-up transactions.
+   - Transfer fixes: `update_transaction` to change category to/from Internal Transfer.
+   - Matcher rule fixes: `update_recurring` per Phase 2.4.
+
+2. **Update profile sections relevant to this batch** (incremental updates per the C3 design — Task 5 of this plan adds the detailed handling).
+
+3. **Prune the in-memory findings list.** Remove every item that was just written. The findings list is now smaller; what remains is what's still to fix.
+
+4. **Confirm to user.** Brief, factual: "Done — recategorized 3 Uber Eats transactions to Dining, marked 5 old transactions as reviewed." If a write failed, report the specific error and continue with the rest of the batch — do not retry silently.
+
+5. **Loop back to Phase 3** with the pruned findings list. Present the next batch. Repeat until the list is empty or the user signals they're done.
+
+**Why a mutable list, not a re-pull:** writes go through GraphQL directly to Copilot's servers, but the local LevelDB cache is fed by the desktop app's sync (a few minutes' lag). Re-pulling between batches would surface stale reads that don't yet reflect what was just written. The Phase 2 snapshot is the freshest view we have; pruning items as they're fixed keeps it accurate within the session.
 
 ## Phase 5 — Update Profile
 
@@ -204,6 +214,12 @@ End with a brief summary:
 - Any items the user deferred or rejected — note them so they can revisit.
 - Suggested next cleanup date based on transaction volume (e.g., "You get ~120 transactions/month — I'd run this again in 2-3 weeks").
 
+**Sync-lag note:** Always close with:
+
+> "Your fixes are live in Copilot Money. The local cache will catch up on next sync — usually a few minutes. If you re-run /finance-cleanup right away and your fixes seem missing, that's sync lag; wait a couple minutes or check the app directly."
+
+This pre-empts the common confusion when a user re-opens /finance-cleanup right after writing and sees the just-fixed items still flagged.
+
 ## Rules
 
 1. **Never write without asking — except confident batch fixes.** Every write operation must be explicitly approved by the user first. The one exception: when Phase 3 identifies high-confidence fixes (merchant's dominant category is >80%, or user profile has an explicit mapping), you may apply them directly and report what you changed afterward. This avoids dialog fatigue on obvious fixes while still requiring approval for anything uncertain.
@@ -219,3 +235,4 @@ End with a brief summary:
 11. **Large datasets go to disk.** MCP tool responses >100KB are saved to temp files instead of returned inline. Use Python via Bash to process these files — do not try to read them into context. This happens routinely with `get_transactions` (100 txns ~160KB), `get_accounts` (~77KB), and `get_recurring_transactions` (~70KB).
 12. **Income is intentionally uncategorized.** Income transactions (negative amounts) have no category on purpose. Never flag them as uncategorized or try to assign a category.
 13. **`exclude_transfers` defaults to true.** `get_transactions` hides internal transfers by default. To analyze transfers (misclassified transfer detection), pass `exclude_transfers: false`.
+14. **Findings list is the session source of truth.** Within a session, the in-memory findings list from Phase 2 is what Phase 3 presents and Phase 4 prunes. Do NOT re-pull from cache after writes — the local cache is stale until the Copilot Money app syncs (a few minutes after each write). Surface only what remains in the pruned list.

--- a/skills/finance-cleanup/SKILL.md
+++ b/skills/finance-cleanup/SKILL.md
@@ -182,7 +182,12 @@ Phase 2 built an in-memory list of all findings. Phase 3 presents a batch from t
    - Transfer fixes: `update_transaction` to change category to/from Internal Transfer.
    - Matcher rule fixes: `update_recurring` per Phase 2.4.
 
-2. **Update profile sections relevant to this batch** (incremental updates per the C3 design — Task 5 of this plan adds the detailed handling).
+2. **Update profile sections relevant to this batch** (incremental, per-batch — do NOT defer to Phase 5):
+   - `update_recurring` succeeded → append the new rule to the "Recurring Matcher State" section of `~/.claude/copilot-money/user-profile.md`.
+   - `update_transaction` recategorized a **recurring merchant** (appears 3+ times in the 6-month transaction history) → append a merchant→category mapping to the "Cleanup Preferences" section.
+   - `delete_category` / `update_category` (archive or rename) → note it under "Cleanup Preferences" so the next session knows.
+   - One-off merchants (single visit, restaurant, parking, taxi) → do NOT save. The profile is for state worth re-using next session, not a transcript.
+   - Always tell the user what's being saved before writing: "Adding to profile: 'ENC = Healthcare (psychologist)'. OK?" — but only if the entry isn't a near-duplicate of something already in the profile (avoid double-confirming the same fact).
 
 3. **Prune the in-memory findings list.** Remove every item that was just written. The findings list is now smaller; what remains is what's still to fix.
 
@@ -192,20 +197,41 @@ Phase 2 built an in-memory list of all findings. Phase 3 presents a batch from t
 
 **Why a mutable list, not a re-pull:** writes go through GraphQL directly to Copilot's servers, but the local LevelDB cache is fed by the desktop app's sync (a few minutes' lag). Re-pulling between batches would surface stale reads that don't yet reflect what was just written. The Phase 2 snapshot is the freshest view we have; pruning items as they're fixed keeps it accurate within the session.
 
-## Phase 5 — Update Profile
+## Phase 5 — Final Sweep + Profile Summary
 
-After all fixes are applied, update `~/.claude/copilot-money/user-profile.md` with any new preferences learned during this session:
+The bulk of profile updates happen incrementally in Phase 4 (per the C3 rule). Phase 5 is the catch-all for things that don't tie to a specific Phase-4 batch.
 
-- New merchant-to-category mappings the user confirmed — **only for recurring merchants/professionals** (e.g., a psychologist, English teacher, ISP). Do not save one-off purchases or single-visit merchants (a restaurant visited once, a parking lot, a taxi). The profile should contain preferences that will be useful in future cleanup sessions.
-- Any accounts the user said to always skip.
-- Any categories the user said to never touch.
-- Frequency preferences (e.g., "run cleanup monthly").
-- **Recurring Matcher State** — whenever you use `update_recurring` to fix a matcher rule during Phase 2.4, record the final state under "Recurring Matcher State." This is the single most valuable thing the profile can carry between sessions: without it, next cleanup re-investigates the same overdue subs from scratch. For each known-active subscription, record:
-  - Exact merchant substring the payment processor actually posts (not the user-facing brand name).
-  - Current amount range, min–max.
-  - Known oddities — especially semi-annual or annual frequency where Copilot's `next_date` math is buggy and the overdue flag can't be trusted.
+1. **Sweep for session-level preferences** that emerged in conversation but weren't tied to a specific write:
+   - "Always skip the Coinbase account" → save under "Cleanup Preferences"
+   - "Never touch the Business expenses category" → save under "Cleanup Preferences"
+   - Frequency preference: "run cleanup monthly" → save under "Cleanup Preferences"
 
-**Tell the user exactly what you are saving before writing.** Example: "I'm adding to your profile: 'ENC = Healthcare (psychologist)', 'Skip Coinbase account for cleanup', 'Matcher: Gym Membership — `GYMNAME`, $45–$55, annual price bump expected each January'. OK?"
+2. **Summarize all profile updates from this session.** Count what was saved across Phase 4 batches + this final sweep:
+
+   > "Profile updates this session: [N] matcher rules, [M] merchant mappings, [K] skip preferences."
+
+   The user should see, in one line, what their profile gained — so they know the work compounds across sessions.
+
+3. **Tell the user exactly what you're saving before writing** any final-sweep entry. Example: "Adding to profile: 'Skip Coinbase account for cleanup'. OK?"
+
+**Reference — what gets saved where** (handled inline in Phase 4, repeated here for the reader):
+
+| Trigger | Profile section |
+|---|---|
+| `update_recurring` succeeds | Recurring Matcher State |
+| `update_transaction` on a recurring merchant | Cleanup Preferences (merchant→category) |
+| `delete_category` / `update_category` | Cleanup Preferences (note) |
+| Account-skip preference stated | Cleanup Preferences |
+| Category-never-touch preference stated | Cleanup Preferences |
+
+**Recurring Matcher State format** (per entry):
+
+```
+- <Display name>
+  - Merchant substring: `<exact text the processor posts>`
+  - Amount range: $min – $max
+  - Oddities: <e.g. "semi-annual; Copilot next_date is buggy">
+```
 
 ## Phase 6 — Summary
 
@@ -236,3 +262,4 @@ This pre-empts the common confusion when a user re-opens /finance-cleanup right 
 12. **Income is intentionally uncategorized.** Income transactions (negative amounts) have no category on purpose. Never flag them as uncategorized or try to assign a category.
 13. **`exclude_transfers` defaults to true.** `get_transactions` hides internal transfers by default. To analyze transfers (misclassified transfer detection), pass `exclude_transfers: false`.
 14. **Findings list is the session source of truth.** Within a session, the in-memory findings list from Phase 2 is what Phase 3 presents and Phase 4 prunes. Do NOT re-pull from cache after writes — the local cache is stale until the Copilot Money app syncs (a few minutes after each write). Surface only what remains in the pruned list.
+15. **Profile updates are per-batch, not end-of-session.** The user may walk away mid-cleanup; preserve learned state immediately so the next session benefits. Phase 5 is a final-sweep catch-all, not the primary write point.

--- a/skills/finance-pulse/SKILL.md
+++ b/skills/finance-pulse/SKILL.md
@@ -55,7 +55,7 @@ Run this BETWEEN Phase 1's read and Phase 2's compute. It catches the common cas
    - `## Irregular Expenses (Sinking Funds)`
    - `## Accounts`
 
-   `## Savings & Goals` is intentionally NOT in this list — the savings target comes live from `get_goals` each session, so there's no stale-profile concern. The `last_verified` stamp on that section in the template is still there as a marker, but Phase 1.5 doesn't act on it.
+   `## Savings & Goals` is intentionally NOT in this list — the savings target comes live from `get_goals` each session, so there's no stale-profile concern. The template doesn't carry a `last_verified` stamp for that section.
 
    Each section has a comment of the form `<!-- last_verified: YYYY-MM-DD -->` or `<!-- last_verified: never -->`. Extract the date.
 

--- a/skills/finance-pulse/SKILL.md
+++ b/skills/finance-pulse/SKILL.md
@@ -41,8 +41,8 @@ Give the user a 30-second financial check-in. One number, a few flags, prospecti
 
    Paginate `get_transactions` if needed (100 per page). Use `limit` and `offset`.
 
-3. **Handle large datasets.** Transaction data will be large. Do NOT try to hold all transactions in your context. Instead:
-   - Use Python via Bash for all aggregations, grouping, and arithmetic
+3. **Handle large datasets and do all math via Python.** Transaction data will be large. Do NOT try to hold all transactions in your context, and do NOT do mental math on more than ~10 numbers. Instead:
+   - Use Python via Bash for ALL aggregations, averages, projections, grouping, and arithmetic
    - Save transaction data to temp files and process with Python scripts
    - Only bring summary statistics back into your context for presentation
 
@@ -117,7 +117,7 @@ Free Money = Net Monthly Income
 
 Steps:
 1. Sum fixed obligations from profile (or detected in bootstrap)
-2. Sum savings targets from `get_goals` or profile
+2. Sum savings targets from `get_goals` or profile. If `get_goals` returns 0 AND the profile has no savings target, set this term to 0 and note it for Phase 3 output: "No savings target set — Free Money doesn't reserve anything for savings."
 3. Sum amortized irregular expenses from profile
 4. Sum this month's discretionary spending: total spending minus transactions that match fixed obligation merchants (by name/category). Do NOT subtract the profile's fixed amount — subtract the actual charges from those merchants. This ensures over-charges (e.g., rent higher than usual) are correctly captured rather than silently inflating Free Money.
 5. Free Money = Net Income − Fixed − Savings − Irregular − Already Spent
@@ -232,14 +232,10 @@ After presenting, silently check if any profile sections should be updated:
 
 1. **Read-only.** This skill never writes to Copilot Money. No `set_*`, no `create_*`, no `review_*` calls.
 2. **3-5 flags max.** Never dump 15 findings. Pick the most important ones. Alert fatigue kills usefulness.
-3. **Prospective framing.** Always "you have $X left" not "you spent $X". Restore the pain of paying.
-4. **Use Python for math.** All aggregations, averages, projections via Bash with Python. No mental math on >10 numbers.
-5. **One screen.** The entire output should fit on one screen. If it doesn't, cut the least important parts.
-6. **Respect profile.** Don't flag spending the user said to ignore. Don't flag categories they don't care about.
-7. **Show full merchant names.** When referencing a transaction, use the full `name` or `original_name`, not the truncated `normalized_merchant`.
-8. **First run is special.** If profile is mostly empty, spend time bootstrapping — ask the user to confirm detected income, obligations, and account roles before computing Free Money. This is a one-time cost for accuracy.
-9. **Scheduled runs are silent.** When triggered by a schedule (not interactive), output the pulse as a report without asking questions. Use whatever profile data is available. Note any profile gaps as "could not compute X — profile missing Y."
-10. **Income is intentionally uncategorized.** Income transactions (negative amounts) have no category on purpose. Never flag them as uncategorized or missing a category.
-11. **Large datasets go to disk.** MCP tool responses >100KB are saved to temp files instead of returned inline. Use Python via Bash to process these files. This happens routinely with `get_transactions`, `get_accounts`, and `get_recurring_transactions`.
-12. **Reference existing budgets.** The user has budgets set up in Copilot Money (`get_budgets`). Use these to inform spending flags — if a category has a budget, flag when spending exceeds or approaches the budget amount, not just when it exceeds the 90-day average.
-13. **No savings goals set.** If `get_goals` returns 0, note this in the pulse output: "No savings target set — Free Money doesn't reserve anything for savings." Suggest setting one if this persists across runs.
+3. **One screen.** The entire output should fit on one screen. If it doesn't, cut the least important parts.
+4. **Respect profile.** Don't flag spending the user said to ignore. Don't flag categories they don't care about.
+5. **First run is special.** If profile is mostly empty, spend time bootstrapping — ask the user to confirm detected income, obligations, and account roles before computing Free Money. This is a one-time cost for accuracy.
+6. **Scheduled runs are silent.** When triggered by a schedule (not interactive), output the pulse as a report without asking questions. Use whatever profile data is available. Note any profile gaps as "could not compute X — profile missing Y."
+7. **Income is intentionally uncategorized.** Income transactions (negative amounts) have no category on purpose. Never flag them as uncategorized or missing a category.
+8. **Large datasets go to disk.** MCP tool responses >100KB are saved to temp files instead of returned inline. Use Python via Bash to process these files. This happens routinely with `get_transactions`, `get_accounts`, and `get_recurring_transactions`.
+9. **Reference existing budgets.** The user has budgets set up in Copilot Money (`get_budgets`). Use these to inform spending flags — if a category has a budget, flag when spending exceeds or approaches the budget amount, not just when it exceeds the 90-day average.

--- a/skills/finance-pulse/SKILL.md
+++ b/skills/finance-pulse/SKILL.md
@@ -50,19 +50,24 @@ Give the user a 30-second financial check-in. One number, a few flags, prospecti
 
 Run this BETWEEN Phase 1's read and Phase 2's compute. It catches the common case where the profile was bootstrapped months ago and the underlying numbers (income, fixed obligations, account roles) have drifted.
 
-1. **Parse `last_verified` from each major profile section's HTML comment.** Sections to check:
+1. **Parse `last_verified` from each profile section's HTML comment.** Sections to check:
    - `## Income & Obligations`
-   - `## Savings & Goals`
    - `## Irregular Expenses (Sinking Funds)`
    - `## Accounts`
 
+   `## Savings & Goals` is intentionally NOT in this list — the savings target comes live from `get_goals` each session, so there's no stale-profile concern. The `last_verified` stamp on that section in the template is still there as a marker, but Phase 1.5 doesn't act on it.
+
    Each section has a comment of the form `<!-- last_verified: YYYY-MM-DD -->` or `<!-- last_verified: never -->`. Extract the date.
 
-2. **Read `staleness_threshold_days` from `## Preferences`.** It's stored as a comment: `<!-- staleness_threshold_days: 90 -->`. Default to `90` if the comment or value is absent.
+2. **Read `staleness_threshold_days` from `## Preferences`.** It's stored as a comment of the form `<!-- staleness_threshold_days: <N> ... -->` — extract the first integer after the colon (any trailing text is human-readable documentation only). Default to `90` if the comment is absent or the value can't be parsed.
 
 3. **For each section older than the threshold (or with `last_verified: never`):**
 
-   - **Interactive mode (default):** Prompt the user once, listing every stale section at once: "Your profile sections are stale: [Income & Obligations] last verified [N] days ago; [Savings & Goals] last verified [M] days ago. Re-bootstrap? [y/skip]". A single y/skip applies to all stale sections.
+   - **Interactive mode (default):** Prompt the user once, listing every stale section at once. For each section, format the freshness clause based on the stamp:
+     - `last_verified: never` → "never verified"
+     - valid date → "last verified [N] days ago" (where N is today minus the stamp date)
+
+     Example prompt: "Your profile sections are stale: [Income & Obligations] last verified 142 days ago; [Accounts] never verified. Re-bootstrap? [y/skip]". A single y/skip applies to all stale sections.
    - **Scheduled mode (per Rule "Scheduled runs are silent"):** Skip the prompt; tag each stale section for the Phase 3 warning prefix and proceed.
 
 4. **If the user picks `y`:** run only the bootstrap subflow for each stale section (the corresponding step from Phase 2.1: step 1 for Income, step 2 for Obligations, step 3 for Accounts, step 4 for Irregular Expenses). Skip the bootstrap steps for non-stale sections. After each section's bootstrap saves to profile, also update its `<!-- last_verified: -->` comment to today's date in YYYY-MM-DD form.
@@ -171,9 +176,11 @@ Prioritize using 3-tier system:
 
 > ⚠️ Using stale profile data:
 > - Income & Obligations: last verified [date] ([N] days ago)
-> - Accounts: last verified [date] ([N] days ago)
+> - Accounts: never verified
 >
 > Re-run with `re-bootstrap` if these numbers feel off.
+
+Format each line based on the stamp value: a real date shows "[date] ([N] days ago)"; `never` shows "never verified".
 
 Only include sections that were actually skipped — don't list every section unconditionally.
 

--- a/skills/finance-pulse/SKILL.md
+++ b/skills/finance-pulse/SKILL.md
@@ -46,6 +46,31 @@ Give the user a 30-second financial check-in. One number, a few flags, prospecti
    - Save transaction data to temp files and process with Python scripts
    - Only bring summary statistics back into your context for presentation
 
+## Phase 1.5 — Profile Freshness Check
+
+Run this BETWEEN Phase 1's read and Phase 2's compute. It catches the common case where the profile was bootstrapped months ago and the underlying numbers (income, fixed obligations, account roles) have drifted.
+
+1. **Parse `last_verified` from each major profile section's HTML comment.** Sections to check:
+   - `## Income & Obligations`
+   - `## Savings & Goals`
+   - `## Irregular Expenses (Sinking Funds)`
+   - `## Accounts`
+
+   Each section has a comment of the form `<!-- last_verified: YYYY-MM-DD -->` or `<!-- last_verified: never -->`. Extract the date.
+
+2. **Read `staleness_threshold_days` from `## Preferences`.** It's stored as a comment: `<!-- staleness_threshold_days: 90 -->`. Default to `90` if the comment or value is absent.
+
+3. **For each section older than the threshold (or with `last_verified: never`):**
+
+   - **Interactive mode (default):** Prompt the user once, listing every stale section at once: "Your profile sections are stale: [Income & Obligations] last verified [N] days ago; [Savings & Goals] last verified [M] days ago. Re-bootstrap? [y/skip]". A single y/skip applies to all stale sections.
+   - **Scheduled mode (per Rule "Scheduled runs are silent"):** Skip the prompt; tag each stale section for the Phase 3 warning prefix and proceed.
+
+4. **If the user picks `y`:** run only the bootstrap subflow for each stale section (the corresponding step from Phase 2.1: step 1 for Income, step 2 for Obligations, step 3 for Accounts, step 4 for Irregular Expenses). Skip the bootstrap steps for non-stale sections. After each section's bootstrap saves to profile, also update its `<!-- last_verified: -->` comment to today's date in YYYY-MM-DD form.
+
+5. **If the user picks `skip`:** proceed with stale data. Pass the list of stale section names + their `last_verified` dates to Phase 3 for warning output.
+
+6. **If no sections are stale:** skip Phase 1.5 silently — no output.
+
 ## Phase 2 — Compute Financial State
 
 ### 2.1 Bootstrap (first run only)
@@ -76,7 +101,7 @@ If `~/.claude/copilot-money/user-profile.md` has empty Income & Obligations sect
    - Amortize detected amounts to monthly: annual ÷ 12, semi-annual ÷ 6
    - Present: "I found these irregular expenses: [list]. Monthly reserve: ~$X"
 
-5. **Save to profile.** After user confirms, update the relevant sections of `~/.claude/copilot-money/user-profile.md`. On subsequent runs, skip bootstrapping and read the profile directly.
+5. **Save to profile.** After user confirms, update the relevant sections of `~/.claude/copilot-money/user-profile.md`. For each section saved, also update its `<!-- last_verified: -->` HTML comment to today's date in YYYY-MM-DD form (this is what Phase 1.5 reads to decide if the section is stale). On subsequent runs, skip bootstrapping and read the profile directly.
 
 ### 2.2 Compute Free Money
 
@@ -141,6 +166,16 @@ Prioritize using 3-tier system:
 ## Phase 3 — Present
 
 **Tone:** Match `~/.claude/copilot-money/user-profile.md` Communication Style. Default: blunt, simple, dollar amounts.
+
+**Stale-data warning prefix (if Phase 1.5 flagged any stale sections that the user chose to skip).** Prepend the output with a warning block, then continue with The Number / Flags / Quick Stats as normal:
+
+> ⚠️ Using stale profile data:
+> - Income & Obligations: last verified [date] ([N] days ago)
+> - Accounts: last verified [date] ([N] days ago)
+>
+> Re-run with `re-bootstrap` if these numbers feel off.
+
+Only include sections that were actually skipped — don't list every section unconditionally.
 
 **Structure — always this order:**
 

--- a/skills/user-profile.template.md
+++ b/skills/user-profile.template.md
@@ -8,7 +8,6 @@
 
 ## Savings & Goals
 <!-- Auto-populated from Copilot goals and user conversations -->
-<!-- last_verified: never -->
 
 ## Irregular Expenses (Sinking Funds)
 <!-- Auto-populated: annual/semi-annual payments detected from transaction history -->

--- a/skills/user-profile.template.md
+++ b/skills/user-profile.template.md
@@ -4,18 +4,23 @@
 
 ## Income & Obligations
 <!-- Auto-populated when skills learn about your income and fixed expenses -->
+<!-- last_verified: never -->
 
 ## Savings & Goals
 <!-- Auto-populated from Copilot goals and user conversations -->
+<!-- last_verified: never -->
 
 ## Irregular Expenses (Sinking Funds)
 <!-- Auto-populated: annual/semi-annual payments detected from transaction history -->
+<!-- last_verified: never -->
 
 ## Preferences
 <!-- Auto-populated as you use skills and express preferences -->
+<!-- staleness_threshold_days: 90 (used by /finance-pulse to decide when a section needs re-bootstrapping; lower means more frequent prompts) -->
 
 ## Accounts
 <!-- Auto-populated: which accounts serve which purpose -->
+<!-- last_verified: never -->
 
 ## Trip Tracking
 <!-- Only active/recent trips (within 3 weeks of end date). Concluded trips are tracked via tags in Copilot Money, not here. -->


### PR DESCRIPTION
## Summary

- **P1 — Stale-profile detection in /finance-pulse.** Each major profile section now carries a `last_verified` timestamp (HTML comment). New Phase 1.5 between read and compute prompts for re-bootstrap when any section is older than `staleness_threshold_days` (default 90); if the user skips, Phase 3 prepends a warning.
- **P5 — Rules dedup in /finance-pulse.** Trimmed the Rules section from 13 to 9 items by folding duplicated guidance (prospective framing, Python for math, full merchant names, no-savings-goals note) into the relevant phase prose. Zero behavior change.
- **C1 — Findings-list as session source of truth in /finance-cleanup.** Phase 4 restructured as a loop that prunes the in-memory findings list as writes complete; Phase 6 closes with a sync-lag caveat so re-running right after writes doesn't confuse users. New Rule 14.
- **C3 — Incremental profile updates in /finance-cleanup.** Profile updates move into Phase 4's per-batch loop (was Phase 5 end-of-session); Phase 5 repurposed as final-sweep + summary. New Rule 15.
- Template gains 4 `last_verified: never` stamps + an optional `staleness_threshold_days` preference.

## Test plan

- [ ] `bun run check:skills` passes
- [ ] Fresh `/finance-pulse` on a profile with one section's `last_verified` set 100+ days ago surfaces the warning prompt
- [ ] `/finance-cleanup` mid-session: after approving a batch, the next batch doesn't re-surface the just-fixed items
- [ ] `/finance-cleanup` early-exit (user walks away after batch 1): profile shows the matcher rule / merchant mapping from batch 1 was saved
- [ ] `/finance-pulse` Rules section reads cleanly with 9 items; the old Rule 4 ("use Python") info is now in Phase 1 step 3