### PR TITLE
[codex] Discover Chrome profile token stores

### DIFF
--- a/src/core/auth/browser-token.ts
+++ b/src/core/auth/browser-token.ts
@@ -24,21 +24,51 @@ export interface TokenResult {
 
 /** Firebase refresh token regex: AMf- followed by 100+ URL-safe base64 chars. */
 const REFRESH_TOKEN_REGEX = /AMf-[A-Za-z0-9_-]{100,}/g;
+const COPILOT_INDEXEDDB_DIR = 'IndexedDB/https_app.copilot.money_0.indexeddb.leveldb';
+const LOCAL_STORAGE_DIR = 'Local Storage/leveldb';
+
+/**
+ * Build token search paths for Chromium profile directories.
+ *
+ * Chrome profile directory names are not guaranteed to be `Default`; once users
+ * create/delete profiles, the sole active profile can be `Profile 1`,
+ * `Profile 3`, etc. Firebase Web SDK v9+ stores Copilot auth in per-profile
+ * IndexedDB, so scan all normal Chrome profile directories and prefer
+ * IndexedDB before the older Local Storage fallback.
+ */
+export function getChromiumProfileStoragePaths(userDataDir: string): string[] {
+  const profileDirs = new Set<string>(['Default']);
+  if (existsSync(userDataDir)) {
+    try {
+      for (const entry of readdirSync(userDataDir, { withFileTypes: true })) {
+        if (entry.isDirectory() && /^Profile \d+$/.test(entry.name)) {
+          profileDirs.add(entry.name);
+        }
+      }
+    } catch {
+      /* Fall back to Default below */
+    }
+  }
+
+  const sortedProfiles = Array.from(profileDirs).sort((a, b) => {
+    if (a === 'Default') return -1;
+    if (b === 'Default') return 1;
+    return Number(a.slice('Profile '.length)) - Number(b.slice('Profile '.length));
+  });
+
+  return sortedProfiles.flatMap((profile) => [
+    join(userDataDir, profile, COPILOT_INDEXEDDB_DIR),
+    join(userDataDir, profile, LOCAL_STORAGE_DIR),
+  ]);
+}
 
 /** Default browser configurations for macOS. */
 export const BROWSER_CONFIGS: BrowserConfig[] = [
   {
     name: 'Chrome',
-    paths: [
-      // Firebase Web SDK v9+ stores auth tokens in IndexedDB, not Local Storage.
-      // Search the Copilot Money IndexedDB first (most reliable source).
-      join(
-        homedir(),
-        'Library/Application Support/Google/Chrome/Default/IndexedDB/https_app.copilot.money_0.indexeddb.leveldb'
-      ),
-      join(homedir(), 'Library/Application Support/Google/Chrome/Default/Local Storage/leveldb'),
-      join(homedir(), 'Library/Application Support/Google/Chrome/Profile 1/Local Storage/leveldb'),
-    ],
+    paths: getChromiumProfileStoragePaths(
+      join(homedir(), 'Library/Application Support/Google/Chrome')
+    ),
     type: 'chromium',
   },
   {

--- a/tests/core/auth/browser-token.test.ts
+++ b/tests/core/auth/browser-token.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import {
   extractRefreshToken,
   BROWSER_CONFIGS,
+  getChromiumProfileStoragePaths,
   type BrowserConfig,
 } from '../../../src/core/auth/browser-token.js';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync, symlinkSync, chmodSync } from 'fs';
@@ -28,6 +29,32 @@ describe('extractRefreshToken', () => {
 
   afterEach(() => {
     rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('discovers IndexedDB and Local Storage paths for all Chrome profile directories', () => {
+    const chromeDir = join(tempDir, 'Chrome');
+    mkdirSync(join(chromeDir, 'Default'), { recursive: true });
+    mkdirSync(join(chromeDir, 'Profile 3'), { recursive: true });
+    mkdirSync(join(chromeDir, 'Profile 1'), { recursive: true });
+    mkdirSync(join(chromeDir, 'System Profile'), { recursive: true });
+
+    expect(getChromiumProfileStoragePaths(chromeDir)).toEqual([
+      join(chromeDir, 'Default/IndexedDB/https_app.copilot.money_0.indexeddb.leveldb'),
+      join(chromeDir, 'Default/Local Storage/leveldb'),
+      join(chromeDir, 'Profile 1/IndexedDB/https_app.copilot.money_0.indexeddb.leveldb'),
+      join(chromeDir, 'Profile 1/Local Storage/leveldb'),
+      join(chromeDir, 'Profile 3/IndexedDB/https_app.copilot.money_0.indexeddb.leveldb'),
+      join(chromeDir, 'Profile 3/Local Storage/leveldb'),
+    ]);
+  });
+
+  test('uses Default profile paths when Chromium user data dir is missing', () => {
+    const chromeDir = join(tempDir, 'missing-chrome');
+
+    expect(getChromiumProfileStoragePaths(chromeDir)).toEqual([
+      join(chromeDir, 'Default/IndexedDB/https_app.copilot.money_0.indexeddb.leveldb'),
+      join(chromeDir, 'Default/Local Storage/leveldb'),
+    ]);
   });
 
   test('extracts token from .ldb file containing refresh token', async () => {


### PR DESCRIPTION
## Summary

- discover Chrome token stores from the actual Chrome user-data directory instead of hardcoding only Default plus Profile 1 Local Storage
- scan Default and every Profile N directory, checking Copilot IndexedDB before Local Storage for each profile
- add unit coverage for multi-profile discovery and missing-user-data fallback

## Why

Chrome profile directory names are not stable. A user can have a single active profile stored as Profile 1, Profile 3, or another Profile N directory. Copilot's Firebase Web SDK session is stored in per-profile IndexedDB, so the previous static path list could miss a valid browser session.

## Validation

- bun test tests/core/auth/browser-token.test.ts
- bun run typecheck
- bun run format:check src/core/auth/browser-token.ts tests/core/auth/browser-token.test.ts
- bun run check via pre-push hook