### PR TITLE
test(e2e): spawned tools/call round-trip over stdio (E2)

### DIFF
--- a/tests/integration/mcpb-bundle.test.ts
+++ b/tests/integration/mcpb-bundle.test.ts
@@ -64,11 +64,11 @@ function readResponse(
     const onStderr = (chunk: Buffer) => {
       stderr += chunk.toString('utf8');
     };
-    const onExit = (code: number | null) => {
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
       cleanup();
       reject(
         new Error(
-          `Server exited with code ${code} before responding to id=${id}\n` +
+          `Server exited (code=${code}, signal=${signal}) before responding to id=${id}\n` +
             `stdout buffer: ${buffer}\nstderr: ${stderr}`
         )
       );
@@ -87,7 +87,7 @@ function readResponse(
     };
     proc.stdout.on('data', onData);
     proc.stderr.on('data', onStderr);
-    proc.once('exit', onExit);
+    proc.on('exit', onExit);
   });
 }
 
@@ -237,6 +237,8 @@ describe('mcpb bundle', () => {
       expect(payload.count).toBe(1);
       expect(payload.accounts[0].account_id).toBe(SYNTHETIC_ACCOUNT_ID);
       expect(payload.accounts[0].name).toBe('Synthetic Checking');
+      // Numeric fields exercise the serialization path this test exists for.
+      expect(payload.accounts[0].current_balance).toBe(100);
     } finally {
       proc.kill('SIGTERM');
     }

--- a/tests/integration/mcpb-bundle.test.ts
+++ b/tests/integration/mcpb-bundle.test.ts
@@ -19,6 +19,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createAccountDb } from '../helpers/test-db';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..', '..');
@@ -95,9 +96,10 @@ function send(proc: ChildProcessWithoutNullStreams, msg: object): void {
 }
 
 async function startAndInitialize(
-  extractDir: string
+  extractDir: string,
+  cliArgs: string[] = []
 ): Promise<{ proc: ChildProcessWithoutNullStreams; initializeResult: JsonRpcResponse }> {
-  const proc = spawn('node', [join(extractDir, 'dist/cli.js')], {
+  const proc = spawn('node', [join(extractDir, 'dist/cli.js'), ...cliArgs], {
     cwd: extractDir,
     env: { ...process.env, NODE_PATH: '' },
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -122,11 +124,15 @@ async function startAndInitialize(
   }
 }
 
+// Firestore-shaped opaque ID (trivial IDs mask resolution bugs).
+const SYNTHETIC_ACCOUNT_ID = 'qZx8Kw2nRfTb6Lm1Vc3PYd0a';
+
 describe('mcpb bundle', () => {
   let extractDir: string;
+  let syntheticDbDir: string;
   let bundledVersion: string;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     // `unzip` is used to extract the bundle the way Claude Desktop does.
     // Pre-flight so the failure is clear on minimal images (e.g. Alpine).
     try {
@@ -142,11 +148,28 @@ describe('mcpb bundle', () => {
     extractDir = mkdtempSync(join(tmpdir(), 'copilot-mcpb-test-'));
     execSync(`unzip -q ${JSON.stringify(bundlePath)} -d ${JSON.stringify(extractDir)}`);
     bundledVersion = JSON.parse(readFileSync(join(extractDir, 'package.json'), 'utf8')).version;
+
+    // Synthetic LevelDB for the tools/call round-trip test. Built here (in the
+    // test process) and handed to the spawned bundle via --db-path.
+    syntheticDbDir = mkdtempSync(join(tmpdir(), 'copilot-mcpb-db-'));
+    await createAccountDb(syntheticDbDir, [
+      {
+        account_id: SYNTHETIC_ACCOUNT_ID,
+        name: 'Synthetic Checking',
+        account_type: 'depository',
+        subtype: 'checking',
+        current_balance: 100,
+        iso_currency_code: 'USD',
+      },
+    ]);
   }, 120_000);
 
   afterAll(() => {
     if (extractDir) {
       rmSync(extractDir, { recursive: true, force: true });
+    }
+    if (syntheticDbDir) {
+      rmSync(syntheticDbDir, { recursive: true, force: true });
     }
   });
 
@@ -176,6 +199,44 @@ describe('mcpb bundle', () => {
       expect(Array.isArray(tools)).toBe(true);
       // Bundled CLI runs read-only; write tools are excluded.
       expect(tools.length).toBe(14);
+    } finally {
+      proc.kill('SIGTERM');
+    }
+  }, 20_000);
+
+  test('tools/call round-trips a well-formed result over stdio', async () => {
+    const { proc } = await startAndInitialize(extractDir, ['--db-path', syntheticDbDir]);
+    try {
+      send(proc, { jsonrpc: '2.0', method: 'notifications/initialized' });
+      send(proc, {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'get_accounts', arguments: {} },
+      });
+      const response = await readResponse(proc, 2, 10_000);
+
+      expect(response.error).toBeUndefined();
+      const result = response.result as {
+        content: Array<{ type: string; text: string }>;
+        isError?: boolean;
+      };
+      expect(result.isError).toBeFalsy();
+
+      // A well-formed MCP result carries text content blocks whose payload is
+      // valid JSON — this is where non-serializable tool output would surface.
+      expect(Array.isArray(result.content)).toBe(true);
+      expect(result.content.length).toBeGreaterThan(0);
+      const block = result.content[0];
+      expect(block.type).toBe('text');
+
+      const payload = JSON.parse(block.text) as {
+        count: number;
+        accounts: Array<{ account_id: string; name?: string; current_balance?: number }>;
+      };
+      expect(payload.count).toBe(1);
+      expect(payload.accounts[0].account_id).toBe(SYNTHETIC_ACCOUNT_ID);
+      expect(payload.accounts[0].name).toBe('Synthetic Checking');
     } finally {
       proc.kill('SIGTERM');
     }

--- a/tests/integration/mcpb-bundle.test.ts
+++ b/tests/integration/mcpb-bundle.test.ts
@@ -19,7 +19,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createAccountDb } from '../helpers/test-db';
+import { createAccountDb } from '../helpers/test-db.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..', '..');


### PR DESCRIPTION
## Summary

Part of Epic E (#431). Closes #447

`tests/integration/mcpb-bundle.test.ts` spawned the packed bundle and spoke real JSON-RPC, but stopped at `tools/list` — no test exercised a full `tools/call` through a real process boundary, so serialization bugs (e.g. non-JSON-serializable values in tool output) would pass every in-process test.

## Changes

- `beforeAll` now also builds a synthetic LevelDB (one account, Firestore-shaped opaque ID, synthetic numbers) via `tests/helpers/test-db.ts`
- `startAndInitialize` accepts extra CLI args so the spawned bundle can be pointed at the synthetic DB via `--db-path`
- New test: `initialize` → `notifications/initialized` → `tools/call get_accounts` → asserts a well-formed MCP result (`content[0].type === 'text'`, no `isError`) whose text payload parses back to the synthetic account

## Verification

- `bun test tests/integration/mcpb-bundle.test.ts` — 4 pass (packs the bundle, extracts it, runs all four spawned-process tests)
- `bun run check` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)