### PR TITLE
fix(tools): correct create_recurring frequency values + dedup into RECURRING_FREQUENCIES

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "check:server-json": "bun run scripts/check-server-json.ts",
     "check:skills": "python3 scripts/check-skills.py",
     "fix": "bun run lint:fix && bun run format",
+    "smoke:recurring-frequency": "bun run scripts/smoke/recurring-frequency-conformance.ts",
     "clean": "rm -rf dist coverage .bun-build",
     "pack:mcpb": "bun run scripts/pack-mcpb.ts",
     "pack:mcpb:write": "bun run scripts/sync-manifest.ts -- --write && bun run scripts/pack-mcpb.ts -- --write",

--- a/scripts/smoke/recurring-frequency-conformance.ts
+++ b/scripts/smoke/recurring-frequency-conformance.ts
@@ -1,0 +1,125 @@
+/**
+ * Conformance smoke: assert our `RECURRING_FREQUENCIES` constant matches the
+ * server's real `RecurringFrequency` GraphQL enum (issue #419).
+ *
+ * Run: `bun run scripts/smoke/recurring-frequency-conformance.ts`
+ *      (or `bun run smoke:recurring-frequency`)
+ *
+ * NON-MUTATING. Requires an authenticated app.copilot.money browser session.
+ *
+ * How it works without touching real data:
+ *   For each candidate frequency we send a VALIDATION-ONLY probe — an
+ *   `editRecurring` mutation whose `input.state` is a malformed object
+ *   (`{z:1}` where the server expects a scalar). That malformation makes the
+ *   server reject the request during query *validation*, BEFORE any resolver
+ *   runs — so even with the fake id "x" nothing is ever mutated. The frequency
+ *   enum literal is inlined into the query string (not passed as a variable),
+ *   so the server validates the enum value at parse time and, if the value is
+ *   unknown, emits `Value "<X>" does not exist in "RecurringFrequency" enum.`.
+ *
+ *   - For each value in RECURRING_FREQUENCIES: assert the response does NOT
+ *     contain that enum error → the value is server-valid.
+ *   - As a CONTROL, probe a KNOWN-BAD value (YEARLY) and assert the server
+ *     DOES emit the enum error → proving the probe actually discriminates.
+ *
+ * Prints a PASS/FAIL summary and exits non-zero on any mismatch.
+ */
+
+import { FirebaseAuth } from '../../src/core/auth/firebase-auth.js';
+import { extractRefreshToken } from '../../src/core/auth/browser-token.js';
+import { RECURRING_FREQUENCIES } from '../../src/core/graphql/recurrings.js';
+
+const ENDPOINT = 'https://app.copilot.money/api/graphql';
+const KNOWN_BAD = 'YEARLY';
+const ENUM_ERROR_FRAGMENT = 'does not exist in "RecurringFrequency" enum';
+
+/**
+ * Send a validation-only editRecurring probe with the given frequency enum
+ * value inlined into the query. Returns the raw response text so the caller
+ * can inspect it for the enum-rejection fragment.
+ */
+async function probeFrequency(idToken: string, frequency: string): Promise<string> {
+  // Inline the enum literal so it is validated at parse time. The malformed
+  // `state: {z: 1}` guarantees validation fails before execution → no mutation.
+  const query = `mutation FrequencyProbe {
+  editRecurring(id: "x", input: { frequency: ${frequency}, state: { z: 1 } }) {
+    recurring {
+      id
+    }
+  }
+}`;
+
+  const response = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${idToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ operationName: 'FrequencyProbe', query, variables: {} }),
+  });
+
+  // Both 200 (errors array) and 400 (validation failure) carry the message
+  // body we care about; read as text and scan regardless of status.
+  return response.text();
+}
+
+function log(msg: string, fields?: Record<string, unknown>): void {
+  const prefix = `[smoke] ${msg}`;
+  if (fields) {
+    console.error(prefix, fields);
+  } else {
+    console.error(prefix);
+  }
+}
+
+async function main(): Promise<void> {
+  // Same auth path the production server and other smokes use (FirebaseAuth via
+  // extractRefreshToken from a live app.copilot.money browser session).
+  const auth = new FirebaseAuth(() => extractRefreshToken());
+  const idToken = await auth.getIdToken();
+
+  const failures: string[] = [];
+
+  // 1. Every value in our constant must be server-valid (no enum error).
+  for (const freq of RECURRING_FREQUENCIES) {
+    const body = await probeFrequency(idToken, freq);
+    const rejected = body.includes(ENUM_ERROR_FRAGMENT) && body.includes(`"${freq}"`);
+    if (rejected) {
+      failures.push(`${freq}: REJECTED by server but present in RECURRING_FREQUENCIES`);
+      log('value', { freq, serverValid: false });
+    } else {
+      log('value', { freq, serverValid: true });
+    }
+  }
+
+  // 2. Control: a known-bad value MUST be rejected, proving the probe works.
+  const controlBody = await probeFrequency(idToken, KNOWN_BAD);
+  const controlRejected =
+    controlBody.includes(ENUM_ERROR_FRAGMENT) && controlBody.includes(`"${KNOWN_BAD}"`);
+  if (!controlRejected) {
+    failures.push(
+      `control ${KNOWN_BAD}: expected server to reject it, but it was accepted — ` +
+        `the probe is not discriminating (smoke is unreliable)`
+    );
+    log('control', { freq: KNOWN_BAD, rejected: false });
+  } else {
+    log('control', { freq: KNOWN_BAD, rejected: true });
+  }
+
+  // Summary.
+  if (failures.length > 0) {
+    console.error('\n[smoke] FAIL — RECURRING_FREQUENCIES does not match the server enum:');
+    for (const f of failures) console.error(`  - ${f}`);
+    process.exit(1);
+  }
+
+  console.error(
+    `\n[smoke] PASS — all ${RECURRING_FREQUENCIES.length} values are server-valid ` +
+      `and the ${KNOWN_BAD} control was correctly rejected.`
+  );
+}
+
+main().catch((err: unknown) => {
+  console.error('[smoke] FAIL:', err);
+  process.exit(1);
+});

--- a/scripts/smoke/recurring-frequency-conformance.ts
+++ b/scripts/smoke/recurring-frequency-conformance.ts
@@ -35,8 +35,12 @@ const ENUM_ERROR_FRAGMENT = 'does not exist in "RecurringFrequency" enum';
 
 /**
  * Send a validation-only editRecurring probe with the given frequency enum
- * value inlined into the query. Returns the raw response text so the caller
- * can inspect it for the enum-rejection fragment.
+ * value inlined into the query. Returns the server's error messages joined into
+ * one string (with unescaped quotes), so the caller can scan for the
+ * enum-rejection fragment. We parse the JSON `errors[].message` rather than
+ * scanning the raw body: in the raw response the quotes in
+ * `... "RecurringFrequency" enum` are JSON-escaped (`\"`), so a literal-quote
+ * fragment would never match the raw text (a false "valid" for every value).
  */
 async function probeFrequency(idToken: string, frequency: string): Promise<string> {
   // Inline the enum literal so it is validated at parse time. The malformed
@@ -58,9 +62,16 @@ async function probeFrequency(idToken: string, frequency: string): Promise<strin
     body: JSON.stringify({ operationName: 'FrequencyProbe', query, variables: {} }),
   });
 
-  // Both 200 (errors array) and 400 (validation failure) carry the message
-  // body we care about; read as text and scan regardless of status.
-  return response.text();
+  // Both 200 (errors array) and 400 (validation failure) carry an `errors`
+  // array. Parse it and join the messages so quotes are unescaped; fall back to
+  // raw text if the body isn't JSON.
+  const text = await response.text();
+  try {
+    const json = JSON.parse(text) as { errors?: Array<{ message: string }> };
+    return (json.errors ?? []).map((e) => e.message).join(' || ');
+  } catch {
+    return text;
+  }
 }
 
 function log(msg: string, fields?: Record<string, unknown>): void {

--- a/src/core/graphql/recurrings.ts
+++ b/src/core/graphql/recurrings.ts
@@ -1,6 +1,21 @@
 import type { GraphQLClient } from './client.js';
 import { CREATE_RECURRING, EDIT_RECURRING, DELETE_RECURRING } from './operations.generated.js';
 
+/** The 8 valid Copilot `RecurringFrequency` GraphQL enum values (uppercase wire form).
+ * Verified against production (issue #419). Single source of truth for both
+ * create_recurring and update_recurring validation + schema. */
+export const RECURRING_FREQUENCIES = [
+  'WEEKLY',
+  'BIWEEKLY',
+  'MONTHLY',
+  'BIMONTHLY',
+  'QUARTERLY',
+  'QUADMONTHLY',
+  'SEMIANNUALLY',
+  'ANNUALLY',
+] as const;
+export type RecurringFrequency = (typeof RECURRING_FREQUENCIES)[number];
+
 export interface CreateRecurringInput {
   frequency: string;
   transaction: { accountId: string; itemId: string; transactionId: string };

--- a/src/core/graphql/recurrings.ts
+++ b/src/core/graphql/recurrings.ts
@@ -17,7 +17,7 @@ export const RECURRING_FREQUENCIES = [
 export type RecurringFrequency = (typeof RECURRING_FREQUENCIES)[number];
 
 export interface CreateRecurringInput {
-  frequency: string;
+  frequency: RecurringFrequency;
   transaction: { accountId: string; itemId: string; transactionId: string };
 }
 
@@ -62,7 +62,7 @@ export interface EditRecurringInputRule {
 export interface EditRecurringInput {
   name?: string;
   categoryId?: string;
-  frequency?: string;
+  frequency?: RecurringFrequency;
   state?: string;
   rule?: EditRecurringInputRule;
 }

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -35,6 +35,7 @@ import {
   createRecurring as gqlCreateRecurring,
   editRecurring as gqlEditRecurring,
   deleteRecurring as gqlDeleteRecurring,
+  RECURRING_FREQUENCIES,
 } from '../core/graphql/recurrings.js';
 import { setBudget as gqlSetBudget } from '../core/graphql/budgets.js';
 import { graphQLErrorToMcpError } from './errors.js';
@@ -3476,10 +3477,9 @@ export class CopilotMoneyTools {
     frequency: string;
   }> {
     const client = this.getGraphQLClient();
-    const VALID_FREQUENCIES = ['WEEKLY', 'BIWEEKLY', 'MONTHLY', 'YEARLY'];
-    if (!VALID_FREQUENCIES.includes(args.frequency)) {
+    if (!(RECURRING_FREQUENCIES as readonly string[]).includes(args.frequency)) {
       throw new Error(
-        `frequency must be one of: ${VALID_FREQUENCIES.join(', ')}. Got: ${args.frequency}`
+        `frequency must be one of: ${RECURRING_FREQUENCIES.join(', ')}. Got: ${args.frequency}`
       );
     }
 
@@ -3575,19 +3575,9 @@ export class CopilotMoneyTools {
       }
     }
     if (args.frequency !== undefined) {
-      const VALID_FREQUENCIES = [
-        'WEEKLY',
-        'BIWEEKLY',
-        'MONTHLY',
-        'BIMONTHLY',
-        'QUARTERLY',
-        'QUADMONTHLY',
-        'SEMIANNUALLY',
-        'ANNUALLY',
-      ];
-      if (!VALID_FREQUENCIES.includes(args.frequency)) {
+      if (!(RECURRING_FREQUENCIES as readonly string[]).includes(args.frequency)) {
         throw new Error(
-          `frequency must be one of: ${VALID_FREQUENCIES.join(', ')}. Got: ${args.frequency}`
+          `frequency must be one of: ${RECURRING_FREQUENCIES.join(', ')}. Got: ${args.frequency}`
         );
       }
     }
@@ -5027,7 +5017,7 @@ export function createWriteToolSchemas(): ToolSchema[] {
           },
           frequency: {
             type: 'string' as const,
-            enum: ['WEEKLY', 'BIWEEKLY', 'MONTHLY', 'YEARLY'] as const,
+            enum: [...RECURRING_FREQUENCIES],
             description: 'How often the recurring payment occurs.',
           },
         },
@@ -5065,16 +5055,7 @@ export function createWriteToolSchemas(): ToolSchema[] {
           },
           frequency: {
             type: 'string' as const,
-            enum: [
-              'WEEKLY',
-              'BIWEEKLY',
-              'MONTHLY',
-              'BIMONTHLY',
-              'QUARTERLY',
-              'QUADMONTHLY',
-              'SEMIANNUALLY',
-              'ANNUALLY',
-            ] as const,
+            enum: [...RECURRING_FREQUENCIES],
             description:
               'How often the recurring repeats. Maps to the Copilot frequency options: ' +
               'WEEKLY (every week), BIWEEKLY (every 2 weeks), MONTHLY (every month), ' +

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -36,6 +36,7 @@ import {
   editRecurring as gqlEditRecurring,
   deleteRecurring as gqlDeleteRecurring,
   RECURRING_FREQUENCIES,
+  type RecurringFrequency,
 } from '../core/graphql/recurrings.js';
 import { setBudget as gqlSetBudget } from '../core/graphql/budgets.js';
 import { graphQLErrorToMcpError } from './errors.js';
@@ -3477,6 +3478,8 @@ export class CopilotMoneyTools {
     frequency: string;
   }> {
     const client = this.getGraphQLClient();
+    // .includes() on the `as const` tuple needs widening to string[] to accept
+    // an arbitrary string arg (TS narrows the tuple's element type otherwise).
     if (!(RECURRING_FREQUENCIES as readonly string[]).includes(args.frequency)) {
       throw new Error(
         `frequency must be one of: ${RECURRING_FREQUENCIES.join(', ')}. Got: ${args.frequency}`
@@ -3495,7 +3498,8 @@ export class CopilotMoneyTools {
     try {
       const result = await gqlCreateRecurring(client, {
         input: {
-          frequency: args.frequency,
+          // Validated against RECURRING_FREQUENCIES above, so the widening cast is safe.
+          frequency: args.frequency as RecurringFrequency,
           transaction: {
             accountId: txn.account_id,
             itemId: txn.item_id,
@@ -3575,6 +3579,8 @@ export class CopilotMoneyTools {
       }
     }
     if (args.frequency !== undefined) {
+      // .includes() on the `as const` tuple needs widening to string[] to accept
+      // an arbitrary string arg (TS narrows the tuple's element type otherwise).
       if (!(RECURRING_FREQUENCIES as readonly string[]).includes(args.frequency)) {
         throw new Error(
           `frequency must be one of: ${RECURRING_FREQUENCIES.join(', ')}. Got: ${args.frequency}`
@@ -5018,7 +5024,11 @@ export function createWriteToolSchemas(): ToolSchema[] {
           frequency: {
             type: 'string' as const,
             enum: [...RECURRING_FREQUENCIES],
-            description: 'How often the recurring payment occurs.',
+            description:
+              'How often the recurring repeats. Maps to the Copilot frequency options: ' +
+              'WEEKLY (every week), BIWEEKLY (every 2 weeks), MONTHLY (every month), ' +
+              'BIMONTHLY (every 2 months), QUARTERLY (every 3 months), QUADMONTHLY (every 4 months), ' +
+              'SEMIANNUALLY (every 6 months), ANNUALLY (every year).',
           },
         },
         required: ['transaction_id', 'frequency'],

--- a/tests/tools/write-tools-phase3.test.ts
+++ b/tests/tools/write-tools-phase3.test.ts
@@ -139,8 +139,44 @@ describe('createRecurring', () => {
 
     await expect(
       tools.createRecurring({ transaction_id: 'txn-abc', frequency: 'daily' })
-    ).rejects.toThrow('frequency must be one of: WEEKLY, BIWEEKLY, MONTHLY, YEARLY');
+    ).rejects.toThrow('frequency must be one of:');
     expect(client._calls).toHaveLength(0);
+  });
+
+  test('rejects YEARLY locally (regression: not a valid RecurringFrequency)', async () => {
+    // YEARLY is NOT a server-valid RecurringFrequency value (issue #419). It must
+    // be rejected LOCALLY — never forwarded to fail at the server with SCHEMA_ERROR.
+    const client = createMockGraphQLClient({});
+    tools = new CopilotMoneyTools(mockDb, client);
+
+    await expect(
+      tools.createRecurring({ transaction_id: 'txn-abc', frequency: 'YEARLY' })
+    ).rejects.toThrow('frequency must be one of:');
+    expect(client._calls).toHaveLength(0);
+  });
+
+  test('accepts ANNUALLY (previously wrongly rejected)', async () => {
+    const client = createMockGraphQLClient({
+      CreateRecurring: {
+        createRecurring: {
+          id: 'rec-annual',
+          name: 'Netflix',
+          state: 'ACTIVE',
+          frequency: 'ANNUALLY',
+        },
+      },
+    });
+    tools = new CopilotMoneyTools(mockDb, client);
+
+    const result = await tools.createRecurring({
+      transaction_id: 'txn-abc',
+      frequency: 'ANNUALLY',
+    });
+
+    expect(result.frequency).toBe('ANNUALLY');
+    expect(client._calls).toHaveLength(1);
+    expect(client._calls[0].op).toBe('CreateRecurring');
+    expect((client._calls[0].variables as any).input.frequency).toBe('ANNUALLY');
   });
 
   test('throws when transaction is not found in local cache', async () => {
@@ -167,8 +203,20 @@ describe('createRecurring', () => {
     expect(client._calls).toHaveLength(0);
   });
 
-  test('accepts all valid frequencies', async () => {
-    for (const freq of ['WEEKLY', 'BIWEEKLY', 'MONTHLY', 'YEARLY']) {
+  test('accepts all 8 valid frequencies including BIMONTHLY/QUARTERLY/etc', async () => {
+    // The full server-verified set (issue #419) — includes the 5 values
+    // (BIMONTHLY, QUARTERLY, QUADMONTHLY, SEMIANNUALLY, ANNUALLY) that the
+    // old WEEKLY/BIWEEKLY/MONTHLY/YEARLY allowlist wrongly rejected.
+    for (const freq of [
+      'WEEKLY',
+      'BIWEEKLY',
+      'MONTHLY',
+      'BIMONTHLY',
+      'QUARTERLY',
+      'QUADMONTHLY',
+      'SEMIANNUALLY',
+      'ANNUALLY',
+    ]) {
       const client = createMockGraphQLClient({
         CreateRecurring: {
           createRecurring: { id: `rec-${freq}`, name: 'Netflix', state: 'ACTIVE', frequency: freq },

--- a/tests/tools/write-tools-phase3.test.ts
+++ b/tests/tools/write-tools-phase3.test.ts
@@ -7,6 +7,7 @@
 import { describe, test, expect, beforeEach } from 'bun:test';
 import { CopilotMoneyTools } from '../../src/tools/tools.js';
 import { CopilotDatabase } from '../../src/core/database.js';
+import { RECURRING_FREQUENCIES } from '../../src/core/graphql/recurrings.js';
 import { createMockGraphQLClient } from '../helpers/mock-graphql.js';
 
 describe('updateTag', () => {
@@ -207,16 +208,8 @@ describe('createRecurring', () => {
     // The full server-verified set (issue #419) — includes the 5 values
     // (BIMONTHLY, QUARTERLY, QUADMONTHLY, SEMIANNUALLY, ANNUALLY) that the
     // old WEEKLY/BIWEEKLY/MONTHLY/YEARLY allowlist wrongly rejected.
-    for (const freq of [
-      'WEEKLY',
-      'BIWEEKLY',
-      'MONTHLY',
-      'BIMONTHLY',
-      'QUARTERLY',
-      'QUADMONTHLY',
-      'SEMIANNUALLY',
-      'ANNUALLY',
-    ]) {
+    // Iterate the source of truth so a 9th value added later is covered automatically.
+    for (const freq of RECURRING_FREQUENCIES) {
       const client = createMockGraphQLClient({
         CreateRecurring: {
           createRecurring: { id: `rec-${freq}`, name: 'Netflix', state: 'ACTIVE', frequency: freq },


### PR DESCRIPTION
## Summary

Fixes #419. `create_recurring`'s frequency allowlist was wrong: it **rejected** 5 server-valid cadences (`ANNUALLY`, `BIMONTHLY`, `QUARTERLY`, `QUADMONTHLY`, `SEMIANNUALLY`) and **accepted** `YEARLY`, which the server rejects — surfacing to the user as a misleading *"Copilot's API changed… report this issue."* Confirmed live.

**This was not an upstream change** — the list was a wrong assumption baked in at the Firestore→GraphQL migration (`059739b`) and never matched the server's `RecurringFrequency` enum. The duplication is what let it hide: the same list lived in 4 places and `create_recurring`'s two copies drifted from `update_recurring`'s (which was probe-derived in #417).

### Changes
- New single source of truth: `RECURRING_FREQUENCIES` (8 server-verified values) + `RecurringFrequency` type in `src/core/graphql/recurrings.ts`.
- All **four** sites now reference it — `create_recurring` + `update_recurring`, each × {runtime guard, schema enum}. No inline frequency literal remains.
- New **permanent, non-mutating conformance smoke** (`scripts/smoke/recurring-frequency-conformance.ts`, `bun run smoke:recurring-frequency`): probes the live server and asserts our constant exactly matches the real enum, with a discriminating `YEARLY` control. This replaces the throwaway-script pattern and is the first piece of a planned smoke-coverage suite.

## Test plan
- [x] Unit: `create_recurring` now accepts `ANNUALLY` and all 8 values; **rejects `YEARLY` locally** (no GraphQL call issued — locks the regression).
- [x] Full `bun run check` green (1943 tests, 0 fail).
- [x] **Live conformance smoke run:** all 8 values server-valid; `YEARLY` control correctly rejected → PASS. (The control caught a JSON-escaping bug in the smoke's matcher during development — fixed in `84f19b4`, which is itself proof the control works.)

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
