### PR TITLE
Extend Chromium profile token discovery to all Chromium browsers

### DIFF
--- a/src/core/auth/browser-token.ts
+++ b/src/core/auth/browser-token.ts
@@ -2,8 +2,8 @@
  * Browser token extractor for Firebase refresh tokens.
  *
  * Searches Chromium browsers (Chrome, Arc, Edge, Brave, Vivaldi, Chromium,
- * Opera), Safari, and Firefox LevelDB/IndexedDB storage for Copilot Money
- * Firebase refresh tokens (prefixed with "AMf-").
+ * Opera, Opera GX), Safari, and Firefox LevelDB/IndexedDB storage for Copilot
+ * Money Firebase refresh tokens (prefixed with "AMf-").
  */
 
 import { readdirSync, readFileSync, existsSync, statSync } from 'fs';
@@ -80,9 +80,12 @@ const CHROMIUM_USER_DATA_DIRS: ReadonlyArray<{ name: string; userDataDir: string
 ];
 
 /**
- * Opera-family browsers keep their single profile at the user-data root (no
- * `Default` subdirectory), unlike the browsers above. Multi-profile discovery
- * does not apply, so their storage dirs sit directly under the user-data dir.
+ * Opera-family browsers historically kept their single profile at the
+ * user-data root (no `Default` subdirectory), but recent Chromium-based Opera
+ * builds may use Chrome's `Default` / `Profile N` layout. We can't know which
+ * a given install uses, so we search both: the storage dirs directly under the
+ * user-data root plus the standard per-profile paths. Non-existent paths are
+ * skipped cheaply at search time.
  */
 const OPERA_USER_DATA_DIRS: ReadonlyArray<{ name: string; userDataDir: string }> = [
   { name: 'Opera', userDataDir: 'Library/Application Support/com.operasoftware.Opera' },
@@ -98,16 +101,20 @@ export const BROWSER_CONFIGS: BrowserConfig[] = [
       type: 'chromium',
     })
   ),
-  ...OPERA_USER_DATA_DIRS.map(
-    ({ name, userDataDir }): BrowserConfig => ({
+  ...OPERA_USER_DATA_DIRS.map(({ name, userDataDir }): BrowserConfig => {
+    const root = join(homedir(), userDataDir);
+    return {
       name,
+      // Root layout (older builds) first, then the Chrome-style Default/Profile
+      // N layout (recent builds) via the shared multi-profile discovery.
       paths: [
-        join(homedir(), userDataDir, COPILOT_INDEXEDDB_DIR),
-        join(homedir(), userDataDir, LOCAL_STORAGE_DIR),
+        join(root, COPILOT_INDEXEDDB_DIR),
+        join(root, LOCAL_STORAGE_DIR),
+        ...getChromiumProfileStoragePaths(root),
       ],
       type: 'chromium',
-    })
-  ),
+    };
+  }),
   {
     name: 'Safari',
     paths: [
@@ -227,7 +234,7 @@ function searchSafariDatabases(dbDir: string): string | undefined {
 /**
  * Extract a Firebase refresh token from browser local storage.
  * Searches browsers in order: the Chromium family (Chrome, Arc, Edge, Brave,
- * Vivaldi, Chromium, Opera), then Safari, then Firefox.
+ * Vivaldi, Chromium, Opera, Opera GX), then Safari, then Firefox.
  * @param browserOverrides - Override browser configs for testing
  * @throws Error if no token is found in any browser
  */

--- a/src/core/auth/browser-token.ts
+++ b/src/core/auth/browser-token.ts
@@ -1,8 +1,9 @@
 /**
  * Browser token extractor for Firebase refresh tokens.
  *
- * Searches Chrome, Arc, Safari, and Firefox LevelDB/IndexedDB storage
- * for Copilot Money Firebase refresh tokens (prefixed with "AMf-").
+ * Searches Chromium browsers (Chrome, Arc, Edge, Brave, Vivaldi, Chromium,
+ * Opera), Safari, and Firefox LevelDB/IndexedDB storage for Copilot Money
+ * Firebase refresh tokens (prefixed with "AMf-").
  */
 
 import { readdirSync, readFileSync, existsSync, statSync } from 'fs';
@@ -62,26 +63,51 @@ export function getChromiumProfileStoragePaths(userDataDir: string): string[] {
   ]);
 }
 
+/**
+ * Chromium-based browsers that use the standard Chrome user-data layout
+ * (`Default` / `Profile N` subdirectories), keyed to their macOS user-data
+ * directory relative to the home folder. They all store Copilot's Firebase
+ * Web SDK session under per-profile IndexedDB/Local Storage, so they share
+ * getChromiumProfileStoragePaths for multi-profile discovery.
+ */
+const CHROMIUM_USER_DATA_DIRS: ReadonlyArray<{ name: string; userDataDir: string }> = [
+  { name: 'Chrome', userDataDir: 'Library/Application Support/Google/Chrome' },
+  { name: 'Arc', userDataDir: 'Library/Application Support/Arc/User Data' },
+  { name: 'Microsoft Edge', userDataDir: 'Library/Application Support/Microsoft Edge' },
+  { name: 'Brave', userDataDir: 'Library/Application Support/BraveSoftware/Brave-Browser' },
+  { name: 'Vivaldi', userDataDir: 'Library/Application Support/Vivaldi' },
+  { name: 'Chromium', userDataDir: 'Library/Application Support/Chromium' },
+];
+
+/**
+ * Opera-family browsers keep their single profile at the user-data root (no
+ * `Default` subdirectory), unlike the browsers above. Multi-profile discovery
+ * does not apply, so their storage dirs sit directly under the user-data dir.
+ */
+const OPERA_USER_DATA_DIRS: ReadonlyArray<{ name: string; userDataDir: string }> = [
+  { name: 'Opera', userDataDir: 'Library/Application Support/com.operasoftware.Opera' },
+  { name: 'Opera GX', userDataDir: 'Library/Application Support/com.operasoftware.OperaGX' },
+];
+
 /** Default browser configurations for macOS. */
 export const BROWSER_CONFIGS: BrowserConfig[] = [
-  {
-    name: 'Chrome',
-    paths: getChromiumProfileStoragePaths(
-      join(homedir(), 'Library/Application Support/Google/Chrome')
-    ),
-    type: 'chromium',
-  },
-  {
-    name: 'Arc',
-    paths: [
-      join(
-        homedir(),
-        'Library/Application Support/Arc/User Data/Default/IndexedDB/https_app.copilot.money_0.indexeddb.leveldb'
-      ),
-      join(homedir(), 'Library/Application Support/Arc/User Data/Default/Local Storage/leveldb'),
-    ],
-    type: 'chromium',
-  },
+  ...CHROMIUM_USER_DATA_DIRS.map(
+    ({ name, userDataDir }): BrowserConfig => ({
+      name,
+      paths: getChromiumProfileStoragePaths(join(homedir(), userDataDir)),
+      type: 'chromium',
+    })
+  ),
+  ...OPERA_USER_DATA_DIRS.map(
+    ({ name, userDataDir }): BrowserConfig => ({
+      name,
+      paths: [
+        join(homedir(), userDataDir, COPILOT_INDEXEDDB_DIR),
+        join(homedir(), userDataDir, LOCAL_STORAGE_DIR),
+      ],
+      type: 'chromium',
+    })
+  ),
   {
     name: 'Safari',
     paths: [
@@ -200,7 +226,8 @@ function searchSafariDatabases(dbDir: string): string | undefined {
 
 /**
  * Extract a Firebase refresh token from browser local storage.
- * Searches browsers in order: Chrome, Arc, Safari, Firefox.
+ * Searches browsers in order: the Chromium family (Chrome, Arc, Edge, Brave,
+ * Vivaldi, Chromium, Opera), then Safari, then Firefox.
  * @param browserOverrides - Override browser configs for testing
  * @throws Error if no token is found in any browser
  */

--- a/tests/core/auth/browser-token.test.ts
+++ b/tests/core/auth/browser-token.test.ts
@@ -28,27 +28,38 @@ describe('BROWSER_CONFIGS', () => {
   test('standard Chromium browsers search per-profile IndexedDB then Local Storage', () => {
     for (const name of ['Chrome', 'Arc', 'Microsoft Edge', 'Brave', 'Vivaldi', 'Chromium']) {
       const config = BROWSER_CONFIGS.find((b) => b.name === name);
-      expect(config?.type).toBe('chromium');
+      expect(config).toBeDefined();
+      expect(config!.type).toBe('chromium');
       // At minimum, the Default profile's IndexedDB and Local Storage are searched.
       expect(
-        config?.paths.some((p) =>
+        config!.paths.some((p) =>
           p.endsWith('Default/IndexedDB/https_app.copilot.money_0.indexeddb.leveldb')
         )
       ).toBe(true);
-      expect(config?.paths.some((p) => p.endsWith('Default/Local Storage/leveldb'))).toBe(true);
+      expect(config!.paths.some((p) => p.endsWith('Default/Local Storage/leveldb'))).toBe(true);
     }
   });
 
-  test('Opera-family browsers search storage dirs at the user-data root (no Default profile)', () => {
+  test('Opera-family browsers search both the root layout and the Default profile layout', () => {
     for (const name of ['Opera', 'Opera GX']) {
       const config = BROWSER_CONFIGS.find((b) => b.name === name);
-      expect(config?.type).toBe('chromium');
-      expect(config?.paths).toEqual([
-        expect.stringMatching(/IndexedDB\/https_app\.copilot\.money_0\.indexeddb\.leveldb$/),
-        expect.stringMatching(/Local Storage\/leveldb$/),
-      ]);
-      // Root layout: no Default/Profile N segment in the path.
-      expect(config?.paths.every((p) => !/\/(Default|Profile \d+)\//.test(p))).toBe(true);
+      expect(config).toBeDefined();
+      expect(config!.type).toBe('chromium');
+      // Root layout (older builds): the first two paths sit directly under the
+      // user-data dir with no Default/Profile N segment.
+      expect(config!.paths[0]).toMatch(
+        /IndexedDB\/https_app\.copilot\.money_0\.indexeddb\.leveldb$/
+      );
+      expect(config!.paths[1]).toMatch(/Local Storage\/leveldb$/);
+      expect(config!.paths.slice(0, 2).every((p) => !/\/(Default|Profile \d+)\//.test(p))).toBe(
+        true
+      );
+      // Default layout (recent builds) is also covered.
+      expect(
+        config!.paths.some((p) =>
+          p.endsWith('Default/IndexedDB/https_app.copilot.money_0.indexeddb.leveldb')
+        )
+      ).toBe(true);
     }
   });
 });

--- a/tests/core/auth/browser-token.test.ts
+++ b/tests/core/auth/browser-token.test.ts
@@ -10,13 +10,46 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 
 describe('BROWSER_CONFIGS', () => {
-  test('defines configs for Chrome, Arc, Safari, and Firefox', () => {
+  test('defines configs for all supported Chromium browsers plus Safari and Firefox', () => {
     const names = BROWSER_CONFIGS.map((b) => b.name);
     expect(names).toContain('Chrome');
     expect(names).toContain('Arc');
+    expect(names).toContain('Microsoft Edge');
+    expect(names).toContain('Brave');
+    expect(names).toContain('Vivaldi');
+    expect(names).toContain('Chromium');
+    expect(names).toContain('Opera');
+    expect(names).toContain('Opera GX');
     expect(names).toContain('Safari');
     expect(names).toContain('Firefox');
-    expect(names).toHaveLength(4);
+    expect(names).toHaveLength(10);
+  });
+
+  test('standard Chromium browsers search per-profile IndexedDB then Local Storage', () => {
+    for (const name of ['Chrome', 'Arc', 'Microsoft Edge', 'Brave', 'Vivaldi', 'Chromium']) {
+      const config = BROWSER_CONFIGS.find((b) => b.name === name);
+      expect(config?.type).toBe('chromium');
+      // At minimum, the Default profile's IndexedDB and Local Storage are searched.
+      expect(
+        config?.paths.some((p) =>
+          p.endsWith('Default/IndexedDB/https_app.copilot.money_0.indexeddb.leveldb')
+        )
+      ).toBe(true);
+      expect(config?.paths.some((p) => p.endsWith('Default/Local Storage/leveldb'))).toBe(true);
+    }
+  });
+
+  test('Opera-family browsers search storage dirs at the user-data root (no Default profile)', () => {
+    for (const name of ['Opera', 'Opera GX']) {
+      const config = BROWSER_CONFIGS.find((b) => b.name === name);
+      expect(config?.type).toBe('chromium');
+      expect(config?.paths).toEqual([
+        expect.stringMatching(/IndexedDB\/https_app\.copilot\.money_0\.indexeddb\.leveldb$/),
+        expect.stringMatching(/Local Storage\/leveldb$/),
+      ]);
+      // Root layout: no Default/Profile N segment in the path.
+      expect(config?.paths.every((p) => !/\/(Default|Profile \d+)\//.test(p))).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #409. That PR added `getChromiumProfileStoragePaths` (multi-profile `Default` / `Profile N` discovery) but only wired it into Chrome. This extends the same per-profile discovery to every Chromium browser.

- Build the Chromium `BROWSER_CONFIGS` entries from a small table so each browser reuses `getChromiumProfileStoragePaths` for `Default` + every `Profile N` directory, IndexedDB-first then Local Storage.
- Standard-layout browsers covered: **Chrome, Arc, Microsoft Edge, Brave, Vivaldi, Chromium**. (Arc previously had a static `Default`-only config; it now gets full multi-profile discovery too.)
- **Opera** and **Opera GX**: older builds keep the profile at the user-data root (no `Default` subdir) while recent Chromium-based builds may use Chrome's `Default` / `Profile N` layout. Since we can't tell which an install uses, we search **both** — the root storage dirs plus the standard per-profile paths. Non-existent paths are skipped cheaply at search time.
- Safari and Firefox are unchanged — they use entirely different storage models with their own dedicated search functions.

## Why

Chromium browsers share Chrome's user-data layout, so a user logged into Copilot in Edge/Brave/Arc/etc. should be discoverable the same way as Chrome — including when their only profile is `Profile 3` rather than `Default`.

## Validation

- `bun test tests/core/auth/browser-token.test.ts` — coverage asserts all Chromium browsers are configured, that standard browsers search per-profile IndexedDB + Local Storage, and that Opera-family browsers cover both the root layout and the `Default` layout.
- `bun run check` (typecheck + lint + format:check + full test suite) passes.