### PR TITLE
A3: Doc-sync gates — fix CLAUDE.md facts and assert tool counts against code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Copilot Money MCP Server
 
-MCP (Model Context Protocol) server that enables AI-powered queries and management of Copilot Money personal finance data. Reads come from the locally cached Firestore database (LevelDB + Protocol Buffers); writes go through Copilot's GraphQL API at `app.copilot.money/api/graphql`. 34 tools (17 read + 17 write). Read-only by default, write tools opt-in via `--write` flag.
+MCP (Model Context Protocol) server that enables AI-powered queries and management of Copilot Money personal finance data. Reads come from the locally cached Firestore database (LevelDB + Protocol Buffers); writes go through Copilot's GraphQL API at `app.copilot.money/api/graphql`. 31 base tools (14 read + 17 write); `--live-reads` swaps 6 cache reads for 13 live tools (21 read tools in live mode). Counting convention: "base" = cache-mode read tools (`createToolSchemas()`) + write tools (`createWriteToolSchemas()`); live-mode `_live` variants are counted separately. Read-only by default, write tools opt-in via `--write` flag.
 
 ## Quick Reference
 
@@ -39,7 +39,8 @@ src/
 │   ├── category.ts     # Category mappings (Plaid taxonomy)
 │   └── ...             # Other entity schemas (30+ models)
 ├── tools/
-│   └── tools.ts        # All MCP tool implementations (34 tools)
+│   ├── tools.ts        # Base tool implementations (14 read + 17 write)
+│   └── live/           # 13 GraphQL-backed live read tools (--live-reads mode)
 ├── utils/
 │   ├── date.ts         # Date period parsing (this_month, last_30_days, etc.)
 │   └── categories.ts   # Category name resolution
@@ -49,7 +50,7 @@ src/
 
 ## Key Files
 
-- **`src/tools/tools.ts`** - All 34 MCP tools (17 read + 17 write) are implemented here as async methods in the `CopilotMoneyTools` class. Read schemas in `createToolSchemas()`, write schemas in `createWriteToolSchemas()`.
+- **`src/tools/tools.ts`** - All 31 base tools (14 read + 17 write) are implemented here as async methods in the `CopilotMoneyTools` class. Read schemas in `createToolSchemas()`, write schemas in `createWriteToolSchemas()`. The 13 live-mode tools live in `src/tools/live/*.ts`.
 - **`src/core/database.ts`** - `CopilotDatabase` class with methods like `getTransactions()`, `getAccounts()`, `getIncome()`, etc.
 - **`src/core/decoder.ts`** - Binary decoder that reads LevelDB files and parses Firestore Protocol Buffers.
 - **`manifest.json`** - MCP bundle metadata for .mcpb packaging.
@@ -66,7 +67,7 @@ src/
 ### Testing
 - Bun test runner
 - Tests in `tests/` mirror `src/` structure
-- Synthetic test fixtures in `tests/fixtures/synthetic-db/`
+- Synthetic test DB is generated at runtime by `tests/helpers/test-db.ts` (no checked-in DB fixtures)
 - Run specific tests: `bun test tests/tools/tools.test.ts`
 
 ### Tool Implementation Pattern
@@ -82,7 +83,7 @@ Each MCP tool follows this pattern:
 - **Privacy First**: Default-mode reads are 100% local with zero network requests. Opt-in writes (`--write`) send authenticated GraphQL requests directly to Copilot Money's own backend at `app.copilot.money/api/graphql` via `src/core/graphql/` — no third-party services, no project-operated servers. `--write` also implies `--live-reads` (see below): once writes are authenticated, there's no privacy reason to keep reads on the stale cache, and write tools need live transaction metadata to resolve account/item IDs outside the local cache window.
 - **Scrub PII before pushing**: real financial figures (account balances, category totals, transaction amounts, account names like "AmEx Platinum" or "Doordash 401(k)") are PII. Never put them in commit messages, PR titles, PR descriptions, or source/test comments. Tests use synthetic numbers (e.g., 100, 200, 5000); narrative uses placeholders ("$X", "the user's data"). Real values belong only in gitignored local scratch (`docs/superpowers/` — already excluded via `.gitignore`; do NOT add new files under that tree to the index — pre-existing tracked files there are design docs that predate the rule and are PII-clean, but anything new stays local). Before every push to a remote branch, scan the diff and the PR body for `\$[0-9]`-style figures, bare 4-digit-or-larger integers in financial context, and bank/account names. If PII slips through to a pushed branch, force-push `--force-with-lease` the redacted version, then check the AI review bot comments with `gh pr view <num> --json comments` — they often quote the body verbatim and need editing too (the repo owner can `PATCH` bot comments via `gh api repos/<owner>/<repo>/issues/comments/<id>`).
 - **Read-Only by Default**: Write tools require `--write` flag, which also auto-enables `--live-reads`
-- **Live Reads (Opt-in, also implied by `--write`)**: `--live-reads` swaps cache-backed reads (`get_transactions`, `get_accounts`, `get_categories`, `get_budgets`, `get_recurring_transactions`) for GraphQL-backed `_live` variants (`get_recurring_transactions` → `get_recurring_live`; the others follow the `{name}_live` pattern) and adds `get_tags_live`. See `docs/graphql-live-reads.md`. Requires browser session auth.
+- **Live Reads (Opt-in, also implied by `--write`)**: `--live-reads` swaps 6 cache-backed reads (`get_transactions`, `get_accounts`, `get_categories`, `get_budgets`, `get_recurring_transactions`, `get_holdings`) for GraphQL-backed `_live` variants (`get_recurring_transactions` → `get_recurring_live`; the others follow the `{name}_live` pattern) and adds 7 net-new tools (`get_tags_live`, `get_networth_live`, `get_upcoming_recurrings_live`, `get_monthly_spend_live`, `get_balance_history_live`, `get_investment_prices_live`, `refresh_cache`) — 13 live tools total. See `docs/graphql-live-reads.md`. Requires browser session auth.
 - **Verify `--live-reads` is on (when needed)**: before any work that depends on live mode (parity audits, smoke tests, anything that must reflect current server state), confirm the running MCP host has `--live-reads` enabled. **Cheap check:** call `mcp__copilot-money__get_accounts` (or any read tool that has a `_live` variant) — if the tool list contains `get_accounts_live` and excludes `get_accounts`, `--live-reads` is on. If you see the cache-mode names, the flag is missing — add `--live-reads` to the `args` array of the `copilot-money` entry in `~/.claude.json` (or `~/Library/Application Support/Claude/claude_desktop_config.json` for Claude Desktop), then ask the user to restart the MCP host (Claude Code: `/mcp` reload, or quit + relaunch). Do NOT proceed with live-mode work assuming the flag is on without verifying.
 - **Database Location**: `~/Library/Containers/com.copilot.production/Data/Library/Application Support/firestore/__FIRAPP_DEFAULT/copilot-production-22904/main`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ bun run sync-manifest  # Verify manifest.json matches code
 #### Writes-enabled bundle (local-only)
 
 `bun run pack:mcpb:write` produces `copilot-money-mcp-write.mcpb`, a variant
-that advertises all 34 tools (17 read + 17 write) and passes `--write` to the
+that advertises all 31 base tools (14 read + 17 write) and passes `--write` to the
 CLI so write tools are unlocked. It is intended for **self-install only** and
 is **not published to Claude Desktop**; the release workflow continues to ship
 only the read-only bundle. The committed `manifest.json` is never modified —
@@ -56,7 +56,7 @@ the writes-enabled metadata is generated into a gitignored
 1. Copilot Money stores data in a local LevelDB/Firestore cache on macOS
 2. `src/core/decoder.ts` reads `.ldb` files and parses Firestore Protocol Buffers
 3. `src/core/database.ts` provides cached, filtered access to all collections
-4. `src/tools/tools.ts` implements 34 MCP tools (17 read + 17 write)
+4. `src/tools/tools.ts` implements the 31 base tools (14 read + 17 write); `src/tools/live/` adds 13 GraphQL-backed live read tools in `--live-reads` mode
 5. `src/server.ts` handles MCP protocol communication and tool routing
 6. Write tools use `src/core/graphql/` to call Copilot's GraphQL API at `app.copilot.money/api/graphql`
 
@@ -82,7 +82,8 @@ src/
 │   ├── balance-history.ts   # Balance history schema
 │   └── ...                  # Other entity schemas (tag, category, etc.)
 ├── tools/
-│   └── tools.ts             # All MCP tool implementations
+│   ├── tools.ts             # Base tool implementations (cache reads + writes)
+│   └── live/                # GraphQL-backed live read tools (--live-reads mode)
 ├── utils/
 │   ├── date.ts              # Date period parsing (this_month, last_30_days, etc.)
 │   └── categories.ts        # Category name resolution
@@ -92,7 +93,7 @@ src/
 
 ### Key Files
 
-- **`src/tools/tools.ts`** — All 34 tools as async methods in `CopilotMoneyTools`. Read tool schemas in `createToolSchemas()`, write tool schemas in `createWriteToolSchemas()`.
+- **`src/tools/tools.ts`** — All 31 base tools (14 read + 17 write) as async methods in `CopilotMoneyTools`. Read tool schemas in `createToolSchemas()`, write tool schemas in `createWriteToolSchemas()`.
 - **`src/core/database.ts`** — `CopilotDatabase` class with 5-minute cache TTL, batch loading via `decodeAllCollectionsIsolated()` (worker thread), and filtered accessors.
 - **`src/core/decoder.ts`** — Binary decoder that reads LevelDB and parses Firestore Protocol Buffers. Decodes 30+ collection paths.
 - **`src/server.ts`** — MCP server with tool routing switch. `WRITE_TOOLS` set gates write operations behind the `--write` flag.
@@ -141,7 +142,7 @@ bun test tests/tools/tools.test.ts          # Specific file
 bun test --filter "getBalanceHistory"        # Pattern match
 ```
 
-Tests mirror the `src/` structure in `tests/`. Synthetic fixtures in `tests/fixtures/synthetic-db/`.
+Tests mirror the `src/` structure in `tests/`. The synthetic test DB is generated at runtime by `tests/helpers/test-db.ts` (no checked-in DB fixtures).
 
 ### Writing Tests
 

--- a/tests/unit/doc-sync.test.ts
+++ b/tests/unit/doc-sync.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Doc-sync gates: assert that the tool counts stated in CLAUDE.md,
+ * CONTRIBUTING.md, and README.md match the code.
+ *
+ * Counting convention (documented in CLAUDE.md):
+ *   - "base" tools = cache-mode read tools (`createToolSchemas()`) plus
+ *     write tools (`createWriteToolSchemas()`).
+ *   - Live-mode tools are counted separately. `--live-reads` removes some
+ *     cache reads and adds GraphQL-backed live tools; both numbers are
+ *     derived here from `CopilotMoneyServer.handleListTools()` rather than
+ *     hardcoded, so the gate stays correct as tools are added or removed.
+ *
+ * Same pattern as tests/unit/manifest-sync.test.ts: if a doc count rots,
+ * this test fails in CI with a message pointing at the stale file.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { createToolSchemas, createWriteToolSchemas } from '../../src/tools/tools.js';
+import { CopilotMoneyServer } from '../../src/server.js';
+
+const repoRoot = join(import.meta.dir, '../..');
+const claudeMd = readFileSync(join(repoRoot, 'CLAUDE.md'), 'utf-8');
+const contributingMd = readFileSync(join(repoRoot, 'CONTRIBUTING.md'), 'utf-8');
+const readmeMd = readFileSync(join(repoRoot, 'README.md'), 'utf-8');
+
+// --- Counts derived from code (never hardcoded) ---
+
+const readCount = createToolSchemas().length;
+const writeCount = createWriteToolSchemas().length;
+const baseCount = readCount + writeCount;
+
+// Live-mode counts come from the server's own tool-list assembly so the
+// gate tracks src/server.ts (which wires in src/tools/live/*.ts) exactly.
+const cacheModeNames = new Set(
+  new CopilotMoneyServer('/nonexistent/doc-sync').handleListTools().tools.map((t) => t.name)
+);
+const liveModeNames = new CopilotMoneyServer('/nonexistent/doc-sync', undefined, false, true)
+  .handleListTools()
+  .tools.map((t) => t.name);
+
+const liveModeReadCount = liveModeNames.length;
+const survivingCacheCount = liveModeNames.filter((n) => cacheModeNames.has(n)).length;
+const liveToolCount = liveModeReadCount - survivingCacheCount;
+const swappedCacheCount = readCount - survivingCacheCount;
+
+function allMatches(content: string, regex: RegExp): RegExpExecArray[] {
+  const out: RegExpExecArray[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(content)) !== null) {
+    out.push(m);
+  }
+  return out;
+}
+
+describe('Doc-sync: tool counts match code', () => {
+  test('sanity: derived counts are coherent', () => {
+    expect(readCount).toBeGreaterThan(0);
+    expect(writeCount).toBeGreaterThan(0);
+    expect(liveToolCount).toBeGreaterThan(0);
+    expect(survivingCacheCount + liveToolCount).toBe(liveModeReadCount);
+  });
+
+  // Pinned phrase: "N base tools (R read + W write)"
+  test.each([
+    ['CLAUDE.md', claudeMd, 2],
+    ['CONTRIBUTING.md', contributingMd, 3],
+  ])('%s: every "base tools" phrase matches code counts', (file, content, minOccurrences) => {
+    const matches = allMatches(content, /(\d+) base tools \((\d+) read \+ (\d+) write\)/g);
+    expect(matches.length).toBeGreaterThanOrEqual(minOccurrences);
+    for (const m of matches) {
+      expect(
+        { file, phrase: m[0], total: Number(m[1]), read: Number(m[2]), write: Number(m[3]) },
+        `${file} says "${m[0]}" but code has ${baseCount} base tools (${readCount} read + ${writeCount} write)`
+      ).toEqual({
+        file,
+        phrase: m[0],
+        total: baseCount,
+        read: readCount,
+        write: writeCount,
+      });
+    }
+  });
+
+  // Catch reintroduced stale "(X read + Y write)" anywhere, even without
+  // the "base tools" wording.
+  test.each([
+    ['CLAUDE.md', claudeMd],
+    ['CONTRIBUTING.md', contributingMd],
+  ])('%s: every "(X read + Y write)" matches code counts', (file, content) => {
+    const matches = allMatches(content, /\((\d+) read \+ (\d+) write\)/g);
+    expect(matches.length).toBeGreaterThan(0);
+    for (const m of matches) {
+      expect(Number(m[1]), `${file}: "${m[0]}" read count != ${readCount}`).toBe(readCount);
+      expect(Number(m[2]), `${file}: "${m[0]}" write count != ${writeCount}`).toBe(writeCount);
+    }
+  });
+
+  test('CLAUDE.md: live-mode counts in the headline match code', () => {
+    const m = claudeMd.match(
+      /swaps (\d+) cache reads for (\d+) live tools \((\d+) read tools in live mode\)/
+    );
+    expect(m, 'CLAUDE.md is missing the pinned live-mode phrase').not.toBeNull();
+    expect(Number(m![1]), 'swapped cache reads').toBe(swappedCacheCount);
+    expect(Number(m![2]), 'live tool count').toBe(liveToolCount);
+    expect(Number(m![3]), 'live-mode read tool total').toBe(liveModeReadCount);
+  });
+
+  test('README.md: headline tool counts match code', () => {
+    const m = readmeMd.match(
+      /(\d+) cache-mode read tools \(or (\d+) in `--live-reads` mode: (\d+) surviving cache \+ (\d+) live\), plus up to (\d+) write tools/
+    );
+    expect(m, 'README.md is missing the pinned headline phrase').not.toBeNull();
+    expect(Number(m![1]), 'cache-mode read count').toBe(readCount);
+    expect(Number(m![2]), 'live-mode read total').toBe(liveModeReadCount);
+    expect(Number(m![3]), 'surviving cache count').toBe(survivingCacheCount);
+    expect(Number(m![4]), 'live tool count').toBe(liveToolCount);
+    expect(Number(m![5]), 'write tool count').toBe(writeCount);
+  });
+
+  test('docs do not reference the nonexistent tests/fixtures/synthetic-db path', () => {
+    expect(claudeMd).not.toInclude('fixtures/synthetic-db');
+    expect(contributingMd).not.toInclude('fixtures/synthetic-db');
+    expect(readmeMd).not.toInclude('fixtures/synthetic-db');
+  });
+});

--- a/tests/unit/doc-sync.test.ts
+++ b/tests/unit/doc-sync.test.ts
@@ -19,6 +19,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { createToolSchemas, createWriteToolSchemas } from '../../src/tools/tools.js';
 import { CopilotMoneyServer } from '../../src/server.js';
+import type { GraphQLClient } from '../../src/core/graphql/client.js';
 
 const repoRoot = join(import.meta.dir, '../..');
 const claudeMd = readFileSync(join(repoRoot, 'CLAUDE.md'), 'utf-8');
@@ -36,12 +37,28 @@ const baseCount = readCount + writeCount;
 const cacheModeNames = new Set(
   new CopilotMoneyServer('/nonexistent/doc-sync').handleListTools().tools.map((t) => t.name)
 );
-const liveModeNames = new CopilotMoneyServer('/nonexistent/doc-sync', undefined, false, true)
+// Inject a stub GraphQLClient so the live-mode constructor never touches
+// FirebaseAuth/browser-session token extraction (handleListTools() is pure
+// list assembly and must not need real auth).
+const stubGraphqlClient = {
+  query: () => Promise.reject(new Error('doc-sync gate must not issue GraphQL requests')),
+  mutate: () => Promise.reject(new Error('doc-sync gate must not issue GraphQL requests')),
+} as unknown as GraphQLClient;
+const liveModeNames = new CopilotMoneyServer(
+  '/nonexistent/doc-sync',
+  undefined,
+  false,
+  true,
+  stubGraphqlClient
+)
   .handleListTools()
   .tools.map((t) => t.name);
 
 const liveModeReadCount = liveModeNames.length;
 const survivingCacheCount = liveModeNames.filter((n) => cacheModeNames.has(n)).length;
+// All live tool schemas (cache-read replacements + net-new tools), NOT just
+// the net-new ones. E.g. 6 swapped cache reads -> 6 `_live` replacements,
+// plus the net-new live tools, all counted here.
 const liveToolCount = liveModeReadCount - survivingCacheCount;
 const swappedCacheCount = readCount - survivingCacheCount;
 
@@ -84,13 +101,15 @@ describe('Doc-sync: tool counts match code', () => {
   });
 
   // Catch reintroduced stale "(X read + Y write)" anywhere, even without
-  // the "base tools" wording.
+  // the "base tools" wording. README.md has no such phrase today
+  // (minOccurrences 0), but any future occurrence is still validated.
   test.each([
-    ['CLAUDE.md', claudeMd],
-    ['CONTRIBUTING.md', contributingMd],
-  ])('%s: every "(X read + Y write)" matches code counts', (file, content) => {
+    ['CLAUDE.md', claudeMd, 1],
+    ['CONTRIBUTING.md', contributingMd, 1],
+    ['README.md', readmeMd, 0],
+  ])('%s: every "(X read + Y write)" matches code counts', (file, content, minOccurrences) => {
     const matches = allMatches(content, /\((\d+) read \+ (\d+) write\)/g);
-    expect(matches.length).toBeGreaterThan(0);
+    expect(matches.length).toBeGreaterThanOrEqual(minOccurrences);
     for (const m of matches) {
       expect(Number(m[1]), `${file}: "${m[0]}" read count != ${readCount}`).toBe(readCount);
       expect(Number(m[2]), `${file}: "${m[0]}" write count != ${writeCount}`).toBe(writeCount);

--- a/tests/unit/manifest-sync.test.ts
+++ b/tests/unit/manifest-sync.test.ts
@@ -1,10 +1,12 @@
 /**
  * Tests to ensure manifest.json stays in sync with the published tool set.
  *
- * The published CLI runs read-only, so the manifest only lists read tools.
- * Write schemas (`createWriteToolSchemas()`) are intentionally excluded from
- * `actualSchemas` here — they still exist in the source for a future
- * GraphQL-based write path, but are not shipped.
+ * The published bundle runs read-only by default, so the committed
+ * manifest.json only lists the cache-mode read tools. Write schemas
+ * (`createWriteToolSchemas()`) are intentionally excluded from
+ * `actualSchemas` here — write tools ship behind the `--write` flag and are
+ * packaged separately via the generated `manifest.write.json`
+ * (`bun run pack:mcpb:write`; see scripts/build-write-manifest.ts).
  */
 
 import { describe, test, expect } from 'bun:test';


### PR DESCRIPTION
Closes #434 (part of Epic A #428)

## Why

CLAUDE.md is agent-facing infrastructure — a wrong fact there is amplified into every future agent session. It had drifted: it claimed "34 tools (17 read + 17 write)" while `createToolSchemas()` returns 14 read tools (31 base tools total), referenced a nonexistent `tests/fixtures/synthetic-db/` path, and `manifest-sync.test.ts` still described writes as "a future GraphQL-based write path".

## What

**Doc fixes**
- **Counting convention documented** in the CLAUDE.md headline: "base" = cache-mode read tools (`createToolSchemas()`) + write tools (`createWriteToolSchemas()`) = 31 (14 + 17); `--live-reads` swaps 6 cache reads for 13 live tools → 21 read tools in live mode. Live variants are counted separately so the numbers stay unambiguous.
- Fixed all three stale "34 tools (17 read + 17 write)" claims in CLAUDE.md and all three in CONTRIBUTING.md.
- Updated CLAUDE.md's Live Reads bullet, which had also drifted (it listed only 5 swapped reads and 1 net-new tool): now lists all 6 swapped reads + 7 net-new live tools.
- Replaced the `tests/fixtures/synthetic-db/` references (CLAUDE.md + CONTRIBUTING.md) with the real mechanism: synthetic DB generated at runtime by `tests/helpers/test-db.ts`.
- Added `src/tools/live/` to both project-structure trees, which omitted it entirely.
- Rewrote the stale `manifest-sync.test.ts` header — writes shipped long ago and are packaged via `manifest.write.json` (`pack:mcpb:write`).

**Gate**
- New `tests/unit/doc-sync.test.ts` (same pattern as `manifest-sync.test.ts`): derives read/write counts from `createToolSchemas()` / `createWriteToolSchemas()` and live-mode counts from `CopilotMoneyServer.handleListTools()` (default vs `liveReadsEnabled`), then asserts the pinned phrases in CLAUDE.md, CONTRIBUTING.md, and README.md match. No count is hardcoded in the test, so it tracks `src/server.ts`'s actual tool assembly. Also guards against any reintroduced `(X read + Y write)` drift and the dead fixtures path.
- README.md swept per spec — its counts were already correct, so it only gained gate coverage, no edits.

## Verification

- `bun run check` green (typecheck + lint + format:check + 1951 tests)
- Mutation-tested the gate: temporarily restoring the stale "34/(17 read" numbers makes 2 doc-sync tests fail with file-pointing messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)