### PR TITLE
Make --write imply --live-reads

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,7 +56,7 @@ Usage:
 Options:
   --db-path <path>    Path to LevelDB database (default: Copilot Money's default location)
   --timeout <ms>      Decode timeout in milliseconds (default: 90000 = 90 seconds)
-  --write             Enable write tools (sends authenticated requests to Copilot Money's GraphQL API)
+  --write             Enable write tools (implies --live-reads)
   --live-reads        Enable GraphQL-backed get_transactions_live (replaces cache-backed get_transactions). Requires authenticated browser session at app.copilot.money.
   --verbose, -v       Enable verbose logging
   --help, -h          Show this help message
@@ -68,6 +68,10 @@ Environment:
 `);
       process.exit(0);
     }
+  }
+
+  if (writeFlagSeen) {
+    liveReadsEnabled = true;
   }
 
   return { dbPath, verbose, timeoutMs, writeFlagSeen, liveReadsEnabled };

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -140,6 +140,19 @@ describe('CLI entry point', () => {
 
       expect(stderr).toContain('Write tools enabled');
     });
+
+    test('--write implies --live-reads', async () => {
+      const { stderr } = await runCli(['--write', '-v']);
+
+      expect(stderr).toContain('Write tools enabled');
+      expect(stderr).toContain('Live reads enabled');
+    });
+
+    test('--write without --live-reads still enables live reads', async () => {
+      const { stderr } = await runCli(['--write', '-v']);
+
+      expect(stderr).toContain('Live reads enabled');
+    });
   });
 
   describe('no arguments', () => {


### PR DESCRIPTION
## Summary

- `--write` now automatically enables `--live-reads`, collapsing the flag matrix as discussed in #406
- Write tools resolved `account_id`/`item_id` from the local LevelDB cache (~30 days), causing failures on older transactions even though the GraphQL API handles them fine
- Since `--write` already requires the Firebase auth token, there's no privacy or perf reason to keep reads on the stale cache

## Changes

One-line logic change in `src/cli.ts` + help text update.

## Test plan

- [x] `bun run check` clean (typecheck, lint, format, 1919 pass / 0 fail / 20 skip)
- [x] Users with `--write` only get the same behavior as `--write --live-reads`
- [x] `--live-reads` without `--write` is unchanged
- [x] No flags (default) is unchanged