### PR TITLE
refactor(tools): dedup internal literal sets (granularity, transaction_type, view, price_type)

### DIFF
--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -36,7 +36,13 @@ import {
   Item,
   getTransactionDisplayName,
 } from '../models/index.js';
-import type { Security, HoldingsHistory, Tag, InvestmentSplit } from '../models/index.js';
+import type {
+  Security,
+  HoldingsHistory,
+  Tag,
+  InvestmentSplit,
+  PriceType,
+} from '../models/index.js';
 import type { BalanceHistory } from '../models/balance-history.js';
 import { getCategoryName } from '../utils/categories.js';
 
@@ -1353,7 +1359,7 @@ export class CopilotDatabase {
       tickerSymbol?: string;
       startDate?: string;
       endDate?: string;
-      priceType?: 'daily' | 'hf';
+      priceType?: PriceType;
     } = {}
   ): Promise<InvestmentPrice[]> {
     const { tickerSymbol, startDate, endDate, priceType } = options;

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -21,7 +21,11 @@ import { Recurring, RecurringSchema } from '../models/recurring.js';
 import { Budget, BudgetSchema } from '../models/budget.js';
 import { Goal, GoalSchema } from '../models/goal.js';
 import { GoalHistory, GoalHistorySchema, DailySnapshot } from '../models/goal-history.js';
-import { InvestmentPrice, InvestmentPriceSchema } from '../models/investment-price.js';
+import {
+  InvestmentPrice,
+  InvestmentPriceSchema,
+  type PriceType,
+} from '../models/investment-price.js';
 import {
   InvestmentSplit,
   InvestmentSplitSchema,
@@ -448,7 +452,7 @@ export async function decodeInvestmentPrices(
     tickerSymbol?: string;
     startDate?: string;
     endDate?: string;
-    priceType?: 'daily' | 'hf';
+    priceType?: PriceType;
   } = {}
 ): Promise<InvestmentPrice[]> {
   const { tickerSymbol, startDate, endDate, priceType } = options;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -60,6 +60,8 @@ export {
 export {
   InvestmentPriceSchema,
   type InvestmentPrice,
+  PRICE_TYPES,
+  type PriceType,
   getBestPrice,
   getPriceDate,
   isHighFrequencyPrice,

--- a/src/models/investment-price.ts
+++ b/src/models/investment-price.ts
@@ -12,6 +12,15 @@
 import { z } from 'zod';
 
 /**
+ * The two investment-price subcollections in the Firestore cache.
+ * Single source of truth for the `price_type` filter accepted by the decoder,
+ * `CopilotDatabase.getInvestmentPrices`, and the `get_investment_prices` tool
+ * (param type + schema enum).
+ */
+export const PRICE_TYPES = ['daily', 'hf'] as const;
+export type PriceType = (typeof PRICE_TYPES)[number];
+
+/**
  * Date format regex for YYYY-MM-DD validation.
  */
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;

--- a/src/models/investment-price.ts
+++ b/src/models/investment-price.ts
@@ -62,7 +62,7 @@ export const InvestmentPriceSchema = z
     // Metadata
     currency: z.string().optional(), // "USD", etc.
     source: z.string().optional(), // Data source identifier
-    price_type: z.string().optional(), // "daily" or "hf"
+    price_type: z.enum(PRICE_TYPES).optional(), // always decoder-assigned from the subcollection path
 
     // Nested price payload. For daily docs this is keyed by day-of-month (`01`–`31`);
     // for hf docs it's keyed by intraday timestamp. Values carry the numeric price

--- a/src/tools/live/transactions.ts
+++ b/src/tools/live/transactions.ts
@@ -16,11 +16,22 @@ import type {
 } from '../../core/graphql/queries/transactions.js';
 import { fetchCategories } from '../../core/graphql/queries/categories.js';
 import { fetchTags } from '../../core/graphql/queries/tags.js';
-import type { ToolSchema } from '../tools.js';
+import type { ToolSchema, TransactionTypeFilter } from '../tools.js';
 import { normalizeMerchantName } from '../tools.js';
 import { parsePeriod } from '../../utils/date.js';
 
-export type LiveTransactionType = 'refunds' | 'credits' | 'hsa_eligible' | 'tagged';
+/**
+ * Subset of `TRANSACTION_TYPE_FILTERS` supported in live mode (`foreign` and
+ * `duplicates` are cache-only). The `satisfies` clause guarantees at compile
+ * time that every entry is a valid cache-mode filter value.
+ */
+export const LIVE_TRANSACTION_TYPES = [
+  'refunds',
+  'credits',
+  'hsa_eligible',
+  'tagged',
+] as const satisfies readonly TransactionTypeFilter[];
+export type LiveTransactionType = (typeof LIVE_TRANSACTION_TYPES)[number];
 
 export interface GetTransactionsLiveOptions {
   period?: string;
@@ -330,8 +341,7 @@ export class LiveTransactionsTools {
 
   private validate(opts: GetTransactionsLiveOptions): void {
     const o = opts as Record<string, unknown>;
-    const supported =
-      'start_date, end_date, period, account_id (+ item_id), category, merchant, query, tag, min_amount, max_amount, limit, offset, pending, exclude_transfers, exclude_deleted, exclude_excluded, transaction_type (refunds|credits|hsa_eligible|tagged), transaction_id (+ account_id + item_id)';
+    const supported = `start_date, end_date, period, account_id (+ item_id), category, merchant, query, tag, min_amount, max_amount, limit, offset, pending, exclude_transfers, exclude_deleted, exclude_excluded, transaction_type (${LIVE_TRANSACTION_TYPES.join('|')}), transaction_id (+ account_id + item_id)`;
 
     for (const key of UNSUPPORTED_KEYS) {
       if (o[key] !== undefined) {
@@ -343,10 +353,10 @@ export class LiveTransactionsTools {
 
     if (
       opts.transaction_type !== undefined &&
-      !['refunds', 'credits', 'hsa_eligible', 'tagged'].includes(opts.transaction_type)
+      !(LIVE_TRANSACTION_TYPES as readonly string[]).includes(opts.transaction_type)
     ) {
       throw new Error(
-        `Parameter 'transaction_type=${opts.transaction_type}' is not supported in live mode. Retry with one of: refunds, credits, hsa_eligible, tagged.`
+        `Parameter 'transaction_type=${opts.transaction_type}' is not supported in live mode. Retry with one of: ${LIVE_TRANSACTION_TYPES.join(', ')}.`
       );
     }
 
@@ -481,7 +491,7 @@ export function createLiveToolSchemas(): ToolSchema[] {
           },
           transaction_type: {
             type: 'string',
-            enum: ['refunds', 'credits', 'hsa_eligible', 'tagged'],
+            enum: [...LIVE_TRANSACTION_TYPES],
             description:
               'Filter by special type. Note: foreign and duplicates are NOT supported in live mode.',
           },

--- a/src/tools/live/transactions.ts
+++ b/src/tools/live/transactions.ts
@@ -341,7 +341,7 @@ export class LiveTransactionsTools {
 
   private validate(opts: GetTransactionsLiveOptions): void {
     const o = opts as Record<string, unknown>;
-    const supported = `start_date, end_date, period, account_id (+ item_id), category, merchant, query, tag, min_amount, max_amount, limit, offset, pending, exclude_transfers, exclude_deleted, exclude_excluded, transaction_type (${LIVE_TRANSACTION_TYPES.join('|')}), transaction_id (+ account_id + item_id)`;
+    const supported = `start_date, end_date, period, account_id (+ item_id), category, merchant, query, tag, min_amount, max_amount, limit, offset, pending, exclude_transfers, exclude_deleted, exclude_excluded, transaction_type (${LIVE_TRANSACTION_TYPES.join(', ')}), transaction_id (+ account_id + item_id)`;
 
     for (const key of UNSUPPORTED_KEYS) {
       if (o[key] !== undefined) {

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -51,7 +51,15 @@ import {
   isIncomeCategory,
   isKnownPlaidCategory,
 } from '../utils/categories.js';
-import type { Transaction, Account, InvestmentPrice, Tag, Recurring } from '../models/index.js';
+import type {
+  Transaction,
+  Account,
+  InvestmentPrice,
+  Tag,
+  Recurring,
+  PriceType,
+} from '../models/index.js';
+import { PRICE_TYPES } from '../models/index.js';
 import {
   getTransactionDisplayName,
   getRecurringDisplayName,
@@ -120,6 +128,37 @@ const DEFAULT_QUERY_LIMIT = 100;
 
 /** Minimum allowed limit */
 const MIN_QUERY_LIMIT = 1;
+
+// ============================================
+// Tool Value-Set Constants
+// ============================================
+
+/**
+ * Special transaction-type filters accepted by `get_transactions` (cache mode).
+ * Single source of truth for the param type, schema enum, tool description,
+ * and `_filterByTransactionType` branching. The live tool supports a subset —
+ * see `LIVE_TRANSACTION_TYPES` in `live/transactions.ts`.
+ */
+export const TRANSACTION_TYPE_FILTERS = [
+  'foreign',
+  'refunds',
+  'credits',
+  'duplicates',
+  'hsa_eligible',
+  'tagged',
+] as const;
+export type TransactionTypeFilter = (typeof TRANSACTION_TYPE_FILTERS)[number];
+
+/** View modes accepted by `get_categories` (param type + schema enum + handler branching). */
+export const CATEGORY_VIEWS = ['list', 'tree', 'search'] as const;
+export type CategoryView = (typeof CATEGORY_VIEWS)[number];
+
+/**
+ * Downsampling granularities accepted by `get_balance_history`
+ * (param type + runtime guard + error messages + schema enum).
+ */
+export const BALANCE_HISTORY_GRANULARITIES = ['daily', 'weekly', 'monthly'] as const;
+export type BalanceHistoryGranularity = (typeof BALANCE_HISTORY_GRANULARITIES)[number];
 
 // ============================================
 // Amount Validation Constants
@@ -482,7 +521,7 @@ export class CopilotMoneyTools {
     // NEW: Text search
     query?: string;
     // NEW: Special types
-    transaction_type?: 'foreign' | 'refunds' | 'credits' | 'duplicates' | 'hsa_eligible' | 'tagged';
+    transaction_type?: TransactionTypeFilter;
     // NEW: Tag filter
     tag?: string;
     // NEW: Location
@@ -723,7 +762,7 @@ export class CopilotMoneyTools {
    */
   private _filterByTransactionType(
     transactions: Transaction[],
-    type: 'foreign' | 'refunds' | 'credits' | 'duplicates' | 'hsa_eligible' | 'tagged',
+    type: TransactionTypeFilter,
     _startDate?: string,
     _endDate?: string
   ): { transactions: Transaction[]; typeSpecificData?: Record<string, unknown> } {
@@ -1128,7 +1167,7 @@ export class CopilotMoneyTools {
    */
   async getCategories(
     options: {
-      view?: 'list' | 'tree' | 'search';
+      view?: CategoryView;
       parent_id?: string;
       query?: string;
       period?: string;
@@ -2079,7 +2118,7 @@ export class CopilotMoneyTools {
       ticker_symbol?: string;
       start_date?: string;
       end_date?: string;
-      price_type?: 'daily' | 'hf';
+      price_type?: PriceType;
       limit?: number;
       offset?: number;
     } = {}
@@ -3693,7 +3732,7 @@ export class CopilotMoneyTools {
     account_id?: string;
     start_date?: string;
     end_date?: string;
-    granularity: 'daily' | 'weekly' | 'monthly';
+    granularity: BalanceHistoryGranularity;
     limit?: number;
     offset?: number;
   }): Promise<{
@@ -3716,12 +3755,13 @@ export class CopilotMoneyTools {
     const validatedOffset = validateOffset(options.offset);
 
     if (!granularity) {
-      throw new Error('granularity is required — must be "daily", "weekly", or "monthly"');
-    }
-    const validGranularities = ['daily', 'weekly', 'monthly'] as const;
-    if (!(validGranularities as readonly string[]).includes(granularity)) {
       throw new Error(
-        `Invalid granularity: ${granularity}. Must be one of: ${validGranularities.join(', ')}`
+        `granularity is required — must be one of: ${BALANCE_HISTORY_GRANULARITIES.join(', ')}`
+      );
+    }
+    if (!(BALANCE_HISTORY_GRANULARITIES as readonly string[]).includes(granularity)) {
+      throw new Error(
+        `Invalid granularity: ${granularity}. Must be one of: ${BALANCE_HISTORY_GRANULARITIES.join(', ')}`
       );
     }
     if (start_date) validateDate(start_date, 'start_date');
@@ -3882,7 +3922,7 @@ export function createToolSchemas(): ToolSchema[] {
         '(1) Filter-based: Use period, date range, category, merchant, amount filters. ' +
         '(2) Single lookup: Provide transaction_id to get one transaction. ' +
         '(3) Text search: Use query for free-text merchant search. ' +
-        '(4) Special types: Use transaction_type for foreign/refunds/credits/duplicates/hsa_eligible/tagged. ' +
+        `(4) Special types: Use transaction_type for ${TRANSACTION_TYPE_FILTERS.join('/')}. ` +
         '(5) Location-based: Use city or lat/lon with radius_km. ' +
         '(6) Tag filter: Use tag to find transactions with a specific tag. ' +
         'Returns human-readable category names and normalized merchant names.',
@@ -3989,7 +4029,7 @@ export function createToolSchemas(): ToolSchema[] {
           // NEW: Special transaction types
           transaction_type: {
             type: 'string',
-            enum: ['foreign', 'refunds', 'credits', 'duplicates', 'hsa_eligible', 'tagged'],
+            enum: [...TRANSACTION_TYPE_FILTERS],
             description:
               'Filter by special type: foreign (international), refunds, credits (cashback/rewards), ' +
               'duplicates (potential duplicate transactions), hsa_eligible (medical expenses), tagged (has tags)',
@@ -4109,7 +4149,7 @@ export function createToolSchemas(): ToolSchema[] {
         properties: {
           view: {
             type: 'string',
-            enum: ['list', 'tree', 'search'],
+            enum: [...CATEGORY_VIEWS],
             description:
               'View mode: list (categories with spend totals), tree (parent/child hierarchy), search (find by keyword)',
           },
@@ -4264,7 +4304,7 @@ export function createToolSchemas(): ToolSchema[] {
           end_date: { type: 'string', description: 'End date (YYYY-MM-DD or YYYY-MM)' },
           price_type: {
             type: 'string',
-            enum: ['daily', 'hf'],
+            enum: [...PRICE_TYPES],
             description:
               'Filter by price type: daily (monthly aggregates) or hf (high-frequency intraday)',
           },
@@ -4368,7 +4408,7 @@ export function createToolSchemas(): ToolSchema[] {
         'Get daily balance snapshots for accounts over time. Each entry returns current_balance, ' +
         'available_balance, limit, account_id, and account_name. The response also includes an ' +
         '`accounts` array listing the distinct account IDs in the paginated page. Requires a ' +
-        'granularity parameter (daily, weekly, or monthly) to control response size. Weekly and ' +
+        `granularity parameter (${BALANCE_HISTORY_GRANULARITIES.join(', ')}) to control response size. Weekly and ` +
         'monthly modes downsample by keeping the last data point per period. Filter by ' +
         'account_id and date range.',
       inputSchema: {
@@ -4388,7 +4428,7 @@ export function createToolSchemas(): ToolSchema[] {
           },
           granularity: {
             type: 'string',
-            enum: ['daily', 'weekly', 'monthly'],
+            enum: [...BALANCE_HISTORY_GRANULARITIES],
             description:
               'Required. Controls response density: daily (every day), weekly (one per week), ' +
               'or monthly (one per month). Use weekly or monthly for longer time ranges.',

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3922,7 +3922,7 @@ export function createToolSchemas(): ToolSchema[] {
         '(1) Filter-based: Use period, date range, category, merchant, amount filters. ' +
         '(2) Single lookup: Provide transaction_id to get one transaction. ' +
         '(3) Text search: Use query for free-text merchant search. ' +
-        `(4) Special types: Use transaction_type for ${TRANSACTION_TYPE_FILTERS.join('/')}. ` +
+        `(4) Special types: Use transaction_type for ${TRANSACTION_TYPE_FILTERS.join(', ')}. ` +
         '(5) Location-based: Use city or lat/lon with radius_km. ' +
         '(6) Tag filter: Use tag to find transactions with a specific tag. ' +
         'Returns human-readable category names and normalized merchant names.',

--- a/tests/tools/live/transactions.test.ts
+++ b/tests/tools/live/transactions.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, mock } from 'bun:test';
 import {
   LiveTransactionsTools,
   createLiveToolSchemas,
+  LIVE_TRANSACTION_TYPES,
 } from '../../../src/tools/live/transactions.js';
 import { LiveCopilotDatabase } from '../../../src/core/live-database.js';
 import type { GraphQLClient } from '../../../src/core/graphql/client.js';
@@ -49,12 +50,15 @@ describe('LiveTransactionsTools — input validation', () => {
 
   test('rejects transaction_type=foreign and =duplicates', async () => {
     const tools = new LiveTransactionsTools(mkLive());
+    const retryHint = `Retry with one of: ${LIVE_TRANSACTION_TYPES.join(', ')}.`;
     await expect(tools.getTransactions({ transaction_type: 'foreign' } as never)).rejects.toThrow(
-      /foreign.*not supported/i
+      `Parameter 'transaction_type=foreign' is not supported in live mode. ${retryHint}`
     );
     await expect(
       tools.getTransactions({ transaction_type: 'duplicates' } as never)
-    ).rejects.toThrow(/duplicates.*not supported/i);
+    ).rejects.toThrow(
+      `Parameter 'transaction_type=duplicates' is not supported in live mode. ${retryHint}`
+    );
   });
 
   test('rejects exclude_split_parents=false', async () => {
@@ -432,7 +436,9 @@ describe('createLiveToolSchemas', () => {
     const { inputSchema } = createLiveToolSchemas()[0]!;
     const ttype = (inputSchema as { properties: { transaction_type?: { enum?: string[] } } })
       .properties.transaction_type;
-    expect(ttype?.enum).toEqual(['refunds', 'credits', 'hsa_eligible', 'tagged']);
+    expect(ttype?.enum).toEqual([...LIVE_TRANSACTION_TYPES]);
+    expect(ttype?.enum).not.toContain('foreign');
+    expect(ttype?.enum).not.toContain('duplicates');
   });
 
   test('readOnlyHint is true', () => {

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -3,7 +3,11 @@
  */
 
 import { describe, test, expect, beforeEach } from 'bun:test';
-import { CopilotMoneyTools, createToolSchemas } from '../../src/tools/tools.js';
+import {
+  CopilotMoneyTools,
+  createToolSchemas,
+  BALANCE_HISTORY_GRANULARITIES,
+} from '../../src/tools/tools.js';
 import { CopilotDatabase } from '../../src/core/database.js';
 import type { Transaction, Account, Security, HoldingsHistory } from '../../src/models/index.js';
 import { createMockGraphQLClient } from '../helpers/mock-graphql.js';
@@ -3226,12 +3230,14 @@ describe('getBalanceHistory', () => {
   });
 
   test('requires granularity parameter', async () => {
-    await expect(tools.getBalanceHistory({} as any)).rejects.toThrow('granularity is required');
+    await expect(tools.getBalanceHistory({} as any)).rejects.toThrow(
+      `granularity is required — must be one of: ${BALANCE_HISTORY_GRANULARITIES.join(', ')}`
+    );
   });
 
   test('rejects invalid granularity', async () => {
     await expect(tools.getBalanceHistory({ granularity: 'hourly' as any })).rejects.toThrow(
-      'Invalid granularity'
+      `Invalid granularity: hourly. Must be one of: ${BALANCE_HISTORY_GRANULARITIES.join(', ')}`
     );
   });
 

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -7,7 +7,10 @@ import {
   CopilotMoneyTools,
   createToolSchemas,
   BALANCE_HISTORY_GRANULARITIES,
+  CATEGORY_VIEWS,
+  TRANSACTION_TYPE_FILTERS,
 } from '../../src/tools/tools.js';
+import { PRICE_TYPES } from '../../src/models/index.js';
 import { CopilotDatabase } from '../../src/core/database.js';
 import type { Transaction, Account, Security, HoldingsHistory } from '../../src/models/index.js';
 import { createMockGraphQLClient } from '../helpers/mock-graphql.js';
@@ -1875,6 +1878,24 @@ describe('createToolSchemas', () => {
 
     // Should have exactly 14 tools
     expect(names.length).toBe(14);
+  });
+
+  test('schema enums render from the value-set constants', async () => {
+    const schemas = createToolSchemas();
+    const enumOf = (tool: string, prop: string): string[] | undefined => {
+      const schema = schemas.find((s) => s.name === tool);
+      const props = schema?.inputSchema.properties as
+        | Record<string, { enum?: string[] }>
+        | undefined;
+      return props?.[prop]?.enum;
+    };
+
+    expect(enumOf('get_transactions', 'transaction_type')).toEqual([...TRANSACTION_TYPE_FILTERS]);
+    expect(enumOf('get_categories', 'view')).toEqual([...CATEGORY_VIEWS]);
+    expect(enumOf('get_investment_prices', 'price_type')).toEqual([...PRICE_TYPES]);
+    expect(enumOf('get_balance_history', 'granularity')).toEqual([
+      ...BALANCE_HISTORY_GRANULARITIES,
+    ]);
   });
 });
 


### PR DESCRIPTION
Closes #432

Part of Epic A (#428). Applies the #420 dedup pattern to the four remaining internal (non-server) value-sets, so each set now has exactly one source of truth (house pattern: `as const` array + `(typeof X)[number]` type, same as `RECURRING_FREQUENCIES`).

## Constants introduced

| Constant | Lives in | Replaces inline copies in |
|---|---|---|
| `BALANCE_HISTORY_GRANULARITIES` | `src/tools/tools.ts` | param type, required-error message, `validGranularities` guard + invalid-error message, schema enum, tool description |
| `TRANSACTION_TYPE_FILTERS` | `src/tools/tools.ts` | param type, `_filterByTransactionType` signature, schema enum, tool description |
| `CATEGORY_VIEWS` | `src/tools/tools.ts` | `get_categories` param type, schema enum |
| `PRICE_TYPES` / `PriceType` | `src/models/investment-price.ts` (re-exported via `models/index.ts`) | decoder option type, `CopilotDatabase.getInvestmentPrices` option type, tool param type, schema enum |

Additionally, the live-mode subset `LIVE_TRANSACTION_TYPES` (in `src/tools/live/transactions.ts`) is now declared `as const satisfies readonly TransactionTypeFilter[]`, so the compiler guarantees every live filter value is a valid cache-mode value; its schema enum, validation guard, and both error messages render from it.

## Tests

- Granularity error-message tests (`tests/tools/tools.test.ts`) and live `transaction_type` rejection tests (`tests/tools/live/transactions.test.ts`) now assert the full message rendered from the constants, so they can't drift.
- Live schema-enum test renders from `LIVE_TRANSACTION_TYPES` and explicitly asserts `foreign`/`duplicates` are excluded.

## Notes

- Grep-clean: no inline copy of any of the four sets remains in `src/` (switch-case branch labels are individual members type-checked against the derived union, per the #420 pattern).
- No additional duplicated sets were found beyond the issue's inventory.
- These are internal enums (not server-side facts), so no conformance-ledger entries; with this PR the #420 pattern now covers all internal value-sets.
- `manifest.json` re-synced via `bun run sync-manifest` — no changes needed.
- `bun run check` green (typecheck, lint, format, 1943 tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)