### PR TITLE
feat(graphql): bounded retry/backoff for network-level failures (C4)

### DIFF
--- a/src/core/graphql/client.ts
+++ b/src/core/graphql/client.ts
@@ -160,7 +160,7 @@ export class GraphQLError extends Error {
 
 export interface GraphQLClientOptions {
   /**
-   * Per-attempt timeout in ms (default 30s). Pass Infinity to disable.
+   * Per-attempt timeout in ms (default 30s). Pass 0 or Infinity to disable.
    * A timed-out QUERY is retried; a timed-out MUTATION is NOT (ambiguous —
    * the request may have been sent).
    */
@@ -205,12 +205,18 @@ function isProvablyUnsent(err: unknown): boolean {
   for (let depth = 0; depth < 5 && current instanceof Error; depth++) {
     const code = (current as Error & { code?: unknown }).code;
     if (typeof code === 'string' && PROVABLY_UNSENT_CODES.has(code)) return true;
+    const cause = (current as Error & { cause?: unknown }).cause;
     // Some runtimes only embed the errno string in the message
-    // (e.g. "connect ECONNREFUSED 127.0.0.1:443").
-    for (const known of PROVABLY_UNSENT_CODES) {
-      if (current.message.includes(known)) return true;
+    // (e.g. "connect ECONNREFUSED 127.0.0.1:443"). Scan only the INNERMOST
+    // error: a wrapper whose message merely quotes a code string (log
+    // fragment, stringified cause) must not flag an ambiguous mutation
+    // failure as provably unsent — a false positive here re-sends a write.
+    if (cause == null) {
+      for (const known of PROVABLY_UNSENT_CODES) {
+        if (current.message.includes(known)) return true;
+      }
     }
-    current = (current as Error & { cause?: unknown }).cause;
+    current = cause;
   }
   return false;
 }

--- a/src/core/graphql/client.ts
+++ b/src/core/graphql/client.ts
@@ -4,6 +4,15 @@
  * Single-op requests (object body, not array). Reuses the existing
  * FirebaseAuth class to mint JWTs. All failure modes surface as a
  * typed GraphQLError with a discriminated `code` field.
+ *
+ * Retry policy (issue #443): bounded exponential backoff for
+ * TRANSPORT-level failures only — never for GraphQL-level errors.
+ *  - Queries are idempotent → retry fetch rejections, timeouts, and 5xx
+ *    responses that carry no GraphQL error body.
+ *  - Mutations retry ONLY when the request provably never reached the
+ *    server (connection refused / DNS failure before send). A timeout or
+ *    mid-flight reset after send is ambiguous — the write may have
+ *    executed — so it surfaces immediately with `writeMayHaveApplied`.
  */
 
 import type { FirebaseAuth } from '../auth/firebase-auth.js';
@@ -104,23 +113,211 @@ function classifyHttpError(status: number, parsed?: ParsedErrorBody): GraphQLErr
   return 'UNKNOWN';
 }
 
+export interface GraphQLErrorMeta {
+  /**
+   * Three-state delivery evidence:
+   *  - true       → an HTTP response arrived, so the request definitely
+   *                 reached the server
+   *  - false      → the failure provably happened before send (connection
+   *                 refused, DNS failure) — the server never saw it
+   *  - undefined  → ambiguous (timeout, mid-flight reset); the request may
+   *                 or may not have been processed
+   * This is what makes mutation retries safe: only `false` is retryable.
+   */
+  requestReachedServer?: boolean;
+  /**
+   * Set on mutation failures where the write may have executed server-side
+   * (ambiguous transport failure or 5xx). Callers must verify state before
+   * retrying.
+   */
+  writeMayHaveApplied?: boolean;
+  /** Total attempts made before this error surfaced (≥ 1). */
+  attempts?: number;
+}
+
 export class GraphQLError extends Error {
+  public readonly requestReachedServer?: boolean;
+  public readonly writeMayHaveApplied: boolean;
+  public readonly attempts: number;
+
   constructor(
     public readonly code: GraphQLErrorCode,
     message: string,
     public readonly operationName?: string,
     public readonly httpStatus?: number,
-    public readonly serverErrors?: unknown
+    public readonly serverErrors?: unknown,
+    meta: GraphQLErrorMeta = {}
   ) {
     super(message);
     this.name = 'GraphQLError';
+    this.requestReachedServer = meta.requestReachedServer;
+    this.writeMayHaveApplied = meta.writeMayHaveApplied ?? false;
+    this.attempts = meta.attempts ?? 1;
   }
 }
 
+// ── Retry / timeout configuration ───────────────────────────────────────────
+
+export interface GraphQLClientOptions {
+  /**
+   * Per-attempt timeout in ms (default 30s). Pass Infinity to disable.
+   * A timed-out QUERY is retried; a timed-out MUTATION is NOT (ambiguous —
+   * the request may have been sent).
+   */
+  timeoutMs?: number;
+  /**
+   * Backoff delays between attempts in ms. Length = max retries, so the
+   * default allows 4 total attempts. Pass [] to disable retries.
+   */
+  retryDelaysMs?: readonly number[];
+  /** Max random jitter in ms added to each backoff delay (default 250). */
+  jitterMs?: number;
+}
+
+export const DEFAULT_TIMEOUT_MS = 30_000;
+export const DEFAULT_RETRY_DELAYS_MS: readonly number[] = [250, 1_000, 4_000];
+export const DEFAULT_JITTER_MS = 250;
+
+/**
+ * Error codes (anywhere in the fetch rejection's `cause` chain) that prove
+ * the request never reached the server: TCP connect refused, DNS resolution
+ * failure, or no network route. Deliberately EXCLUDES ambiguous codes like
+ * ECONNRESET / EPIPE / ETIMEDOUT, which can fire after the request bytes
+ * were already on the wire. Unknown codes default to "not provably unsent"
+ * (the conservative direction for mutation safety).
+ */
+const PROVABLY_UNSENT_CODES: ReadonlySet<string> = new Set([
+  // Node / undici system error codes
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENETDOWN',
+  // Bun fetch error codes
+  'ConnectionRefused',
+  'FailedToOpenSocket',
+  'DNSResolveFailed',
+]);
+
+function isProvablyUnsent(err: unknown): boolean {
+  let current: unknown = err;
+  for (let depth = 0; depth < 5 && current instanceof Error; depth++) {
+    const code = (current as Error & { code?: unknown }).code;
+    if (typeof code === 'string' && PROVABLY_UNSENT_CODES.has(code)) return true;
+    // Some runtimes only embed the errno string in the message
+    // (e.g. "connect ECONNREFUSED 127.0.0.1:443").
+    for (const known of PROVABLY_UNSENT_CODES) {
+      if (current.message.includes(known)) return true;
+    }
+    current = (current as Error & { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+function isAbortOrTimeout(err: unknown): boolean {
+  return err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+type RequestKind = 'query' | 'mutation';
+
+/**
+ * Whether a failed attempt is safe to retry.
+ *  - Queries are idempotent: any transport-level failure (fetch rejection,
+ *    timeout, 5xx with no GraphQL error body) is retryable. GraphQL-level
+ *    errors (schema/auth/ownership, or 5xx that carries an errors[] body)
+ *    are deterministic — never retried.
+ *  - Mutations: only when the request provably never reached the server.
+ */
+function isRetryable(e: GraphQLError, kind: RequestKind): boolean {
+  if (kind === 'mutation') return e.requestReachedServer === false;
+  if (e.code === 'NETWORK') return true;
+  if (e.code === 'SERVER_ERROR' && e.serverErrors === undefined) return true;
+  return false;
+}
+
 export class GraphQLClient {
-  constructor(private auth: FirebaseAuth) {}
+  private readonly timeoutMs: number;
+  private readonly retryDelaysMs: readonly number[];
+  private readonly jitterMs: number;
+
+  constructor(
+    private auth: FirebaseAuth,
+    opts: GraphQLClientOptions = {}
+  ) {
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.retryDelaysMs = opts.retryDelaysMs ?? DEFAULT_RETRY_DELAYS_MS;
+    this.jitterMs = opts.jitterMs ?? DEFAULT_JITTER_MS;
+  }
 
   async mutate<TVariables, TResponse>(
+    operationName: string,
+    query: string,
+    variables: TVariables
+  ): Promise<TResponse> {
+    return this.request<TVariables, TResponse>('mutation', operationName, query, variables);
+  }
+
+  /**
+   * Send a GraphQL query. Same transport, auth, and error classification
+   * as mutate(), but with the broader (idempotent-safe) retry policy.
+   */
+  async query<TVariables, TResponse>(
+    operationName: string,
+    query: string,
+    variables: TVariables
+  ): Promise<TResponse> {
+    return this.request<TVariables, TResponse>('query', operationName, query, variables);
+  }
+
+  private async request<TVariables, TResponse>(
+    kind: RequestKind,
+    operationName: string,
+    query: string,
+    variables: TVariables
+  ): Promise<TResponse> {
+    const maxAttempts = this.retryDelaysMs.length + 1;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await this.requestOnce<TVariables, TResponse>(operationName, query, variables);
+      } catch (e) {
+        if (!(e instanceof GraphQLError)) throw e;
+        if (attempt >= maxAttempts || !isRetryable(e, kind)) {
+          throw this.finalize(e, kind, attempt);
+        }
+        const delayMs =
+          (this.retryDelaysMs[attempt - 1] ?? 0) + Math.floor(Math.random() * this.jitterMs);
+        console.error(
+          `[graphql] ${operationName} attempt ${attempt}/${maxAttempts} failed (code=${e.code}) — retrying in ${delayMs}ms`
+        );
+        await sleep(delayMs);
+      }
+    }
+  }
+
+  /**
+   * Annotate the final error with attempt count and — for mutations whose
+   * failure does not prove the request went unprocessed — the
+   * `writeMayHaveApplied` flag so callers verify state before retrying.
+   */
+  private finalize(e: GraphQLError, kind: RequestKind, attempts: number): GraphQLError {
+    const writeMayHaveApplied =
+      kind === 'mutation' &&
+      e.requestReachedServer !== false &&
+      (e.code === 'NETWORK' || e.code === 'SERVER_ERROR');
+    if (attempts === e.attempts && writeMayHaveApplied === e.writeMayHaveApplied) return e;
+    return new GraphQLError(e.code, e.message, e.operationName, e.httpStatus, e.serverErrors, {
+      requestReachedServer: e.requestReachedServer,
+      writeMayHaveApplied,
+      attempts,
+    });
+  }
+
+  private async requestOnce<TVariables, TResponse>(
     operationName: string,
     query: string,
     variables: TVariables
@@ -136,12 +333,28 @@ export class GraphQLClient {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ operationName, query, variables }),
+        signal:
+          Number.isFinite(this.timeoutMs) && this.timeoutMs > 0
+            ? AbortSignal.timeout(this.timeoutMs)
+            : undefined,
       });
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
+      const timedOut = isAbortOrTimeout(e);
+      const msg = timedOut
+        ? `request timed out after ${this.timeoutMs}ms`
+        : e instanceof Error
+          ? e.message
+          : String(e);
       this.logError(operationName, 'NETWORK', undefined);
-      throw new GraphQLError('NETWORK', msg, operationName);
+      throw new GraphQLError('NETWORK', msg, operationName, undefined, undefined, {
+        // A timeout may have fired after the request was sent → ambiguous
+        // (undefined). Only pre-connection failures are provably unsent.
+        requestReachedServer: !timedOut && isProvablyUnsent(e) ? false : undefined,
+      });
     }
+
+    // From here on an HTTP response exists, so the request reached the server.
+    const reached: GraphQLErrorMeta = { requestReachedServer: true };
 
     // Classify HTTP-level failures by body CONTENT first, status as fallback,
     // and always carry the server's raw error text (truncated) in the message.
@@ -157,7 +370,8 @@ export class GraphQLClient {
         `${response.status}: ${truncate(serverSaid)}`,
         operationName,
         response.status,
-        parsed?.raw
+        parsed?.raw,
+        reached
       );
     }
 
@@ -174,7 +388,9 @@ export class GraphQLClient {
         'UNKNOWN',
         `Invalid JSON response: ${msg}`,
         operationName,
-        response.status
+        response.status,
+        undefined,
+        reached
       );
     }
 
@@ -196,7 +412,8 @@ export class GraphQLClient {
         truncate(firstMessage),
         operationName,
         response.status,
-        body.errors
+        body.errors,
+        reached
       );
     }
 
@@ -206,24 +423,13 @@ export class GraphQLClient {
         'UNKNOWN',
         'Response missing data field',
         operationName,
-        response.status
+        response.status,
+        undefined,
+        reached
       );
     }
 
     return body.data;
-  }
-
-  /**
-   * Send a GraphQL query. Same transport, auth, and error classification
-   * as mutate(). Semantic alias kept separate so call sites and logs
-   * distinguish reads from writes.
-   */
-  async query<TVariables, TResponse>(
-    operationName: string,
-    query: string,
-    variables: TVariables
-  ): Promise<TResponse> {
-    return this.mutate<TVariables, TResponse>(operationName, query, variables);
   }
 
   private logError(operationName: string, code: GraphQLErrorCode, httpStatus?: number): void {

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -7,8 +7,8 @@
  * categories, budgets, recurring, and tags.
  *
  * The class owns cross-cutting concerns shared by every method:
- *   - one retry on NETWORK errors (other GraphQL codes surface)
  *   - optional verbose logging to stderr for latency measurement
+ * (Transport retry/backoff lives in GraphQLClient itself — issue #443.)
  *
  * Phase 2 adds tiered-cache primitives (SnapshotCache per entity type +
  * TransactionWindowCache for month-keyed transaction windows) and
@@ -19,7 +19,7 @@
  * See docs/superpowers/plans/2026-04-25-graphql-live-tiered-cache.md.
  */
 
-import { GraphQLError, type GraphQLClient } from './graphql/client.js';
+import type { GraphQLClient } from './graphql/client.js';
 import type { CopilotDatabase } from './database.js';
 import {
   buildTransactionFilter,
@@ -47,8 +47,6 @@ import { ONE_HOUR_MS, SIX_HOURS_MS, ONE_DAY_MS, ONE_WEEK_MS } from '../utils/dur
 export interface LiveDatabaseOptions {
   verbose?: boolean;
 }
-
-const RETRY_BACKOFF_MS = 500;
 
 const DEFAULT_MAX_TX_ROWS = 20_000;
 
@@ -171,18 +169,6 @@ export class LiveCopilotDatabase {
     return this.cache;
   }
 
-  async withRetry<T>(op: () => Promise<T>): Promise<T> {
-    try {
-      return await op();
-    } catch (err) {
-      if (err instanceof GraphQLError && err.code === 'NETWORK') {
-        await new Promise((resolve) => setTimeout(resolve, RETRY_BACKOFF_MS));
-        return await op();
-      }
-      throw err;
-    }
-  }
-
   /**
    * Fetch + paginate one month of transactions; ingest into the
    * window cache; return the rows along with the timestamp the
@@ -200,11 +186,10 @@ export class LiveCopilotDatabase {
     const fetched_at = Date.now();
     let pages = 0;
     const rawRows = await paginateTransactions(
-      (after) =>
-        this.withRetry(async () => {
-          pages += 1;
-          return fetchTransactionsPage(this.graphql, { first: pageSize, after, filter, sort });
-        }),
+      async (after) => {
+        pages += 1;
+        return fetchTransactionsPage(this.graphql, { first: pageSize, after, filter, sort });
+      },
       { startDate: monthStart }
     );
     // Trim leaked tail-page rows that fall outside this month's window.

--- a/src/tools/errors.ts
+++ b/src/tools/errors.ts
@@ -1,6 +1,20 @@
 import { GraphQLError } from '../core/graphql/client.js';
 
 /**
+ * Appended when a mutation failed in a way that does not prove the write
+ * went unprocessed (timeout after send, mid-flight reset, 5xx). The client
+ * never auto-retries these (issue #443); the caller must verify first.
+ */
+const WRITE_AMBIGUITY_WARNING =
+  'WARNING: this was a write and it may or may not have applied on the server — ' +
+  'verify the current state (re-read the entity) before retrying.';
+
+/** "after N attempts" fragment when the client already retried (issue #443). */
+function attemptsNote(e: GraphQLError): string {
+  return e.attempts > 1 ? ` after ${e.attempts} attempts` : '';
+}
+
+/**
  * Map a classified GraphQLError to a user-facing message with the RIGHT
  * attribution (issue #441):
  *  - SCHEMA_ERROR        → this tool's model of the API may be outdated
@@ -21,10 +35,18 @@ export function graphQLErrorToMcpError(e: GraphQLError): string {
       );
     case 'USER_ACTION_REQUIRED':
       return `Copilot's server rejected the request: ${e.message}`;
-    case 'SERVER_ERROR':
-      return `Copilot's server failed to process the request (HTTP ${e.httpStatus ?? 'unknown'}). This may be transient — retry. Server said: ${e.message}`;
+    case 'SERVER_ERROR': {
+      const base = `Copilot's server failed to process the request (HTTP ${e.httpStatus ?? 'unknown'})${attemptsNote(e)}.`;
+      const advice = e.writeMayHaveApplied
+        ? ` ${WRITE_AMBIGUITY_WARNING}`
+        : ' This may be transient — retry.';
+      return `${base}${advice} Server said: ${e.message}`;
+    }
     case 'NETWORK':
-      return `Transient network problem contacting Copilot — retry. (${e.message})`;
+      if (e.writeMayHaveApplied) {
+        return `Network failure while sending a write to Copilot. ${WRITE_AMBIGUITY_WARNING} (${e.message})`;
+      }
+      return `Transient network problem contacting Copilot${attemptsNote(e)} — retry. (${e.message})`;
     case 'UNKNOWN':
     default:
       return `Copilot API request failed: ${e.message}`;

--- a/src/tools/live/balance-history.ts
+++ b/src/tools/live/balance-history.ts
@@ -133,13 +133,11 @@ export class LiveBalanceHistoryTools {
     if (entry !== undefined && startedAt - entry.fetched_at < this.ttlMs) {
       hit = true;
     } else {
-      const rows = await this.live.withRetry(() =>
-        fetchAccountBalanceHistory(this.live.getClient(), {
-          itemId: args.item_id,
-          accountId: args.account_id,
-          timeFrame: args.time_frame,
-        })
-      );
+      const rows = await fetchAccountBalanceHistory(this.live.getClient(), {
+        itemId: args.item_id,
+        accountId: args.account_id,
+        timeFrame: args.time_frame,
+      });
       entry = { rows, fetched_at: Date.now() };
       this.cache.set(key, entry);
     }

--- a/src/tools/live/investment-prices.ts
+++ b/src/tools/live/investment-prices.ts
@@ -193,12 +193,10 @@ export class LiveInvestmentPricesTools {
     timeFrame: TimeFrame
   ): Promise<HighFrequencyPricePointNode[]> {
     try {
-      return await this.live.withRetry(() =>
-        fetchSecurityPricesHighFrequency(this.live.getClient(), {
-          id: securityId,
-          timeFrame,
-        })
-      );
+      return await fetchSecurityPricesHighFrequency(this.live.getClient(), {
+        id: securityId,
+        timeFrame,
+      });
     } catch (err) {
       translateNotFound(err, securityId);
     }
@@ -209,12 +207,10 @@ export class LiveInvestmentPricesTools {
     timeFrame: TimeFrame
   ): Promise<SecurityPricePointNode[]> {
     try {
-      return await this.live.withRetry(() =>
-        fetchSecurityPrices(this.live.getClient(), {
-          id: securityId,
-          timeFrame,
-        })
-      );
+      return await fetchSecurityPrices(this.live.getClient(), {
+        id: securityId,
+        timeFrame,
+      });
     } catch (err) {
       translateNotFound(err, securityId);
     }
@@ -245,9 +241,9 @@ export class LiveInvestmentPricesTools {
       if (entry !== undefined && startedAt - entry.fetched_at < this.intradayTtlMs) {
         hit = true;
       } else {
-        // Translate the ownership-gated error OUTSIDE withRetry. Doing it
-        // inside would swallow the typed GraphQLError before withRetry can
-        // see (and retry) NETWORK errors.
+        // Translate the ownership-gated error AFTER the fetch resolves —
+        // transport-level retry lives inside GraphQLClient (issue #443), so
+        // the typed GraphQLError reaches translateNotFound untouched.
         const rows = await this.fetchIntraday(args.security_id, timeFrame);
         entry = { rows, fetched_at: Date.now() };
         this.intradayCache.set(key, entry);

--- a/tests/core/graphql/client.test.ts
+++ b/tests/core/graphql/client.test.ts
@@ -563,6 +563,41 @@ describe('GraphQLClient — retry/backoff (#443)', () => {
     expect(fetchCalls).toHaveLength(2);
   });
 
+  test('mutation retries when the errno lives two levels deep in the cause chain', async () => {
+    const inner = new Error('connect ECONNREFUSED 127.0.0.1:443');
+    const mid = new Error('connect error') as Error & { cause?: unknown };
+    mid.cause = inner;
+    const outer = new Error('fetch failed') as Error & { cause?: unknown };
+    outer.cause = mid;
+    mockFetchSequence([{ throwErr: outer }, { body: { data: { ok: true } } }]);
+    const out = await silencingConsoleError(() =>
+      fastClient().mutate<unknown, { ok: boolean }>('M', 'mutation M { ok }', {})
+    );
+    expect(out.ok).toBe(true);
+    expect(fetchCalls).toHaveLength(2);
+  });
+
+  test('mutation does NOT retry when only a WRAPPER message quotes an errno string', async () => {
+    // The innermost error is ambiguous (no code, no errno text); the wrapper
+    // merely quotes "ECONNREFUSED" in prose. Message-scanning must not treat
+    // this as provably unsent — the write may have been sent.
+    const inner = new Error('socket hang up mid-flight');
+    const outer = new Error('request failed (saw ECONNREFUSED earlier in pool)') as Error & {
+      cause?: unknown;
+    };
+    outer.cause = inner;
+    mockFetchSequence([{ throwErr: outer }]);
+    await silencingConsoleError(async () => {
+      try {
+        await fastClient().mutate('M', 'mutation M { ok }', {});
+        expect.unreachable('mutate should have thrown');
+      } catch (e) {
+        expect((e as GraphQLError).writeMayHaveApplied).toBe(true);
+      }
+    });
+    expect(fetchCalls).toHaveLength(1);
+  });
+
   test('mutation retries Bun-style ConnectionRefused (top-level code, no cause)', async () => {
     const bunErr = new Error('Unable to connect.') as Error & { code?: string };
     bunErr.code = 'ConnectionRefused';

--- a/tests/core/graphql/client.test.ts
+++ b/tests/core/graphql/client.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect, afterEach, mock } from 'bun:test';
-import { GraphQLClient, GraphQLError } from '../../../src/core/graphql/client.js';
+import {
+  GraphQLClient,
+  GraphQLError,
+  DEFAULT_RETRY_DELAYS_MS,
+  DEFAULT_TIMEOUT_MS,
+} from '../../../src/core/graphql/client.js';
 import type { FirebaseAuth } from '../../../src/core/auth/firebase-auth.js';
 
 let fetchCalls: { url: string; options: RequestInit }[] = [];
@@ -333,6 +338,17 @@ describe('GraphQLClient', () => {
     }
   });
 
+  test('failed responses carry requestReachedServer=true (an HTTP response arrived)', async () => {
+    mockFetch('upstream blew up', 502);
+    const client = new GraphQLClient(createMockAuth());
+    try {
+      await client.mutate('TestOp', 'mutation TestOp { ok }', {});
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect((e as GraphQLError).requestReachedServer).toBe(true);
+    }
+  });
+
   test('logs to stderr when throwing on classified errors', async () => {
     mockFetch({ errors: [{ message: 'unauthorized' }] }, 401);
     const originalError = console.error;
@@ -359,5 +375,310 @@ describe('GraphQLClient', () => {
     } finally {
       console.error = originalError;
     }
+  });
+});
+
+// ── Retry / backoff (issue #443) ─────────────────────────────────────────────
+
+type FetchStep = { throwErr: Error } | { body: unknown; status?: number };
+
+/** Mock fetch with a per-call script; the last step repeats if exhausted. */
+function mockFetchSequence(steps: FetchStep[]) {
+  fetchCalls = [];
+  let i = 0;
+  globalThis.fetch = mock((url: string | URL | Request, options?: RequestInit) => {
+    fetchCalls.push({ url: String(url), options: options ?? {} });
+    const step = steps[Math.min(i, steps.length - 1)];
+    i += 1;
+    if ('throwErr' in step) return Promise.reject(step.throwErr);
+    return Promise.resolve(
+      new Response(JSON.stringify(step.body), {
+        status: step.status ?? 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  }) as typeof fetch;
+}
+
+/** Client with zero backoff/jitter so retry tests run instantly. */
+function fastClient(opts: ConstructorParameters<typeof GraphQLClient>[1] = {}) {
+  return new GraphQLClient(createMockAuth(), { retryDelaysMs: [0, 0, 0], jitterMs: 0, ...opts });
+}
+
+/** Node-shaped fetch rejection: TypeError('fetch failed') with errno cause. */
+function fetchRejection(code?: string, causeMessage = 'socket-level failure'): Error {
+  const err = new Error('fetch failed') as Error & { cause?: unknown };
+  if (code) {
+    const cause = new Error(`${causeMessage} (${code})`) as Error & { code?: string };
+    cause.code = code;
+    err.cause = cause;
+  }
+  return err;
+}
+
+function silencingConsoleError<T>(fn: () => Promise<T>): Promise<T> {
+  const original = console.error;
+  console.error = (() => {}) as typeof console.error;
+  return fn().finally(() => {
+    console.error = original;
+  });
+}
+
+describe('GraphQLClient — retry/backoff (#443)', () => {
+  afterEach(() => restoreFetch());
+
+  test('default backoff schedule is 3 retries at 250ms/1s/4s', () => {
+    expect([...DEFAULT_RETRY_DELAYS_MS]).toEqual([250, 1000, 4000]);
+    expect(DEFAULT_TIMEOUT_MS).toBe(30_000);
+  });
+
+  test('passes an AbortSignal (timeout) to fetch by default', async () => {
+    mockFetch({ data: { ok: true } });
+    await new GraphQLClient(createMockAuth()).query('Q', 'query Q { ok }', {});
+    expect(fetchCalls[0].options.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test('timeoutMs: Infinity disables the abort signal', async () => {
+    mockFetch({ data: { ok: true } });
+    await new GraphQLClient(createMockAuth(), { timeoutMs: Infinity }).query(
+      'Q',
+      'query Q { ok }',
+      {}
+    );
+    expect(fetchCalls[0].options.signal).toBeUndefined();
+  });
+
+  test('query recovers from a transient fetch rejection', async () => {
+    mockFetchSequence([{ throwErr: fetchRejection() }, { body: { data: { ok: true } } }]);
+    const out = await silencingConsoleError(() =>
+      fastClient().query<unknown, { ok: boolean }>('Q', 'query Q { ok }', {})
+    );
+    expect(out.ok).toBe(true);
+    expect(fetchCalls).toHaveLength(2);
+  });
+
+  test('query recovers from a 5xx with no GraphQL error body', async () => {
+    mockFetchSequence([{ body: 'bad gateway', status: 502 }, { body: { data: { ok: true } } }]);
+    const out = await silencingConsoleError(() =>
+      fastClient().query<unknown, { ok: boolean }>('Q', 'query Q { ok }', {})
+    );
+    expect(out.ok).toBe(true);
+    expect(fetchCalls).toHaveLength(2);
+  });
+
+  test('query does NOT retry a 5xx that carries a GraphQL errors[] body', async () => {
+    mockFetchSequence([
+      { body: { errors: [{ message: 'resolver exploded' }] }, status: 500 },
+      { body: { data: { ok: true } } },
+    ]);
+    await silencingConsoleError(async () => {
+      try {
+        await fastClient().query('Q', 'query Q { ok }', {});
+        throw new Error('should have thrown');
+      } catch (e) {
+        expect((e as GraphQLError).code).toBe('SERVER_ERROR');
+      }
+    });
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test('query does NOT retry GraphQL-level errors (2xx + errors[])', async () => {
+    mockFetchSequence([
+      { body: { errors: [{ message: 'Budgeting is disabled.' }] } },
+      { body: { data: { ok: true } } },
+    ]);
+    await silencingConsoleError(async () => {
+      try {
+        await fastClient().query('Q', 'query Q { ok }', {});
+        throw new Error('should have thrown');
+      } catch (e) {
+        expect((e as GraphQLError).code).toBe('USER_ACTION_REQUIRED');
+      }
+    });
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test('query gives up after exhausting retries; error carries attempts', async () => {
+    mockFetchSequence([{ throwErr: fetchRejection() }]);
+    await silencingConsoleError(async () => {
+      try {
+        await fastClient().query('Q', 'query Q { ok }', {});
+        throw new Error('should have thrown');
+      } catch (e) {
+        expect((e as GraphQLError).code).toBe('NETWORK');
+        expect((e as GraphQLError).attempts).toBe(4);
+      }
+    });
+    expect(fetchCalls).toHaveLength(4); // 1 initial + 3 retries
+  });
+
+  test('query retries a timed-out attempt and recovers', async () => {
+    fetchCalls = [];
+    let call = 0;
+    globalThis.fetch = mock((url: string | URL | Request, options?: RequestInit) => {
+      fetchCalls.push({ url: String(url), options: options ?? {} });
+      call += 1;
+      if (call === 1) {
+        // Hang until the timeout signal aborts us.
+        return new Promise<Response>((_resolve, reject) => {
+          options?.signal?.addEventListener('abort', () => reject(options.signal?.reason));
+        });
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ data: { ok: true } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    }) as typeof fetch;
+
+    const out = await silencingConsoleError(() =>
+      fastClient({ timeoutMs: 20 }).query<unknown, { ok: boolean }>('Q', 'query Q { ok }', {})
+    );
+    expect(out.ok).toBe(true);
+    expect(fetchCalls).toHaveLength(2);
+  });
+
+  test('mutation retries a provably-unsent failure (ECONNREFUSED) and recovers', async () => {
+    mockFetchSequence([
+      { throwErr: fetchRejection('ECONNREFUSED') },
+      { body: { data: { ok: true } } },
+    ]);
+    const out = await silencingConsoleError(() =>
+      fastClient().mutate<unknown, { ok: boolean }>('M', 'mutation M { ok }', {})
+    );
+    expect(out.ok).toBe(true);
+    expect(fetchCalls).toHaveLength(2);
+  });
+
+  test('mutation retries a DNS failure (ENOTFOUND) and recovers', async () => {
+    mockFetchSequence([
+      { throwErr: fetchRejection('ENOTFOUND', 'getaddrinfo failure') },
+      { body: { data: { ok: true } } },
+    ]);
+    const out = await silencingConsoleError(() =>
+      fastClient().mutate<unknown, { ok: boolean }>('M', 'mutation M { ok }', {})
+    );
+    expect(out.ok).toBe(true);
+    expect(fetchCalls).toHaveLength(2);
+  });
+
+  test('mutation retries Bun-style ConnectionRefused (top-level code, no cause)', async () => {
+    const bunErr = new Error('Unable to connect.') as Error & { code?: string };
+    bunErr.code = 'ConnectionRefused';
+    mockFetchSequence([{ throwErr: bunErr }, { body: { data: { ok: true } } }]);
+    const out = await silencingConsoleError(() =>
+      fastClient().mutate<unknown, { ok: boolean }>('M', 'mutation M { ok }', {})
+    );
+    expect(out.ok).toBe(true);
+    expect(fetchCalls).toHaveLength(2);
+  });
+
+  test('exhausted provably-unsent mutation keeps writeMayHaveApplied=false', async () => {
+    mockFetchSequence([{ throwErr: fetchRejection('ECONNREFUSED') }]);
+    await silencingConsoleError(async () => {
+      try {
+        await fastClient().mutate('M', 'mutation M { ok }', {});
+        throw new Error('should have thrown');
+      } catch (e) {
+        const err = e as GraphQLError;
+        expect(err.code).toBe('NETWORK');
+        expect(err.requestReachedServer).toBe(false);
+        expect(err.writeMayHaveApplied).toBe(false);
+        expect(err.attempts).toBe(4);
+      }
+    });
+    expect(fetchCalls).toHaveLength(4);
+  });
+
+  test('mutation does NOT retry an ambiguous fetch rejection (ECONNRESET)', async () => {
+    mockFetchSequence([
+      { throwErr: new Error('read ECONNRESET') },
+      { body: { data: { ok: true } } },
+    ]);
+    await silencingConsoleError(async () => {
+      try {
+        await fastClient().mutate('M', 'mutation M { ok }', {});
+        throw new Error('should have thrown');
+      } catch (e) {
+        const err = e as GraphQLError;
+        expect(err.code).toBe('NETWORK');
+        expect(err.requestReachedServer).toBeUndefined();
+        expect(err.writeMayHaveApplied).toBe(true);
+      }
+    });
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test('mutation does NOT retry a timeout; flags writeMayHaveApplied', async () => {
+    fetchCalls = [];
+    globalThis.fetch = mock((url: string | URL | Request, options?: RequestInit) => {
+      fetchCalls.push({ url: String(url), options: options ?? {} });
+      return new Promise<Response>((_resolve, reject) => {
+        options?.signal?.addEventListener('abort', () => reject(options.signal?.reason));
+      });
+    }) as typeof fetch;
+
+    await silencingConsoleError(async () => {
+      try {
+        await fastClient({ timeoutMs: 20 }).mutate('M', 'mutation M { ok }', {});
+        throw new Error('should have thrown');
+      } catch (e) {
+        const err = e as GraphQLError;
+        expect(err.code).toBe('NETWORK');
+        expect(err.message).toContain('timed out after 20ms');
+        expect(err.writeMayHaveApplied).toBe(true);
+      }
+    });
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test('mutation does NOT retry a 5xx; flags writeMayHaveApplied', async () => {
+    mockFetchSequence([{ body: 'internal error', status: 500 }, { body: { data: { ok: true } } }]);
+    await silencingConsoleError(async () => {
+      try {
+        await fastClient().mutate('M', 'mutation M { ok }', {});
+        throw new Error('should have thrown');
+      } catch (e) {
+        const err = e as GraphQLError;
+        expect(err.code).toBe('SERVER_ERROR');
+        expect(err.writeMayHaveApplied).toBe(true);
+      }
+    });
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test('server-rejected mutation (SCHEMA_ERROR) is definitive: no retry, no ambiguity flag', async () => {
+    mockFetchSequence([
+      {
+        body: { errors: [{ message: 'bad enum', extensions: { code: 'BAD_USER_INPUT' } }] },
+        status: 400,
+      },
+    ]);
+    await silencingConsoleError(async () => {
+      try {
+        await fastClient().mutate('M', 'mutation M { ok }', {});
+        throw new Error('should have thrown');
+      } catch (e) {
+        const err = e as GraphQLError;
+        expect(err.code).toBe('SCHEMA_ERROR');
+        expect(err.writeMayHaveApplied).toBe(false);
+      }
+    });
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test('retryDelaysMs: [] disables retries entirely', async () => {
+    mockFetchSequence([{ throwErr: fetchRejection() }]);
+    await silencingConsoleError(async () => {
+      try {
+        await fastClient({ retryDelaysMs: [] }).query('Q', 'query Q { ok }', {});
+        throw new Error('should have thrown');
+      } catch (e) {
+        expect((e as GraphQLError).code).toBe('NETWORK');
+        expect((e as GraphQLError).attempts).toBe(1);
+      }
+    });
+    expect(fetchCalls).toHaveLength(1);
   });
 });

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -17,54 +17,8 @@ function mkCache(): CopilotDatabase {
   return { getAccounts: mock() } as unknown as CopilotDatabase;
 }
 
-describe('LiveCopilotDatabase — withRetry', () => {
-  test('succeeds on first try without retry', async () => {
-    const live = new LiveCopilotDatabase(mkClient(), mkCache());
-    let calls = 0;
-    const result = await live.withRetry(async () => {
-      calls += 1;
-      return 'ok';
-    });
-    expect(result).toBe('ok');
-    expect(calls).toBe(1);
-  });
-
-  test('retries once on NETWORK error and succeeds', async () => {
-    const live = new LiveCopilotDatabase(mkClient(), mkCache());
-    let calls = 0;
-    const result = await live.withRetry(async () => {
-      calls += 1;
-      if (calls === 1) throw new GraphQLError('NETWORK', 'boom', 'Op');
-      return 'ok';
-    });
-    expect(result).toBe('ok');
-    expect(calls).toBe(2);
-  });
-
-  test('does not retry on AUTH_FAILED', async () => {
-    const live = new LiveCopilotDatabase(mkClient(), mkCache());
-    let calls = 0;
-    await expect(
-      live.withRetry(async () => {
-        calls += 1;
-        throw new GraphQLError('AUTH_FAILED', '401', 'Op');
-      })
-    ).rejects.toThrow('401');
-    expect(calls).toBe(1);
-  });
-
-  test('surfaces error after second NETWORK failure', async () => {
-    const live = new LiveCopilotDatabase(mkClient(), mkCache());
-    let calls = 0;
-    await expect(
-      live.withRetry(async () => {
-        calls += 1;
-        throw new GraphQLError('NETWORK', 'still broken', 'Op');
-      })
-    ).rejects.toThrow('still broken');
-    expect(calls).toBe(2);
-  });
-});
+// NOTE: transport retry/backoff moved into GraphQLClient (issue #443);
+// LiveCopilotDatabase no longer has a withRetry layer of its own.
 
 describe('LiveCopilotDatabase.getTransactions (windowed)', () => {
   function mkClientReturning(pages: TransactionsPage[]): GraphQLClient {

--- a/tests/tools/errors.test.ts
+++ b/tests/tools/errors.test.ts
@@ -64,6 +64,44 @@ describe('graphQLErrorToMcpError', () => {
     expect(msg).toContain('418: teapot');
   });
 
+  test('NETWORK write with ambiguous delivery → "may or may not have applied" warning (#443)', () => {
+    const err = new GraphQLError(
+      'NETWORK',
+      'request timed out after 30000ms',
+      'EditTag',
+      undefined,
+      undefined,
+      {
+        writeMayHaveApplied: true,
+      }
+    );
+    const msg = graphQLErrorToMcpError(err);
+    expect(msg).toContain('may or may not have applied');
+    expect(msg).toContain('verify the current state');
+    expect(msg).toContain('request timed out after 30000ms');
+    // Must NOT advise a blind retry.
+    expect(msg).not.toContain('Transient network problem');
+  });
+
+  test('SERVER_ERROR write with ambiguous delivery → warning instead of blind-retry advice (#443)', () => {
+    const err = new GraphQLError('SERVER_ERROR', '500: internal error', 'EditTag', 500, undefined, {
+      writeMayHaveApplied: true,
+    });
+    const msg = graphQLErrorToMcpError(err);
+    expect(msg).toContain('may or may not have applied');
+    expect(msg).not.toContain('This may be transient — retry.');
+    expect(msg).toContain('500: internal error');
+  });
+
+  test('NETWORK read failure after exhausted retries mentions attempt count (#443)', () => {
+    const err = new GraphQLError('NETWORK', 'fetch failed', 'Transactions', undefined, undefined, {
+      attempts: 4,
+    });
+    const msg = graphQLErrorToMcpError(err);
+    expect(msg).toContain('after 4 attempts');
+    expect(msg).toContain('retry');
+  });
+
   test('no branch emits the old misleading blanket message', () => {
     const codes = [
       'AUTH_FAILED',


### PR DESCRIPTION
Closes #443 (part of Epic C #429; builds on the C2 taxonomy from #441).

## What

`GraphQLClient` was single-attempt: a wifi blip was indistinguishable from a real failure, polluting drift signals and degrading UX. This PR adds bounded retry/backoff for **transport-level** failures only, with a hard safety split between reads and writes.

### Retry policy

| Failure | Query (read) | Mutation (write) |
|---|---|---|
| Fetch rejection, provably unsent (ECONNREFUSED / DNS / no-route, anywhere in the `cause` chain) | retry | **retry** (server provably never saw it) |
| Fetch rejection, ambiguous (e.g. mid-flight ECONNRESET) | retry | **no retry** + `writeMayHaveApplied` |
| Timeout (new per-attempt `AbortSignal.timeout`, default 30s, configurable) | retry | **no retry** + `writeMayHaveApplied` |
| 5xx with no GraphQL error body | retry | **no retry** + `writeMayHaveApplied` |
| 5xx with GraphQL `errors[]` body | no retry | no retry |
| Any GraphQL-level error (SCHEMA_ERROR / AUTH_FAILED / USER_ACTION_REQUIRED) | no retry | no retry |

Backoff: 3 retries at 250ms / 1s / 4s + random jitter (≤250ms), all configurable via new `GraphQLClientOptions` (`timeoutMs`, `retryDelaysMs`, `jitterMs`). Unknown error codes default to "not provably unsent" — the conservative direction for mutation safety.

### Surfacing

- `GraphQLError` gains `requestReachedServer` (three-state delivery evidence: true = HTTP response arrived / false = provably unsent / undefined = ambiguous), `writeMayHaveApplied`, and `attempts`.
- `graphQLErrorToMcpError` now warns on ambiguous write failures: *"this was a write and it may or may not have applied on the server — verify the current state (re-read the entity) before retrying"* — and mentions attempt counts on exhausted-retry network errors (no more blind "retry" advice for ambiguous writes).

### Consolidation

Removed the pre-existing single-retry `LiveCopilotDatabase.withRetry` layer (one NETWORK retry, 500ms) — with retry now inside the client it would have stacked multiplicatively (up to 8 attempts). Its three call sites (`fetchMonth`, balance-history, investment-prices) now call through directly.

## Conformance ledger

No change — this is purely internal transport behavior; no external assumption verified or strengthened.

## Definition of done (from #443)

- [x] Transient transport failure recovers (query + provably-unsent mutation tests)
- [x] GraphQL error does not retry (2xx+errors[], 5xx-with-body, SCHEMA_ERROR tests)
- [x] Ambiguous mutation timeout does not retry and surfaces the warning
- [x] `bun run check` green (typecheck + lint + format + 2006 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)