### PR TITLE
C1: weekly scheduled drift check via launchd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ scripts/*
 !scripts/check-version-sync.ts
 !scripts/check-server-json.ts
 !scripts/check-skills.py
+!scripts/scheduled-smoke.ts
+!scripts/install-scheduled-smoke.sh
+!scripts/uninstall-scheduled-smoke.sh
 # License-check scratch directory (created by CI license gate)
 .license-check/
 # Generated test fixtures

--- a/docs/scheduled-smoke.md
+++ b/docs/scheduled-smoke.md
@@ -1,0 +1,39 @@
+# Scheduled drift check (weekly smoke)
+
+Every other conformance gate in this repo is activity-triggered (push,
+pre-push, PR review). If Copilot changes their API while no development is
+happening, the first detector would be a confused user. The scheduled smoke
+closes that gap: a launchd user agent runs the Tier-1 conformance suite
+(`bun run smoke` — non-mutating; never the B4 round-trip smokes) once a week
+on the owner's machine, where the browser-session auth lives.
+
+## Install / uninstall
+
+```bash
+scripts/install-scheduled-smoke.sh    # weekly, Monday 10:00 local
+scripts/uninstall-scheduled-smoke.sh
+```
+
+launchd coalesces missed runs: a laptop asleep at the scheduled time runs the
+check on next wake. Manual trigger:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.copilot-money-mcp.scheduled-smoke
+```
+
+## Outcomes (three-state by design)
+
+| Result | Meaning | Behavior |
+| --- | --- | --- |
+| `pass` | All gated surfaces match the server | Silent |
+| `fail` | Conformance failure — likely API drift | macOS notification + dated report under `~/.claude/copilot-money/smoke-reports/` |
+| `auth-missing` | No Copilot browser session — **drift NOT checked** | Recorded distinctly; absence of auth must never look like absence of drift |
+
+Every run writes `~/.claude/copilot-money/scheduled-smoke.json`
+(`last_run`, `result`, `summary`, `report`). The `get_connection_status` MCP
+tool surfaces this as `scheduled_smoke`, so a dev session sees staleness or
+failures without hunting for logs. `null` there means the job was never
+installed or has never run.
+
+Runner: `scripts/scheduled-smoke.ts` (env overrides for testing:
+`COPILOT_MCP_REPO`, `COPILOT_MCP_SMOKE_STATUS_PATH`).

--- a/scripts/install-scheduled-smoke.sh
+++ b/scripts/install-scheduled-smoke.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Install the weekly scheduled drift check (#440) as a launchd user agent.
+# Re-running updates the plist in place (paths are resolved at install time).
+set -euo pipefail
+
+LABEL="com.copilot-money-mcp.scheduled-smoke"
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BUN="$(command -v bun || echo "$HOME/.bun/bin/bun")"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+LOG_DIR="$HOME/.claude/copilot-money/logs"
+
+[ -x "$BUN" ] || { echo "error: bun not found — install bun first" >&2; exit 1; }
+mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR"
+
+# Weekly: Monday 10:00 local. launchd coalesces missed runs on wake, so a
+# laptop asleep on Monday morning still runs the check when it wakes.
+cat > "$PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$BUN</string>
+    <string>run</string>
+    <string>$REPO_DIR/scripts/scheduled-smoke.ts</string>
+  </array>
+  <key>WorkingDirectory</key><string>$REPO_DIR</string>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Weekday</key><integer>1</integer>
+    <key>Hour</key><integer>10</integer>
+    <key>Minute</key><integer>0</integer>
+  </dict>
+  <key>StandardOutPath</key><string>$LOG_DIR/scheduled-smoke.out.log</string>
+  <key>StandardErrorPath</key><string>$LOG_DIR/scheduled-smoke.err.log</string>
+</dict>
+</plist>
+EOF
+
+launchctl bootout "gui/$(id -u)" "$PLIST" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST"
+echo "installed: $LABEL (weekly, Monday 10:00 local)"
+echo "manual run: launchctl kickstart -k gui/$(id -u)/$LABEL"
+echo "status file: ~/.claude/copilot-money/scheduled-smoke.json"

--- a/scripts/install-scheduled-smoke.sh
+++ b/scripts/install-scheduled-smoke.sh
@@ -39,6 +39,11 @@ cat > "$PLIST" <<EOF
 </plist>
 EOF
 
+plutil -lint "$PLIST" > /dev/null || {
+  echo "error: generated plist is malformed — check for XML special chars in $REPO_DIR / $BUN" >&2
+  exit 1
+}
+
 launchctl bootout "gui/$(id -u)" "$PLIST" 2>/dev/null || true
 launchctl bootstrap "gui/$(id -u)" "$PLIST"
 echo "installed: $LABEL (weekly, Monday 10:00 local)"

--- a/scripts/scheduled-smoke.ts
+++ b/scripts/scheduled-smoke.ts
@@ -41,11 +41,14 @@ export function summarizeSmokeOutput(result: ScheduledSmokeResult, output: strin
     return 'no Copilot browser session — drift NOT checked (log into app.copilot.money)';
   }
   const lines = output.trim().split('\n');
-  const marker = lines.reverse().find((l) => l.startsWith('[smoke]'));
+  const marker = [...lines].reverse().find((l) => l.startsWith('[smoke]'));
   return (marker ?? lines[0] ?? '').slice(0, 300);
 }
 
 function notify(title: string, message: string): void {
+  // COPILOT_MCP_SMOKE_QUIET suppresses the popup (tests exercise the fail
+  // path; they must not spam real notifications).
+  if (process.env.COPILOT_MCP_SMOKE_QUIET) return;
   // Best-effort; a failed notification must not mask the status write.
   spawnSync('osascript', [
     '-e',
@@ -72,7 +75,8 @@ function main(): void {
   let report: string | null = null;
   if (result === 'fail') {
     mkdirSync(reportsDir, { recursive: true });
-    report = join(reportsDir, `${lastRun.slice(0, 10)}-smoke-failure.txt`);
+    // Full timestamp so same-day failures (manual kickstarts) never overwrite.
+    report = join(reportsDir, `${lastRun.replace(/[:.]/g, '-')}-smoke-failure.txt`);
     writeFileSync(report, output);
     notify(
       'Copilot MCP drift check FAILED',

--- a/scripts/scheduled-smoke.ts
+++ b/scripts/scheduled-smoke.ts
@@ -1,0 +1,97 @@
+/**
+ * Scheduled Tier-1 drift check (#440), invoked weekly by launchd (see
+ * scripts/install-scheduled-smoke.sh). Runs `bun run smoke` — non-mutating
+ * conformance only, NEVER the B4 round-trip smokes — and records the outcome
+ * where the next dev session can see it (get_connection_status reads the
+ * status file via src/utils/scheduled-smoke-status.ts).
+ *
+ * Outcomes are three-state on purpose: a machine with no Copilot browser
+ * session must report `auth-missing`, never `pass` — absence of auth is not
+ * absence of drift.
+ *
+ * On failure: a macOS notification + a dated report file under
+ * ~/.claude/copilot-money/smoke-reports/. On pass: silent.
+ */
+import { mkdirSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { dirname, join } from 'path';
+import { spawnSync } from 'child_process';
+import {
+  defaultScheduledSmokeStatusPath,
+  type ScheduledSmokeResult,
+} from '../src/utils/scheduled-smoke-status.js';
+
+/** Signatures that mean "could not authenticate", not "the API drifted". */
+const AUTH_MISSING_PATTERNS = [
+  /No Copilot Money session found/i,
+  /token exchange failed/i,
+  /PROJECT_NUMBER_MISMATCH/,
+  /UNAUTHENTICATED/,
+  /expired or unauthenticated session/i,
+];
+
+export function classifySmokeOutcome(exitCode: number, output: string): ScheduledSmokeResult {
+  if (exitCode === 0) return 'pass';
+  return AUTH_MISSING_PATTERNS.some((p) => p.test(output)) ? 'auth-missing' : 'fail';
+}
+
+/** Last [smoke]/[ledger] line of output — a one-line human summary. */
+export function summarizeSmokeOutput(result: ScheduledSmokeResult, output: string): string {
+  if (result === 'auth-missing') {
+    return 'no Copilot browser session — drift NOT checked (log into app.copilot.money)';
+  }
+  const lines = output.trim().split('\n');
+  const marker = lines.reverse().find((l) => l.startsWith('[smoke]'));
+  return (marker ?? lines[0] ?? '').slice(0, 300);
+}
+
+function notify(title: string, message: string): void {
+  // Best-effort; a failed notification must not mask the status write.
+  spawnSync('osascript', [
+    '-e',
+    `display notification ${JSON.stringify(message)} with title ${JSON.stringify(title)}`,
+  ]);
+}
+
+function main(): void {
+  const repoDir = process.env.COPILOT_MCP_REPO ?? join(import.meta.dir, '..');
+  const statusPath = process.env.COPILOT_MCP_SMOKE_STATUS_PATH ?? defaultScheduledSmokeStatusPath();
+  const reportsDir = join(dirname(statusPath), 'smoke-reports');
+  mkdirSync(dirname(statusPath), { recursive: true });
+
+  const run = spawnSync(process.execPath, ['run', 'smoke'], {
+    cwd: repoDir,
+    encoding: 'utf-8',
+    timeout: 10 * 60 * 1000,
+  });
+  const output = `${run.stdout ?? ''}${run.stderr ?? ''}`;
+  const exitCode = run.status ?? 1;
+  const result = classifySmokeOutcome(exitCode, output);
+  const lastRun = new Date().toISOString();
+
+  let report: string | null = null;
+  if (result === 'fail') {
+    mkdirSync(reportsDir, { recursive: true });
+    report = join(reportsDir, `${lastRun.slice(0, 10)}-smoke-failure.txt`);
+    writeFileSync(report, output);
+    notify(
+      'Copilot MCP drift check FAILED',
+      `Scheduled smoke found a conformance failure. Report: ${report}`
+    );
+  }
+
+  writeFileSync(
+    statusPath,
+    JSON.stringify(
+      { last_run: lastRun, result, summary: summarizeSmokeOutput(result, output), report },
+      null,
+      2
+    )
+  );
+
+  // launchd treats nonzero exit as job failure; auth-missing is an expected
+  // state (machine logged out), recorded in the status file, so exit 0.
+  process.exit(result === 'fail' ? 1 : 0);
+}
+
+if (import.meta.main) main();

--- a/scripts/scheduled-smoke.ts
+++ b/scripts/scheduled-smoke.ts
@@ -49,14 +49,17 @@ function notify(title: string, message: string): void {
   // COPILOT_MCP_SMOKE_QUIET suppresses the popup (tests exercise the fail
   // path; they must not spam real notifications).
   if (process.env.COPILOT_MCP_SMOKE_QUIET) return;
-  // Best-effort; a failed notification must not mask the status write.
-  spawnSync('osascript', [
-    '-e',
-    `display notification ${JSON.stringify(message)} with title ${JSON.stringify(title)}`,
-  ]);
+  // Best-effort; a failed or hung notification must not mask the status write.
+  spawnSync(
+    'osascript',
+    ['-e', `display notification ${JSON.stringify(message)} with title ${JSON.stringify(title)}`],
+    { timeout: 10_000 }
+  );
 }
 
-function main(): void {
+/** Runs one drift check and returns the process exit code (importable so
+ * tests can execute the full flow in-process, where coverage is visible). */
+export function runScheduledSmoke(): number {
   const repoDir = process.env.COPILOT_MCP_REPO ?? join(import.meta.dir, '..');
   const statusPath = process.env.COPILOT_MCP_SMOKE_STATUS_PATH ?? defaultScheduledSmokeStatusPath();
   const reportsDir = join(dirname(statusPath), 'smoke-reports');
@@ -95,7 +98,7 @@ function main(): void {
 
   // launchd treats nonzero exit as job failure; auth-missing is an expected
   // state (machine logged out), recorded in the status file, so exit 0.
-  process.exit(result === 'fail' ? 1 : 0);
+  return result === 'fail' ? 1 : 0;
 }
 
-if (import.meta.main) main();
+if (import.meta.main) process.exit(runScheduledSmoke());

--- a/scripts/uninstall-scheduled-smoke.sh
+++ b/scripts/uninstall-scheduled-smoke.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Remove the weekly scheduled drift check (#440).
+set -euo pipefail
+
+LABEL="com.copilot-money-mcp.scheduled-smoke"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+
+launchctl bootout "gui/$(id -u)" "$PLIST" 2>/dev/null || true
+rm -f "$PLIST"
+echo "uninstalled: $LABEL (status/report files under ~/.claude/copilot-money/ left in place)"

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -44,6 +44,10 @@ import {
 import { setBudget as gqlSetBudget } from '../core/graphql/budgets.js';
 import { graphQLErrorToMcpError } from './errors.js';
 import { parsePeriod } from '../utils/date.js';
+import {
+  readScheduledSmokeStatus,
+  type ScheduledSmokeStatus,
+} from '../utils/scheduled-smoke-status.js';
 import { computeTotalReturnPercent, roundAmount } from '../utils/round.js';
 import {
   getCategoryName,
@@ -1098,6 +1102,7 @@ export class CopilotMoneyTools {
       needs_attention: number;
     };
     decode_health: DecodeHealth;
+    scheduled_smoke: ScheduledSmokeStatus | null;
   }> {
     const items = await this.db.getItems();
 
@@ -1149,6 +1154,7 @@ export class CopilotMoneyTools {
         needs_attention: needsAttention,
       },
       decode_health: this.db.getDecodeHealth(),
+      scheduled_smoke: readScheduledSmokeStatus(),
     };
   }
 
@@ -4133,7 +4139,9 @@ export function createToolSchemas(): ToolSchema[] {
         'for transactions and investments, login requirements, and error states. ' +
         'Use this to check when accounts were last synced or to identify connections needing attention. ' +
         'Also reports decode_health: per-collection counts of cached documents dropped on schema ' +
-        'validation failure (a "degraded" status means some documents are missing from results).',
+        'validation failure (a "degraded" status means some documents are missing from results). ' +
+        'Also reports scheduled_smoke: the last scheduled API-drift check (pass / fail / ' +
+        'auth-missing with timestamp), or null if the weekly job is not installed.',
       inputSchema: {
         type: 'object',
         properties: {},

--- a/src/utils/scheduled-smoke-status.ts
+++ b/src/utils/scheduled-smoke-status.ts
@@ -1,0 +1,58 @@
+/**
+ * Reader for the scheduled drift-check status written by
+ * scripts/scheduled-smoke.ts (#440). The launchd job records its last run
+ * here so get_connection_status can surface drift-check staleness/failures
+ * inside a dev session. Missing or unreadable status is `null` — the tool
+ * must never fail because the scheduled job isn't installed.
+ */
+import { readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+export const SCHEDULED_SMOKE_RESULTS = ['pass', 'fail', 'auth-missing'] as const;
+export type ScheduledSmokeResult = (typeof SCHEDULED_SMOKE_RESULTS)[number];
+
+export interface ScheduledSmokeStatus {
+  last_run: string;
+  result: ScheduledSmokeResult;
+  summary: string;
+  /** Dated report file for failures; null for pass/auth-missing. */
+  report: string | null;
+}
+
+export function defaultScheduledSmokeStatusPath(): string {
+  return join(homedir(), '.claude', 'copilot-money', 'scheduled-smoke.json');
+}
+
+export function readScheduledSmokeStatus(
+  path: string = defaultScheduledSmokeStatusPath()
+): ScheduledSmokeStatus | null {
+  let raw: string;
+  try {
+    raw = readFileSync(path, 'utf-8');
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+  if (
+    typeof obj.last_run !== 'string' ||
+    typeof obj.summary !== 'string' ||
+    typeof obj.result !== 'string' ||
+    !(SCHEDULED_SMOKE_RESULTS as readonly string[]).includes(obj.result)
+  ) {
+    return null;
+  }
+  return {
+    last_run: obj.last_run,
+    result: obj.result as ScheduledSmokeResult,
+    summary: obj.summary,
+    report: typeof obj.report === 'string' ? obj.report : null,
+  };
+}

--- a/src/utils/scheduled-smoke-status.ts
+++ b/src/utils/scheduled-smoke-status.ts
@@ -8,17 +8,24 @@
 import { readFileSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
+import { z } from 'zod';
 
 export const SCHEDULED_SMOKE_RESULTS = ['pass', 'fail', 'auth-missing'] as const;
 export type ScheduledSmokeResult = (typeof SCHEDULED_SMOKE_RESULTS)[number];
 
-export interface ScheduledSmokeStatus {
-  last_run: string;
-  result: ScheduledSmokeResult;
-  summary: string;
+const ScheduledSmokeStatusSchema = z.object({
+  last_run: z.string(),
+  result: z.enum(SCHEDULED_SMOKE_RESULTS),
+  summary: z.string(),
   /** Dated report file for failures; null for pass/auth-missing. */
-  report: string | null;
-}
+  report: z
+    .string()
+    .nullable()
+    .optional()
+    .transform((v) => v ?? null),
+});
+
+export type ScheduledSmokeStatus = z.infer<typeof ScheduledSmokeStatusSchema>;
 
 export function defaultScheduledSmokeStatusPath(): string {
   return join(homedir(), '.claude', 'copilot-money', 'scheduled-smoke.json');
@@ -39,20 +46,6 @@ export function readScheduledSmokeStatus(
   } catch {
     return null;
   }
-  if (typeof parsed !== 'object' || parsed === null) return null;
-  const obj = parsed as Record<string, unknown>;
-  if (
-    typeof obj.last_run !== 'string' ||
-    typeof obj.summary !== 'string' ||
-    typeof obj.result !== 'string' ||
-    !(SCHEDULED_SMOKE_RESULTS as readonly string[]).includes(obj.result)
-  ) {
-    return null;
-  }
-  return {
-    last_run: obj.last_run,
-    result: obj.result as ScheduledSmokeResult,
-    summary: obj.summary,
-    report: typeof obj.report === 'string' ? obj.report : null,
-  };
+  const result = ScheduledSmokeStatusSchema.safeParse(parsed);
+  return result.success ? result.data : null;
 }

--- a/tests/scripts/scheduled-smoke-e2e.test.ts
+++ b/tests/scripts/scheduled-smoke-e2e.test.ts
@@ -1,0 +1,75 @@
+/**
+ * End-to-end runs of scripts/scheduled-smoke.ts against a stub repo whose
+ * `smoke` script produces each outcome. Exercises main(): subprocess spawn,
+ * outcome classification, status-file write, report write, and exit codes —
+ * without touching the network or the real status file.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const RUNNER = join(import.meta.dir, '../../scripts/scheduled-smoke.ts');
+
+let dir: string | null = null;
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  dir = null;
+});
+
+function runScheduledSmoke(smokeScript: string): {
+  exitCode: number;
+  status: Record<string, unknown>;
+  statusPath: string;
+} {
+  dir = mkdtempSync(join(tmpdir(), 'sched-smoke-e2e-'));
+  writeFileSync(join(dir, 'package.json'), JSON.stringify({ scripts: { smoke: smokeScript } }));
+  const statusPath = join(dir, 'status.json');
+  const run = spawnSync(process.execPath, ['run', RUNNER], {
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      COPILOT_MCP_REPO: dir,
+      COPILOT_MCP_SMOKE_STATUS_PATH: statusPath,
+      COPILOT_MCP_SMOKE_QUIET: '1',
+    },
+  });
+  return {
+    exitCode: run.status ?? -1,
+    status: JSON.parse(readFileSync(statusPath, 'utf-8')) as Record<string, unknown>,
+    statusPath,
+  };
+}
+
+describe('scheduled-smoke runner (subprocess e2e)', () => {
+  test('passing smoke → result pass, no report, exit 0', () => {
+    const { exitCode, status } = runScheduledSmoke("echo '[smoke] PASS — synthetic all-clear'");
+    expect(exitCode).toBe(0);
+    expect(status.result).toBe('pass');
+    expect(status.summary).toBe('[smoke] PASS — synthetic all-clear');
+    expect(status.report).toBeNull();
+    expect(typeof status.last_run).toBe('string');
+  });
+
+  test('failing smoke → result fail, dated report with full output, exit 1', () => {
+    const { exitCode, status } = runScheduledSmoke(
+      "echo '[smoke] FAIL — synthetic drift detected' && exit 1"
+    );
+    expect(exitCode).toBe(1);
+    expect(status.result).toBe('fail');
+    expect(typeof status.report).toBe('string');
+    expect(existsSync(status.report as string)).toBe(true);
+    expect(readFileSync(status.report as string, 'utf-8')).toContain('synthetic drift detected');
+  });
+
+  test('auth failure → result auth-missing, no report, exit 0', () => {
+    const { exitCode, status } = runScheduledSmoke(
+      "echo 'error: No Copilot Money session found. Searched: Chrome' && exit 1"
+    );
+    expect(exitCode).toBe(0);
+    expect(status.result).toBe('auth-missing');
+    expect(status.summary).toContain('drift NOT checked');
+    expect(status.report).toBeNull();
+  });
+});

--- a/tests/scripts/scheduled-smoke-e2e.test.ts
+++ b/tests/scripts/scheduled-smoke-e2e.test.ts
@@ -1,50 +1,49 @@
 /**
- * End-to-end runs of scripts/scheduled-smoke.ts against a stub repo whose
- * `smoke` script produces each outcome. Exercises main(): subprocess spawn,
- * outcome classification, status-file write, report write, and exit codes —
- * without touching the network or the real status file.
+ * Full-flow runs of the scheduled-smoke runner against a stub repo whose
+ * `smoke` script produces each outcome. runScheduledSmoke() executes
+ * in-process (so coverage sees it); only `bun run smoke` is a subprocess.
+ * Exercises outcome classification, status-file write, report write, and
+ * exit codes — without touching the network or the real status file.
  */
 import { afterEach, describe, expect, test } from 'bun:test';
-import { spawnSync } from 'child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { runScheduledSmoke } from '../../scripts/scheduled-smoke.js';
 
-const RUNNER = join(import.meta.dir, '../../scripts/scheduled-smoke.ts');
-
+const ENV_KEYS = ['COPILOT_MCP_REPO', 'COPILOT_MCP_SMOKE_STATUS_PATH', 'COPILOT_MCP_SMOKE_QUIET'];
+const savedEnv = new Map(ENV_KEYS.map((k) => [k, process.env[k]]));
 let dir: string | null = null;
+
 afterEach(() => {
+  for (const [k, v] of savedEnv) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
   if (dir) rmSync(dir, { recursive: true, force: true });
   dir = null;
 });
 
-function runScheduledSmoke(smokeScript: string): {
+function runWithStubSmoke(smokeScript: string): {
   exitCode: number;
   status: Record<string, unknown>;
-  statusPath: string;
 } {
   dir = mkdtempSync(join(tmpdir(), 'sched-smoke-e2e-'));
   writeFileSync(join(dir, 'package.json'), JSON.stringify({ scripts: { smoke: smokeScript } }));
   const statusPath = join(dir, 'status.json');
-  const run = spawnSync(process.execPath, ['run', RUNNER], {
-    encoding: 'utf-8',
-    env: {
-      ...process.env,
-      COPILOT_MCP_REPO: dir,
-      COPILOT_MCP_SMOKE_STATUS_PATH: statusPath,
-      COPILOT_MCP_SMOKE_QUIET: '1',
-    },
-  });
+  process.env.COPILOT_MCP_REPO = dir;
+  process.env.COPILOT_MCP_SMOKE_STATUS_PATH = statusPath;
+  process.env.COPILOT_MCP_SMOKE_QUIET = '1';
+  const exitCode = runScheduledSmoke();
   return {
-    exitCode: run.status ?? -1,
+    exitCode,
     status: JSON.parse(readFileSync(statusPath, 'utf-8')) as Record<string, unknown>,
-    statusPath,
   };
 }
 
-describe('scheduled-smoke runner (subprocess e2e)', () => {
+describe('scheduled-smoke runner (full flow, stub smoke)', () => {
   test('passing smoke → result pass, no report, exit 0', () => {
-    const { exitCode, status } = runScheduledSmoke("echo '[smoke] PASS — synthetic all-clear'");
+    const { exitCode, status } = runWithStubSmoke("echo '[smoke] PASS — synthetic all-clear'");
     expect(exitCode).toBe(0);
     expect(status.result).toBe('pass');
     expect(status.summary).toBe('[smoke] PASS — synthetic all-clear');
@@ -53,7 +52,7 @@ describe('scheduled-smoke runner (subprocess e2e)', () => {
   });
 
   test('failing smoke → result fail, dated report with full output, exit 1', () => {
-    const { exitCode, status } = runScheduledSmoke(
+    const { exitCode, status } = runWithStubSmoke(
       "echo '[smoke] FAIL — synthetic drift detected' && exit 1"
     );
     expect(exitCode).toBe(1);
@@ -64,7 +63,7 @@ describe('scheduled-smoke runner (subprocess e2e)', () => {
   });
 
   test('auth failure → result auth-missing, no report, exit 0', () => {
-    const { exitCode, status } = runScheduledSmoke(
+    const { exitCode, status } = runWithStubSmoke(
       "echo 'error: No Copilot Money session found. Searched: Chrome' && exit 1"
     );
     expect(exitCode).toBe(0);

--- a/tests/scripts/scheduled-smoke.test.ts
+++ b/tests/scripts/scheduled-smoke.test.ts
@@ -47,6 +47,22 @@ describe('summarizeSmokeOutput', () => {
     expect(summarizeSmokeOutput('pass', out)).toBe('[smoke] PASS — all 3 enums match.');
   });
 
+  test('fail summaries also come from the last [smoke] marker line', () => {
+    const out = '[smoke] value ...\n[smoke] FAIL — conformance drift detected:\ndetail line';
+    expect(summarizeSmokeOutput('fail', out)).toBe('[smoke] FAIL — conformance drift detected:');
+  });
+
+  test('truncates summaries to 300 chars', () => {
+    const out = `[smoke] ${'x'.repeat(500)}`;
+    expect(summarizeSmokeOutput('fail', out).length).toBe(300);
+  });
+
+  test('falls back to the first line when no [smoke] marker exists', () => {
+    expect(summarizeSmokeOutput('fail', 'error: something exploded\nstack')).toBe(
+      'error: something exploded'
+    );
+  });
+
   test('auth-missing has a fixed actionable summary', () => {
     expect(summarizeSmokeOutput('auth-missing', 'whatever')).toContain('drift NOT checked');
   });

--- a/tests/scripts/scheduled-smoke.test.ts
+++ b/tests/scripts/scheduled-smoke.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Outcome classification for the scheduled drift check (#440). The critical
+ * property: auth failures classify as `auth-missing`, never `pass` (absence
+ * of auth is not absence of drift) and never `fail` (logged-out is not
+ * drift).
+ */
+import { describe, expect, test } from 'bun:test';
+import { classifySmokeOutcome, summarizeSmokeOutput } from '../../scripts/scheduled-smoke.js';
+
+describe('classifySmokeOutcome', () => {
+  test('exit 0 is a pass', () => {
+    expect(classifySmokeOutcome(0, '[smoke] PASS — all good')).toBe('pass');
+  });
+
+  test('nonzero exit with a conformance failure is a fail', () => {
+    expect(classifySmokeOutcome(1, '[smoke] FAIL: bogus_value REJECTED by server')).toBe('fail');
+  });
+
+  test('no-browser-session output is auth-missing, not fail', () => {
+    expect(
+      classifySmokeOutcome(1, 'error: No Copilot Money session found. Searched: Chrome, Safari')
+    ).toBe('auth-missing');
+  });
+
+  test('token-exchange failures are auth-missing (incl. foreign-token #454 case)', () => {
+    expect(
+      classifySmokeOutcome(
+        1,
+        'error: Firebase token exchange failed (400): {"error":{"message":"PROJECT_NUMBER_MISMATCH"}}'
+      )
+    ).toBe('auth-missing');
+  });
+
+  test('mid-run session expiry (non-JSON probe response) is auth-missing', () => {
+    expect(
+      classifySmokeOutcome(
+        1,
+        'error: validation probe got a non-JSON response (HTTP 401) — likely an expired or unauthenticated session'
+      )
+    ).toBe('auth-missing');
+  });
+});
+
+describe('summarizeSmokeOutput', () => {
+  test('uses the last [smoke] marker line', () => {
+    const out = '[smoke] value ...\n[ledger] distribution ...\n[smoke] PASS — all 3 enums match.';
+    expect(summarizeSmokeOutput('pass', out)).toBe('[smoke] PASS — all 3 enums match.');
+  });
+
+  test('auth-missing has a fixed actionable summary', () => {
+    expect(summarizeSmokeOutput('auth-missing', 'whatever')).toContain('drift NOT checked');
+  });
+});

--- a/tests/tools/scheduled-smoke-status.test.ts
+++ b/tests/tools/scheduled-smoke-status.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Scheduled-smoke status surfacing (#440): get_connection_status reports the
+ * last scheduled drift-check run so a dev session (or the user) can see
+ * staleness and failures without hunting for log files. Absence of the file
+ * (job never installed / never ran) is `null`, never an error.
+ */
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { readScheduledSmokeStatus } from '../../src/utils/scheduled-smoke-status.js';
+
+let dir: string | null = null;
+afterEach(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  dir = null;
+});
+
+function statusFile(content: string): string {
+  dir = mkdtempSync(join(tmpdir(), 'smoke-status-'));
+  const file = join(dir, 'scheduled-smoke.json');
+  writeFileSync(file, content);
+  return file;
+}
+
+describe('readScheduledSmokeStatus', () => {
+  test('returns null when the status file does not exist', () => {
+    expect(readScheduledSmokeStatus('/nonexistent/path/scheduled-smoke.json')).toBeNull();
+  });
+
+  test('parses a valid status file', () => {
+    const file = statusFile(
+      JSON.stringify({
+        last_run: '2026-06-11T10:00:00Z',
+        result: 'pass',
+        summary: 'all 3 enums and 12 input types match the server',
+      })
+    );
+    expect(readScheduledSmokeStatus(file)).toEqual({
+      last_run: '2026-06-11T10:00:00Z',
+      result: 'pass',
+      summary: 'all 3 enums and 12 input types match the server',
+      report: null,
+    });
+  });
+
+  test('carries the report path on failures', () => {
+    const file = statusFile(
+      JSON.stringify({
+        last_run: '2026-06-11T10:00:00Z',
+        result: 'fail',
+        summary: '1 surface failed',
+        report: '/Users/x/.claude/copilot-money/smoke-reports/2026-06-11.txt',
+      })
+    );
+    expect(readScheduledSmokeStatus(file)?.report).toBe(
+      '/Users/x/.claude/copilot-money/smoke-reports/2026-06-11.txt'
+    );
+  });
+
+  test('auth-missing is a distinct result, not a pass or fail', () => {
+    const file = statusFile(
+      JSON.stringify({
+        last_run: '2026-06-11T10:00:00Z',
+        result: 'auth-missing',
+        summary: 'no Copilot browser session — drift NOT checked',
+      })
+    );
+    expect(readScheduledSmokeStatus(file)?.result).toBe('auth-missing');
+  });
+
+  test('returns null on malformed JSON instead of throwing', () => {
+    const file = statusFile('not json {');
+    expect(readScheduledSmokeStatus(file)).toBeNull();
+  });
+
+  test('returns null on JSON with the wrong shape', () => {
+    const file = statusFile(JSON.stringify({ something: 'else' }));
+    expect(readScheduledSmokeStatus(file)).toBeNull();
+  });
+});

--- a/tests/tools/scheduled-smoke-status.test.ts
+++ b/tests/tools/scheduled-smoke-status.test.ts
@@ -78,4 +78,11 @@ describe('readScheduledSmokeStatus', () => {
     const file = statusFile(JSON.stringify({ something: 'else' }));
     expect(readScheduledSmokeStatus(file)).toBeNull();
   });
+
+  test('returns null on an unknown result value (hand-edited file)', () => {
+    const file = statusFile(
+      JSON.stringify({ last_run: '2026-06-11T10:00:00Z', result: 'unknown', summary: 'x' })
+    );
+    expect(readScheduledSmokeStatus(file)).toBeNull();
+  });
 });


### PR DESCRIPTION
# Summary

Weekly launchd job running the Tier-1 conformance smoke on the owner's machine, so API drift is detected within a week even when no development is happening. Closes #440

## External assumptions

None — this PR adds scheduling/reporting around the existing smoke; it asserts no new facts about Copilot's API. (The auth-missing classification patterns reference our own error strings, gated by unit tests.)

## What

- `scripts/scheduled-smoke.ts` — runner: executes `bun run smoke` (Tier-1 only, never B4 round-trips), classifies pass / fail / auth-missing, writes `~/.claude/copilot-money/scheduled-smoke.json`. Fail → macOS notification + dated report under `smoke-reports/`; auth-missing is distinct by design (absence of auth must not look like absence of drift); pass is silent.
- `scripts/install-scheduled-smoke.sh` / `uninstall-scheduled-smoke.sh` — launchd user agent, Monday 10:00 local, missed runs coalesce on wake.
- `get_connection_status` now surfaces `scheduled_smoke` (null when the job was never installed).
- `docs/scheduled-smoke.md`.

## Definition of Done (observed on the owner's machine, 2026-06-11)

- Installed; one real launchd-triggered run observed → `pass` with the current 15-surface summary.
- Failure path exercised by temporarily adding a known-bad frequency value → server rejected it, status `fail`, dated report written, notification fired; injection reverted.
- Auth-missing path exercised with an empty `$HOME` (no browser storage) → status `auth-missing`, exit 0, actionable summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)