### PR TITLE
C3: surface schema-drop counts in get_cache_info / get_connection_status

### DIFF
--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -24,6 +24,7 @@ import {
   UserAccountCustomization,
   AllCollectionsResult,
 } from './decoder.js';
+import type { DecodeStatsByCollection } from './schema-warn.js';
 import {
   Account,
   Transaction,
@@ -132,6 +133,26 @@ function getCacheTTLMs(): number {
 }
 
 /**
+ * Decode-health summary surfaced via get_cache_info / get_connection_status
+ * (issue #442). Makes silent schema drops visible to MCP users who never see
+ * the stderr warnings.
+ *
+ * - `status`: 'ok' (no drops), 'degraded' (>=1 document dropped on schema
+ *   validation failure), or 'unknown' (no decode pass has run, e.g. cache was
+ *   injected or never loaded).
+ * - `note`: human-readable health line. Terse in the zero-drop case; when
+ *   drops exist it explains what happened and what to do.
+ * - `collections`: per-collection `{ decoded, dropped, unread_field_warnings }`
+ *   counters, present only when at least one collection has drops or
+ *   unread-field warnings (so clean output stays terse).
+ */
+export interface DecodeHealth {
+  status: 'ok' | 'degraded' | 'unknown';
+  note: string;
+  collections?: DecodeStatsByCollection;
+}
+
+/**
  * Abstraction layer for querying Copilot Money data.
  *
  * Wraps the decoder and provides filtering capabilities.
@@ -176,6 +197,10 @@ export class CopilotDatabase {
   // Batch loading state
   private _loadingAllCollections: Promise<AllCollectionsResult> | null = null;
   private _allCollectionsLoaded = false;
+
+  // Per-collection decode health from the last full decode pass (issue #442).
+  // Null until a real decode has run (e.g. injected/mocked data has no stats).
+  private _decodeStats: DecodeStatsByCollection | null = null;
 
   // Cache TTL tracking
   private _cacheLoadedAt: number | null = null;
@@ -295,6 +320,7 @@ export class CopilotDatabase {
     // Reset batch loading state
     this._allCollectionsLoaded = false;
     this._cacheLoadedAt = null;
+    this._decodeStats = null;
 
     if (wasLoaded || hadData) {
       return {
@@ -522,6 +548,69 @@ export class CopilotDatabase {
   }
 
   /**
+   * Summarize per-collection decode health from the last full decode pass.
+   *
+   * Surfaces silent schema drops (issue #442): documents that failed Zod
+   * validation are omitted from results with only a deduped stderr warning,
+   * which MCP users never see. This summary makes the drop counts visible
+   * via get_cache_info and get_connection_status.
+   */
+  getDecodeHealth(): DecodeHealth {
+    const stats = this._decodeStats;
+    if (stats === null) {
+      return {
+        status: 'unknown',
+        note: 'Decode statistics unavailable — the local database has not been decoded in this session.',
+      };
+    }
+
+    let totalDecoded = 0;
+    let totalDropped = 0;
+    let totalUnread = 0;
+    const flagged: DecodeStatsByCollection = {};
+    for (const [collection, s] of Object.entries(stats)) {
+      totalDecoded += s.decoded;
+      totalDropped += s.dropped;
+      totalUnread += s.unread_field_warnings;
+      if (s.dropped > 0 || s.unread_field_warnings > 0) {
+        flagged[collection] = { ...s };
+      }
+    }
+
+    if (totalDropped > 0) {
+      const phrase =
+        totalDropped === 1
+          ? '1 document failed schema validation and is missing from results'
+          : `${totalDropped} documents failed schema validation and are missing from results`;
+      return {
+        status: 'degraded',
+        note:
+          `${phrase} — likely a Copilot app update changed the data shape. ` +
+          'File an issue at https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues ' +
+          "and include the 'schema drop' warnings from the MCP server's stderr log.",
+        collections: flagged,
+      };
+    }
+
+    if (totalUnread > 0) {
+      const fields = totalUnread === 1 ? 'field' : 'fields';
+      return {
+        status: 'ok',
+        note:
+          `All ${totalDecoded} validated documents decoded cleanly, but ${totalUnread} raw ${fields} ` +
+          'in the cache are not yet read by the decoder (see unread-field warnings on stderr). ' +
+          'No data was dropped.',
+        collections: flagged,
+      };
+    }
+
+    return {
+      status: 'ok',
+      note: `All ${totalDecoded} validated documents decoded cleanly. No schema drops.`,
+    };
+  }
+
+  /**
    * Load all collections in a single database pass for optimal performance.
    *
    * This is ~10x faster than loading each collection individually because
@@ -571,6 +660,8 @@ export class CopilotDatabase {
       this._holdingsHistory = result.holdingsHistory;
       this._tags = result.tags;
       this._balanceHistory = result.balanceHistory;
+
+      this._decodeStats = result.decodeStats;
 
       this._allCollectionsLoaded = true;
       this._cacheLoadedAt = Date.now();
@@ -1534,6 +1625,7 @@ export class CopilotDatabase {
     newest_transaction_date: string | null;
     transaction_count: number;
     cache_note: string;
+    decode_health: DecodeHealth;
   }> {
     const transactions = await this.loadTransactions();
     if (transactions.length === 0) {
@@ -1542,6 +1634,7 @@ export class CopilotDatabase {
         newest_transaction_date: null,
         transaction_count: 0,
         cache_note: 'No transactions in local cache. Open Copilot Money app to sync data.',
+        decode_health: this.getDecodeHealth(),
       };
     }
 
@@ -1557,6 +1650,7 @@ export class CopilotDatabase {
         `Local cache contains ${transactions.length} transactions from ${oldestDate} to ${newestDate}. ` +
         'This is a subset of your full transaction history. ' +
         'Open Copilot Money app and browse transactions to sync more data.',
+      decode_health: this.getDecodeHealth(),
     };
   }
 

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -11,7 +11,13 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { iterateDocuments } from './leveldb-reader.js';
 import { type FirestoreValue, toPlainObject } from './protobuf-parser.js';
-import { validateOrWarn, warnUnreadFields } from './schema-warn.js';
+import {
+  validateOrWarn,
+  warnUnreadFields,
+  getDecodeStats,
+  resetDecodeStats,
+  type DecodeStatsByCollection,
+} from './schema-warn.js';
 
 // Re-export for potential use by other modules
 export { toPlainObject } from './protobuf-parser.js';
@@ -666,6 +672,13 @@ export interface AllCollectionsResult {
   userItems: UserItems[];
   featureTracking: FeatureTracking[];
   supportDocs: Support[];
+  /**
+   * Per-collection decode health for this pass: docs that passed Zod
+   * (`decoded`), docs silently dropped on Zod failure (`dropped`), and unique
+   * unread raw fields (`unread_field_warnings`). Surfaced to users via
+   * get_cache_info / get_connection_status (issue #442).
+   */
+  decodeStats: DecodeStatsByCollection;
 }
 
 /**
@@ -2694,6 +2707,11 @@ export function collectionMatches(collection: string, target: string): boolean {
  * @returns All collections decoded and deduplicated
  */
 export async function decodeAllCollections(dbPath: string): Promise<AllCollectionsResult> {
+  // Fresh counters per pass so `decodeStats` always describes this load.
+  // (In production each pass runs in a fresh worker thread anyway; this
+  // matters for in-process callers like tests and the fallback path.)
+  resetDecodeStats();
+
   const rawTransactions: Transaction[] = [];
   const rawAccounts: Account[] = [];
   const rawRecurring: Recurring[] = [];
@@ -3195,6 +3213,7 @@ export async function decodeAllCollections(dbPath: string): Promise<AllCollectio
     userItems,
     featureTracking,
     supportDocs,
+    decodeStats: getDecodeStats(),
   };
 }
 

--- a/src/core/schema-warn.ts
+++ b/src/core/schema-warn.ts
@@ -18,6 +18,54 @@ export type DecodeContext = {
   docId: string;
 };
 
+/**
+ * Per-collection decode counters, accumulated during a decode pass.
+ *
+ * Unlike the warn dedupe sets (which persist for the process lifetime so a
+ * refresh doesn't re-flood stderr), these counters are reset at the start of
+ * every `decodeAllCollections` pass so they always describe the latest load:
+ *   - `decoded`: docs that passed Zod validation (raw, pre-dedup).
+ *   - `dropped`: docs that failed Zod validation and were silently omitted
+ *     from results. Counted per document, NOT deduped like the warnings.
+ *   - `unread_field_warnings`: unique `(collection, field)` pairs present in
+ *     raw docs but neither consumed nor explicitly ignored by the processor.
+ */
+export type CollectionDecodeStats = {
+  decoded: number;
+  dropped: number;
+  unread_field_warnings: number;
+};
+
+export type DecodeStatsByCollection = Record<string, CollectionDecodeStats>;
+
+const decodeStats = new Map<string, CollectionDecodeStats>();
+
+// Per-pass dedupe for the unread_field_warnings counter. Separate from
+// `warnedUnreadKeys` (process-lifetime, governs stderr flood control) so a
+// re-decode in the same process still counts fields that are still unread
+// even though their stderr warning was already emitted on an earlier pass.
+const countedUnreadKeys = new Set<string>();
+
+function statsFor(collection: string): CollectionDecodeStats {
+  let stats = decodeStats.get(collection);
+  if (!stats) {
+    stats = { decoded: 0, dropped: 0, unread_field_warnings: 0 };
+    decodeStats.set(collection, stats);
+  }
+  return stats;
+}
+
+/** Snapshot of the per-collection counters (deep copy, safe to mutate). */
+export function getDecodeStats(): DecodeStatsByCollection {
+  return Object.fromEntries([...decodeStats].map(([k, v]) => [k, { ...v }]));
+}
+
+/** Reset counters. Called at the start of each full decode pass. */
+export function resetDecodeStats(): void {
+  decodeStats.clear();
+  countedUnreadKeys.clear();
+}
+
 // Dedupe key = `${collection}::${firstIssue.path.join('.')}::${firstIssue.code}`.
 // One warn per unique key per process. Prevents log flood when Copilot ships
 // a new field shape that affects every doc in a collection. Note: only the
@@ -33,7 +81,14 @@ const warnedUnreadKeys = new Set<string>();
 
 export function validateOrWarn<T>(schema: ZodType<T>, data: unknown, ctx: DecodeContext): T | null {
   const result = schema.safeParse(data);
-  if (result.success) return result.data;
+  if (result.success) {
+    statsFor(ctx.collection).decoded++;
+    return result.data;
+  }
+
+  // Count every dropped doc — drops are NOT deduped like the warnings below,
+  // so the counters reflect the true number of missing documents.
+  statsFor(ctx.collection).dropped++;
 
   // Zod always provides ≥1 issue on failure; guard is defensive only.
   const first = result.error.issues[0];
@@ -82,6 +137,10 @@ export function warnUnreadFields(
   for (const key of fields.keys()) {
     if (known.has(key)) continue;
     const dedupeKey = `unread::${ctx.collection}::${key}`;
+    if (!countedUnreadKeys.has(dedupeKey)) {
+      countedUnreadKeys.add(dedupeKey);
+      statsFor(ctx.collection).unread_field_warnings++;
+    }
     if (warnedUnreadKeys.has(dedupeKey)) continue;
     warnedUnreadKeys.add(dedupeKey);
     console.warn(
@@ -90,8 +149,10 @@ export function warnUnreadFields(
   }
 }
 
-// Exposed for tests only.
+// Exposed for tests only. Clears dedupe sets AND the per-pass counters so
+// each test starts from a clean slate.
 export function __resetWarnedKeys(): void {
   warnedKeys.clear();
   warnedUnreadKeys.clear();
+  resetDecodeStats();
 }

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -4,7 +4,7 @@
  * Exposes database functionality through the Model Context Protocol.
  */
 
-import { CopilotDatabase } from '../core/database.js';
+import { CopilotDatabase, type DecodeHealth } from '../core/database.js';
 import type { LiveCopilotDatabase } from '../core/live-database.js';
 import type { GraphQLClient } from '../core/graphql/client.js';
 import { GraphQLError } from '../core/graphql/client.js';
@@ -923,6 +923,7 @@ export class CopilotMoneyTools {
     newest_transaction_date: string | null;
     transaction_count: number;
     cache_note: string;
+    decode_health: DecodeHealth;
   }> {
     return await this.db.getCacheInfo();
   }
@@ -1057,6 +1058,7 @@ export class CopilotMoneyTools {
       connected: number;
       needs_attention: number;
     };
+    decode_health: DecodeHealth;
   }> {
     const items = await this.db.getItems();
 
@@ -1107,6 +1109,7 @@ export class CopilotMoneyTools {
         connected: connections.length - needsAttention,
         needs_attention: needsAttention,
       },
+      decode_health: this.db.getDecodeHealth(),
     };
   }
 
@@ -4028,7 +4031,9 @@ export function createToolSchemas(): ToolSchema[] {
       description:
         'Get information about the local data cache, including the date range of cached transactions ' +
         'and total count. Useful for understanding data availability before running historical queries. ' +
-        'This tool reads from a local cache that may not contain your complete transaction history.',
+        'This tool reads from a local cache that may not contain your complete transaction history. ' +
+        'Also reports decode_health: per-collection counts of documents dropped on schema validation ' +
+        'failure (a "degraded" status means some cached documents are missing from results).',
       inputSchema: {
         type: 'object',
         properties: {},
@@ -4086,7 +4091,9 @@ export function createToolSchemas(): ToolSchema[] {
         'Get connection status for all linked financial institutions. ' +
         'Shows per-institution sync health including last successful update timestamps ' +
         'for transactions and investments, login requirements, and error states. ' +
-        'Use this to check when accounts were last synced or to identify connections needing attention.',
+        'Use this to check when accounts were last synced or to identify connections needing attention. ' +
+        'Also reports decode_health: per-collection counts of cached documents dropped on schema ' +
+        'validation failure (a "degraded" status means some documents are missing from results).',
       inputSchema: {
         type: 'object',
         properties: {},

--- a/tests/core/decode-stats.test.ts
+++ b/tests/core/decode-stats.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Read-side drop visibility (issue #442).
+ *
+ * A Zod parse failure on a cached document silently drops it from results
+ * with only a deduped stderr warning that MCP users never see. These tests
+ * verify the drop counters flow from the decoder through CopilotDatabase to
+ * the get_cache_info / get_connection_status tool surfaces.
+ *
+ * Uses a synthetic LevelDB with a deliberately malformed document: the
+ * transaction's `date` is a string (so it survives the decoder's defensive
+ * field extraction) but does not match the schema's YYYY-MM-DD regex, so it
+ * fails Zod validation and is dropped.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import path from 'node:path';
+import fs from 'node:fs';
+import { decodeAllCollections } from '../../src/core/decoder.js';
+import { CopilotDatabase } from '../../src/core/database.js';
+import { CopilotMoneyTools } from '../../src/tools/tools.js';
+import { __resetWarnedKeys } from '../../src/core/schema-warn.js';
+import { createTestDb } from '../helpers/test-db.js';
+
+const FIXTURES_DIR = path.join(__dirname, '../fixtures/decode-stats-tests');
+
+const VALID_TXN = {
+  collection: 'transactions',
+  id: 'txn_good',
+  fields: {
+    transaction_id: 'txn_good',
+    amount: 100,
+    date: '2024-01-15',
+    name: 'Synthetic Coffee',
+  },
+};
+
+// String date passes the decoder's truthiness check but fails the
+// TransactionSchema YYYY-MM-DD regex → validateOrWarn returns null → dropped.
+const MALFORMED_TXN = {
+  collection: 'transactions',
+  id: 'txn_bad',
+  fields: {
+    transaction_id: 'txn_bad',
+    amount: 200,
+    date: 'not-a-date',
+    name: 'Synthetic Malformed',
+  },
+};
+
+const ITEM_DOC = {
+  collection: 'items',
+  id: 'item_1',
+  fields: {
+    item_id: 'item_1',
+    institution_name: 'Synthetic Bank',
+  },
+};
+
+let warnSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+  __resetWarnedKeys();
+  warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  if (fs.existsSync(FIXTURES_DIR)) {
+    fs.rmSync(FIXTURES_DIR, { recursive: true, force: true });
+  }
+});
+
+describe('decodeAllCollections decodeStats', () => {
+  test('counts a malformed document as dropped and omits it from results', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'malformed-db');
+    await createTestDb(dbPath, [VALID_TXN, MALFORMED_TXN]);
+
+    const result = await decodeAllCollections(dbPath);
+
+    expect(result.transactions.map((t) => t.transaction_id)).toEqual(['txn_good']);
+    expect(result.decodeStats.transactions).toEqual({
+      decoded: 1,
+      dropped: 1,
+      unread_field_warnings: 0,
+    });
+  });
+
+  test('reports zero drops for a clean database', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'clean-db');
+    await createTestDb(dbPath, [VALID_TXN]);
+
+    const result = await decodeAllCollections(dbPath);
+
+    expect(result.decodeStats.transactions).toEqual({
+      decoded: 1,
+      dropped: 0,
+      unread_field_warnings: 0,
+    });
+  });
+});
+
+describe('decode_health on the tool surface', () => {
+  test('get_cache_info reports degraded health with per-collection counts when a document drops', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'tool-malformed-db');
+    await createTestDb(dbPath, [VALID_TXN, MALFORMED_TXN, ITEM_DOC]);
+
+    const tools = new CopilotMoneyTools(new CopilotDatabase(dbPath));
+    const info = await tools.getCacheInfo();
+
+    expect(info.transaction_count).toBe(1);
+    expect(info.decode_health.status).toBe('degraded');
+    // The note explains what a drop means and what to do about it.
+    expect(info.decode_health.note).toContain('1 document failed schema validation');
+    expect(info.decode_health.note).toContain('missing from results');
+    expect(info.decode_health.note).toContain('Copilot app update');
+    expect(info.decode_health.note).toContain('issue');
+    // Per-collection breakdown only includes flagged collections.
+    expect(info.decode_health.collections).toEqual({
+      transactions: { decoded: 1, dropped: 1, unread_field_warnings: 0 },
+    });
+  }, 30_000);
+
+  test('get_connection_status carries the same decode_health summary', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'conn-malformed-db');
+    await createTestDb(dbPath, [VALID_TXN, MALFORMED_TXN, ITEM_DOC]);
+
+    const tools = new CopilotMoneyTools(new CopilotDatabase(dbPath));
+    const status = await tools.getConnectionStatus();
+
+    expect(status.summary.total).toBe(1);
+    expect(status.decode_health.status).toBe('degraded');
+    expect(status.decode_health.collections?.transactions?.dropped).toBe(1);
+  }, 30_000);
+
+  test('zero-drop output stays terse: ok status, short note, no per-collection breakdown', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'tool-clean-db');
+    await createTestDb(dbPath, [VALID_TXN, ITEM_DOC]);
+
+    const tools = new CopilotMoneyTools(new CopilotDatabase(dbPath));
+    const info = await tools.getCacheInfo();
+
+    expect(info.decode_health.status).toBe('ok');
+    expect(info.decode_health.note).toContain('decoded cleanly');
+    // Shape check: the terse case has no collections key at all.
+    expect(Object.keys(info.decode_health).sort()).toEqual(['note', 'status']);
+
+    const status = await tools.getConnectionStatus();
+    expect(status.decode_health.status).toBe('ok');
+    expect(status.decode_health.collections).toBeUndefined();
+  }, 30_000);
+
+  test('injected (non-decoded) data reports unknown decode health', async () => {
+    const db = new CopilotDatabase('/fake/path');
+    db._injectDataForTesting({
+      transactions: [
+        {
+          transaction_id: 'txn_mock',
+          amount: 100,
+          date: '2024-01-15',
+        },
+      ],
+      items: [],
+    });
+
+    const tools = new CopilotMoneyTools(db);
+    const info = await tools.getCacheInfo();
+
+    expect(info.decode_health.status).toBe('unknown');
+    expect(info.decode_health.collections).toBeUndefined();
+  });
+
+  test('clearCache resets decode health to unknown until the next decode', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'clear-cache-db');
+    await createTestDb(dbPath, [VALID_TXN]);
+
+    const db = new CopilotDatabase(dbPath);
+    await db.getCacheInfo();
+    expect(db.getDecodeHealth().status).toBe('ok');
+
+    db.clearCache();
+    expect(db.getDecodeHealth().status).toBe('unknown');
+  }, 30_000);
+});

--- a/tests/core/schema-warn.test.ts
+++ b/tests/core/schema-warn.test.ts
@@ -11,7 +11,13 @@
 
 import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { z } from 'zod';
-import { validateOrWarn, warnUnreadFields, __resetWarnedKeys } from '../../src/core/schema-warn.js';
+import {
+  validateOrWarn,
+  warnUnreadFields,
+  __resetWarnedKeys,
+  getDecodeStats,
+  resetDecodeStats,
+} from '../../src/core/schema-warn.js';
 import type { FirestoreValue } from '../../src/core/protobuf-parser.js';
 
 const Schema = z.object({
@@ -275,5 +281,117 @@ describe('warnUnreadFields', () => {
       { collection: 'transactions', docId: 'doc2' }
     );
     expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+// Per-collection decode counters (issue #442). Unlike the stderr warns above,
+// drops are counted per document (NOT deduped) so the counters reflect the
+// true number of missing documents.
+describe('decode stats counters', () => {
+  let warnSpy: ReturnType<typeof spyOn>;
+
+  function fakeFields(keys: string[]): Map<string, FirestoreValue> {
+    return new Map(keys.map((k) => [k, { type: 'string', value: '' } as FirestoreValue]));
+  }
+
+  beforeEach(() => {
+    __resetWarnedKeys();
+    warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test('counts decoded and dropped documents per collection', () => {
+    validateOrWarn(Schema, { id: 'a', amount: 1 }, { collection: 'accounts', docId: 'doc1' });
+    validateOrWarn(Schema, { id: 'b', amount: 2 }, { collection: 'accounts', docId: 'doc2' });
+    validateOrWarn(Schema, { id: 'c', amount: 'bad' }, { collection: 'accounts', docId: 'doc3' });
+
+    expect(getDecodeStats()).toEqual({
+      accounts: { decoded: 2, dropped: 1, unread_field_warnings: 0 },
+    });
+  });
+
+  test('drops are counted per document even when the stderr warn is deduped', () => {
+    // Same failure path + code in both docs → one stderr warn, two drops.
+    validateOrWarn(Schema, { id: 'a', amount: 'bad' }, { collection: 'accounts', docId: 'doc1' });
+    validateOrWarn(
+      Schema,
+      { id: 'b', amount: 'also-bad' },
+      { collection: 'accounts', docId: 'doc2' }
+    );
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(getDecodeStats().accounts?.dropped).toBe(2);
+  });
+
+  test('tracks collections independently', () => {
+    validateOrWarn(Schema, { id: 'a', amount: 1 }, { collection: 'accounts', docId: 'doc1' });
+    validateOrWarn(Schema, { id: 'b', amount: 'bad' }, { collection: 'transactions', docId: 'd2' });
+
+    expect(getDecodeStats()).toEqual({
+      accounts: { decoded: 1, dropped: 0, unread_field_warnings: 0 },
+      transactions: { decoded: 0, dropped: 1, unread_field_warnings: 0 },
+    });
+  });
+
+  test('counts unique unread fields once per (collection, field)', () => {
+    warnUnreadFields(
+      fakeFields(['mystery_a', 'mystery_b']),
+      { consumed: [], ignored: [] },
+      { collection: 'transactions', docId: 'doc1' }
+    );
+    // Same fields on a second doc — already counted.
+    warnUnreadFields(
+      fakeFields(['mystery_a', 'mystery_b']),
+      { consumed: [], ignored: [] },
+      { collection: 'transactions', docId: 'doc2' }
+    );
+
+    expect(getDecodeStats().transactions?.unread_field_warnings).toBe(2);
+  });
+
+  test('resetDecodeStats clears counters but not stderr dedupe state', () => {
+    validateOrWarn(Schema, { id: 'a', amount: 'bad' }, { collection: 'accounts', docId: 'doc1' });
+    warnUnreadFields(
+      fakeFields(['mystery']),
+      { consumed: [], ignored: [] },
+      { collection: 'accounts', docId: 'doc1' }
+    );
+    expect(getDecodeStats().accounts).toEqual({
+      decoded: 0,
+      dropped: 1,
+      unread_field_warnings: 1,
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+
+    resetDecodeStats();
+    expect(getDecodeStats()).toEqual({});
+
+    // A new pass re-counts the still-unread field even though its stderr
+    // warning was already emitted (per-pass counter vs process-lifetime warn).
+    validateOrWarn(Schema, { id: 'b', amount: 'bad' }, { collection: 'accounts', docId: 'doc2' });
+    warnUnreadFields(
+      fakeFields(['mystery']),
+      { consumed: [], ignored: [] },
+      { collection: 'accounts', docId: 'doc2' }
+    );
+    expect(getDecodeStats().accounts).toEqual({
+      decoded: 0,
+      dropped: 1,
+      unread_field_warnings: 1,
+    });
+    // No new stderr output: both the schema-drop and unread-field warns dedupe
+    // for the lifetime of the process.
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('getDecodeStats returns an independent snapshot', () => {
+    validateOrWarn(Schema, { id: 'a', amount: 1 }, { collection: 'accounts', docId: 'doc1' });
+    const snapshot = getDecodeStats();
+    snapshot.accounts.decoded = 999;
+
+    expect(getDecodeStats().accounts?.decoded).toBe(1);
   });
 });

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -1808,6 +1808,7 @@ describe('refreshDatabase', () => {
       newest_transaction_date: '2024-03-01',
       transaction_count: 100,
       cache_note: 'Test cache info',
+      decode_health: { status: 'ok' as const, note: 'test' },
     };
     db.getCacheInfo = async () => mockCacheInfo;
 

--- a/tests/tools/unit-coverage-gaps.test.ts
+++ b/tests/tools/unit-coverage-gaps.test.ts
@@ -136,6 +136,7 @@ describe('refreshDatabase — expanded', () => {
       newest_transaction_date: '2024-06-01',
       transaction_count: 2,
       cache_note: 'test',
+      decode_health: { status: 'ok' as const, note: 'test' },
     });
 
     const result = await tools.refreshDatabase();
@@ -160,6 +161,7 @@ describe('refreshDatabase — expanded', () => {
       newest_transaction_date: null,
       transaction_count: 0,
       cache_note: 'empty',
+      decode_health: { status: 'ok' as const, note: 'test' },
     });
 
     const result = await tools.refreshDatabase();
@@ -182,6 +184,7 @@ describe('refreshDatabase — expanded', () => {
         newest_transaction_date: '2024-02-01',
         transaction_count: 1,
         cache_note: `call ${callCount}`,
+        decode_health: { status: 'ok' as const, note: 'test' },
       };
     };
 


### PR DESCRIPTION
Closes #442 (part of Epic C, #429).

## Why

A Zod parse failure on a cached document drops it from the in-memory cache with only a deduped stderr warning (`validateOrWarn` returns `null`). MCP users never see stderr, so they see incomplete finances with zero signal.

## What

- **`src/core/schema-warn.ts`** — per-collection counters: `decoded` (passed Zod), `dropped` (failed Zod, counted per document — NOT deduped like the stderr warnings), and `unread_field_warnings` (unique `(collection, field)` pairs, with a per-pass dedupe set kept separate from the process-lifetime stderr flood control).
- **`src/core/decoder.ts`** — `decodeAllCollections` resets the counters at the start of each pass and returns a `decodeStats` snapshot in `AllCollectionsResult`; it survives the decode worker's structured clone unchanged.
- **`src/core/database.ts`** — stores the stats from the last decode pass, clears them in `clearCache()`, and exposes `getDecodeHealth()`: `ok` / `degraded` / `unknown` plus a human-readable note. The per-collection breakdown is only included when a collection has drops or unread-field warnings, so the zero-drop case stays terse.
- **`src/tools/tools.ts`** — `decode_health` added to the `get_cache_info` and `get_connection_status` responses and to both tool descriptions.

When drops > 0, the note explains what it means: "N documents failed schema validation and are missing from results — likely a Copilot app update changed the data shape. File an issue ... and include the 'schema drop' warnings from the MCP server's stderr log."

## Tests

- `tests/core/decode-stats.test.ts` — synthetic-LevelDB tests with a deliberately malformed document (string date that fails the YYYY-MM-DD regex): drop counted, doc omitted from results, `degraded` health on both tool surfaces; zero-drop output stays terse (`decode_health` has only `status` + `note`, no `collections` key); injected data reports `unknown`; `clearCache` resets health.
- `tests/core/schema-warn.test.ts` — counter unit tests: per-document drop counting under stderr dedupe, per-pass unread-field dedupe, reset semantics, snapshot independence.

`bun run check` green (1965 pass / 0 fail), branch rebased on origin/main (includes the #448 doc-sync gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
