### PR TITLE
feat(errors): C2 error taxonomy — classify GraphQL errors by content, surface raw server text

### DIFF
--- a/src/core/graphql/client.ts
+++ b/src/core/graphql/client.ts
@@ -58,18 +58,17 @@ function parseErrorBody(text: string): ParsedErrorBody | undefined {
 }
 
 /**
- * Classify a non-2xx response by CONTENT (Apollo `errors[].extensions.code`)
- * first, falling back to HTTP status. This is what attributes failures
- * correctly:
- *  - parse/validation/coercion rejections → SCHEMA_ERROR (OUR request shape
- *    or enum model doesn't match the server schema — a client-side bug)
- *  - ownership / resource errors → USER_ACTION_REQUIRED (server rejected
- *    the request for reasons the user/agent can act on)
- *  - auth → AUTH_FAILED; 5xx → SERVER_ERROR (possibly transient)
+ * Classify by Apollo `errors[].extensions.code` alone (shared by the non-2xx
+ * and 2xx-with-errors[] paths). Returns undefined when no recognizable code
+ * is present so callers can apply their own status-based fallback.
+ *
+ * Priority is intentional: auth first, then ownership/resource errors
+ * (USER_ACTION_REQUIRED) BEFORE schema codes — if a response carries both,
+ * the ownership error is the one the user/agent can act on, while the schema
+ * code on the same response is usually downstream noise. Don't reorder.
  */
-function classifyHttpError(status: number, parsed?: ParsedErrorBody): GraphQLErrorCode {
-  const codes = parsed?.extensionCodes ?? new Set<string>();
-  if (status === 401 || codes.has('UNAUTHENTICATED')) return 'AUTH_FAILED';
+function classifyExtensionCodes(codes: Set<string>): GraphQLErrorCode | undefined {
+  if (codes.has('UNAUTHENTICATED')) return 'AUTH_FAILED';
   if (codes.has('FORBIDDEN') || codes.has('NOT_FOUND')) return 'USER_ACTION_REQUIRED';
   if (
     codes.has('GRAPHQL_PARSE_FAILED') ||
@@ -81,6 +80,23 @@ function classifyHttpError(status: number, parsed?: ParsedErrorBody): GraphQLErr
   ) {
     return 'SCHEMA_ERROR';
   }
+  return undefined;
+}
+
+/**
+ * Classify a non-2xx response by CONTENT (Apollo `errors[].extensions.code`)
+ * first, falling back to HTTP status. This is what attributes failures
+ * correctly:
+ *  - parse/validation/coercion rejections → SCHEMA_ERROR (OUR request shape
+ *    or enum model doesn't match the server schema — a client-side bug)
+ *  - ownership / resource errors → USER_ACTION_REQUIRED (server rejected
+ *    the request for reasons the user/agent can act on)
+ *  - auth → AUTH_FAILED; 5xx → SERVER_ERROR (possibly transient)
+ */
+function classifyHttpError(status: number, parsed?: ParsedErrorBody): GraphQLErrorCode {
+  if (status === 401) return 'AUTH_FAILED';
+  const fromCodes = classifyExtensionCodes(parsed?.extensionCodes ?? new Set<string>());
+  if (fromCodes) return fromCodes;
   if (status >= 500) return 'SERVER_ERROR';
   // A 400 without a recognizable extension code is still a parse-time
   // rejection of our request shape.
@@ -163,10 +179,16 @@ export class GraphQLClient {
     }
 
     if (body.errors && body.errors.length > 0) {
-      // 2xx + errors[] = a resolver-level rejection (input/ownership/domain).
-      // Auth expiry can also surface here as UNAUTHENTICATED with HTTP 200.
-      const isAuth = body.errors.some((e) => e.extensions?.code === 'UNAUTHENTICATED');
-      const code: GraphQLErrorCode = isAuth ? 'AUTH_FAILED' : 'USER_ACTION_REQUIRED';
+      // 2xx + errors[] is usually a resolver-level rejection
+      // (input/ownership/domain) → USER_ACTION_REQUIRED, but extension codes
+      // still win when present: auth expiry surfaces as UNAUTHENTICATED with
+      // HTTP 200, and a spec-legal 200 + GRAPHQL_VALIDATION_FAILED is still
+      // a schema mismatch on our side.
+      const extensionCodes = new Set(
+        body.errors.map((e) => e.extensions?.code).filter((c): c is string => typeof c === 'string')
+      );
+      const code: GraphQLErrorCode =
+        classifyExtensionCodes(extensionCodes) ?? 'USER_ACTION_REQUIRED';
       const firstMessage = body.errors[0]?.message ?? 'GraphQL error (no message)';
       this.logError(operationName, code, response.status);
       throw new GraphQLError(

--- a/src/core/graphql/client.ts
+++ b/src/core/graphql/client.ts
@@ -14,8 +14,79 @@ export type GraphQLErrorCode =
   | 'AUTH_FAILED'
   | 'SCHEMA_ERROR'
   | 'USER_ACTION_REQUIRED'
+  | 'SERVER_ERROR'
   | 'NETWORK'
   | 'UNKNOWN';
+
+/** Cap on how much raw server text we embed in error messages. */
+const MAX_SERVER_TEXT = 600;
+
+function truncate(text: string): string {
+  return text.length > MAX_SERVER_TEXT ? `${text.slice(0, MAX_SERVER_TEXT)}… [truncated]` : text;
+}
+
+interface ParsedErrorBody {
+  messages: string[];
+  extensionCodes: Set<string>;
+  raw: unknown;
+}
+
+/**
+ * Parse a GraphQL error response body (`{ errors: [...] }`) if possible.
+ * Returns undefined for non-JSON bodies or bodies without an errors array.
+ */
+function parseErrorBody(text: string): ParsedErrorBody | undefined {
+  try {
+    const json = JSON.parse(text) as {
+      errors?: Array<{ message?: string; extensions?: { code?: string } }>;
+    };
+    if (!json || !Array.isArray(json.errors) || json.errors.length === 0) return undefined;
+    return {
+      messages: json.errors
+        .map((e) => e?.message)
+        .filter((m): m is string => typeof m === 'string' && m.length > 0),
+      extensionCodes: new Set(
+        json.errors
+          .map((e) => e?.extensions?.code)
+          .filter((c): c is string => typeof c === 'string')
+      ),
+      raw: json.errors,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Classify a non-2xx response by CONTENT (Apollo `errors[].extensions.code`)
+ * first, falling back to HTTP status. This is what attributes failures
+ * correctly:
+ *  - parse/validation/coercion rejections → SCHEMA_ERROR (OUR request shape
+ *    or enum model doesn't match the server schema — a client-side bug)
+ *  - ownership / resource errors → USER_ACTION_REQUIRED (server rejected
+ *    the request for reasons the user/agent can act on)
+ *  - auth → AUTH_FAILED; 5xx → SERVER_ERROR (possibly transient)
+ */
+function classifyHttpError(status: number, parsed?: ParsedErrorBody): GraphQLErrorCode {
+  const codes = parsed?.extensionCodes ?? new Set<string>();
+  if (status === 401 || codes.has('UNAUTHENTICATED')) return 'AUTH_FAILED';
+  if (codes.has('FORBIDDEN') || codes.has('NOT_FOUND')) return 'USER_ACTION_REQUIRED';
+  if (
+    codes.has('GRAPHQL_PARSE_FAILED') ||
+    codes.has('GRAPHQL_VALIDATION_FAILED') ||
+    codes.has('BAD_USER_INPUT') ||
+    codes.has('PERSISTED_QUERY_NOT_FOUND') ||
+    codes.has('PERSISTED_QUERY_NOT_SUPPORTED') ||
+    codes.has('OPERATION_RESOLUTION_FAILURE')
+  ) {
+    return 'SCHEMA_ERROR';
+  }
+  if (status >= 500) return 'SERVER_ERROR';
+  // A 400 without a recognizable extension code is still a parse-time
+  // rejection of our request shape.
+  if (status === 400) return 'SCHEMA_ERROR';
+  return 'UNKNOWN';
+}
 
 export class GraphQLError extends Error {
   constructor(
@@ -56,43 +127,28 @@ export class GraphQLClient {
       throw new GraphQLError('NETWORK', msg, operationName);
     }
 
-    // Classify HTTP-level failures BEFORE parsing body (body may not be JSON).
-    if (response.status === 401) {
-      const text = await response.text().catch(() => '');
-      this.logError(operationName, 'AUTH_FAILED', 401);
-      throw new GraphQLError(
-        'AUTH_FAILED',
-        `401 Unauthorized: ${text || 'no body'}`,
-        operationName,
-        401
-      );
-    }
-    if (response.status === 400 || response.status === 500) {
-      // Both are schema/wire-shape errors:
-      //  - 400 → GRAPHQL_VALIDATION_FAILED or BAD_USER_INPUT (our request
-      //    doesn't match the server schema — wrong types, orphan fragments).
-      //  - 500 → server couldn't process the request.
-      const text = await response.text().catch(() => '');
-      this.logError(operationName, 'SCHEMA_ERROR', response.status);
-      throw new GraphQLError(
-        'SCHEMA_ERROR',
-        `${response.status} Schema Error: ${text || 'no body'}`,
-        operationName,
-        response.status
-      );
-    }
+    // Classify HTTP-level failures by body CONTENT first, status as fallback,
+    // and always carry the server's raw error text (truncated) in the message.
     if (!response.ok) {
       const text = await response.text().catch(() => '');
-      this.logError(operationName, 'UNKNOWN', response.status);
+      const parsed = parseErrorBody(text);
+      const code = classifyHttpError(response.status, parsed);
+      const serverSaid =
+        parsed && parsed.messages.length > 0 ? parsed.messages.join(' | ') : text || 'no body';
+      this.logError(operationName, code, response.status);
       throw new GraphQLError(
-        'UNKNOWN',
-        `${response.status}: ${text || 'no body'}`,
+        code,
+        `${response.status}: ${truncate(serverSaid)}`,
         operationName,
-        response.status
+        response.status,
+        parsed?.raw
       );
     }
 
-    let body: { data?: TResponse; errors?: Array<{ message: string }> };
+    let body: {
+      data?: TResponse;
+      errors?: Array<{ message: string; extensions?: { code?: string } }>;
+    };
     try {
       body = (await response.json()) as typeof body;
     } catch (e) {
@@ -107,11 +163,15 @@ export class GraphQLClient {
     }
 
     if (body.errors && body.errors.length > 0) {
+      // 2xx + errors[] = a resolver-level rejection (input/ownership/domain).
+      // Auth expiry can also surface here as UNAUTHENTICATED with HTTP 200.
+      const isAuth = body.errors.some((e) => e.extensions?.code === 'UNAUTHENTICATED');
+      const code: GraphQLErrorCode = isAuth ? 'AUTH_FAILED' : 'USER_ACTION_REQUIRED';
       const firstMessage = body.errors[0]?.message ?? 'GraphQL error (no message)';
-      this.logError(operationName, 'USER_ACTION_REQUIRED', response.status);
+      this.logError(operationName, code, response.status);
       throw new GraphQLError(
-        'USER_ACTION_REQUIRED',
-        firstMessage,
+        code,
+        truncate(firstMessage),
         operationName,
         response.status,
         body.errors

--- a/src/tools/errors.ts
+++ b/src/tools/errors.ts
@@ -1,15 +1,30 @@
 import { GraphQLError } from '../core/graphql/client.js';
 
+/**
+ * Map a classified GraphQLError to a user-facing message with the RIGHT
+ * attribution (issue #441):
+ *  - SCHEMA_ERROR        → this tool's model of the API may be outdated
+ *  - USER_ACTION_REQUIRED → the server rejected the request (server's reason)
+ *  - NETWORK             → transient, retry
+ *
+ * Every branch surfaces the server's raw error text (already truncated by the
+ * GraphQL client) so failures are diagnosable without re-running with logging.
+ */
 export function graphQLErrorToMcpError(e: GraphQLError): string {
   switch (e.code) {
     case 'AUTH_FAILED':
-      return 'Authentication with Copilot failed. Sign in to the Copilot web app and try again.';
+      return `Authentication with Copilot failed. Sign in to the Copilot web app and try again. (server said: ${e.message})`;
     case 'SCHEMA_ERROR':
-      return "Copilot's API changed in a way this tool doesn't handle yet. Please report this issue.";
+      return (
+        "This tool's model of Copilot's API may be outdated — run `bun run smoke` " +
+        `and report this issue with the text below.\nServer said: ${e.message}`
+      );
     case 'USER_ACTION_REQUIRED':
-      return e.message;
+      return `Copilot's server rejected the request: ${e.message}`;
+    case 'SERVER_ERROR':
+      return `Copilot's server failed to process the request (HTTP ${e.httpStatus ?? 'unknown'}). This may be transient — retry. Server said: ${e.message}`;
     case 'NETWORK':
-      return `Network error contacting Copilot: ${e.message}`;
+      return `Transient network problem contacting Copilot — retry. (${e.message})`;
     case 'UNKNOWN':
     default:
       return `Copilot API request failed: ${e.message}`;

--- a/tests/core/graphql/client.test.ts
+++ b/tests/core/graphql/client.test.ts
@@ -154,6 +154,45 @@ describe('GraphQLClient', () => {
     }
   });
 
+  test('4xx with FORBIDDEN extension is USER_ACTION_REQUIRED (ownership)', async () => {
+    const body = {
+      errors: [
+        {
+          message: 'Not authorized to modify this transaction',
+          extensions: { code: 'FORBIDDEN' },
+        },
+      ],
+    };
+    mockFetch(body, 403);
+    const client = new GraphQLClient(createMockAuth());
+    try {
+      await client.mutate('EditTransaction', 'mutation EditTransaction { ok }', {});
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect((e as GraphQLError).code).toBe('USER_ACTION_REQUIRED');
+      expect((e as GraphQLError).message).toContain('Not authorized to modify this transaction');
+    }
+  });
+
+  test('2xx + GRAPHQL_VALIDATION_FAILED errors[] is SCHEMA_ERROR (not USER_ACTION_REQUIRED)', async () => {
+    mockFetch({
+      errors: [
+        {
+          message: 'Cannot query field "bogus" on type "Mutation".',
+          extensions: { code: 'GRAPHQL_VALIDATION_FAILED' },
+        },
+      ],
+    });
+    const client = new GraphQLClient(createMockAuth());
+    try {
+      await client.mutate('TestOp', 'mutation TestOp { ok }', {});
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect((e as GraphQLError).code).toBe('SCHEMA_ERROR');
+      expect((e as GraphQLError).message).toContain('Cannot query field "bogus"');
+    }
+  });
+
   test('UNAUTHENTICATED extension is AUTH_FAILED regardless of HTTP status', async () => {
     const body = {
       errors: [{ message: 'Token expired', extensions: { code: 'UNAUTHENTICATED' } }],

--- a/tests/core/graphql/client.test.ts
+++ b/tests/core/graphql/client.test.ts
@@ -81,15 +81,116 @@ describe('GraphQLClient', () => {
     }
   });
 
-  test.each([400, 500])('classifies HTTP %i as SCHEMA_ERROR', async (status) => {
-    mockFetch('Schema/validation error body', status);
+  test('classifies bare 400 (no recognizable body) as SCHEMA_ERROR with raw text', async () => {
+    mockFetch('Schema/validation error body', 400);
     const client = new GraphQLClient(createMockAuth());
     try {
       await client.mutate('TestOp', 'mutation TestOp { ok }', {});
       throw new Error('should have thrown');
     } catch (e) {
       expect((e as GraphQLError).code).toBe('SCHEMA_ERROR');
-      expect((e as GraphQLError).httpStatus).toBe(status);
+      expect((e as GraphQLError).httpStatus).toBe(400);
+      expect((e as GraphQLError).message).toContain('Schema/validation error body');
+    }
+  });
+
+  test.each([500, 502, 503])(
+    'classifies HTTP %i as SERVER_ERROR (not SCHEMA_ERROR)',
+    async (status) => {
+      mockFetch('upstream blew up', status);
+      const client = new GraphQLClient(createMockAuth());
+      try {
+        await client.mutate('TestOp', 'mutation TestOp { ok }', {});
+        throw new Error('should have thrown');
+      } catch (e) {
+        expect((e as GraphQLError).code).toBe('SERVER_ERROR');
+        expect((e as GraphQLError).httpStatus).toBe(status);
+        expect((e as GraphQLError).message).toContain('upstream blew up');
+      }
+    }
+  );
+
+  test('400 with BAD_USER_INPUT (variable coercion, the #419 shape) is SCHEMA_ERROR', async () => {
+    const body = {
+      errors: [
+        {
+          message:
+            'Variable "$input" got invalid value "YEARLY" at "input.frequency"; Value "YEARLY" does not exist in "RecurringFrequency" enum.',
+          extensions: { code: 'BAD_USER_INPUT' },
+        },
+      ],
+    };
+    mockFetch(body, 400);
+    const client = new GraphQLClient(createMockAuth());
+    try {
+      await client.mutate('CreateRecurring', 'mutation CreateRecurring { ok }', {});
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect((e as GraphQLError).code).toBe('SCHEMA_ERROR');
+      // Raw server reason is surfaced, not swallowed.
+      expect((e as GraphQLError).message).toContain(
+        'Value "YEARLY" does not exist in "RecurringFrequency" enum.'
+      );
+    }
+  });
+
+  test('4xx with NOT_FOUND/FORBIDDEN extensions is USER_ACTION_REQUIRED (input/ownership)', async () => {
+    const body = {
+      errors: [
+        {
+          message: 'Recurring not found or not owned by user',
+          extensions: { code: 'NOT_FOUND' },
+        },
+      ],
+    };
+    mockFetch(body, 404);
+    const client = new GraphQLClient(createMockAuth());
+    try {
+      await client.mutate('EditRecurring', 'mutation EditRecurring { ok }', {});
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect((e as GraphQLError).code).toBe('USER_ACTION_REQUIRED');
+      expect((e as GraphQLError).message).toContain('Recurring not found');
+    }
+  });
+
+  test('UNAUTHENTICATED extension is AUTH_FAILED regardless of HTTP status', async () => {
+    const body = {
+      errors: [{ message: 'Token expired', extensions: { code: 'UNAUTHENTICATED' } }],
+    };
+    mockFetch(body, 403);
+    const client = new GraphQLClient(createMockAuth());
+    try {
+      await client.mutate('TestOp', 'mutation TestOp { ok }', {});
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect((e as GraphQLError).code).toBe('AUTH_FAILED');
+    }
+  });
+
+  test('2xx + UNAUTHENTICATED errors[] is AUTH_FAILED', async () => {
+    mockFetch({
+      errors: [{ message: 'Token expired', extensions: { code: 'UNAUTHENTICATED' } }],
+    });
+    const client = new GraphQLClient(createMockAuth());
+    try {
+      await client.mutate('TestOp', 'mutation TestOp { ok }', {});
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect((e as GraphQLError).code).toBe('AUTH_FAILED');
+    }
+  });
+
+  test('truncates oversized raw server text in the error message', async () => {
+    mockFetch('x'.repeat(5000), 502);
+    const client = new GraphQLClient(createMockAuth());
+    try {
+      await client.mutate('TestOp', 'mutation TestOp { ok }', {});
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect((e as GraphQLError).code).toBe('SERVER_ERROR');
+      expect((e as GraphQLError).message).toContain('[truncated]');
+      expect((e as GraphQLError).message.length).toBeLessThan(1000);
     }
   });
 

--- a/tests/core/graphql/client.test.ts
+++ b/tests/core/graphql/client.test.ts
@@ -134,7 +134,7 @@ describe('GraphQLClient', () => {
     }
   });
 
-  test('4xx with NOT_FOUND/FORBIDDEN extensions is USER_ACTION_REQUIRED (input/ownership)', async () => {
+  test('4xx with NOT_FOUND extension is USER_ACTION_REQUIRED (input/ownership)', async () => {
     const body = {
       errors: [
         {

--- a/tests/tools/errors.test.ts
+++ b/tests/tools/errors.test.ts
@@ -2,40 +2,82 @@ import { describe, test, expect } from 'bun:test';
 import { graphQLErrorToMcpError } from '../../src/tools/errors.js';
 import { GraphQLError } from '../../src/core/graphql/client.js';
 
+// Assertions here check attribution fragments + raw-server-text inclusion,
+// not full message strings (issue #441: codes over message fragility).
 describe('graphQLErrorToMcpError', () => {
-  test('AUTH_FAILED → sign-in prompt', () => {
-    const err = new GraphQLError('AUTH_FAILED', '401 bad token', 'EditTransaction', 401);
-    expect(graphQLErrorToMcpError(err)).toBe(
-      'Authentication with Copilot failed. Sign in to the Copilot web app and try again.'
-    );
+  test('AUTH_FAILED → sign-in prompt, includes server text', () => {
+    const err = new GraphQLError('AUTH_FAILED', '401: bad token', 'EditTransaction', 401);
+    const msg = graphQLErrorToMcpError(err);
+    expect(msg).toContain('Sign in to the Copilot web app');
+    expect(msg).toContain('401: bad token');
   });
 
-  test('SCHEMA_ERROR → report-issue message', () => {
-    const err = new GraphQLError('SCHEMA_ERROR', '500 bad schema', 'EditBudget', 500);
-    expect(graphQLErrorToMcpError(err)).toBe(
-      "Copilot's API changed in a way this tool doesn't handle yet. Please report this issue."
+  test('SCHEMA_ERROR → attributes to this tool, points at smoke, includes server text', () => {
+    const err = new GraphQLError(
+      'SCHEMA_ERROR',
+      '400: Value "YEARLY" does not exist in "RecurringFrequency" enum.',
+      'CreateRecurring',
+      400
     );
+    const msg = graphQLErrorToMcpError(err);
+    expect(msg).toContain("This tool's model of Copilot's API may be outdated");
+    expect(msg).toContain('bun run smoke');
+    expect(msg).toContain('Value "YEARLY" does not exist in "RecurringFrequency" enum.');
+    // The old blanket message blamed the server for client-side bugs (#419).
+    expect(msg).not.toContain("Copilot's API changed");
   });
 
-  test('USER_ACTION_REQUIRED → surfaces server message verbatim', () => {
+  test('USER_ACTION_REQUIRED → server-rejected attribution + server reason', () => {
     const err = new GraphQLError(
       'USER_ACTION_REQUIRED',
       'Budgeting is disabled. Enable it in Copilot settings.',
       'EditBudget',
       200
     );
-    expect(graphQLErrorToMcpError(err)).toBe(
-      'Budgeting is disabled. Enable it in Copilot settings.'
-    );
+    const msg = graphQLErrorToMcpError(err);
+    expect(msg).toContain("Copilot's server rejected the request");
+    expect(msg).toContain('Budgeting is disabled. Enable it in Copilot settings.');
   });
 
-  test('NETWORK → network prefix + details', () => {
+  test('SERVER_ERROR → transient attribution with status + server text', () => {
+    const err = new GraphQLError('SERVER_ERROR', '500: internal error', 'EditTag', 500);
+    const msg = graphQLErrorToMcpError(err);
+    expect(msg).toContain('HTTP 500');
+    expect(msg).toContain('transient');
+    expect(msg).toContain('retry');
+    expect(msg).toContain('500: internal error');
+    expect(msg).not.toContain("Copilot's API changed");
+  });
+
+  test('NETWORK → transient retry attribution + details', () => {
     const err = new GraphQLError('NETWORK', 'ECONNRESET', 'EditTag');
-    expect(graphQLErrorToMcpError(err)).toBe('Network error contacting Copilot: ECONNRESET');
+    const msg = graphQLErrorToMcpError(err);
+    expect(msg).toContain('Transient network problem');
+    expect(msg).toContain('retry');
+    expect(msg).toContain('ECONNRESET');
   });
 
   test('UNKNOWN → generic prefix + details', () => {
     const err = new GraphQLError('UNKNOWN', '418: teapot', 'EditTag', 418);
-    expect(graphQLErrorToMcpError(err)).toBe('Copilot API request failed: 418: teapot');
+    const msg = graphQLErrorToMcpError(err);
+    expect(msg).toContain('Copilot API request failed');
+    expect(msg).toContain('418: teapot');
+  });
+
+  test('no branch emits the old misleading blanket message', () => {
+    const codes = [
+      'AUTH_FAILED',
+      'SCHEMA_ERROR',
+      'USER_ACTION_REQUIRED',
+      'SERVER_ERROR',
+      'NETWORK',
+      'UNKNOWN',
+    ] as const;
+    for (const code of codes) {
+      const msg = graphQLErrorToMcpError(new GraphQLError(code, 'detail', 'Op', 200));
+      expect(msg).not.toContain("Copilot's API changed in a way this tool doesn't handle yet");
+      // Every branch surfaces the underlying error text.
+      expect(msg).toContain('detail');
+    }
   });
 });


### PR DESCRIPTION
Closes #441 — part of Epic C (#429).

## Why

#419's user-facing symptom was the blanket `SCHEMA_ERROR` message — *"Copilot's API changed in a way this tool doesn't handle yet"* — which blamed the server for a client-side bug and hid the server's actual error text. This PR attributes boundary failures correctly and makes every error path loud about what the server actually said.

## What changed

**`src/core/graphql/client.ts`**
- Non-2xx responses are now classified by body content first (Apollo `errors[].extensions.code`), HTTP status as fallback:
  - `GRAPHQL_PARSE_FAILED` / `GRAPHQL_VALIDATION_FAILED` / `BAD_USER_INPUT` / persisted-query codes → `SCHEMA_ERROR` (our model of the API is wrong)
  - `NOT_FOUND` / `FORBIDDEN` → `USER_ACTION_REQUIRED` (server rejected for actionable reasons)
  - `UNAUTHENTICATED` → `AUTH_FAILED` at **any** HTTP status, including 2xx bodies (token expiry can surface as HTTP 200 + errors[])
  - 5xx → new `SERVER_ERROR` code (possibly transient), no longer lumped into `SCHEMA_ERROR`
  - bare 400 without a recognizable extension code → still `SCHEMA_ERROR`
- Every thrown `GraphQLError` carries the server's raw error message, truncated at 600 chars, plus the parsed `errors[]` as `serverErrors`

**`src/tools/errors.ts`** — three correct attributions per the issue spec:
- `SCHEMA_ERROR` → "This tool's model of Copilot's API may be outdated — run `bun run smoke` and report with the text below"
- `USER_ACTION_REQUIRED` → "Copilot's server rejected the request: \<server reason\>"
- `SERVER_ERROR` / `NETWORK` → transient, retry
- Every branch (including `AUTH_FAILED` and `UNKNOWN`) now embeds the underlying server text

**Tests** — per-classification-branch unit tests with realistic GraphQL error payloads (including the #419 enum-coercion shape); assertions check **codes + attribution fragments** rather than full message strings, reducing the error-string fragility flagged in the audit; an explicit test verifies no path emits the old blanket message.

## Definition of done

- [x] Unit tests per classification branch using realistic GraphQL error payloads
- [x] No path emits the old misleading blanket message
- [x] `bun run check` green (1952 pass / 0 fail)

Note for C4 (retry): `SERVER_ERROR` and `NETWORK` are the retryable buckets this classification sets up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)