### PR TITLE
feat(tools): resolve transactions via live GraphQL when local cache misses

### DIFF
--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -23,6 +23,7 @@ import {
   deleteCategory as gqlDeleteCategory,
 } from '../core/graphql/categories.js';
 import type { CategoryNode } from '../core/graphql/queries/categories.js';
+import type { TransactionNode } from '../core/graphql/queries/transactions.js';
 import type { TagNode } from '../core/graphql/queries/tags.js';
 import type { RecurringNode } from '../core/graphql/queries/recurrings.js';
 import {
@@ -37,7 +38,7 @@ import {
 } from '../core/graphql/recurrings.js';
 import { setBudget as gqlSetBudget } from '../core/graphql/budgets.js';
 import { graphQLErrorToMcpError } from './errors.js';
-import { parsePeriod } from '../utils/date.js';
+import { parsePeriod, getMonthRange } from '../utils/date.js';
 import { computeTotalReturnPercent, roundAmount } from '../utils/round.js';
 import {
   getCategoryName,
@@ -338,7 +339,7 @@ export class CopilotMoneyTools {
    *
    * @param database - CopilotDatabase instance
    * @param graphqlClient - Optional GraphQL client for write operations.
-   * @param liveDb - Optional LiveCopilotDatabase for write-through to live cache.
+   * @param liveDb - Optional LiveCopilotDatabase for read-fallback and write-through cache patching when --live-reads is active.
    */
   constructor(
     database: CopilotDatabase,
@@ -358,6 +359,104 @@ export class CopilotMoneyTools {
       throw new Error('Write tools require --write flag to be set');
     }
     return this.graphqlClient;
+  }
+
+  private transactionNodeToLocal(node: TransactionNode): Transaction {
+    return {
+      transaction_id: node.id,
+      account_id: node.accountId,
+      item_id: node.itemId,
+      amount: node.amount,
+      date: node.date,
+      name: node.name,
+      category_id: node.categoryId ?? undefined,
+      pending: node.isPending,
+      user_reviewed: node.isReviewed,
+      user_note: node.userNotes ?? undefined,
+      recurring_id: node.recurringId ?? undefined,
+      parent_transaction_id: node.parentId ?? undefined,
+      tag_ids: node.tags.map((t) => t.id),
+      internal_transfer: node.type === 'INTERNAL_TRANSFER',
+      iso_currency_code: node.isoCurrencyCode ?? undefined,
+    };
+  }
+
+  /** Resolve a transaction by ID: local cache → live window cache → GraphQL fetch. */
+  private async resolveTransaction(id: string, dateHint?: string): Promise<Transaction> {
+    // Local LevelDB cache (fast, always available)
+    const allTxns = await this.db.getAllTransactions();
+    const local = allTxns.find((t) => t.transaction_id === id);
+    if (local) return local;
+
+    if (!this.liveDb) {
+      throw new Error(`Transaction not found: ${id}`);
+    }
+
+    // Live window cache scan
+    const windowCache = this.liveDb.getTransactionsWindowCache();
+    for (const month of windowCache.cachedMonths()) {
+      const row = windowCache.entriesForMonth(month).find((r) => r.id === id);
+      if (row) return this.transactionNodeToLocal(row);
+    }
+
+    // GraphQL fetch scoped to the transaction's month
+    if (dateHint) {
+      const year = Number(dateHint.slice(0, 4));
+      const month = Number(dateHint.slice(5, 7));
+      const [from, to] = getMonthRange(year, month);
+      try {
+        const { rows } = await this.liveDb.getTransactions({ from, to });
+        const match = rows.find((r) => r.id === id);
+        if (match) return this.transactionNodeToLocal(match);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        throw new Error(`Transaction not found: ${id} (live lookup failed: ${msg})`, { cause: e });
+      }
+    }
+
+    throw new Error(`Transaction not found: ${id}`);
+  }
+
+  /** Batch-resolve transactions by ID with one local scan and one live pass. */
+  private async resolveTransactions(ids: string[]): Promise<Map<string, Transaction>> {
+    const result = new Map<string, Transaction>();
+    const allTxns = await this.db.getAllTransactions();
+    const localMap = new Map(allTxns.map((t) => [t.transaction_id, t]));
+
+    const remaining: string[] = [];
+    for (const id of ids) {
+      const local = localMap.get(id);
+      if (local) {
+        result.set(id, local);
+      } else {
+        remaining.push(id);
+      }
+    }
+
+    if (remaining.length === 0) return result;
+
+    if (!this.liveDb) {
+      throw new Error(`Transactions not found: ${remaining.join(', ')}`);
+    }
+
+    const windowCache = this.liveDb.getTransactionsWindowCache();
+    const remainingSet = new Set(remaining);
+
+    for (const month of windowCache.cachedMonths()) {
+      for (const row of windowCache.entriesForMonth(month)) {
+        if (remainingSet.has(row.id)) {
+          result.set(row.id, this.transactionNodeToLocal(row));
+          remainingSet.delete(row.id);
+        }
+      }
+      if (remainingSet.size === 0) break;
+    }
+
+    if (remainingSet.size > 0) {
+      throw new Error(`Transactions not found: ${Array.from(remainingSet).join(', ')}`);
+    }
+
+    return result;
   }
 
   /**
@@ -2453,13 +2552,7 @@ export class CopilotMoneyTools {
 
     validateDocId(transaction_id, 'transaction_id');
 
-    // Resolve the transaction from the local cache so we can supply accountId /
-    // itemId to the GraphQL mutation.
-    const allTxns = await this.db.getAllTransactions();
-    const txn = allTxns.find((t) => t.transaction_id === transaction_id);
-    if (!txn) {
-      throw new Error(`Transaction not found: ${transaction_id}`);
-    }
+    const txn = await this.resolveTransaction(transaction_id);
 
     // Per-field validation (runs BEFORE any write for atomicity).
     if ('category_id' in args && args.category_id !== undefined) {
@@ -2495,7 +2588,7 @@ export class CopilotMoneyTools {
     if ('tag_ids' in args && args.tag_ids !== undefined) input.tagIds = args.tag_ids;
 
     if (!txn.account_id || !txn.item_id) {
-      throw new Error(`Transaction ${transaction_id} missing account_id or item_id in local cache`);
+      throw new Error(`Transaction ${transaction_id} missing account_id or item_id`);
     }
 
     try {
@@ -2896,14 +2989,8 @@ export class CopilotMoneyTools {
       }
     }
 
-    // Resolve parent from the cache — needed for default name/date and the
-    // client-side sum check. Reject if missing, matching update_transaction's
-    // "Transaction not found" contract.
-    const allTxns = await this.db.getAllTransactions();
-    const parentTxn = allTxns.find((t) => t.transaction_id === transaction_id);
-    if (!parentTxn) {
-      throw new Error(`Transaction not found: ${transaction_id}`);
-    }
+    // Resolve parent — needed for default name/date and the client-side sum check.
+    const parentTxn = await this.resolveTransaction(transaction_id);
 
     // Client-side sum check. Server also enforces this, but a local error
     // saves a round-trip and gives the caller more actionable numbers.
@@ -3018,20 +3105,14 @@ export class CopilotMoneyTools {
       validateDocId(id, 'transaction_id');
     }
 
-    const allTransactions = await this.db.getAllTransactions();
-    const txnMap = new Map(allTransactions.map((t) => [t.transaction_id, t]));
-
-    const missing = transaction_ids.filter((id) => !txnMap.has(id));
-    if (missing.length > 0) {
-      throw new Error(`Transactions not found: ${missing.join(', ')}`);
-    }
+    const txnMap = await this.resolveTransactions(transaction_ids);
 
     // Pre-flight: confirm every transaction has account/item ids before
     // issuing any writes. Keeps partial-failure surface small.
     for (const id of transaction_ids) {
       const txn = txnMap.get(id)!;
       if (!txn.account_id || !txn.item_id) {
-        throw new Error(`Transaction ${id} missing account_id or item_id in local cache`);
+        throw new Error(`Transaction ${id} missing account_id or item_id`);
       }
     }
 
@@ -3445,13 +3526,9 @@ export class CopilotMoneyTools {
       );
     }
 
-    const all = await this.db.getAllTransactions();
-    const txn = all.find((t) => t.transaction_id === args.transaction_id);
-    if (!txn) throw new Error(`Transaction not found: ${args.transaction_id}`);
+    const txn = await this.resolveTransaction(args.transaction_id);
     if (!txn.account_id || !txn.item_id) {
-      throw new Error(
-        `Transaction ${args.transaction_id} missing account_id or item_id in local cache`
-      );
+      throw new Error(`Transaction ${args.transaction_id} missing account_id or item_id`);
     }
 
     try {

--- a/tests/tools/live-fallback-writes.test.ts
+++ b/tests/tools/live-fallback-writes.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Tests for live-fallback resolution in write methods.
+ *
+ * When a transaction is not in the local LevelDB cache (>30-day window),
+ * write methods should fall back to the live window cache before failing.
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { CopilotMoneyTools } from '../../src/tools/tools.js';
+import { CopilotDatabase } from '../../src/core/database.js';
+import { LiveCopilotDatabase } from '../../src/core/live-database.js';
+import { createMockGraphQLClient } from '../helpers/mock-graphql.js';
+import type { TransactionNode } from '../../src/core/graphql/queries/transactions.js';
+import type { GraphQLClient } from '../../src/core/graphql/client.js';
+
+function makeLiveNode(overrides: Partial<TransactionNode> = {}): TransactionNode {
+  return {
+    id: 'txn-live-1',
+    accountId: 'acct-live',
+    itemId: 'item-live',
+    categoryId: 'cat1',
+    recurringId: null,
+    parentId: null,
+    isReviewed: false,
+    isPending: false,
+    amount: 42.5,
+    date: '2025-11-15',
+    name: 'Old Purchase',
+    type: 'REGULAR',
+    userNotes: null,
+    tipAmount: null,
+    suggestedCategoryIds: [],
+    isoCurrencyCode: 'USD',
+    createdAt: 1700000000,
+    tags: [],
+    goal: null,
+    ...overrides,
+  };
+}
+
+function makeDb(): CopilotDatabase {
+  const db = new CopilotDatabase('/fake');
+  (db as any)._allCollectionsLoaded = true;
+  (db as any)._cacheLoadedAt = Date.now();
+  (db as any)._transactions = [];
+  (db as any)._userCategories = [{ category_id: 'cat1', name: 'Food' }];
+  (db as any)._tags = [];
+  return db;
+}
+
+function makeLive(gqlClient?: GraphQLClient): LiveCopilotDatabase {
+  const client =
+    gqlClient ??
+    ({
+      mutate: () => Promise.resolve({}),
+      query: () => Promise.resolve({}),
+    } as unknown as GraphQLClient);
+  return new LiveCopilotDatabase(client, new CopilotDatabase('/fake'));
+}
+
+describe('updateTransaction — live fallback', () => {
+  let db: CopilotDatabase;
+
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  test('resolves from live window cache when local misses', async () => {
+    const editClient = createMockGraphQLClient({
+      EditTransaction: {
+        editTransaction: {
+          transaction: {
+            id: 'txn-live-1',
+            categoryId: 'cat1',
+            userNotes: 'updated',
+            isReviewed: false,
+            tags: [],
+          },
+        },
+      },
+    });
+
+    const liveDb = makeLive(editClient);
+    liveDb.getTransactionsWindowCache().ingestMonth('2025-11', [makeLiveNode()], Date.now());
+
+    const tools = new CopilotMoneyTools(db, editClient, liveDb);
+    const result = await tools.updateTransaction({
+      transaction_id: 'txn-live-1',
+      note: 'updated',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.transaction_id).toBe('txn-live-1');
+    expect(editClient._calls[0].variables).toMatchObject({
+      id: 'txn-live-1',
+      accountId: 'acct-live',
+      itemId: 'item-live',
+    });
+  });
+
+  test('uses local cache when available (no fallback)', async () => {
+    (db as any)._transactions = [
+      {
+        transaction_id: 'txn-local',
+        amount: 10,
+        date: '2026-05-01',
+        name: 'Local Coffee',
+        category_id: 'cat1',
+        account_id: 'acct-local',
+        item_id: 'item-local',
+      },
+    ];
+
+    const editClient = createMockGraphQLClient({
+      EditTransaction: {
+        editTransaction: {
+          transaction: {
+            id: 'txn-local',
+            categoryId: 'cat1',
+            userNotes: 'note',
+            isReviewed: false,
+            tags: [],
+          },
+        },
+      },
+    });
+
+    const liveDb = makeLive(editClient);
+    const tools = new CopilotMoneyTools(db, editClient, liveDb);
+    const result = await tools.updateTransaction({
+      transaction_id: 'txn-local',
+      note: 'note',
+    });
+
+    expect(result.success).toBe(true);
+    expect(editClient._calls[0].variables).toMatchObject({
+      accountId: 'acct-local',
+      itemId: 'item-local',
+    });
+  });
+
+  test('throws when --live-reads is off and local cache misses', async () => {
+    const editClient = createMockGraphQLClient({});
+    const tools = new CopilotMoneyTools(db, editClient);
+
+    await expect(
+      tools.updateTransaction({ transaction_id: 'txn-gone', note: 'x' })
+    ).rejects.toThrow('Transaction not found: txn-gone');
+  });
+});
+
+describe('reviewTransactions — live fallback', () => {
+  let db: CopilotDatabase;
+
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  test('batch resolves mix of local + live', async () => {
+    (db as any)._transactions = [
+      {
+        transaction_id: 'txn-local-1',
+        amount: 10,
+        date: '2026-05-01',
+        name: 'Local',
+        category_id: 'cat1',
+        account_id: 'acct-local',
+        item_id: 'item-local',
+        user_reviewed: false,
+      },
+    ];
+
+    const editClient = createMockGraphQLClient({
+      EditTransaction: (vars: any) => ({
+        editTransaction: {
+          transaction: {
+            id: vars.id,
+            categoryId: 'cat1',
+            userNotes: null,
+            isReviewed: true,
+            tags: [],
+          },
+        },
+      }),
+    });
+
+    const liveDb = makeLive(editClient);
+    liveDb
+      .getTransactionsWindowCache()
+      .ingestMonth(
+        '2025-11',
+        [makeLiveNode({ id: 'txn-live-2', accountId: 'acct-live-2', itemId: 'item-live-2' })],
+        Date.now()
+      );
+
+    const tools = new CopilotMoneyTools(db, editClient, liveDb);
+    const result = await tools.reviewTransactions({
+      transaction_ids: ['txn-local-1', 'txn-live-2'],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.reviewed_count).toBe(2);
+
+    const localCall = editClient._calls.find((c: any) => c.variables.id === 'txn-local-1');
+    const liveCall = editClient._calls.find((c: any) => c.variables.id === 'txn-live-2');
+    expect(localCall!.variables).toMatchObject({ accountId: 'acct-local', itemId: 'item-local' });
+    expect(liveCall!.variables).toMatchObject({ accountId: 'acct-live-2', itemId: 'item-live-2' });
+  });
+
+  test('throws listing missing IDs when --live-reads is off', async () => {
+    const editClient = createMockGraphQLClient({});
+    const tools = new CopilotMoneyTools(db, editClient);
+
+    await expect(
+      tools.reviewTransactions({ transaction_ids: ['miss-1', 'miss-2'] })
+    ).rejects.toThrow('Transactions not found: miss-1, miss-2');
+  });
+});
+
+describe('createRecurring — live fallback', () => {
+  test('resolves from live window cache', async () => {
+    const db = makeDb();
+    const gqlClient = createMockGraphQLClient({
+      CreateRecurring: {
+        createRecurring: {
+          id: 'rec-new',
+          name: 'Old Purchase',
+          state: 'ACTIVE',
+          frequency: 'MONTHLY',
+        },
+      },
+    });
+
+    const liveDb = makeLive(gqlClient);
+    liveDb.getTransactionsWindowCache().ingestMonth('2025-11', [makeLiveNode()], Date.now());
+
+    const tools = new CopilotMoneyTools(db, gqlClient, liveDb);
+    const result = await tools.createRecurring({
+      transaction_id: 'txn-live-1',
+      frequency: 'MONTHLY',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.recurring_id).toBe('rec-new');
+    expect(gqlClient._calls[0].variables).toMatchObject({
+      input: {
+        transaction: {
+          accountId: 'acct-live',
+          itemId: 'item-live',
+          transactionId: 'txn-live-1',
+        },
+      },
+    });
+  });
+});
+
+describe('splitTransaction — live fallback', () => {
+  test('resolves parent from live window cache', async () => {
+    const db = makeDb();
+    const node = makeLiveNode({ amount: 100 });
+    const gqlClient = createMockGraphQLClient({
+      SplitTransaction: {
+        splitTransaction: {
+          parentTransaction: {
+            id: 'txn-live-1',
+            amount: 100,
+            date: '2025-11-15',
+            name: 'Old Purchase',
+            accountId: 'acct-live',
+            itemId: 'item-live',
+            categoryId: 'cat1',
+            isPending: false,
+            isReviewed: false,
+            userNotes: null,
+            recurringId: null,
+            tags: [],
+            type: 'REGULAR',
+          },
+          splitTransactions: [
+            {
+              id: 'split-1',
+              amount: 60,
+              date: '2025-11-15',
+              name: 'Old Purchase',
+              accountId: 'acct-live',
+              itemId: 'item-live',
+              categoryId: 'cat1',
+              isPending: false,
+              isReviewed: false,
+              userNotes: null,
+              recurringId: null,
+              tags: [],
+              type: 'REGULAR',
+            },
+            {
+              id: 'split-2',
+              amount: 40,
+              date: '2025-11-15',
+              name: 'Old Purchase',
+              accountId: 'acct-live',
+              itemId: 'item-live',
+              categoryId: 'cat1',
+              isPending: false,
+              isReviewed: false,
+              userNotes: null,
+              recurringId: null,
+              tags: [],
+              type: 'REGULAR',
+            },
+          ],
+        },
+      },
+    });
+
+    const liveDb = makeLive(gqlClient);
+    liveDb.getTransactionsWindowCache().ingestMonth('2025-11', [node], Date.now());
+
+    const tools = new CopilotMoneyTools(db, gqlClient, liveDb);
+    const result = await tools.splitTransaction({
+      transaction_id: 'txn-live-1',
+      account_id: 'acct-live',
+      item_id: 'item-live',
+      splits: [
+        { amount: 60, category_id: 'cat1' },
+        { amount: 40, category_id: 'cat1' },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.child_transaction_ids).toEqual(['split-1', 'split-2']);
+  });
+});


### PR DESCRIPTION
## Problem

Write tools (`update_transaction`, `split_transaction`, `review_transactions`, `create_recurring`) resolve `account_id` and `item_id` from the local LevelDB cache before sending GraphQL mutations. Transactions outside the ~30-day cache window throw "Transaction not found" even though the GraphQL API can update them.

Real-world trigger: tagging historical transactions (e.g., a vacation from months ago) that `get_transactions_live` can read but write tools can't reach.

## Solution

When `--live-reads` is active, write tools now fall back to the live transaction window cache (populated by prior `get_transactions_live` calls) before failing. An optional `dateHint` parameter enables a scoped GraphQL fetch for the transaction's month when the window cache also misses.

Three-tier lookup: local LevelDB cache -> live window cache -> GraphQL fetch (month-scoped, only with dateHint).

No behavior change when `--live-reads` is off.

## Changes

- `resolveTransaction(id, dateHint?)` — three-tier lookup with honest error surfacing (GraphQL failures are wrapped, not swallowed)
- `resolveTransactions(ids)` — batch variant for `review_transactions`
- `transactionNodeToLocal(node)` — maps camelCase GraphQL shape to snake_case local Transaction
- Four call sites replaced: `updateTransaction`, `splitTransaction`, `reviewTransactions`, `createRecurring`
- `deleteTransaction` and `addTransactionToRecurring` unchanged (already require explicit IDs)

## Test plan

- [x] 7 new tests in `tests/tools/live-fallback-writes.test.ts`
- [x] 1926 pass, 0 fail, 20 skip
- [x] `bun run check` clean (typecheck, lint, format)
- [x] Manual: tagged 43 transactions from February 2026 that were outside the local cache