### PR TITLE
feat(tools): support frequency field in update_recurring

### DIFF
--- a/src/core/graphql/recurrings.ts
+++ b/src/core/graphql/recurrings.ts
@@ -47,6 +47,7 @@ export interface EditRecurringInputRule {
 export interface EditRecurringInput {
   name?: string;
   categoryId?: string;
+  frequency?: string;
   state?: string;
   rule?: EditRecurringInputRule;
 }
@@ -54,6 +55,7 @@ export interface EditRecurringInput {
 export interface EditRecurringChanges {
   name?: string;
   categoryId?: string;
+  frequency?: string;
   state?: string;
   rule?: EditRecurringInputRule;
 }
@@ -79,6 +81,7 @@ interface EditRecurringResponse {
       id: string;
       name: string;
       categoryId: string;
+      frequency: string;
       state: string;
     };
   };
@@ -105,11 +108,14 @@ export async function editRecurring(
   const wireInput: {
     name?: string;
     categoryId?: string;
+    frequency?: string;
     state?: string;
     rule?: EditRecurringWireRule;
   } = {};
   if ('name' in args.input) wireInput.name = args.input.name;
   if ('categoryId' in args.input) wireInput.categoryId = args.input.categoryId;
+  // Send frequency as-is (uppercase RecurringFrequency enum) — no float conversion.
+  if ('frequency' in args.input) wireInput.frequency = args.input.frequency;
   if ('state' in args.input) wireInput.state = args.input.state;
   if ('rule' in args.input && args.input.rule) {
     const rule = args.input.rule;
@@ -128,7 +134,13 @@ export async function editRecurring(
   const data = await client.mutate<
     {
       id: string;
-      input: { name?: string; categoryId?: string; state?: string; rule?: EditRecurringWireRule };
+      input: {
+        name?: string;
+        categoryId?: string;
+        frequency?: string;
+        state?: string;
+        rule?: EditRecurringWireRule;
+      };
     },
     EditRecurringResponse
   >('EditRecurring', EDIT_RECURRING, { id: args.id, input: wireInput });
@@ -142,6 +154,7 @@ export async function editRecurring(
   const changed: EditRecurringChanges = {};
   if ('name' in args.input) changed.name = recurring.name;
   if ('categoryId' in args.input) changed.categoryId = recurring.categoryId;
+  if ('frequency' in args.input) changed.frequency = recurring.frequency;
   if ('state' in args.input) changed.state = recurring.state;
   if ('rule' in args.input && args.input.rule) {
     changed.rule = { ...args.input.rule };

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3524,6 +3524,7 @@ export class CopilotMoneyTools {
     recurring_id: string;
     name?: string;
     category_id?: string;
+    frequency?: string;
     rule?: {
       name_contains?: string;
       min_amount?: string;
@@ -3546,6 +3547,23 @@ export class CopilotMoneyTools {
         throw new Error(`Category not found: ${args.category_id}`);
       }
     }
+    if (args.frequency !== undefined) {
+      const VALID_FREQUENCIES = [
+        'WEEKLY',
+        'BIWEEKLY',
+        'MONTHLY',
+        'BIMONTHLY',
+        'QUARTERLY',
+        'QUADMONTHLY',
+        'SEMIANNUALLY',
+        'ANNUALLY',
+      ];
+      if (!VALID_FREQUENCIES.includes(args.frequency)) {
+        throw new Error(
+          `frequency must be one of: ${VALID_FREQUENCIES.join(', ')}. Got: ${args.frequency}`
+        );
+      }
+    }
     if (args.state !== undefined) {
       const VALID_STATES = ['ACTIVE', 'PAUSED', 'ARCHIVED'];
       if (!VALID_STATES.includes(args.state)) {
@@ -3555,6 +3573,7 @@ export class CopilotMoneyTools {
     const input: Record<string, unknown> = {};
     if (args.name !== undefined) input.name = args.name.trim();
     if (args.category_id !== undefined) input.categoryId = args.category_id;
+    if (args.frequency !== undefined) input.frequency = args.frequency;
     if (args.state !== undefined) input.state = args.state;
     if (args.rule !== undefined) {
       const rule: Record<string, unknown> = {};
@@ -3573,6 +3592,12 @@ export class CopilotMoneyTools {
       const patch: Partial<Recurring> = { recurring_id: args.recurring_id };
       if (args.name !== undefined) patch.name = args.name.trim();
       if (args.category_id !== undefined) patch.category_id = args.category_id;
+      if (args.frequency !== undefined) {
+        // The GraphQL enum value ANNUALLY maps to 'yearly' in the read-side cache
+        // model (KNOWN_FREQUENCIES); every other lowercased value matches directly.
+        const lowered = args.frequency.toLowerCase();
+        patch.frequency = lowered === 'annually' ? 'yearly' : lowered;
+      }
       if (args.state !== undefined) {
         patch.state = args.state.toLowerCase() as 'active' | 'paused' | 'archived';
       }
@@ -3610,6 +3635,7 @@ export class CopilotMoneyTools {
             ...cached,
             ...(args.name !== undefined ? { name: args.name.trim() } : {}),
             ...(args.category_id !== undefined ? { categoryId: args.category_id } : {}),
+            ...(args.frequency !== undefined ? { frequency: args.frequency } : {}),
             ...(args.state !== undefined ? { state: args.state } : {}),
             rule: mergedRule,
           };
@@ -4974,7 +5000,7 @@ export function createWriteToolSchemas(): ToolSchema[] {
       name: 'update_recurring',
       description:
         'Update an existing recurring transaction. Pass recurring_id plus any combination of ' +
-        'name, category_id, state, or rule (name_contains, min_amount, max_amount, days). ' +
+        'name, category_id, frequency, state, or rule (name_contains, min_amount, max_amount, days). ' +
         'At least one mutable field must be provided besides recurring_id. ' +
         'Writes directly to Copilot Money via GraphQL.',
       inputSchema: {
@@ -4992,6 +5018,24 @@ export function createWriteToolSchemas(): ToolSchema[] {
             type: 'string' as const,
             description:
               'New category ID to assign (from get_categories results). Changes the default category for future matched transactions.',
+          },
+          frequency: {
+            type: 'string' as const,
+            enum: [
+              'WEEKLY',
+              'BIWEEKLY',
+              'MONTHLY',
+              'BIMONTHLY',
+              'QUARTERLY',
+              'QUADMONTHLY',
+              'SEMIANNUALLY',
+              'ANNUALLY',
+            ] as const,
+            description:
+              'How often the recurring repeats. Maps to the Copilot frequency options: ' +
+              'WEEKLY (every week), BIWEEKLY (every 2 weeks), MONTHLY (every month), ' +
+              'BIMONTHLY (every 2 months), QUARTERLY (every 3 months), QUADMONTHLY (every 4 months), ' +
+              'SEMIANNUALLY (every 6 months), ANNUALLY (every year).',
           },
           state: {
             type: 'string' as const,

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -3475,6 +3475,40 @@ describe('updateRecurring', () => {
     expect(client._calls).toHaveLength(0);
   });
 
+  test('dispatches EditRecurring with frequency', async () => {
+    const client = createMockGraphQLClient({
+      EditRecurring: {
+        editRecurring: {
+          recurring: {
+            id: 'rec-1',
+            name: 'Netflix',
+            categoryId: 'entertainment',
+            state: 'ACTIVE',
+            frequency: 'ANNUALLY',
+          },
+        },
+      },
+    });
+    tools = new CopilotMoneyTools(mockDb, client);
+
+    const result = await tools.updateRecurring({ recurring_id: 'rec-1', frequency: 'ANNUALLY' });
+    expect(result.success).toBe(true);
+    expect(result.updated).toEqual(['frequency']);
+    expect(client._calls[0].variables).toEqual({
+      id: 'rec-1',
+      input: { frequency: 'ANNUALLY' },
+    });
+  });
+
+  test('invalid frequency throws', async () => {
+    const client = createMockGraphQLClient({});
+    tools = new CopilotMoneyTools(mockDb, client);
+    await expect(
+      tools.updateRecurring({ recurring_id: 'rec-1', frequency: 'YEARLY' })
+    ).rejects.toThrow(/frequency must be one of/i);
+    expect(client._calls).toHaveLength(0);
+  });
+
   test('dispatches EditRecurring with state', async () => {
     const client = createMockGraphQLClient({
       EditRecurring: {

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -3509,6 +3509,34 @@ describe('updateRecurring', () => {
     expect(client._calls).toHaveLength(0);
   });
 
+  test('frequency cache patch lowercases, mapping ANNUALLY to "yearly"', async () => {
+    const mockEdit = (freq: string) =>
+      createMockGraphQLClient({
+        EditRecurring: {
+          editRecurring: {
+            recurring: {
+              id: 'rec-1',
+              name: 'Netflix',
+              categoryId: 'entertainment',
+              state: 'ACTIVE',
+              frequency: freq,
+            },
+          },
+        },
+      });
+
+    // General branch: the lowercased enum matches KNOWN_FREQUENCIES directly.
+    tools = new CopilotMoneyTools(mockDb, mockEdit('MONTHLY'));
+    await tools.updateRecurring({ recurring_id: 'rec-1', frequency: 'MONTHLY' });
+    expect((mockDb as any)._recurring[0].frequency).toBe('monthly');
+
+    // Special case: ANNUALLY's lowercase ('annually') is NOT in KNOWN_FREQUENCIES,
+    // so it must be stored as 'yearly' to keep read-side cache values consistent.
+    tools = new CopilotMoneyTools(mockDb, mockEdit('ANNUALLY'));
+    await tools.updateRecurring({ recurring_id: 'rec-1', frequency: 'ANNUALLY' });
+    expect((mockDb as any)._recurring[0].frequency).toBe('yearly');
+  });
+
   test('dispatches EditRecurring with state', async () => {
     const client = createMockGraphQLClient({
       EditRecurring: {


### PR DESCRIPTION
## Summary

Adds `frequency` as a writable field on the `update_recurring` MCP tool, exposing the `RecurringFrequency` enum that `EditRecurringInput` already accepts on the server.

This is a follow-up to #414 (which added `name`/`category_id` to `update_recurring`). It came out of a **live audit of the full GraphQL write surface**: error-leak probing confirmed `EditRecurringInput.frequency` is writable, and the value set matches the Copilot web app's frequency dropdown **exactly**.

**8 accepted values** (1:1 with the app's options):

| Value | Copilot UI |
|---|---|
| `WEEKLY` | Every week |
| `BIWEEKLY` | Every 2 weeks |
| `MONTHLY` | Every month |
| `BIMONTHLY` | Every 2 months |
| `QUARTERLY` | Every 3 months |
| `QUADMONTHLY` | Every 4 months |
| `SEMIANNUALLY` | Every 6 months |
| `ANNUALLY` | Every year |

Validated against the enum before any write; sent as-is; the server-confirmed value is read back. Optimistic cache patches mirror how `state` is handled: Firestore cache lowercased (`ANNUALLY`→`yearly` to match the read-side `KNOWN_FREQUENCIES`), live cache patched with the uppercase enum as-is.

## Test plan

- [x] Unit (mirrors the #414 `name`/`category_id` tests): dispatch with `frequency` asserts wire variables + `updated: ['frequency']`; an invalid value (`YEARLY`, intentionally not in the enum) is rejected with **no write issued**.
- [x] `typecheck` 0 errors, `lint` 0 errors, full pre-push `bun run check` green (1935 pass, 0 fail).
- [x] **Live reversible round-trip** against production: flipped a real recurring `MONTHLY → ANNUALLY` (server echoed `ANNUALLY` = applied), then reverted to `MONTHLY` (confirmed). No residual change. Confirms the trickiest enum value (`ANNUALLY`) round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
