### PR TITLE
feat(tools): support name field in update_transaction

### DIFF
--- a/src/core/graphql/recurrings.ts
+++ b/src/core/graphql/recurrings.ts
@@ -45,11 +45,15 @@ export interface EditRecurringInputRule {
 }
 
 export interface EditRecurringInput {
+  name?: string;
+  categoryId?: string;
   state?: string;
   rule?: EditRecurringInputRule;
 }
 
 export interface EditRecurringChanges {
+  name?: string;
+  categoryId?: string;
   state?: string;
   rule?: EditRecurringInputRule;
 }
@@ -73,6 +77,8 @@ interface EditRecurringResponse {
   editRecurring: {
     recurring: {
       id: string;
+      name: string;
+      categoryId: string;
       state: string;
     };
   };
@@ -96,7 +102,14 @@ export async function editRecurring(
 ): Promise<{ id: string; changed: EditRecurringChanges }> {
   // Convert MCP string amounts to wire Float. Keeps MCP contract stable;
   // matches what setBudget does for its amount field.
-  const wireInput: { state?: string; rule?: EditRecurringWireRule } = {};
+  const wireInput: {
+    name?: string;
+    categoryId?: string;
+    state?: string;
+    rule?: EditRecurringWireRule;
+  } = {};
+  if ('name' in args.input) wireInput.name = args.input.name;
+  if ('categoryId' in args.input) wireInput.categoryId = args.input.categoryId;
   if ('state' in args.input) wireInput.state = args.input.state;
   if ('rule' in args.input && args.input.rule) {
     const rule = args.input.rule;
@@ -113,7 +126,10 @@ export async function editRecurring(
   }
 
   const data = await client.mutate<
-    { id: string; input: { state?: string; rule?: EditRecurringWireRule } },
+    {
+      id: string;
+      input: { name?: string; categoryId?: string; state?: string; rule?: EditRecurringWireRule };
+    },
     EditRecurringResponse
   >('EditRecurring', EDIT_RECURRING, { id: args.id, input: wireInput });
   const recurring = data.editRecurring.recurring;
@@ -124,6 +140,8 @@ export async function editRecurring(
   // non-nullable-nameContains server error). In practice tools.ts builds
   // args.input via conditional spread, so explicit-undefined shouldn't reach us.
   const changed: EditRecurringChanges = {};
+  if ('name' in args.input) changed.name = recurring.name;
+  if ('categoryId' in args.input) changed.categoryId = recurring.categoryId;
   if ('state' in args.input) changed.state = recurring.state;
   if ('rule' in args.input && args.input.rule) {
     changed.rule = { ...args.input.rule };

--- a/src/core/graphql/transactions.ts
+++ b/src/core/graphql/transactions.ts
@@ -77,6 +77,7 @@ export async function createTransaction(
 }
 
 export interface EditTransactionInput {
+  name?: string;
   categoryId?: string;
   userNotes?: string | null;
   tagIds?: string[];
@@ -94,6 +95,7 @@ interface EditTransactionResponse {
   editTransaction: {
     transaction: {
       id: string;
+      name: string;
       categoryId: string;
       userNotes: string | null;
       isReviewed: boolean;
@@ -103,6 +105,7 @@ interface EditTransactionResponse {
 }
 
 export interface EditTransactionChanges {
+  name?: string;
   categoryId?: string;
   userNotes?: string | null;
   isReviewed?: boolean;
@@ -247,6 +250,7 @@ export async function editTransaction(
   // not by value. Lets callers explicitly "change to undefined" if ever needed;
   // tools.ts builds args.input via conditional spread so explicit-undefined
   // shouldn't normally reach us.
+  if ('name' in args.input) changed.name = tx.name;
   if ('categoryId' in args.input) changed.categoryId = tx.categoryId;
   if ('userNotes' in args.input) changed.userNotes = tx.userNotes;
   if ('isReviewed' in args.input) changed.isReviewed = tx.isReviewed;

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3522,6 +3522,8 @@ export class CopilotMoneyTools {
    */
   async updateRecurring(args: {
     recurring_id: string;
+    name?: string;
+    category_id?: string;
     rule?: {
       name_contains?: string;
       min_amount?: string;
@@ -3531,6 +3533,19 @@ export class CopilotMoneyTools {
     state?: string;
   }): Promise<{ success: true; recurring_id: string; updated: string[] }> {
     const client = this.getGraphQLClient();
+    if (args.name !== undefined) {
+      const trimmed = args.name.trim();
+      if (trimmed.length === 0) {
+        throw new Error('update_recurring: name must not be empty');
+      }
+    }
+    if (args.category_id !== undefined) {
+      validateDocId(args.category_id, 'category_id');
+      const categories = await this.db.getUserCategories();
+      if (!categories.find((c) => c.category_id === args.category_id)) {
+        throw new Error(`Category not found: ${args.category_id}`);
+      }
+    }
     if (args.state !== undefined) {
       const VALID_STATES = ['ACTIVE', 'PAUSED', 'ARCHIVED'];
       if (!VALID_STATES.includes(args.state)) {
@@ -3538,6 +3553,8 @@ export class CopilotMoneyTools {
       }
     }
     const input: Record<string, unknown> = {};
+    if (args.name !== undefined) input.name = args.name.trim();
+    if (args.category_id !== undefined) input.categoryId = args.category_id;
     if (args.state !== undefined) input.state = args.state;
     if (args.rule !== undefined) {
       const rule: Record<string, unknown> = {};
@@ -3554,6 +3571,8 @@ export class CopilotMoneyTools {
     try {
       const result = await gqlEditRecurring(client, { id: args.recurring_id, input });
       const patch: Partial<Recurring> = { recurring_id: args.recurring_id };
+      if (args.name !== undefined) patch.name = args.name.trim();
+      if (args.category_id !== undefined) patch.category_id = args.category_id;
       if (args.state !== undefined) {
         patch.state = args.state.toLowerCase() as 'active' | 'paused' | 'archived';
       }
@@ -3589,6 +3608,8 @@ export class CopilotMoneyTools {
               : cached.rule;
           const merged: RecurringNode = {
             ...cached,
+            ...(args.name !== undefined ? { name: args.name.trim() } : {}),
+            ...(args.category_id !== undefined ? { categoryId: args.category_id } : {}),
             ...(args.state !== undefined ? { state: args.state } : {}),
             rule: mergedRule,
           };
@@ -4953,15 +4974,24 @@ export function createWriteToolSchemas(): ToolSchema[] {
       name: 'update_recurring',
       description:
         'Update an existing recurring transaction. Pass recurring_id plus any combination of ' +
-        'state or rule (name_contains, min_amount, max_amount, days). The recurring cannot be ' +
-        'renamed or re-linked to a different transaction through this tool — those fields must ' +
-        'be changed in the Copilot Money web app. Writes directly to Copilot Money via GraphQL.',
+        'name, category_id, state, or rule (name_contains, min_amount, max_amount, days). ' +
+        'At least one mutable field must be provided besides recurring_id. ' +
+        'Writes directly to Copilot Money via GraphQL.',
       inputSchema: {
         type: 'object' as const,
         properties: {
           recurring_id: {
             type: 'string' as const,
             description: 'ID of the recurring to update.',
+          },
+          name: {
+            type: 'string' as const,
+            description: 'New display name for the recurring series. Must not be empty.',
+          },
+          category_id: {
+            type: 'string' as const,
+            description:
+              'New category ID to assign (from get_categories results). Changes the default category for future matched transactions.',
           },
           state: {
             type: 'string' as const,

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2422,6 +2422,7 @@ export class CopilotMoneyTools {
    */
   async updateTransaction(args: {
     transaction_id: string;
+    name?: string;
     category_id?: string;
     note?: string;
     tag_ids?: string[];
@@ -2436,7 +2437,7 @@ export class CopilotMoneyTools {
     // Reject unknown fields (equivalent to JSON Schema additionalProperties: false,
     // but re-checked here as a defense in depth in case the method is called directly
     // without going through the MCP dispatch layer).
-    const allowedKeys = new Set(['transaction_id', 'category_id', 'note', 'tag_ids']);
+    const allowedKeys = new Set(['transaction_id', 'name', 'category_id', 'note', 'tag_ids']);
     for (const key of Object.keys(args)) {
       if (!allowedKeys.has(key)) {
         throw new Error(`update_transaction: unknown field "${key}"`);
@@ -2462,6 +2463,12 @@ export class CopilotMoneyTools {
     }
 
     // Per-field validation (runs BEFORE any write for atomicity).
+    if ('name' in args && args.name !== undefined) {
+      const trimmed = args.name.trim();
+      if (trimmed.length === 0) {
+        throw new Error('update_transaction: name must not be empty');
+      }
+    }
     if ('category_id' in args && args.category_id !== undefined) {
       validateDocId(args.category_id, 'category_id');
       const categories = await this.db.getUserCategories();
@@ -2484,11 +2491,13 @@ export class CopilotMoneyTools {
     }
     // Map MCP fields → EditTransaction input shape.
     const input: {
+      name?: string;
       categoryId?: string;
       userNotes?: string | null;
       tagIds?: string[];
       isReviewed?: boolean;
     } = {};
+    if ('name' in args && args.name !== undefined) input.name = args.name.trim();
     if ('category_id' in args && args.category_id !== undefined)
       input.categoryId = args.category_id;
     if ('note' in args && args.note !== undefined) input.userNotes = args.note;
@@ -2507,6 +2516,7 @@ export class CopilotMoneyTools {
       });
       // Map GraphQL field names back to MCP API names in the response.
       const graphqlToApiName: Record<string, string> = {
+        name: 'name',
         categoryId: 'category_id',
         userNotes: 'note',
         tagIds: 'tag_ids',
@@ -2517,6 +2527,7 @@ export class CopilotMoneyTools {
       // Optimistic cache patch: writes to the in-memory cache so a subsequent
       // read returns the new value without needing refresh_database + re-decode.
       const patch: Partial<Transaction> = {};
+      if ('name' in args && args.name !== undefined) patch.name = args.name.trim();
       if ('category_id' in args && args.category_id !== undefined)
         patch.category_id = args.category_id;
       if ('note' in args && args.note !== undefined) patch.user_note = args.note;
@@ -4571,10 +4582,10 @@ export function createWriteToolSchemas(): ToolSchema[] {
     {
       name: 'update_transaction',
       description:
-        "Update a single transaction's category, note, or tags. Pass transaction_id plus " +
-        'any combination of category_id, note, or tag_ids — only specified fields are changed. ' +
+        "Update a single transaction's name, category, note, or tags. Pass transaction_id plus " +
+        'any combination of name, category_id, note, or tag_ids — only specified fields are changed. ' +
         'Pass note="" to clear the note. Pass tag_ids=[] to clear all tags. At least one mutable ' +
-        'field must be provided besides transaction_id. Other fields (name, excluded, ' +
+        'field must be provided besides transaction_id. Other fields (excluded, ' +
         'internal_transfer, goal_id) are not writable through the GraphQL API and were removed ' +
         'from this tool when the backend was migrated.',
       inputSchema: {
@@ -4584,6 +4595,10 @@ export function createWriteToolSchemas(): ToolSchema[] {
           transaction_id: {
             type: 'string',
             description: 'Transaction ID to update (from get_transactions results)',
+          },
+          name: {
+            type: 'string',
+            description: 'New display name for the transaction. Must not be empty.',
           },
           category_id: {
             type: 'string',

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -745,15 +745,14 @@ describe('handleCallTool — write tools', () => {
     expect((result.content[0] as { text: string }).text).toMatch(/at least one field/i);
   });
 
-  test('update_transaction with legacy field "name" returns error', async () => {
-    // `name` is no longer writable via GraphQL EditTransaction and was removed
-    // from the MCP schema; the defense-in-depth allowedKeys check catches it.
+  test('update_transaction with name field succeeds', async () => {
     const result = await writeServer.handleCallTool('update_transaction', {
       transaction_id: 'txn1',
       name: 'rename attempt',
     });
-    expect(result.isError).toBe(true);
-    expect((result.content[0] as { text: string }).text).toMatch(/unknown field/i);
+    expect(result.isError).toBeUndefined();
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('"success": true');
   });
 
   test('update_transaction with legacy field goal_id returns error', async () => {

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -3369,7 +3369,13 @@ describe('updateRecurring', () => {
   beforeEach(() => {
     mockDb = new CopilotDatabase('/nonexistent');
     (mockDb as any).dbPath = '/fake';
-    (mockDb as any)._recurring = [{ recurring_id: 'rec-1', name: 'Netflix', state: 'ACTIVE' }];
+    (mockDb as any)._recurring = [
+      { recurring_id: 'rec-1', name: 'Netflix', state: 'ACTIVE', category_id: 'entertainment' },
+    ];
+    (mockDb as any)._userCategories = [
+      { category_id: 'entertainment', name: 'Entertainment' },
+      { category_id: 'subscriptions', name: 'Subscriptions' },
+    ];
     (mockDb as any)._allCollectionsLoaded = true;
   });
 
@@ -3391,10 +3397,90 @@ describe('updateRecurring', () => {
     expect(client._calls).toHaveLength(0);
   });
 
+  test('dispatches EditRecurring with name', async () => {
+    const client = createMockGraphQLClient({
+      EditRecurring: {
+        editRecurring: {
+          recurring: {
+            id: 'rec-1',
+            name: 'Netflix HD',
+            categoryId: 'entertainment',
+            state: 'ACTIVE',
+          },
+        },
+      },
+    });
+    tools = new CopilotMoneyTools(mockDb, client);
+
+    const result = await tools.updateRecurring({ recurring_id: 'rec-1', name: 'Netflix HD' });
+    expect(result.success).toBe(true);
+    expect(result.updated).toEqual(['name']);
+    expect(client._calls[0].variables).toEqual({
+      id: 'rec-1',
+      input: { name: 'Netflix HD' },
+    });
+  });
+
+  test('name trims whitespace', async () => {
+    const client = createMockGraphQLClient({
+      EditRecurring: {
+        editRecurring: {
+          recurring: { id: 'rec-1', name: 'Trimmed', categoryId: 'entertainment', state: 'ACTIVE' },
+        },
+      },
+    });
+    tools = new CopilotMoneyTools(mockDb, client);
+
+    await tools.updateRecurring({ recurring_id: 'rec-1', name: '  Trimmed  ' });
+    expect(client._calls[0].variables).toMatchObject({ input: { name: 'Trimmed' } });
+  });
+
+  test('empty name throws', async () => {
+    const client = createMockGraphQLClient({});
+    tools = new CopilotMoneyTools(mockDb, client);
+    await expect(tools.updateRecurring({ recurring_id: 'rec-1', name: '' })).rejects.toThrow(
+      /name must not be empty/i
+    );
+    expect(client._calls).toHaveLength(0);
+  });
+
+  test('dispatches EditRecurring with category_id', async () => {
+    const client = createMockGraphQLClient({
+      EditRecurring: {
+        editRecurring: {
+          recurring: { id: 'rec-1', name: 'Netflix', categoryId: 'subscriptions', state: 'ACTIVE' },
+        },
+      },
+    });
+    tools = new CopilotMoneyTools(mockDb, client);
+
+    const result = await tools.updateRecurring({
+      recurring_id: 'rec-1',
+      category_id: 'subscriptions',
+    });
+    expect(result.success).toBe(true);
+    expect(result.updated).toEqual(['categoryId']);
+    expect(client._calls[0].variables).toEqual({
+      id: 'rec-1',
+      input: { categoryId: 'subscriptions' },
+    });
+  });
+
+  test('non-existent category_id throws', async () => {
+    const client = createMockGraphQLClient({});
+    tools = new CopilotMoneyTools(mockDb, client);
+    await expect(
+      tools.updateRecurring({ recurring_id: 'rec-1', category_id: 'ghost' })
+    ).rejects.toThrow(/Category not found/i);
+    expect(client._calls).toHaveLength(0);
+  });
+
   test('dispatches EditRecurring with state', async () => {
     const client = createMockGraphQLClient({
       EditRecurring: {
-        editRecurring: { recurring: { id: 'rec-1', state: 'PAUSED' } },
+        editRecurring: {
+          recurring: { id: 'rec-1', name: 'Netflix', categoryId: 'entertainment', state: 'PAUSED' },
+        },
       },
     });
     tools = new CopilotMoneyTools(mockDb, client);
@@ -3421,6 +3507,8 @@ describe('updateRecurring', () => {
         editRecurring: {
           recurring: {
             id: 'rec-1',
+            name: 'Netflix',
+            categoryId: 'entertainment',
             state: 'ACTIVE',
             rule: {
               nameContains: 'NETFLIX',
@@ -3464,6 +3552,8 @@ describe('updateRecurring', () => {
         editRecurring: {
           recurring: {
             id: 'rec-1',
+            name: 'Netflix',
+            categoryId: 'entertainment',
             state: 'ARCHIVED',
             rule: { days: [5] },
           },

--- a/tests/unit/update-transaction.test.ts
+++ b/tests/unit/update-transaction.test.ts
@@ -1,8 +1,8 @@
 /**
  * Unit tests for the update_transaction tool (GraphQL-based).
  *
- * Only category_id, note, and tag_ids are supported via GraphQL's
- * EditTransaction mutation. Legacy fields (excluded, name, internal_transfer,
+ * Supported fields: name, category_id, note, and tag_ids via GraphQL's
+ * EditTransaction mutation. Legacy fields (excluded, internal_transfer,
  * goal_id) were removed from the schema when the backend was migrated to
  * GraphQL; they now hit the defense-in-depth "unknown field" check in
  * updateTransaction.
@@ -20,6 +20,7 @@ type EditTxnResponse = {
   editTransaction: {
     transaction: {
       id: string;
+      name: string;
       categoryId: string;
       userNotes: string | null;
       isReviewed: boolean;
@@ -33,6 +34,7 @@ function makeEchoResponse(): (vars: any) => EditTxnResponse {
     editTransaction: {
       transaction: {
         id: vars.id,
+        name: vars.input.name ?? 'Coffee Shop',
         categoryId: vars.input.categoryId ?? 'food',
         userNotes: vars.input.userNotes ?? null,
         isReviewed: vars.input.isReviewed ?? false,
@@ -87,6 +89,49 @@ function makeTools(overrides?: {
 }
 
 describe('updateTransaction — single-field mapping to EditTransaction', () => {
+  test('name: dispatches with name input', async () => {
+    const { tools, client } = makeTools();
+    const result = await tools.updateTransaction({
+      transaction_id: 'txn1',
+      name: 'Renamed Transaction',
+    });
+    expect(result.success).toBe(true);
+    expect(result.transaction_id).toBe('txn1');
+    expect(result.updated).toEqual(['name']);
+
+    expect(client._calls).toHaveLength(1);
+    expect(client._calls[0].variables).toEqual({
+      id: 'txn1',
+      accountId: 'acct1',
+      itemId: 'item1',
+      input: { name: 'Renamed Transaction' },
+    });
+  });
+
+  test('name: trims whitespace', async () => {
+    const { tools, client } = makeTools();
+    await tools.updateTransaction({ transaction_id: 'txn1', name: '  Padded Name  ' });
+    expect(client._calls[0].variables).toMatchObject({
+      input: { name: 'Padded Name' },
+    });
+  });
+
+  test('name: empty string throws', async () => {
+    const { tools, client } = makeTools();
+    await expect(tools.updateTransaction({ transaction_id: 'txn1', name: '' })).rejects.toThrow(
+      /name must not be empty/i
+    );
+    expect(client._calls).toHaveLength(0);
+  });
+
+  test('name: whitespace-only string throws', async () => {
+    const { tools, client } = makeTools();
+    await expect(tools.updateTransaction({ transaction_id: 'txn1', name: '   ' })).rejects.toThrow(
+      /name must not be empty/i
+    );
+    expect(client._calls).toHaveLength(0);
+  });
+
   test('category_id: dispatches with categoryId input', async () => {
     const { tools, client } = makeTools();
     const result = await tools.updateTransaction({
@@ -168,13 +213,12 @@ describe('updateTransaction — multi-field atomic dispatch', () => {
 });
 
 describe('updateTransaction — legacy-field rejection', () => {
-  test.each(['excluded', 'name', 'internal_transfer', 'goal_id'])(
+  test.each(['excluded', 'internal_transfer', 'goal_id'])(
     'rejects legacy (non-GraphQL) field: %s',
     async (field) => {
       const { tools, client } = makeTools();
       const args: Record<string, unknown> = { transaction_id: 'txn1' };
       if (field === 'excluded') args.excluded = true;
-      if (field === 'name') args.name = 'New Name';
       if (field === 'internal_transfer') args.internal_transfer = true;
       if (field === 'goal_id') args.goal_id = 'goal1';
       await expect(tools.updateTransaction(args as any)).rejects.toThrow(/unknown field/i);


### PR DESCRIPTION
## Summary

- Add `name` as a writable field on `update_transaction`, enabling programmatic transaction renaming
- Add `name` and `category_id` as writable fields on `update_recurring`, enabling programmatic renaming and category reassignment of recurring series
- Both fields discovered by probing the live Copilot Money GraphQL API — `EditTransactionInput` and `EditRecurringInput` accept these fields but they were never tested during the original hidden-mutations recon
- Empty/whitespace-only names are rejected before the write is issued; leading/trailing whitespace is trimmed
- `category_id` on recurring is validated against the local category cache before the write

## Test plan

- [x] `update_transaction` name: 4 new unit tests (dispatch, trim, empty rejection, whitespace rejection)
- [x] `update_transaction` e2e: updated from legacy-rejection to success assertion
- [x] `update_recurring` name: 3 new unit tests (dispatch, trim, empty rejection)
- [x] `update_recurring` category_id: 2 new unit tests (dispatch, non-existent rejection)
- [x] Existing recurring mock responses updated to include `name` and `categoryId`
- [x] Live API round-trip verified: renamed a transaction and a recurring via feature branch code against the production Copilot endpoint
- [x] Full suite passes (1947 pass, 0 fail)