### PR TITLE
feat(graphql): B3 — warn-mode Zod validation on mutation responses

### DIFF
--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -134,7 +134,7 @@ const FIELD_PROBE_GATED =
 const RESPONSE_SHAPE_GATED =
   'Hand-written TS interface mirrored into a Zod schema; every mutation response ' +
   'is validated warn-mode at runtime (src/core/graphql/response-validation.ts, ' +
-  'issue #437, PR #TBD)';
+  'issue #437, PR #467)';
 
 // ---------------------------------------------------------------------------
 // Entry factories (keep the inventory compact; pass overrides to upgrade an

--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -41,6 +41,7 @@
 import { TRANSACTION_TYPES } from '../core/graphql/transactions.js';
 import { RECURRING_FREQUENCIES, RECURRING_STATE_VALUES } from '../core/graphql/recurrings.js';
 import { ALL_TIME_FRAMES } from '../core/graphql/queries/_shared.js';
+import { RESPONSE_SHAPE_RUNTIME_CHECK } from '../core/graphql/response-validation.js';
 
 /** What kind of external surface the assumption is about. */
 export const SURFACE_KINDS = ['enum', 'input-field', 'response-shape', 'operation'] as const;
@@ -71,10 +72,13 @@ export type ConformanceOracle = `smoke:${string}` | `runtime:${string}`;
 
 /**
  * Registered always-on runtime checks that `runtime:<name>` oracles may
- * reference. Empty until B3 (#437) lands the zod warn-mode response
- * validators; B3 should register e.g. 'zod-warn' here when it ships.
+ * reference.
+ * - `zod-warn` (B3, #437): every mutation response is validated warn-mode
+ *   against a Zod schema mirroring the hand-written response interface
+ *   (src/core/graphql/response-validation.ts); drift logs a structured
+ *   warning and increments a per-surface counter, never failing the call.
  */
-export const RUNTIME_CHECK_NAMES: readonly string[] = [];
+export const RUNTIME_CHECK_NAMES: readonly string[] = [RESPONSE_SHAPE_RUNTIME_CHECK];
 
 export interface LedgerEntry {
   /** External assumption surface (see naming convention above). Unique. */
@@ -123,11 +127,14 @@ const FIELD_PROBE_GATED =
   'Write-field audit lineage (PR #414/#417/#418/#420) + per-field name probe with ' +
   'unknown-field control; gated by scripts/smoke/conformance.ts (issue #436, PR #456)';
 
-/** Response-shape interfaces are hand-written mirrors of captured
- * responses; nothing validates live responses against them at runtime. */
-const RESPONSE_SHAPE_UNVERIFIED =
-  'Hand-written TS interface mirrors captured responses; no runtime schema ' +
-  'validation, drift would surface only as downstream undefineds';
+/** B3 (#437): response-shape interfaces are mirrored into Zod schemas and
+ * every live mutation response is validated against them warn-mode, so
+ * drift surfaces as a structured warning + counter instead of downstream
+ * undefineds. */
+const RESPONSE_SHAPE_GATED =
+  'Hand-written TS interface mirrored into a Zod schema; every mutation response ' +
+  'is validated warn-mode at runtime (src/core/graphql/response-validation.ts, ' +
+  'issue #437, PR #TBD)';
 
 // ---------------------------------------------------------------------------
 // Entry factories (keep the inventory compact; pass overrides to upgrade an
@@ -184,9 +191,9 @@ function responseShape(name: string, overrides?: Partial<LedgerEntry>): LedgerEn
   return {
     surface: `Mutation.${name}:response`,
     kind: 'response-shape',
-    oracle: null,
-    class: 'unverified',
-    evidence: RESPONSE_SHAPE_UNVERIFIED,
+    oracle: `runtime:${RESPONSE_SHAPE_RUNTIME_CHECK}`,
+    class: 'gated',
+    evidence: RESPONSE_SHAPE_GATED,
     ...overrides,
   };
 }

--- a/src/core/graphql/client.ts
+++ b/src/core/graphql/client.ts
@@ -16,6 +16,7 @@
  */
 
 import type { FirebaseAuth } from '../auth/firebase-auth.js';
+import { validateMutationResponse } from './response-validation.js';
 
 const ENDPOINT = 'https://app.copilot.money/api/graphql';
 
@@ -289,7 +290,13 @@ export class GraphQLClient {
     const maxAttempts = this.retryDelaysMs.length + 1;
     for (let attempt = 1; ; attempt++) {
       try {
-        return await this.requestOnce<TVariables, TResponse>(operationName, query, variables);
+        const data = await this.requestOnce<TVariables, TResponse>(operationName, query, variables);
+        // Warn-mode response-shape validation (issue #437): logs + counts
+        // drift against the registered Zod schema, never throws, never
+        // alters the payload. Mutations only — live-read queries have their
+        // own response handling.
+        if (kind === 'mutation') validateMutationResponse(operationName, data);
+        return data;
       } catch (e) {
         if (!(e instanceof GraphQLError)) throw e;
         if (attempt >= maxAttempts || !isRetryable(e, kind)) {

--- a/src/core/graphql/response-validation.ts
+++ b/src/core/graphql/response-validation.ts
@@ -1,0 +1,276 @@
+/**
+ * Warn-mode Zod validation for mutation response payloads (issue #437,
+ * Epic B #421).
+ *
+ * Why: the write path's response shapes are hand-typed casts (e.g.
+ * `CreatedTransaction` in transactions.ts). If Copilot renames or removes a
+ * response field, downstream code reads `undefined` and output degrades
+ * silently. The read path already solved this pattern — `src/core/
+ * schema-warn.ts` validates and warns with dedup. This module is the same
+ * idea pointed at GraphQL mutation responses.
+ *
+ * Semantics — strictly WARN-MODE:
+ * - A mismatched response NEVER throws and NEVER drops data. The caller
+ *   always receives the server payload unchanged; validation only logs a
+ *   structured drift warning (deduped per process, like schema-warn) and
+ *   increments a per-surface drift counter (exposed via
+ *   `getResponseDriftStats()` so C3's drop-visibility work can surface it).
+ * - Schemas mirror the hand-written response interfaces in the per-domain
+ *   modules (transactions.ts, tags.ts, ...) field-for-field, but use
+ *   `z.looseObject` everywhere so NEW server fields (and `__typename`)
+ *   flow through without warnings. Drift = a field we READ going missing
+ *   or changing type, not the server adding things.
+ *
+ * This is the `runtime:zod-warn` oracle in the conformance ledger
+ * (src/conformance/ledger.ts): every `Mutation.<name>:response` surface it
+ * gates must have a schema registered here — enforced bidirectionally by
+ * `tests/conformance/ledger.test.ts`.
+ */
+
+import { z, type ZodType } from 'zod';
+import { TRANSACTION_TYPES } from './transactions.js';
+
+/**
+ * Name of this runtime check as registered in the ledger's
+ * RUNTIME_CHECK_NAMES. `runtime:zod-warn` oracles point here.
+ */
+export const RESPONSE_SHAPE_RUNTIME_CHECK = 'zod-warn' as const;
+
+// ---------------------------------------------------------------------------
+// Schemas — mirror the response interfaces in the per-domain modules.
+// Keep every object `loose`: unknown keys are expected (new server fields,
+// __typename) and must pass through silently.
+// ---------------------------------------------------------------------------
+
+/** Mirrors the tag objects selected by TagFields (tags.ts). */
+const TagSchema = z.looseObject({
+  id: z.string(),
+  name: z.string(),
+  colorName: z.string(),
+});
+
+/** Mirrors `CreatedTransaction` (transactions.ts), the TransactionFields shape. */
+const CreatedTransactionSchema = z.looseObject({
+  id: z.string(),
+  name: z.string(),
+  date: z.string(),
+  amount: z.number(),
+  categoryId: z.string(),
+  type: z.enum(TRANSACTION_TYPES),
+  accountId: z.string(),
+  itemId: z.string(),
+  isPending: z.boolean(),
+  isReviewed: z.boolean(),
+  createdAt: z.number(),
+  recurringId: z.string().nullable(),
+  userNotes: z.string().nullable(),
+  tipAmount: z.number().nullable(),
+  suggestedCategoryIds: z.array(z.string()),
+  tags: z.array(TagSchema),
+  goal: z.looseObject({ id: z.string(), name: z.string() }).nullable(),
+});
+
+export interface ResponseShapeEntry {
+  /** Conformance ledger surface this schema verifies. */
+  surface: `Mutation.${string}:response`;
+  schema: ZodType;
+}
+
+function entry(mutationField: string, schema: ZodType): ResponseShapeEntry {
+  return { surface: `Mutation.${mutationField}:response`, schema };
+}
+
+/**
+ * Registry keyed by GraphQL OPERATION name (the first argument modules pass
+ * to `client.mutate(...)`) — note operation names don't always match the
+ * mutation field name (EditBudget → editCategoryBudget).
+ *
+ * Every mutation the codebase sends must be registered here; an
+ * unregistered operation name gets a (deduped) warning at runtime, and the
+ * ledger test enforces that registered surfaces exactly match the
+ * `runtime:zod-warn`-gated response-shape entries.
+ */
+export const MUTATION_RESPONSE_SCHEMAS: Readonly<Record<string, ResponseShapeEntry>> = {
+  // ----- Transactions (transactions.ts) -----
+  CreateTransaction: entry(
+    'createTransaction',
+    z.looseObject({ createTransaction: CreatedTransactionSchema })
+  ),
+  // Mirrors EditTransactionResponse — the subset of TransactionFields the
+  // wrapper actually reads back.
+  EditTransaction: entry(
+    'editTransaction',
+    z.looseObject({
+      editTransaction: z.looseObject({
+        transaction: z.looseObject({
+          id: z.string(),
+          name: z.string(),
+          categoryId: z.string(),
+          userNotes: z.string().nullable(),
+          isReviewed: z.boolean(),
+          tags: z.array(z.looseObject({ id: z.string() })),
+        }),
+      }),
+    })
+  ),
+  DeleteTransaction: entry('deleteTransaction', z.looseObject({ deleteTransaction: z.boolean() })),
+  AddTransactionToRecurring: entry(
+    'addTransactionToRecurring',
+    z.looseObject({
+      addTransactionToRecurring: z.looseObject({ transaction: CreatedTransactionSchema }),
+    })
+  ),
+  SplitTransaction: entry(
+    'splitTransaction',
+    z.looseObject({
+      splitTransaction: z.looseObject({
+        parentTransaction: CreatedTransactionSchema,
+        splitTransactions: z.array(CreatedTransactionSchema),
+      }),
+    })
+  ),
+
+  // ----- Tags (tags.ts) -----
+  CreateTag: entry('createTag', z.looseObject({ createTag: TagSchema })),
+  EditTag: entry('editTag', z.looseObject({ editTag: TagSchema })),
+  DeleteTag: entry('deleteTag', z.looseObject({ deleteTag: z.boolean() })),
+
+  // ----- Categories (categories.ts) -----
+  CreateCategory: entry(
+    'createCategory',
+    z.looseObject({
+      createCategory: z.looseObject({ id: z.string(), name: z.string(), colorName: z.string() }),
+    })
+  ),
+  EditCategory: entry(
+    'editCategory',
+    z.looseObject({
+      editCategory: z.looseObject({
+        category: z.looseObject({ id: z.string(), name: z.string(), colorName: z.string() }),
+      }),
+    })
+  ),
+  DeleteCategory: entry('deleteCategory', z.looseObject({ deleteCategory: z.boolean() })),
+
+  // ----- Budgets (budgets.ts) — operation names ≠ mutation field names -----
+  EditBudget: entry('editCategoryBudget', z.looseObject({ editCategoryBudget: z.boolean() })),
+  EditBudgetMonthly: entry(
+    'editCategoryBudgetMonthly',
+    z.looseObject({ editCategoryBudgetMonthly: z.boolean() })
+  ),
+
+  // ----- Recurrings (recurrings.ts) -----
+  CreateRecurring: entry(
+    'createRecurring',
+    z.looseObject({
+      createRecurring: z.looseObject({
+        id: z.string(),
+        name: z.string(),
+        state: z.string(),
+        frequency: z.string(),
+      }),
+    })
+  ),
+  EditRecurring: entry(
+    'editRecurring',
+    z.looseObject({
+      editRecurring: z.looseObject({
+        recurring: z.looseObject({
+          id: z.string(),
+          name: z.string(),
+          categoryId: z.string(),
+          frequency: z.string(),
+          state: z.string(),
+        }),
+      }),
+    })
+  ),
+  DeleteRecurring: entry('deleteRecurring', z.looseObject({ deleteRecurring: z.boolean() })),
+
+  // ----- Accounts (accounts.ts) -----
+  EditAccount: entry(
+    'editAccount',
+    z.looseObject({
+      editAccount: z.looseObject({
+        account: z.looseObject({
+          id: z.string(),
+          name: z.string(),
+          isUserHidden: z.boolean(),
+        }),
+      }),
+    })
+  ),
+};
+
+// ---------------------------------------------------------------------------
+// Warn-mode validation + drift counters
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-surface drift counts accumulated over the process lifetime: how many
+ * mutation responses failed shape validation. NOT deduped (unlike the
+ * warnings) so the counters reflect the true number of drifted responses —
+ * same split as schema-warn's `dropped` counter vs its warn dedup.
+ */
+export type ResponseDriftStats = Record<string, number>;
+
+const driftCounts = new Map<string, number>();
+
+// Dedupe key = `${operationName}::${firstIssue.path}::${firstIssue.code}`.
+// One warn per unique key per process — prevents log flood when every call
+// to the same mutation drifts the same way.
+const warnedKeys = new Set<string>();
+
+/** Snapshot of the per-surface drift counters (copy, safe to mutate). */
+export function getResponseDriftStats(): ResponseDriftStats {
+  return Object.fromEntries(driftCounts);
+}
+
+/**
+ * Validate a mutation response payload against its registered schema,
+ * warn-mode. Never throws; never alters `data` — callers keep using the
+ * raw server payload regardless of the outcome.
+ */
+export function validateMutationResponse(operationName: string, data: unknown): void {
+  const registered = MUTATION_RESPONSE_SCHEMAS[operationName];
+  if (!registered) {
+    const key = `${operationName}::<unregistered>`;
+    if (!warnedKeys.has(key)) {
+      warnedKeys.add(key);
+      // console.warn writes to stderr in Node/Bun — safe for the MCP stdio
+      // transport (stdout carries JSON-RPC).
+      console.warn(
+        `[copilot-money-mcp] response shape drift: operation=${operationName} has no registered ` +
+          'response schema — register it in MUTATION_RESPONSE_SCHEMAS ' +
+          '(src/core/graphql/response-validation.ts) and the conformance ledger'
+      );
+    }
+    return;
+  }
+
+  const result = registered.schema.safeParse(data);
+  if (result.success) return;
+
+  driftCounts.set(registered.surface, (driftCounts.get(registered.surface) ?? 0) + 1);
+
+  // Zod always provides ≥1 issue on failure; guard is defensive only.
+  const first = result.error.issues[0];
+  if (!first) return;
+  const pathStr = first.path.join('.');
+  const key = `${operationName}::${pathStr}::${first.code}`;
+  if (warnedKeys.has(key)) return;
+  warnedKeys.add(key);
+  // `message` describes expected/received TYPES (and enum option lists over
+  // system-controlled values like TransactionType) — it does not embed the
+  // user's data; stderr stays local to the user's machine either way.
+  console.warn(
+    `[copilot-money-mcp] response shape drift: operation=${operationName} ` +
+      `surface=${registered.surface} path=${pathStr} code=${first.code} message="${first.message}"`
+  );
+}
+
+// Exposed for tests only: clears the dedupe set and drift counters.
+export function __resetResponseDriftState(): void {
+  driftCounts.clear();
+  warnedKeys.clear();
+}

--- a/src/core/graphql/response-validation.ts
+++ b/src/core/graphql/response-validation.ts
@@ -49,7 +49,14 @@ const TagSchema = z.looseObject({
   colorName: z.string(),
 });
 
-/** Mirrors `CreatedTransaction` (transactions.ts), the TransactionFields shape. */
+/**
+ * Mirrors `CreatedTransaction` (transactions.ts), the TransactionFields shape.
+ *
+ * Note: `type` is gated by the TransactionType enum on purpose — if the
+ * server ever ships a NEW transaction type, responses carrying it will
+ * warn until TRANSACTION_TYPES (and its smoke conformance probe) are
+ * updated. That first warn is the drift signal working, not a bug.
+ */
 const CreatedTransactionSchema = z.looseObject({
   id: z.string(),
   name: z.string(),
@@ -96,8 +103,10 @@ export const MUTATION_RESPONSE_SCHEMAS: Readonly<Record<string, ResponseShapeEnt
     'createTransaction',
     z.looseObject({ createTransaction: CreatedTransactionSchema })
   ),
-  // Mirrors EditTransactionResponse — the subset of TransactionFields the
-  // wrapper actually reads back.
+  // Mirrors EditTransactionResponse — deliberately the SUBSET of
+  // TransactionFields the wrapper actually reads back (no `type`, `amount`,
+  // etc.). The wire selection returns more, but only fields code consumes
+  // are drift-gated; the rest flow through loose.
   EditTransaction: entry(
     'editTransaction',
     z.looseObject({
@@ -253,20 +262,23 @@ export function validateMutationResponse(operationName: string, data: unknown): 
 
   driftCounts.set(registered.surface, (driftCounts.get(registered.surface) ?? 0) + 1);
 
-  // Zod always provides ≥1 issue on failure; guard is defensive only.
-  const first = result.error.issues[0];
-  if (!first) return;
-  const pathStr = first.path.join('.');
-  const key = `${operationName}::${pathStr}::${first.code}`;
-  if (warnedKeys.has(key)) return;
-  warnedKeys.add(key);
-  // `message` describes expected/received TYPES (and enum option lists over
-  // system-controlled values like TransactionType) — it does not embed the
-  // user's data; stderr stays local to the user's machine either way.
-  console.warn(
-    `[copilot-money-mcp] response shape drift: operation=${operationName} ` +
-      `surface=${registered.surface} path=${pathStr} code=${first.code} message="${first.message}"`
-  );
+  // Warn for EVERY issue (a response dropping several fields at once should
+  // name all of them), each deduped per (operation, path, code) per process
+  // — so the unique drift inventory is logged in full while repeats stay
+  // silent. The dedupe set bounds total output regardless of call volume.
+  for (const issue of result.error.issues) {
+    const pathStr = issue.path.join('.');
+    const key = `${operationName}::${pathStr}::${issue.code}`;
+    if (warnedKeys.has(key)) continue;
+    warnedKeys.add(key);
+    // `message` describes expected/received TYPES (and enum option lists over
+    // system-controlled values like TransactionType) — it does not embed the
+    // user's data; stderr stays local to the user's machine either way.
+    console.warn(
+      `[copilot-money-mcp] response shape drift: operation=${operationName} ` +
+        `surface=${registered.surface} path=${pathStr} code=${issue.code} message="${issue.message}"`
+    );
+  }
 }
 
 // Exposed for tests only: clears the dedupe set and drift counters.

--- a/tests/conformance/ledger.test.ts
+++ b/tests/conformance/ledger.test.ts
@@ -25,6 +25,10 @@ import {
   classDistribution,
   formatClassDistribution,
 } from '../../src/conformance/ledger.js';
+import {
+  MUTATION_RESPONSE_SCHEMAS,
+  RESPONSE_SHAPE_RUNTIME_CHECK,
+} from '../../src/core/graphql/response-validation.js';
 
 const SMOKE_DIR = join(import.meta.dir, '..', '..', 'scripts', 'smoke');
 
@@ -127,6 +131,25 @@ describe('conformance ledger', () => {
           'when it ships, not before'
       ).toBe(true);
     }
+  });
+
+  test('(b) runtime:zod-warn-gated response shapes exactly match the registered Zod schemas', () => {
+    // Bidirectional: a ledger entry claiming the zod-warn oracle without a
+    // registered schema would be a paper gate; a registered schema without a
+    // ledger entry would be untracked verification. Both directions fail here.
+    const ledgerSurfaces = CONFORMANCE_LEDGER.filter(
+      (entry) =>
+        entry.kind === 'response-shape' &&
+        entry.oracle === `runtime:${RESPONSE_SHAPE_RUNTIME_CHECK}`
+    )
+      .map((entry) => entry.surface)
+      .sort();
+    const registeredSurfaces = Object.values(MUTATION_RESPONSE_SCHEMAS)
+      .map((entry) => entry.surface)
+      .sort();
+    expect(registeredSurfaces).toEqual(ledgerSurfaces);
+    // Guard against the comparison passing vacuously.
+    expect(registeredSurfaces.length).toBeGreaterThanOrEqual(17);
   });
 
   test("(c) class 'gated' requires a non-null oracle", () => {

--- a/tests/core/graphql/client.test.ts
+++ b/tests/core/graphql/client.test.ts
@@ -776,4 +776,26 @@ describe('GraphQLClient — warn-mode response-shape validation (#437)', () => {
     expect(warnSpy).not.toHaveBeenCalled();
     expect(getResponseDriftStats()).toEqual({});
   });
+
+  test('validation still runs when a mutation succeeds on a retry attempt', async () => {
+    // Attempt 1 provably never reached the server (retryable for mutations);
+    // attempt 2 succeeds with a drifted payload — the validator must fire on
+    // the retried response.
+    mockFetchSequence([
+      { throwErr: fetchRejection('ECONNREFUSED') },
+      { body: { data: { deleteTag: 'yes' } } },
+    ]);
+    const out = await silencingConsoleError(() =>
+      fastClient().mutate<unknown, { deleteTag: unknown }>(
+        'DeleteTag',
+        'mutation DeleteTag($id: ID!) { deleteTag(id: $id) }',
+        { id: 'tAg111BbB222CcC333Dd' }
+      )
+    );
+    expect(fetchCalls).toHaveLength(2);
+    expect(out).toEqual({ deleteTag: 'yes' });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('response shape drift');
+    expect(getResponseDriftStats()).toEqual({ 'Mutation.deleteTag:response': 1 });
+  });
 });

--- a/tests/core/graphql/client.test.ts
+++ b/tests/core/graphql/client.test.ts
@@ -1,10 +1,14 @@
-import { describe, test, expect, afterEach, mock } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import {
   GraphQLClient,
   GraphQLError,
   DEFAULT_RETRY_DELAYS_MS,
   DEFAULT_TIMEOUT_MS,
 } from '../../../src/core/graphql/client.js';
+import {
+  getResponseDriftStats,
+  __resetResponseDriftState,
+} from '../../../src/core/graphql/response-validation.js';
 import type { FirebaseAuth } from '../../../src/core/auth/firebase-auth.js';
 
 let fetchCalls: { url: string; options: RequestInit }[] = [];
@@ -715,5 +719,61 @@ describe('GraphQLClient — retry/backoff (#443)', () => {
       }
     });
     expect(fetchCalls).toHaveLength(1);
+  });
+});
+
+describe('GraphQLClient — warn-mode response-shape validation (#437)', () => {
+  let warnSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    __resetResponseDriftState();
+    warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    restoreFetch();
+  });
+
+  test('a drifted mutation response warns but still resolves with the payload unchanged', async () => {
+    // DeleteTag's registered schema expects { deleteTag: boolean }; a string
+    // simulates server drift on a field we read.
+    mockFetch({ data: { deleteTag: 'yes' } });
+    const client = new GraphQLClient(createMockAuth());
+    const out = await client.mutate<unknown, { deleteTag: unknown }>(
+      'DeleteTag',
+      'mutation DeleteTag($id: ID!) { deleteTag(id: $id) }',
+      { id: 'tAg111BbB222CcC333Dd' }
+    );
+    expect(out).toEqual({ deleteTag: 'yes' }); // payload untouched — warn-mode
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('response shape drift');
+    expect(getResponseDriftStats()).toEqual({ 'Mutation.deleteTag:response': 1 });
+  });
+
+  test('a conforming mutation response produces no warnings and no drift counts', async () => {
+    mockFetch({ data: { deleteTag: true } });
+    const client = new GraphQLClient(createMockAuth());
+    const out = await client.mutate<unknown, { deleteTag: boolean }>(
+      'DeleteTag',
+      'mutation DeleteTag($id: ID!) { deleteTag(id: $id) }',
+      { id: 'tAg111BbB222CcC333Dd' }
+    );
+    expect(out.deleteTag).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(getResponseDriftStats()).toEqual({});
+  });
+
+  test('query responses are not shape-validated (live reads have their own handling)', async () => {
+    mockFetch({ data: { tags: 'not-even-an-array' } });
+    const client = new GraphQLClient(createMockAuth());
+    const out = await client.query<unknown, { tags: unknown }>(
+      'Tags',
+      'query Tags { tags { id } }',
+      {}
+    );
+    expect(out).toEqual({ tags: 'not-even-an-array' });
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(getResponseDriftStats()).toEqual({});
   });
 });

--- a/tests/core/graphql/response-validation.test.ts
+++ b/tests/core/graphql/response-validation.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Unit tests for warn-mode mutation response-shape validation (issue #437).
+ *
+ * Contract under test:
+ * - happy path: a response matching the registered schema produces zero
+ *   warnings and zero drift counts (covered for ALL registered operations);
+ * - drift (missing/renamed/retyped field we read): one structured
+ *   `console.warn` on first occurrence, deduped per (operation, path, code)
+ *   per process, with the per-surface counter counting EVERY occurrence;
+ * - never throws, never alters the payload — warn-mode only;
+ * - new/unknown server fields pass through silently (loose schemas).
+ */
+
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import {
+  MUTATION_RESPONSE_SCHEMAS,
+  validateMutationResponse,
+  getResponseDriftStats,
+  __resetResponseDriftState,
+} from '../../../src/core/graphql/response-validation.js';
+
+// ---------------------------------------------------------------------------
+// Synthetic fixtures — one valid payload per registered operation.
+// Opaque Firestore-shaped IDs, synthetic amounts.
+// ---------------------------------------------------------------------------
+
+function makeTransaction(): Record<string, unknown> {
+  return {
+    __typename: 'Transaction',
+    id: 'AbC123dEf456GhI789jK',
+    name: 'Synthetic Coffee Shop',
+    date: '2026-06-01',
+    amount: 4.5,
+    categoryId: 'a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d',
+    type: 'REGULAR',
+    accountId: 'XyZ987wVu654TsR321qP',
+    itemId: 'MnO456pQr789StU012vW',
+    isPending: false,
+    isReviewed: true,
+    createdAt: 1_750_000_000,
+    recurringId: null,
+    userNotes: null,
+    tipAmount: null,
+    suggestedCategoryIds: [],
+    tags: [{ __typename: 'Tag', id: 'tAg111BbB222CcC333Dd', name: 'synthetic', colorName: 'blue' }],
+    goal: null,
+  };
+}
+
+const VALID_RESPONSES: Record<string, unknown> = {
+  CreateTransaction: { createTransaction: makeTransaction() },
+  EditTransaction: {
+    editTransaction: {
+      __typename: 'EditTransactionOutput',
+      transaction: makeTransaction(),
+    },
+  },
+  DeleteTransaction: { deleteTransaction: true },
+  AddTransactionToRecurring: {
+    addTransactionToRecurring: { transaction: makeTransaction() },
+  },
+  SplitTransaction: {
+    splitTransaction: {
+      parentTransaction: makeTransaction(),
+      splitTransactions: [makeTransaction(), makeTransaction()],
+    },
+  },
+  CreateTag: {
+    createTag: { __typename: 'Tag', id: 'tAg111BbB222CcC333Dd', name: 'trip', colorName: 'green' },
+  },
+  EditTag: { editTag: { id: 'tAg111BbB222CcC333Dd', name: 'trip', colorName: 'red' } },
+  DeleteTag: { deleteTag: true },
+  CreateCategory: {
+    createCategory: {
+      id: 'a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d',
+      name: 'Synthetic Category',
+      colorName: 'orange',
+    },
+  },
+  EditCategory: {
+    editCategory: {
+      category: {
+        id: 'a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d',
+        name: 'Synthetic Category',
+        colorName: 'purple',
+      },
+    },
+  },
+  DeleteCategory: { deleteCategory: true },
+  EditBudget: { editCategoryBudget: true },
+  EditBudgetMonthly: { editCategoryBudgetMonthly: true },
+  CreateRecurring: {
+    createRecurring: {
+      id: 'rEc555FfF666GgG777Hh',
+      name: 'Synthetic Streaming',
+      state: 'ACTIVE',
+      frequency: 'MONTHLY',
+    },
+  },
+  EditRecurring: {
+    editRecurring: {
+      recurring: {
+        id: 'rEc555FfF666GgG777Hh',
+        name: 'Synthetic Streaming',
+        categoryId: 'a1b2c3d4-e5f6-4a5b-8c7d-9e0f1a2b3c4d',
+        frequency: 'MONTHLY',
+        state: 'PAUSED',
+      },
+    },
+  },
+  DeleteRecurring: { deleteRecurring: true },
+  EditAccount: {
+    editAccount: {
+      account: { id: 'XyZ987wVu654TsR321qP', name: 'Synthetic Checking', isUserHidden: false },
+    },
+  },
+};
+
+describe('validateMutationResponse', () => {
+  let warnSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    __resetResponseDriftState();
+    warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test('every registered operation has a valid fixture that passes silently', () => {
+    const operations = Object.keys(MUTATION_RESPONSE_SCHEMAS);
+    expect(operations.sort()).toEqual(Object.keys(VALID_RESPONSES).sort());
+    for (const op of operations) {
+      validateMutationResponse(op, VALID_RESPONSES[op]);
+    }
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(getResponseDriftStats()).toEqual({});
+  });
+
+  test('unknown extra fields (new server fields) pass through without warning', () => {
+    const tx = makeTransaction();
+    tx.brandNewServerField = 'whatever';
+    validateMutationResponse('CreateTransaction', {
+      createTransaction: tx,
+      anotherTopLevelExtra: 42,
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(getResponseDriftStats()).toEqual({});
+  });
+
+  test('a removed/renamed field warns once with a structured message and counts the drift', () => {
+    const tx = makeTransaction();
+    delete (tx as Record<string, unknown>).categoryId; // simulate server rename
+    validateMutationResponse('CreateTransaction', { createTransaction: tx });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0][0] as string;
+    expect(message).toContain('[copilot-money-mcp] response shape drift:');
+    expect(message).toContain('operation=CreateTransaction');
+    expect(message).toContain('surface=Mutation.createTransaction:response');
+    expect(message).toContain('path=createTransaction.categoryId');
+    expect(message).toContain('code=');
+    expect(getResponseDriftStats()).toEqual({ 'Mutation.createTransaction:response': 1 });
+  });
+
+  test('dedupes the warning per (operation, path, code) but counts every drifted response', () => {
+    const drifted = () => {
+      const tx = makeTransaction();
+      delete (tx as Record<string, unknown>).categoryId;
+      return { createTransaction: tx };
+    };
+    validateMutationResponse('CreateTransaction', drifted());
+    validateMutationResponse('CreateTransaction', drifted());
+    validateMutationResponse('CreateTransaction', drifted());
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(getResponseDriftStats()).toEqual({ 'Mutation.createTransaction:response': 3 });
+  });
+
+  test('a different drift path on the same operation warns again', () => {
+    const missingCategory = makeTransaction();
+    delete (missingCategory as Record<string, unknown>).categoryId;
+    validateMutationResponse('CreateTransaction', { createTransaction: missingCategory });
+
+    const retypedAmount = makeTransaction();
+    retypedAmount.amount = '4.50'; // simulate Float → String type change
+    validateMutationResponse('CreateTransaction', { createTransaction: retypedAmount });
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(getResponseDriftStats()).toEqual({ 'Mutation.createTransaction:response': 2 });
+  });
+
+  test('drift counters are tracked per surface', () => {
+    validateMutationResponse('DeleteTag', { deleteTag: 'yes' }); // not a boolean
+    validateMutationResponse('EditBudget', { editCategoryBudget: 1 }); // not a boolean
+    validateMutationResponse('EditBudget', { editCategoryBudget: 1 });
+    expect(getResponseDriftStats()).toEqual({
+      'Mutation.deleteTag:response': 1,
+      'Mutation.editCategoryBudget:response': 2,
+    });
+  });
+
+  test('never throws on garbage payloads (warn-mode)', () => {
+    expect(() => validateMutationResponse('CreateTransaction', null)).not.toThrow();
+    expect(() => validateMutationResponse('CreateTransaction', 'not-an-object')).not.toThrow();
+    expect(() =>
+      validateMutationResponse('SplitTransaction', { splitTransaction: null })
+    ).not.toThrow();
+    expect(Object.keys(getResponseDriftStats()).length).toBeGreaterThan(0);
+  });
+
+  test('does not alter the payload', () => {
+    const tx = makeTransaction();
+    delete (tx as Record<string, unknown>).categoryId;
+    const payload = { createTransaction: tx };
+    const snapshot = structuredClone(payload);
+    validateMutationResponse('CreateTransaction', payload);
+    expect(payload).toEqual(snapshot);
+  });
+
+  test('an unregistered mutation operation warns once (and is not counted as drift)', () => {
+    validateMutationResponse('SomeFutureMutation', { someFutureMutation: true });
+    validateMutationResponse('SomeFutureMutation', { someFutureMutation: true });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0][0] as string;
+    expect(message).toContain('operation=SomeFutureMutation');
+    expect(message).toContain('no registered response schema');
+    expect(getResponseDriftStats()).toEqual({});
+  });
+});

--- a/tests/core/graphql/response-validation.test.ts
+++ b/tests/core/graphql/response-validation.test.ts
@@ -178,6 +178,25 @@ describe('validateMutationResponse', () => {
     expect(getResponseDriftStats()).toEqual({ 'Mutation.createTransaction:response': 3 });
   });
 
+  test('multi-field drift in one response warns per field (each deduped), counted once', () => {
+    const drifted = () => {
+      const tx = makeTransaction();
+      delete (tx as Record<string, unknown>).categoryId;
+      delete (tx as Record<string, unknown>).date;
+      return { createTransaction: tx };
+    };
+    validateMutationResponse('CreateTransaction', drifted());
+    expect(warnSpy).toHaveBeenCalledTimes(2); // both missing fields named
+    const messages = warnSpy.mock.calls.map((call) => String(call[0])).join('\n');
+    expect(messages).toContain('path=createTransaction.categoryId');
+    expect(messages).toContain('path=createTransaction.date');
+    expect(getResponseDriftStats()).toEqual({ 'Mutation.createTransaction:response': 1 });
+
+    validateMutationResponse('CreateTransaction', drifted());
+    expect(warnSpy).toHaveBeenCalledTimes(2); // repeats stay silent
+    expect(getResponseDriftStats()).toEqual({ 'Mutation.createTransaction:response': 2 });
+  });
+
   test('a different drift path on the same operation warns again', () => {
     const missingCategory = makeTransaction();
     delete (missingCategory as Record<string, unknown>).categoryId;


### PR DESCRIPTION
# Summary

Adds warn-mode response-shape validation for the write path (Epic B #421): every mutation response is validated against a Zod schema mirroring the hand-written response interface, so server-side renames/removals of fields we read surface as a loud structured warning + drift counter instead of silent downstream `undefined`s. Closes #437

**How it works**

- `src/core/graphql/response-validation.ts` — registry of 17 Zod schemas (one per mutation operation), derived field-for-field from the existing response interfaces in the per-domain modules. All objects are `z.looseObject`, so **new** server fields (and `__typename`) pass through silently — drift means a field we *read* going missing or changing type.
- `GraphQLClient.request()` calls `validateMutationResponse()` after every successful mutation. **Warn-mode**: it never throws and never alters the payload — consistent with the C3 drop-visibility pattern. Warnings are deduped per `(operation, path, code)` per process (same scheme as `schema-warn.ts`); per-surface drift counts are NOT deduped and are exposed via `getResponseDriftStats()` so C3's visibility work can surface them.
- An unregistered mutation operation name also gets a (deduped) warning, so a future mutation wrapper can't silently skip the gate.
- Ledger (#435): all 17 `Mutation.*:response` surfaces upgrade `unverified` → `gated` with oracle `runtime:zod-warn`; `zod-warn` is registered in `RUNTIME_CHECK_NAMES`. A new ledger test enforces the registry↔ledger mapping bidirectionally (a ledger entry claiming the oracle without a schema, or a schema without a ledger entry, fails the build).

**Tests**: valid synthetic fixtures for all 17 operations pass silently; deliberately wrong mocks (removed field, retyped field, garbage payloads) warn once, count every occurrence, never throw, and leave the payload untouched; client-level tests confirm a drifted mutation response still resolves with the raw payload and that query responses are not shape-validated.

**Live gate (pending)**: the DoD's real write round-trip (no false-positive warnings on a live mutation) is to be run by the maintainer via `bun run smoke` before merge — the smoke suite's write round-trips now exercise these validators on every run.

## External assumptions

No NEW assumptions about Copilot's API — this PR converts 17 *existing* response-shape assumptions (previously `unverified`, hand-typed TS casts) into runtime-checked ones:

- `Mutation.createTransaction:response`, `Mutation.editTransaction:response`, `Mutation.deleteTransaction:response`, `Mutation.addTransactionToRecurring:response`, `Mutation.splitTransaction:response`, `Mutation.createTag:response`, `Mutation.editTag:response`, `Mutation.deleteTag:response`, `Mutation.createCategory:response`, `Mutation.editCategory:response`, `Mutation.deleteCategory:response`, `Mutation.editCategoryBudget:response`, `Mutation.editCategoryBudgetMonthly:response`, `Mutation.createRecurring:response`, `Mutation.editRecurring:response`, `Mutation.deleteRecurring:response`, `Mutation.editAccount:response`
- Evidence class: **gated** (`runtime:zod-warn`) — schemas transcribed from the captured-response interfaces; every live mutation re-verifies the shape warn-mode at runtime. Maintainer's pre-merge `bun run smoke` run doubles as the live round-trip confirmation that there are no false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)