### PR TITLE
chore(tools): complete enum dedup + document conformance controls

### DIFF
--- a/scripts/smoke/conformance-checks.ts
+++ b/scripts/smoke/conformance-checks.ts
@@ -38,6 +38,8 @@ export interface ConformanceCheck {
 
 // --- RecurringFrequency -----------------------------------------------------
 // Malformed `state: { z: 1 }` forces pre-execution validation failure.
+// Control: 'YEARLY' is the intuitive-but-wrong value — it's the exact bug from
+// issue #419 (the real enum uses 'ANNUALLY'), so it must be server-rejected.
 export const KNOWN_BAD_RECURRING_FREQUENCY = 'YEARLY';
 
 export const RECURRING_FREQUENCY_CHECK: ConformanceCheck = {
@@ -56,6 +58,8 @@ export const RECURRING_FREQUENCY_CHECK: ConformanceCheck = {
 
 // --- RecurringState ---------------------------------------------------------
 // Malformed `frequency: { z: 1 }` forces pre-execution validation failure.
+// Control: 'ACTIVATED' is a plausible-looking but non-existent state (the real
+// set is ACTIVE/PAUSED/ARCHIVED), so it must be server-rejected.
 export const KNOWN_BAD_RECURRING_STATE = 'ACTIVATED';
 
 export const RECURRING_STATE_CHECK: ConformanceCheck = {
@@ -74,8 +78,15 @@ export const RECURRING_STATE_CHECK: ConformanceCheck = {
 
 // --- TransactionType --------------------------------------------------------
 // Malformed `categoryId: { z: 1 }` forces pre-execution validation failure.
+// Control: 'EXPENSE' is a plausible-but-invalid type — the real set is
+// REGULAR/INCOME/INTERNAL_TRANSFER — so it must be server-rejected.
 export const KNOWN_BAD_TRANSACTION_TYPE = 'EXPENSE';
 
+// We probe `editTransaction` (not `createTransaction`) because the server
+// validates `type` as a `TransactionType` enum there with the fewest required
+// args, keeping the malformed-sibling setup simple. Note `EditTransactionInput`
+// in transactions.ts doesn't expose `type` as a writable field even though the
+// server accepts it — that latent capability is tracked in #415.
 export const TRANSACTION_TYPE_CHECK: ConformanceCheck = {
   enumName: 'TransactionType',
   ourValues: TRANSACTION_TYPES,

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2616,7 +2616,7 @@ export class CopilotMoneyTools {
     // .includes() on the `as const` tuple needs widening to string[] to accept
     // an arbitrary string arg (TS narrows the tuple's element type otherwise).
     if (!(TRANSACTION_TYPES as readonly string[]).includes(type)) {
-      throw new Error(`type must be one of: REGULAR, INCOME, INTERNAL_TRANSFER. Got: ${type}`);
+      throw new Error(`type must be one of: ${TRANSACTION_TYPES.join(', ')}. Got: ${type}`);
     }
 
     // Optional metadata validation (runs BEFORE any write for atomicity).


### PR DESCRIPTION
Follow-up to #422's review.

- **Completes the dedup:** `create_transaction`'s `type` error message still hardcoded `REGULAR, INCOME, INTERNAL_TRANSFER` even though the guard uses `TRANSACTION_TYPES`. Now uses the constant so the message can't drift (the rendered string is identical, so no test churn).
- **Documents the conformance controls:** added a rationale comment to each known-bad value (`YEARLY` = the #419 bug value; `ACTIVATED`/`EXPENSE` = plausible-but-invalid).
- **Documents the probe choice:** noted why `TransactionType` is probed via `editTransaction`, and that `editTransaction` accepts `type` server-side though our TS `EditTransactionInput` doesn't expose it — latent capability tracked in #415.

Pure cleanup/comments; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)