### PR TITLE
[codex] Support live transaction refs for writes

### DIFF
--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -454,8 +454,46 @@ export class LiveCopilotDatabase {
       }
     }
     if (!existing) return;
-    const merged: TransactionNode = { ...existing, ...fields, id };
+    const merged: TransactionNode = {
+      ...existing,
+      ...this.toTransactionNodePatch(fields, existing),
+      id,
+    };
     this.transactionsWindowCache.upsert(merged);
+  }
+
+  private toTransactionNodePatch(
+    fields: Partial<Transaction>,
+    existing: TransactionNode
+  ): Partial<TransactionNode> {
+    const patch: Partial<TransactionNode> = {};
+
+    if (fields.name !== undefined) patch.name = fields.name;
+    if (fields.amount !== undefined) patch.amount = fields.amount;
+    if (fields.date !== undefined) patch.date = fields.date;
+    if (fields.account_id !== undefined) patch.accountId = fields.account_id;
+    if (fields.item_id !== undefined) patch.itemId = fields.item_id;
+    if (fields.category_id !== undefined) patch.categoryId = fields.category_id;
+    if (fields.recurring_id !== undefined) patch.recurringId = fields.recurring_id;
+    if (fields.parent_transaction_id !== undefined) patch.parentId = fields.parent_transaction_id;
+    if (fields.pending !== undefined) patch.isPending = fields.pending;
+    if (fields.user_reviewed !== undefined) patch.isReviewed = fields.user_reviewed;
+    if (fields.user_note !== undefined) patch.userNotes = fields.user_note;
+    if (typeof fields.tip_amount === 'number') patch.tipAmount = fields.tip_amount;
+    if (fields.tip_amount === null) patch.tipAmount = null;
+    if (fields.iso_currency_code !== undefined) patch.isoCurrencyCode = fields.iso_currency_code;
+    if (fields.created_timestamp !== undefined) {
+      const createdAt = Number(fields.created_timestamp);
+      if (Number.isFinite(createdAt)) patch.createdAt = createdAt;
+    }
+    if (fields.tag_ids !== undefined) {
+      const existingTags = new Map(existing.tags.map((t) => [t.id, t]));
+      patch.tags = fields.tag_ids.map((tagId) => {
+        return existingTags.get(tagId) ?? { id: tagId, name: '', colorName: '' };
+      });
+    }
+
+    return patch;
   }
 
   /** Remove a cached transaction by id. No-op if not found. */

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -89,6 +89,24 @@ function validateDocId(id: string, label: string): void {
   }
 }
 
+type TransactionWriteRef = {
+  transaction_id: string;
+  account_id: string;
+  item_id: string;
+};
+
+type OptionalTransactionWriteRef = {
+  transaction_id: string;
+  account_id?: string;
+  item_id?: string;
+};
+
+function hasExplicitTransactionWriteRef(
+  ref: OptionalTransactionWriteRef
+): ref is TransactionWriteRef {
+  return ref.account_id !== undefined && ref.item_id !== undefined;
+}
+
 /**
  * Plaid category ID for foreign transaction fees (snake_case format).
  * @see https://plaid.com/docs/api/products/transactions/#categoriesget
@@ -358,6 +376,52 @@ export class CopilotMoneyTools {
       throw new Error('Write tools require --write flag to be set');
     }
     return this.graphqlClient;
+  }
+
+  private validateTransactionWriteRef(ref: TransactionWriteRef): void {
+    validateDocId(ref.transaction_id, 'transaction_id');
+    validateDocId(ref.account_id, 'account_id');
+    validateDocId(ref.item_id, 'item_id');
+  }
+
+  private async resolveTransactionWriteRef(
+    ref: OptionalTransactionWriteRef,
+    transactionMap?: Map<string, Transaction>
+  ): Promise<TransactionWriteRef> {
+    validateDocId(ref.transaction_id, 'transaction_id');
+
+    if (ref.account_id !== undefined || ref.item_id !== undefined) {
+      if (!hasExplicitTransactionWriteRef(ref)) {
+        throw new Error(
+          `Transaction ${ref.transaction_id} requires both account_id and item_id when either is provided`
+        );
+      }
+      this.validateTransactionWriteRef(ref);
+      return ref;
+    }
+
+    const localTransactionMap =
+      transactionMap ??
+      new Map((await this.db.getAllTransactions()).map((txn) => [txn.transaction_id, txn]));
+    const txn = localTransactionMap.get(ref.transaction_id);
+    if (!txn) {
+      throw new Error(
+        `Transaction not found in local cache: ${ref.transaction_id}. ` +
+          'Pass account_id and item_id from get_transactions_live for live-read transactions.'
+      );
+    }
+    if (!txn.account_id || !txn.item_id) {
+      throw new Error(
+        `Transaction ${ref.transaction_id} missing account_id or item_id in local cache. ` +
+          'Pass account_id and item_id from get_transactions_live.'
+      );
+    }
+
+    return {
+      transaction_id: ref.transaction_id,
+      account_id: txn.account_id,
+      item_id: txn.item_id,
+    };
   }
 
   /**
@@ -2422,6 +2486,8 @@ export class CopilotMoneyTools {
    */
   async updateTransaction(args: {
     transaction_id: string;
+    account_id?: string;
+    item_id?: string;
     category_id?: string;
     note?: string;
     tag_ids?: string[];
@@ -2436,7 +2502,14 @@ export class CopilotMoneyTools {
     // Reject unknown fields (equivalent to JSON Schema additionalProperties: false,
     // but re-checked here as a defense in depth in case the method is called directly
     // without going through the MCP dispatch layer).
-    const allowedKeys = new Set(['transaction_id', 'category_id', 'note', 'tag_ids']);
+    const allowedKeys = new Set([
+      'transaction_id',
+      'account_id',
+      'item_id',
+      'category_id',
+      'note',
+      'tag_ids',
+    ]);
     for (const key of Object.keys(args)) {
       if (!allowedKeys.has(key)) {
         throw new Error(`update_transaction: unknown field "${key}"`);
@@ -2445,21 +2518,16 @@ export class CopilotMoneyTools {
 
     // Require at least one mutable field besides transaction_id.
     const mutableKeys = Object.keys(args).filter(
-      (k) => k !== 'transaction_id' && (args as Record<string, unknown>)[k] !== undefined
+      (k) =>
+        !['transaction_id', 'account_id', 'item_id'].includes(k) &&
+        (args as Record<string, unknown>)[k] !== undefined
     );
     if (mutableKeys.length === 0) {
       throw new Error('update_transaction requires at least one field to update');
     }
 
     validateDocId(transaction_id, 'transaction_id');
-
-    // Resolve the transaction from the local cache so we can supply accountId /
-    // itemId to the GraphQL mutation.
-    const allTxns = await this.db.getAllTransactions();
-    const txn = allTxns.find((t) => t.transaction_id === transaction_id);
-    if (!txn) {
-      throw new Error(`Transaction not found: ${transaction_id}`);
-    }
+    const txnRef = await this.resolveTransactionWriteRef(args);
 
     // Per-field validation (runs BEFORE any write for atomicity).
     if ('category_id' in args && args.category_id !== undefined) {
@@ -2494,15 +2562,11 @@ export class CopilotMoneyTools {
     if ('note' in args && args.note !== undefined) input.userNotes = args.note;
     if ('tag_ids' in args && args.tag_ids !== undefined) input.tagIds = args.tag_ids;
 
-    if (!txn.account_id || !txn.item_id) {
-      throw new Error(`Transaction ${transaction_id} missing account_id or item_id in local cache`);
-    }
-
     try {
       const result = await editTransaction(client, {
         id: transaction_id,
-        accountId: txn.account_id,
-        itemId: txn.item_id,
+        accountId: txnRef.account_id,
+        itemId: txnRef.item_id,
         input,
       });
       // Map GraphQL field names back to MCP API names in the response.
@@ -3001,39 +3065,60 @@ export class CopilotMoneyTools {
    * Validates all transaction IDs, sets isReviewed via GraphQL for each; local
    * cache is refreshed by Copilot's sync process.
    */
-  async reviewTransactions(args: { transaction_ids: string[]; reviewed?: boolean }): Promise<{
+  async reviewTransactions(args: {
+    transaction_ids?: string[];
+    transactions?: OptionalTransactionWriteRef[];
+    reviewed?: boolean;
+  }): Promise<{
     success: boolean;
     reviewed_count: number;
     transaction_ids: string[];
   }> {
     const client = this.getGraphQLClient();
 
-    const { transaction_ids, reviewed = true } = args;
+    const { transaction_ids, transactions, reviewed = true } = args;
+    const hasTransactionIds = transaction_ids !== undefined;
+    const hasTransactions = transactions !== undefined;
 
-    if (!Array.isArray(transaction_ids) || transaction_ids.length === 0) {
-      throw new Error('transaction_ids must be a non-empty array');
+    if (hasTransactionIds && hasTransactions) {
+      throw new Error('Pass either transaction_ids or transactions, not both');
+    }
+    if (!hasTransactionIds && !hasTransactions) {
+      throw new Error('review_transactions requires transaction_ids or transactions');
     }
 
-    for (const id of transaction_ids) {
-      validateDocId(id, 'transaction_id');
-    }
+    let writeRefs: TransactionWriteRef[];
 
-    const allTransactions = await this.db.getAllTransactions();
-    const txnMap = new Map(allTransactions.map((t) => [t.transaction_id, t]));
-
-    const missing = transaction_ids.filter((id) => !txnMap.has(id));
-    if (missing.length > 0) {
-      throw new Error(`Transactions not found: ${missing.join(', ')}`);
-    }
-
-    // Pre-flight: confirm every transaction has account/item ids before
-    // issuing any writes. Keeps partial-failure surface small.
-    for (const id of transaction_ids) {
-      const txn = txnMap.get(id)!;
-      if (!txn.account_id || !txn.item_id) {
-        throw new Error(`Transaction ${id} missing account_id or item_id in local cache`);
+    if (hasTransactions) {
+      if (!Array.isArray(transactions) || transactions.length === 0) {
+        throw new Error('transactions must be a non-empty array');
       }
+
+      writeRefs = transactions.map((ref) => {
+        if (!hasExplicitTransactionWriteRef(ref)) {
+          throw new Error(
+            `Transaction ${ref.transaction_id} requires transaction_id, account_id, and item_id`
+          );
+        }
+        this.validateTransactionWriteRef(ref);
+        return ref;
+      });
+    } else {
+      if (!Array.isArray(transaction_ids) || transaction_ids.length === 0) {
+        throw new Error('transaction_ids must be a non-empty array');
+      }
+      for (const id of transaction_ids) {
+        validateDocId(id, 'transaction_id');
+      }
+
+      const allTransactions = await this.db.getAllTransactions();
+      const txnMap = new Map(allTransactions.map((t) => [t.transaction_id, t]));
+      writeRefs = await Promise.all(
+        transaction_ids.map((id) => this.resolveTransactionWriteRef({ transaction_id: id }, txnMap))
+      );
     }
+
+    const resolvedTransactionIds = writeRefs.map((ref) => ref.transaction_id);
 
     // Bounded concurrency: never more than CONCURRENCY in flight at once.
     // The user explicitly asked to cap parallel writes at 5 to avoid
@@ -3057,33 +3142,32 @@ export class CopilotMoneyTools {
       while (true) {
         if (firstError) return;
         const idx = cursor++;
-        if (idx >= transaction_ids.length) return;
-        const id = transaction_ids[idx]!;
-        const txn = txnMap.get(id)!;
+        if (idx >= writeRefs.length) return;
+        const txn = writeRefs[idx]!;
         try {
           await editTransaction(client, {
-            id,
-            accountId: txn.account_id!,
-            itemId: txn.item_id!,
+            id: txn.transaction_id,
+            accountId: txn.account_id,
+            itemId: txn.item_id,
             input: { isReviewed: reviewed },
           });
           reviewed_count++;
         } catch (e) {
           // Record the first failure only; other in-flight workers settle.
-          if (!firstError) firstError = { id, error: e };
+          if (!firstError) firstError = { id: txn.transaction_id, error: e };
           return;
         }
       }
     };
 
-    const workerCount = Math.min(CONCURRENCY, transaction_ids.length);
+    const workerCount = Math.min(CONCURRENCY, writeRefs.length);
     await Promise.all(Array.from({ length: workerCount }, () => worker()));
 
     if (firstError) {
       const { id, error } = firstError;
       if (error instanceof GraphQLError) {
         throw new Error(
-          `review_transactions failed at id=${id} (${reviewed_count}/${transaction_ids.length} succeeded): ${graphQLErrorToMcpError(error)}`,
+          `review_transactions failed at id=${id} (${reviewed_count}/${writeRefs.length} succeeded): ${graphQLErrorToMcpError(error)}`,
           { cause: error }
         );
       }
@@ -3093,7 +3177,7 @@ export class CopilotMoneyTools {
     // Optimistic cache patch — only for ids that successfully completed.
     // A partial-failure throw above would have bypassed this, so here we
     // patch every id in the batch.
-    for (const id of transaction_ids) {
+    for (const id of resolvedTransactionIds) {
       this.db.patchCachedTransaction(id, { user_reviewed: reviewed });
       this.liveDb?.patchLiveTransaction(id, { user_reviewed: reviewed });
     }
@@ -3101,7 +3185,7 @@ export class CopilotMoneyTools {
     return {
       success: true,
       reviewed_count,
-      transaction_ids,
+      transaction_ids: resolvedTransactionIds,
     };
   }
 
@@ -4573,6 +4657,8 @@ export function createWriteToolSchemas(): ToolSchema[] {
       description:
         "Update a single transaction's category, note, or tags. Pass transaction_id plus " +
         'any combination of category_id, note, or tag_ids — only specified fields are changed. ' +
+        'When updating a row returned by get_transactions_live that may not exist in the local ' +
+        'cache, also pass account_id and item_id. ' +
         'Pass note="" to clear the note. Pass tag_ids=[] to clear all tags. At least one mutable ' +
         'field must be provided besides transaction_id. Other fields (name, excluded, ' +
         'internal_transfer, goal_id) are not writable through the GraphQL API and were removed ' +
@@ -4584,6 +4670,16 @@ export function createWriteToolSchemas(): ToolSchema[] {
           transaction_id: {
             type: 'string',
             description: 'Transaction ID to update (from get_transactions results)',
+          },
+          account_id: {
+            type: 'string',
+            description:
+              'Account ID for this transaction. Optional for local-cache transactions; required with item_id for live-read transactions from get_transactions_live.',
+          },
+          item_id: {
+            type: 'string',
+            description:
+              'Item ID for this transaction. Optional for local-cache transactions; required with account_id for live-read transactions from get_transactions_live.',
           },
           category_id: {
             type: 'string',
@@ -4611,24 +4707,51 @@ export function createWriteToolSchemas(): ToolSchema[] {
       name: 'review_transactions',
       description:
         'Mark one or more transactions as reviewed (or unreviewed). ' +
-        'Accepts an array of transaction_ids. Writes are issued via GraphQL in parallel with ' +
+        'Accepts either legacy transaction_ids, resolved through the local cache, or a ' +
+        'transactions array with transaction_id, account_id, and item_id from get_transactions_live. ' +
+        'Writes are issued via GraphQL in parallel with ' +
         'a cap of 5 in flight at a time. On the first GraphQL error, new writes stop, in-flight ' +
         'writes settle, and the error is thrown with a `reviewed_count` reflecting how many ' +
         'succeeded before the failure (partial success is possible).',
       inputSchema: {
         type: 'object',
+        additionalProperties: false,
         properties: {
           transaction_ids: {
             type: 'array',
             items: { type: 'string' },
-            description: 'Transaction IDs to mark as reviewed',
+            description:
+              'Transaction IDs to mark as reviewed. Use only for transactions present in the local cache.',
+          },
+          transactions: {
+            type: 'array',
+            description:
+              'Full transaction references to mark as reviewed. Use this for transactions returned by get_transactions_live.',
+            items: {
+              type: 'object',
+              additionalProperties: false,
+              properties: {
+                transaction_id: {
+                  type: 'string',
+                  description: 'Transaction ID from get_transactions_live.',
+                },
+                account_id: {
+                  type: 'string',
+                  description: 'Account ID from get_transactions_live.',
+                },
+                item_id: {
+                  type: 'string',
+                  description: 'Item ID from get_transactions_live.',
+                },
+              },
+              required: ['transaction_id', 'account_id', 'item_id'],
+            },
           },
           reviewed: {
             type: 'boolean',
             description: 'Set to true to mark as reviewed, false to unmark. Defaults to true.',
           },
         },
-        required: ['transaction_ids'],
       },
       annotations: {
         readOnlyHint: false,

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -15,6 +15,8 @@ import {
   addTransactionToRecurring as gqlAddTransactionToRecurring,
   splitTransaction as gqlSplitTransaction,
   type CreatedTransaction,
+  type EditTransactionChanges,
+  type EditTransactionInput,
   type TransactionType,
 } from '../core/graphql/transactions.js';
 import {
@@ -376,6 +378,44 @@ export class CopilotMoneyTools {
       throw new Error('Write tools require --write flag to be set');
     }
     return this.graphqlClient;
+  }
+
+  private assertEditTransactionApplied(
+    transactionId: string,
+    requested: EditTransactionInput,
+    changed: EditTransactionChanges
+  ): void {
+    if ('categoryId' in requested && changed.categoryId !== requested.categoryId) {
+      throw new Error(
+        `EditTransaction did not apply categoryId for ${transactionId}: requested ${requested.categoryId}, got ${changed.categoryId ?? 'null'}`
+      );
+    }
+    if ('userNotes' in requested) {
+      const requestedNotes = requested.userNotes;
+      const changedNotes = changed.userNotes;
+      const cleared = requestedNotes === '' && changedNotes === null;
+      if (!cleared && changedNotes !== requestedNotes) {
+        throw new Error(
+          `EditTransaction did not apply userNotes for ${transactionId}: requested ${JSON.stringify(requestedNotes)}, got ${JSON.stringify(changedNotes)}`
+        );
+      }
+    }
+    if ('isReviewed' in requested && changed.isReviewed !== requested.isReviewed) {
+      throw new Error(
+        `EditTransaction did not apply isReviewed for ${transactionId}: requested ${requested.isReviewed}, got ${changed.isReviewed}`
+      );
+    }
+    if ('tagIds' in requested) {
+      const requestedTags = requested.tagIds ?? [];
+      const changedTags = changed.tagIds ?? [];
+      const sameLength = requestedTags.length === changedTags.length;
+      const sameValues = requestedTags.every((id, index) => changedTags[index] === id);
+      if (!sameLength || !sameValues) {
+        throw new Error(
+          `EditTransaction did not apply tagIds for ${transactionId}: requested ${JSON.stringify(requestedTags)}, got ${JSON.stringify(changedTags)}`
+        );
+      }
+    }
   }
 
   private validateTransactionWriteRef(ref: TransactionWriteRef): void {
@@ -2569,6 +2609,7 @@ export class CopilotMoneyTools {
         itemId: txnRef.item_id,
         input,
       });
+      this.assertEditTransactionApplied(transaction_id, input, result.changed);
       // Map GraphQL field names back to MCP API names in the response.
       const graphqlToApiName: Record<string, string> = {
         categoryId: 'category_id',
@@ -3145,12 +3186,17 @@ export class CopilotMoneyTools {
         if (idx >= writeRefs.length) return;
         const txn = writeRefs[idx]!;
         try {
-          await editTransaction(client, {
+          const result = await editTransaction(client, {
             id: txn.transaction_id,
             accountId: txn.account_id,
             itemId: txn.item_id,
             input: { isReviewed: reviewed },
           });
+          this.assertEditTransactionApplied(
+            txn.transaction_id,
+            { isReviewed: reviewed },
+            result.changed
+          );
           reviewed_count++;
         } catch (e) {
           // Record the first failure only; other in-flight workers settle.

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -468,6 +468,43 @@ describe('LiveCopilotDatabase.patchLiveTransaction', () => {
     expect(rows[0]!.id).toBe('tx1');
   });
 
+  test('maps local transaction field names onto GraphQL cache rows', () => {
+    const live = mkLive();
+    const wc = live.getTransactionsWindowCache();
+    wc.ingestMonth(
+      '2024-01',
+      [
+        {
+          id: 'tx1',
+          date: '2024-01-15',
+          categoryId: 'old-cat',
+          isReviewed: false,
+          userNotes: null,
+          tags: [{ id: 'tag-old', name: 'Old Tag', colorName: 'RED1' }],
+        },
+      ],
+      Date.now()
+    );
+
+    live.patchLiveTransaction('tx1', {
+      category_id: 'new-cat',
+      user_reviewed: true,
+      user_note: 'Checked',
+      tag_ids: ['tag-old', 'tag-new'],
+    } as Record<string, unknown>);
+
+    const row = wc.entriesForMonth('2024-01')[0]!;
+    expect(row.categoryId).toBe('new-cat');
+    expect(row.isReviewed).toBe(true);
+    expect(row.userNotes).toBe('Checked');
+    expect(row.tags).toEqual([
+      { id: 'tag-old', name: 'Old Tag', colorName: 'RED1' },
+      { id: 'tag-new', name: '', colorName: '' },
+    ]);
+    expect((row as Record<string, unknown>).category_id).toBeUndefined();
+    expect((row as Record<string, unknown>).user_reviewed).toBeUndefined();
+  });
+
   test('no-op when transaction id is not cached', () => {
     const live = mkLive();
     const wc = live.getTransactionsWindowCache();

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -737,6 +737,48 @@ describe('handleCallTool — write tools', () => {
     expect(data.updated.sort()).toEqual(['category_id', 'note', 'tag_ids']);
   });
 
+  test('update_transaction accepts explicit refs for transactions outside local cache', async () => {
+    const calls: any[] = [];
+    const writeTools = new CopilotMoneyTools(
+      db,
+      createMockGraphQLClient({
+        EditTransaction: (vars: any) => {
+          calls.push(vars);
+          return {
+            editTransaction: {
+              transaction: {
+                id: vars.id,
+                categoryId: vars.input?.categoryId ?? 'c',
+                userNotes: vars.input?.userNotes ?? null,
+                isReviewed: vars.input?.isReviewed ?? false,
+                tags: (vars.input?.tagIds ?? []).map((id: string) => ({ id })),
+              },
+            },
+          };
+        },
+      })
+    );
+    writeServer._injectForTesting(db, writeTools);
+
+    const result = await writeServer.handleCallTool('update_transaction', {
+      transaction_id: 'live_only_txn',
+      account_id: 'live_acc',
+      item_id: 'live_item',
+      category_id: 'custom_cat_1',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = parseToolResult(result) as any;
+    expect(data.success).toBe(true);
+    expect(data.transaction_id).toBe('live_only_txn');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      id: 'live_only_txn',
+      accountId: 'live_acc',
+      itemId: 'live_item',
+    });
+  });
+
   test('update_transaction rejects empty patch', async () => {
     const result = await writeServer.handleCallTool('update_transaction', {
       transaction_id: 'txn1',
@@ -1041,6 +1083,71 @@ describe('handleCallTool — write tools (extended)', () => {
     const data = parseToolResult(result) as any;
     expect(data.success).toBe(true);
     expect(data.reviewed_count).toBe(1);
+  });
+
+  test('review_transactions accepts explicit refs for transactions outside local cache', async () => {
+    const calls: any[] = [];
+    const writeTools = new CopilotMoneyTools(
+      db,
+      createMockGraphQLClient({
+        EditTransaction: (vars: any) => {
+          calls.push(vars);
+          return {
+            editTransaction: {
+              transaction: {
+                id: vars.id,
+                categoryId: vars.input?.categoryId ?? 'c',
+                userNotes: vars.input?.userNotes ?? null,
+                isReviewed: vars.input?.isReviewed ?? false,
+                tags: (vars.input?.tagIds ?? []).map((id: string) => ({ id })),
+              },
+            },
+          };
+        },
+      })
+    );
+    writeServer._injectForTesting(db, writeTools);
+
+    const result = await writeServer.handleCallTool('review_transactions', {
+      transactions: [
+        {
+          transaction_id: 'live_review_txn',
+          account_id: 'live_acc',
+          item_id: 'live_item',
+        },
+      ],
+    });
+
+    expect(result.isError).toBeUndefined();
+    const data = parseToolResult(result) as any;
+    expect(data.success).toBe(true);
+    expect(data.reviewed_count).toBe(1);
+    expect(data.transaction_ids).toEqual(['live_review_txn']);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      id: 'live_review_txn',
+      accountId: 'live_acc',
+      itemId: 'live_item',
+      input: { isReviewed: true },
+    });
+  });
+
+  test('review_transactions rejects mixed legacy IDs and explicit refs', async () => {
+    const result = await writeServer.handleCallTool('review_transactions', {
+      transaction_ids: ['txn1'],
+      transactions: [
+        {
+          transaction_id: 'live_review_txn',
+          account_id: 'live_acc',
+          item_id: 'live_item',
+        },
+      ],
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.content[0] as { text: string }).text).toMatch(
+      /either transaction_ids or transactions/i
+    );
   });
 
   // -- Tag write tools --

--- a/tests/tools/review-transactions-batching.test.ts
+++ b/tests/tools/review-transactions-batching.test.ts
@@ -119,6 +119,28 @@ describe('review_transactions dispatches one EditTransaction per id', () => {
     await tools.reviewTransactions({ transaction_ids: ['a', 'b'], reviewed: false });
     expect(client._calls.every((c) => (c.variables as any).input.isReviewed === false)).toBe(true);
   });
+
+  test('throws when GraphQL returns an unchanged isReviewed value', async () => {
+    const db = makeMockDb(['txn-1']);
+    const client = createMockGraphQLClient({
+      EditTransaction: {
+        editTransaction: {
+          transaction: {
+            id: 'txn-1',
+            categoryId: 'c',
+            userNotes: null,
+            isReviewed: false,
+            tags: [],
+          },
+        },
+      },
+    });
+    const tools = new CopilotMoneyTools(db, client);
+
+    await expect(tools.reviewTransactions({ transaction_ids: ['txn-1'] })).rejects.toThrow(
+      /did not apply isReviewed/
+    );
+  });
 });
 
 describe('review_transactions respects 5-parallel concurrency cap', () => {

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -2887,7 +2887,7 @@ describe('reviewTransactions', () => {
     const client = createMockGraphQLClient({});
     tools = new CopilotMoneyTools(mockDb, client);
     await expect(tools.reviewTransactions({ transaction_ids: ['nonexistent'] })).rejects.toThrow(
-      'Transactions not found: nonexistent'
+      'Transaction not found in local cache: nonexistent'
     );
   });
 

--- a/tests/unit/update-transaction.test.ts
+++ b/tests/unit/update-transaction.test.ts
@@ -141,6 +141,28 @@ describe('updateTransaction — single-field mapping to EditTransaction', () => 
       input: { tagIds: [] },
     });
   });
+
+  test('throws when GraphQL returns an unchanged categoryId', async () => {
+    const { tools } = makeTools({
+      responses: {
+        EditTransaction: {
+          editTransaction: {
+            transaction: {
+              id: 'txn1',
+              categoryId: 'food',
+              userNotes: null,
+              isReviewed: false,
+              tags: [],
+            },
+          },
+        },
+      },
+    });
+
+    await expect(
+      tools.updateTransaction({ transaction_id: 'txn1', category_id: 'groceries' })
+    ).rejects.toThrow(/did not apply categoryId/);
+  });
 });
 
 describe('updateTransaction — multi-field atomic dispatch', () => {


### PR DESCRIPTION
## Summary
- add explicit transaction write refs so update_transaction can use account_id and item_id from get_transactions_live
- add review_transactions support for full transaction refs while preserving legacy transaction_ids
- keep legacy validation order and local-cache fallback behavior for backwards compatibility

## Root cause
Live reads can return transactions that are not present in the local decoded cache, but write tools previously required a local-cache lookup before calling the GraphQL EditTransaction mutation. That made live-readable rows unwritable even though get_transactions_live already returns transaction_id, account_id, and item_id.

## Validation
- bun run check
- bun run build