### PR TITLE
feat(tools): support tag_ids, note, recurring_id in create_transaction

### DIFF
--- a/src/core/graphql/transactions.ts
+++ b/src/core/graphql/transactions.ts
@@ -25,6 +25,9 @@ export interface CreateTransactionInput {
   amount: number;
   categoryId: string;
   type: TransactionType;
+  tagIds?: string[];
+  userNotes?: string | null;
+  recurringId?: string;
 }
 
 export interface CreateTransactionArgs {

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -15,6 +15,7 @@ import {
   addTransactionToRecurring as gqlAddTransactionToRecurring,
   splitTransaction as gqlSplitTransaction,
   type CreatedTransaction,
+  type CreateTransactionInput,
   type TransactionType,
 } from '../core/graphql/transactions.js';
 import {
@@ -2572,6 +2573,9 @@ export class CopilotMoneyTools {
     amount: number;
     category_id: string;
     type: TransactionType;
+    tag_ids?: string[];
+    note?: string;
+    recurring_id?: string;
   }): Promise<{
     success: true;
     transaction_id: string;
@@ -2609,17 +2613,40 @@ export class CopilotMoneyTools {
       throw new Error(`type must be one of: REGULAR, INCOME, INTERNAL_TRANSFER. Got: ${type}`);
     }
 
+    // Optional metadata validation (runs BEFORE any write for atomicity).
+    if (args.tag_ids !== undefined) {
+      for (const tagId of args.tag_ids) {
+        validateDocId(tagId, 'tag_id');
+      }
+      if (args.tag_ids.length > 0) {
+        const tags = await this.db.getTags();
+        for (const tagId of args.tag_ids) {
+          if (!tags.find((t) => t.tag_id === tagId)) {
+            throw new Error(`Tag not found: ${tagId}`);
+          }
+        }
+      }
+    }
+    if (args.recurring_id !== undefined) {
+      validateDocId(args.recurring_id, 'recurring_id');
+    }
+
+    const input: CreateTransactionInput = {
+      name: trimmedName,
+      date,
+      amount,
+      categoryId: category_id,
+      type,
+    };
+    if (args.tag_ids !== undefined) input.tagIds = args.tag_ids;
+    if (args.note !== undefined) input.userNotes = args.note;
+    if (args.recurring_id !== undefined) input.recurringId = args.recurring_id;
+
     try {
       const tx = await gqlCreateTransaction(client, {
         accountId: account_id,
         itemId: item_id,
-        input: {
-          name: trimmedName,
-          date,
-          amount,
-          categoryId: category_id,
-          type,
-        },
+        input,
       });
       // Map the GraphQL camelCase Transaction fields back to the project's
       // local snake_case Transaction shape. Only fields Copilot actually
@@ -4402,11 +4429,14 @@ export function createWriteToolSchemas(): ToolSchema[] {
     {
       name: 'create_transaction',
       description:
-        'Create a brand-new manual transaction on an existing account. All seven ' +
+        'Create a brand-new manual transaction on an existing account. Seven ' +
         'fields are required: account_id, item_id (from get_accounts), name, date ' +
         '(YYYY-MM-DD), amount (positive = expense, negative = income; Copilot sign ' +
         'convention), category_id (from get_categories), and type. type is one of ' +
-        'REGULAR, INCOME, or INTERNAL_TRANSFER. Returns the newly-created transaction.',
+        'REGULAR, INCOME, or INTERNAL_TRANSFER. Three optional metadata fields may ' +
+        'also be supplied: tag_ids (from get_tags), note (free-text), and ' +
+        'recurring_id (link to an existing recurring series, from ' +
+        'get_recurring_transactions). Returns the newly-created transaction.',
       inputSchema: {
         type: 'object',
         additionalProperties: false,
@@ -4442,6 +4472,20 @@ export function createWriteToolSchemas(): ToolSchema[] {
             enum: ['REGULAR', 'INCOME', 'INTERNAL_TRANSFER'],
             description:
               'Transaction type. REGULAR for typical expenses, INCOME for inflows, INTERNAL_TRANSFER for between-account moves.',
+          },
+          tag_ids: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional. Tag IDs to attach to the new transaction (from get_tags).',
+          },
+          note: {
+            type: 'string',
+            description: 'Optional. Free-text note to attach to the new transaction.',
+          },
+          recurring_id: {
+            type: 'string',
+            description:
+              'Optional. Link this new transaction to an existing recurring series (from get_recurring_transactions).',
           },
         },
         required: ['account_id', 'item_id', 'name', 'date', 'amount', 'category_id', 'type'],

--- a/tests/tools/write-tools.test.ts
+++ b/tests/tools/write-tools.test.ts
@@ -559,6 +559,18 @@ describe('createTransaction', () => {
     expect(result.transaction.user_note).toBe('reimbursable');
   });
 
+  test('create_transaction with tag_ids:[] sends empty tagIds and skips existence check', async () => {
+    // No seedTags(): an empty array must skip the getTags() existence lookup
+    // entirely (the length > 0 guard), so this passes without any seeded tags.
+    const client = createMockGraphQLClient({ CreateTransaction: echoCreate });
+    tools = new CopilotMoneyTools(mockDb, client);
+
+    const result = await tools.createTransaction({ ...validArgs, tag_ids: [] });
+
+    expect((client._calls[0].variables as any).input.tagIds).toEqual([]);
+    expect(result.transaction.tag_ids).toEqual([]);
+  });
+
   test('create_transaction with recurring_id dispatches recurringId', async () => {
     const client = createMockGraphQLClient({ CreateTransaction: echoCreate });
     tools = new CopilotMoneyTools(mockDb, client);

--- a/tests/tools/write-tools.test.ts
+++ b/tests/tools/write-tools.test.ts
@@ -511,6 +511,74 @@ describe('createTransaction', () => {
     );
     expect(client._calls).toHaveLength(0);
   });
+
+  // Echoes the create input back into a CreatedTransaction shape so the
+  // returned transaction reflects the optional metadata we sent.
+  const echoCreate = (vars: any) => ({
+    createTransaction: {
+      ...createdTx,
+      recurringId: vars.input.recurringId ?? null,
+      userNotes: vars.input.userNotes ?? null,
+      tags: (vars.input.tagIds ?? []).map((id: string) => ({
+        id,
+        name: id,
+        colorName: 'blue',
+      })),
+    },
+  });
+
+  // Tags must exist in getTags() for the tag-validation path to pass.
+  // _cacheLoadedAt keeps the in-memory cache from being treated as stale
+  // (which would otherwise clear _tags and try to hit the real DB).
+  const seedTags = () => {
+    (mockDb as any)._tags = [
+      { tag_id: 'tag1', name: 'Important' },
+      { tag_id: 'tag2', name: 'Recurring' },
+    ];
+    (mockDb as any)._cacheLoadedAt = Date.now();
+  };
+
+  test('create_transaction with tag_ids dispatches tagIds', async () => {
+    seedTags();
+    const client = createMockGraphQLClient({ CreateTransaction: echoCreate });
+    tools = new CopilotMoneyTools(mockDb, client);
+
+    const result = await tools.createTransaction({ ...validArgs, tag_ids: ['tag1', 'tag2'] });
+
+    expect((client._calls[0].variables as any).input.tagIds).toEqual(['tag1', 'tag2']);
+    expect(result.transaction.tag_ids).toEqual(['tag1', 'tag2']);
+  });
+
+  test('create_transaction with note dispatches userNotes', async () => {
+    const client = createMockGraphQLClient({ CreateTransaction: echoCreate });
+    tools = new CopilotMoneyTools(mockDb, client);
+
+    const result = await tools.createTransaction({ ...validArgs, note: 'reimbursable' });
+
+    expect((client._calls[0].variables as any).input.userNotes).toBe('reimbursable');
+    expect(result.transaction.user_note).toBe('reimbursable');
+  });
+
+  test('create_transaction with recurring_id dispatches recurringId', async () => {
+    const client = createMockGraphQLClient({ CreateTransaction: echoCreate });
+    tools = new CopilotMoneyTools(mockDb, client);
+
+    const result = await tools.createTransaction({ ...validArgs, recurring_id: 'rec1' });
+
+    expect((client._calls[0].variables as any).input.recurringId).toBe('rec1');
+    expect(result.transaction.recurring_id).toBe('rec1');
+  });
+
+  test('create_transaction rejects unknown tag_id', async () => {
+    seedTags();
+    const client = createMockGraphQLClient({ CreateTransaction: echoCreate });
+    tools = new CopilotMoneyTools(mockDb, client);
+
+    await expect(
+      tools.createTransaction({ ...validArgs, tag_ids: ['tag1', 'ghost_tag'] })
+    ).rejects.toThrow(/Tag not found.*ghost_tag/i);
+    expect(client._calls).toHaveLength(0);
+  });
 });
 
 describe('deleteTransaction', () => {


### PR DESCRIPTION
## Summary

Adds three OPTIONAL metadata fields to the `create_transaction` MCP tool — `tag_ids`, `note`, and `recurring_id` — so a manual transaction can be created fully-formed in one call instead of create-then-edit.

Found in the same live GraphQL write-surface audit as #417: `CreateTransactionInput` already accepts `tagIds`, `userNotes`, and `recurringId` (confirmed by probe), and the UI confirms all three are doable. The `CreateTransaction` operation already selects these fields back, so only the input side needed wiring.

- `tag_ids` — validated exactly like `update_transaction` (each ID format-checked, then existence-checked against `get_tags`; unknown tag → `Tag not found`, no write issued).
- `recurring_id` — ID-format validated; existence left to the server (consistent with how create handles `category_id`).
- `note` → `userNotes` (free-text, unvalidated).

All three are optional; the seven required fields are unchanged. All validation runs before the write (atomicity).

## Test plan

- [x] Unit: 4 new tests — tag_ids/note/recurring_id each dispatch the right wire field and surface on the returned transaction; an unknown tag_id is rejected with **zero create calls** issued.
- [x] Full `bun run check` green (1937 pass, 0 fail); typecheck + lint clean.
- [x] **Live create→verify→delete smoke** against production: created a real manual transaction with a tag + note + recurring link; server **applied all three** (verified on the returned transaction), then deleted it (cleanup confirmed). No residual data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
