### PR TITLE
feat(smoke): Tier-2 reversible round-trip smokes per write tool (B4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "fix": "bun run lint:fix && bun run format",
     "smoke": "bun run scripts/smoke/conformance.ts && bun run scripts/smoke/reads.ts",
     "smoke:conformance": "bun run scripts/smoke/conformance.ts",
+    "smoke:roundtrip": "bun run scripts/smoke/roundtrip.ts",
     "smoke:reads": "bun run scripts/smoke/reads.ts",
     "smoke:recurring-frequency": "bun run scripts/smoke/recurring-frequency-conformance.ts",
     "smoke:recurring-state": "bun run scripts/smoke/recurring-state-conformance.ts",

--- a/scripts/smoke/roundtrip-checks.ts
+++ b/scripts/smoke/roundtrip-checks.ts
@@ -414,22 +414,33 @@ export const ROUNDTRIP_CHECKS: readonly RoundtripCheck[] = [
       const categoryId = ctx.state.categoryId;
       if (!categoryId) return { skipped: 'no run-created category (create_category did not pass)' };
       const name = `${ctx.state.marker}-cat-edited`;
-      await editCategory(ctx.client, { id: categoryId, input: { name, isExcluded: true } });
-      const after = (await fetchCategories(ctx.client, { rollovers: false })).find(
-        (cat) => cat.id === categoryId
-      );
-      check(after, `update_category: category ${categoryId} missing from Categories re-read`);
-      check(
-        after.name === name,
-        `update_category: write accepted but re-read name is '${after.name}', expected '${name}'`
-      );
-      check(
-        after.isExcluded === true,
-        'update_category: write accepted but re-read isExcluded is still false'
-      );
-      // Restore isExcluded=false so the budget check below behaves like a
-      // normal category (the category itself is deleted at the end either way).
-      await editCategory(ctx.client, { id: categoryId, input: { isExcluded: false } });
+      try {
+        await editCategory(ctx.client, { id: categoryId, input: { name, isExcluded: true } });
+        const after = (await fetchCategories(ctx.client, { rollovers: false })).find(
+          (cat) => cat.id === categoryId
+        );
+        check(after, `update_category: category ${categoryId} missing from Categories re-read`);
+        check(
+          after.name === name,
+          `update_category: write accepted but re-read name is '${after.name}', expected '${name}'`
+        );
+        check(
+          after.isExcluded === true,
+          'update_category: write accepted but re-read isExcluded is still false'
+        );
+      } finally {
+        // Restore isExcluded=false even when verification failed, so the
+        // set_budget check downstream sees a normal (non-excluded) category
+        // (the category itself is deleted at the end either way).
+        try {
+          await editCategory(ctx.client, { id: categoryId, input: { isExcluded: false } });
+        } catch (err: unknown) {
+          ctx.log('update_category: WARNING — failed to restore isExcluded', {
+            categoryId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
       return undefined;
     },
   },
@@ -596,10 +607,12 @@ export const ROUNDTRIP_CHECKS: readonly RoundtripCheck[] = [
       ctx.registry.add({
         kind: 'recurring',
         id: created.id,
-        // The server derives the recurring's name from the transaction, so it
-        // should carry the marker — but that derivation is the server's, so
-        // the label records what the echo said.
-        label: created.name,
+        // Deliberately NOT `created.name`: the server derives the recurring's
+        // name (usually from the marker-bearing transaction, but that
+        // derivation is the server's), and labels are logged — so a
+        // server-derived name could leak real merchant data into output.
+        // A synthetic marker label keeps logs PII-safe regardless.
+        label: `${ctx.state.marker}-recurring`,
         cleanup: () => deleteRecurring(ctx.client, { id: created.id }).then(() => undefined),
       });
       const after = (await fetchRecurrings(ctx.client)).find((rec) => rec.id === created.id);
@@ -846,6 +859,12 @@ export interface ResidueReaders {
  * whose name was normalized away from the raw `__smoke__` marker. The
  * word-boundary regex catches 'Smoke 176...' style derivations without
  * matching e.g. 'Smokehouse BBQ'.
+ *
+ * Known approximation: a real recurring whose name contains the standalone
+ * word ("Smoke's BBQ", "Smoke Shop") WILL match, and the pre-flight check
+ * will refuse to start. That's the safe direction for an attended local
+ * gate — a false refusal is a one-line message the maintainer can act on,
+ * while a false negative would leave residue undetected.
  */
 const RECURRING_RESIDUE_RE = /\bsmoke\b/i;
 

--- a/scripts/smoke/roundtrip-checks.ts
+++ b/scripts/smoke/roundtrip-checks.ts
@@ -1,0 +1,924 @@
+/**
+ * Tier-2 reversible round-trip check definitions (issue #438, Epic B #421).
+ *
+ * One round-trip per MCP write tool: create→verify→delete, or
+ * set→verify→revert. The verification step always RE-READS the object
+ * through the corresponding read query — never trusts the mutation echo —
+ * because the whole point of Tier 2 is catching accepted-but-ignored
+ * writes (the risk class the 2026-06 write-field audit found).
+ *
+ * !!! MUTATING !!! Everything in this file sends real writes to the LIVE
+ * Copilot endpoint when run through scripts/smoke/roundtrip.ts. It is a
+ * local, consciously-run, attended gate — never scheduled, never part of
+ * `bun run smoke` (Tier 1 stays non-mutating).
+ *
+ * Safety model:
+ * - Every created object carries the `__smoke__<timestamp>` marker in its
+ *   name; names and amounts are synthetic (100/200) — no real PII.
+ * - Checks only mutate objects the run itself created. The single
+ *   unavoidable contact with user data is that created transactions must
+ *   reference a real account_id/item_id (first account from the Accounts
+ *   query, same pick as the Tier-0 read smoke); those transactions are
+ *   deleted and sweep-verified in the same run.
+ * - Created objects register a cleanup closure in the CleanupRegistry; the
+ *   runner executes it LIFO in a `finally`, then runs a final residue
+ *   sweep that fails loudly with the leftover ids.
+ * - Copilot's bulk-edit mutation is NEVER used (enforced by a source-scan
+ *   unit test in tests/scripts/roundtrip-coverage.test.ts).
+ *
+ * Coverage is ratcheted: tests/scripts/roundtrip-coverage.test.ts enforces
+ * a bijection between `WRITE_TOOL_DEFS` (src/tools/registry) and the checks
+ * here, and between each check's `appliesSurfaces` and the conformance
+ * ledger's `Mutation.<x>:applies` entries — a new write tool cannot ship
+ * without a round-trip.
+ */
+
+import type { GraphQLClient } from '../../src/core/graphql/client.js';
+import {
+  createTransaction,
+  deleteTransaction,
+  editTransaction,
+  addTransactionToRecurring,
+  splitTransaction,
+} from '../../src/core/graphql/transactions.js';
+import { createTag, editTag, deleteTag } from '../../src/core/graphql/tags.js';
+import { createCategory, editCategory, deleteCategory } from '../../src/core/graphql/categories.js';
+import { setBudget } from '../../src/core/graphql/budgets.js';
+import {
+  createRecurring,
+  editRecurring,
+  deleteRecurring,
+  type RecurringStateValue,
+} from '../../src/core/graphql/recurrings.js';
+import { fetchAccounts } from '../../src/core/graphql/queries/accounts.js';
+import { fetchTags } from '../../src/core/graphql/queries/tags.js';
+import { fetchCategories, type CategoryBudget } from '../../src/core/graphql/queries/categories.js';
+import { fetchRecurrings } from '../../src/core/graphql/queries/recurrings.js';
+import {
+  buildTransactionFilter,
+  buildTransactionSort,
+  fetchTransactionsPage,
+  paginateTransactions,
+  type TransactionNode,
+} from '../../src/core/graphql/queries/transactions.js';
+
+// ---------------------------------------------------------------------------
+// Marker convention
+// ---------------------------------------------------------------------------
+
+/** Every object this suite creates carries this prefix in its name. */
+export const MARKER_PREFIX = '__smoke__';
+
+/** Per-run marker, e.g. `__smoke__1765432100000`. */
+export function makeMarker(now: number = Date.now()): string {
+  return `${MARKER_PREFIX}${String(now)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup registry
+// ---------------------------------------------------------------------------
+
+export type RoundtripLog = (msg: string, fields?: Record<string, unknown>) => void;
+
+export type CleanupKind = 'tag' | 'category' | 'transaction' | 'recurring';
+
+export interface CleanupItem {
+  kind: CleanupKind;
+  id: string;
+  /** Marker-bearing label (synthetic — safe to log). */
+  label: string;
+  cleanup: () => Promise<void>;
+}
+
+export interface CleanupFailure {
+  kind: CleanupKind;
+  id: string;
+  label: string;
+  error: string;
+}
+
+/**
+ * Tracks every object the run created and still owns. Checks that delete
+ * their target themselves (delete_tag, delete_transaction, ...) call
+ * `remove()` after VERIFYING the deletion; everything else is deleted LIFO
+ * by `runAll()` in the runner's `finally`.
+ */
+export class CleanupRegistry {
+  private items: CleanupItem[] = [];
+
+  add(item: CleanupItem): void {
+    this.items.push(item);
+  }
+
+  /** Deregister after a check has already deleted (and verified) the object. */
+  remove(id: string): void {
+    this.items = this.items.filter((item) => item.id !== id);
+  }
+
+  get pending(): ReadonlyArray<Omit<CleanupItem, 'cleanup'>> {
+    return this.items.map(({ kind, id, label }) => ({ kind, id, label }));
+  }
+
+  /**
+   * Delete every still-registered object, LIFO (dependents before their
+   * dependencies). Never throws — failures are collected and returned so
+   * the runner reports every leftover id loudly instead of dying on the
+   * first one.
+   */
+  async runAll(log: RoundtripLog): Promise<CleanupFailure[]> {
+    const failures: CleanupFailure[] = [];
+    while (this.items.length > 0) {
+      const item = this.items.pop()!;
+      try {
+        await item.cleanup();
+        log(`cleanup: deleted ${item.kind} '${item.label}'`, { id: item.id });
+      } catch (err: unknown) {
+        const error = err instanceof Error ? err.message : String(err);
+        failures.push({ kind: item.kind, id: item.id, label: item.label, error });
+        log(`cleanup: FAILED to delete ${item.kind} '${item.label}'`, { id: item.id, error });
+      }
+    }
+    return failures;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Run context + shared helpers
+// ---------------------------------------------------------------------------
+
+export interface RoundtripAccountRef {
+  accountId: string;
+  itemId: string;
+}
+
+export interface RoundtripState {
+  marker: string;
+  /** First account from the Accounts query — host for created transactions. */
+  account?: RoundtripAccountRef;
+  tagId?: string;
+  categoryId?: string;
+  recurringId?: string;
+  /** Primary smoke transaction (created/edited/reviewed/deleted across checks). */
+  txnA?: { id: string } & RoundtripAccountRef;
+}
+
+export interface RoundtripContext {
+  client: GraphQLClient;
+  state: RoundtripState;
+  registry: CleanupRegistry;
+  log: RoundtripLog;
+}
+
+/** Returned for a deliberately skipped check; failures THROW instead. */
+export interface RoundtripOutcome {
+  skipped?: string;
+}
+
+function check(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function currentMonth(): string {
+  return new Date().toISOString().slice(0, 7);
+}
+
+// --- re-read helpers (verification always goes through these) ---------------
+
+async function readTransactionsByMarker(
+  client: GraphQLClient,
+  search: string
+): Promise<TransactionNode[]> {
+  const filter = buildTransactionFilter({ matchString: search });
+  return paginateTransactions(
+    (after) =>
+      fetchTransactionsPage(client, { first: 25, after, filter, sort: buildTransactionSort() }),
+    {}
+  );
+}
+
+async function readTransactionById(
+  client: GraphQLClient,
+  marker: string,
+  id: string
+): Promise<TransactionNode | undefined> {
+  const rows = await readTransactionsByMarker(client, marker);
+  return rows.find((node) => node.id === id);
+}
+
+async function readSmokeCategoryBudget(
+  client: GraphQLClient,
+  categoryId: string
+): Promise<CategoryBudget | null | undefined> {
+  const rows = await fetchCategories(client, { rollovers: false });
+  return rows.find((cat) => cat.id === categoryId)?.budget;
+}
+
+/**
+ * Resolve the budget amount visible for a month (YYYY-MM). Accepts either
+ * `amount` or `resolvedAmount` — which of the two reflects a freshly-set
+ * default budget is an assumption that stays unverified until the first
+ * attended run; drift to NEITHER fails the check.
+ */
+export function budgetAmountForMonth(
+  budget: CategoryBudget | null | undefined,
+  month: string
+): number | undefined {
+  const nodes = [budget?.current, ...(budget?.histories ?? [])].filter(
+    (node): node is NonNullable<typeof node> => node != null
+  );
+  const node = nodes.find((candidate) => candidate.month.startsWith(month));
+  const raw = node?.amount ?? node?.resolvedAmount;
+  if (raw == null) return undefined;
+  const parsed = parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+// --- lazily-created prerequisites (support `--only <domain>` runs) ----------
+
+async function ensureAccount(ctx: RoundtripContext): Promise<RoundtripAccountRef> {
+  if (!ctx.state.account) {
+    const rows = await fetchAccounts(ctx.client);
+    const first = rows[0];
+    check(
+      first,
+      'prereq: the Accounts query returned no accounts — cannot host smoke transactions'
+    );
+    ctx.state.account = { accountId: first.id, itemId: first.itemId };
+    // Account name/balance are real user data — log only that a pick happened.
+    ctx.log('prereq: using the first account from the Accounts query as transaction host');
+  }
+  return ctx.state.account;
+}
+
+async function ensureCategory(ctx: RoundtripContext): Promise<string> {
+  if (!ctx.state.categoryId) {
+    const name = `${ctx.state.marker}-cat`;
+    const created = await createCategory(ctx.client, {
+      input: { name, colorName: 'GREEN1', emoji: '🧪', isExcluded: false },
+    });
+    ctx.state.categoryId = created.id;
+    ctx.registry.add({
+      kind: 'category',
+      id: created.id,
+      label: name,
+      cleanup: () => deleteCategory(ctx.client, { id: created.id }).then(() => undefined),
+    });
+    ctx.log(`prereq: created category '${name}'`, { id: created.id });
+  }
+  return ctx.state.categoryId;
+}
+
+async function createSmokeTransaction(
+  ctx: RoundtripContext,
+  suffix: string,
+  amount: number
+): Promise<{ id: string } & RoundtripAccountRef> {
+  const account = await ensureAccount(ctx);
+  const categoryId = await ensureCategory(ctx);
+  const name = `${ctx.state.marker}-${suffix}`;
+  const created = await createTransaction(ctx.client, {
+    accountId: account.accountId,
+    itemId: account.itemId,
+    input: { name, date: todayIso(), amount, categoryId, type: 'REGULAR' },
+  });
+  const ref = { id: created.id, ...account };
+  ctx.registry.add({
+    kind: 'transaction',
+    id: created.id,
+    label: name,
+    cleanup: () =>
+      deleteTransaction(ctx.client, {
+        id: created.id,
+        accountId: account.accountId,
+        itemId: account.itemId,
+      }).then(() => undefined),
+  });
+  ctx.log(`prereq: created transaction '${name}'`, { id: created.id });
+  return ref;
+}
+
+async function ensureTxnA(ctx: RoundtripContext): Promise<{ id: string } & RoundtripAccountRef> {
+  if (!ctx.state.txnA) {
+    ctx.state.txnA = await createSmokeTransaction(ctx, 'txn-a', 100);
+  }
+  return ctx.state.txnA;
+}
+
+// ---------------------------------------------------------------------------
+// The checks — one per write tool, in run order (creates before mutators
+// before deletes, so a full run is itself a create→mutate→delete arc).
+// ---------------------------------------------------------------------------
+
+export const ROUNDTRIP_DOMAINS = [
+  'tags',
+  'categories',
+  'budgets',
+  'transactions',
+  'recurring',
+] as const;
+export type RoundtripDomain = (typeof ROUNDTRIP_DOMAINS)[number];
+
+export interface RoundtripCheck {
+  /** MCP write-tool name — must exist in WRITE_TOOL_DEFS (ratchet-tested). */
+  tool: string;
+  domain: RoundtripDomain;
+  /** One-line plan entry: flow → target object (printed by --list). */
+  flow: string;
+  /** Ledger `Mutation.<x>:applies` surfaces this check verifies. */
+  appliesSurfaces: readonly string[];
+  run: (ctx: RoundtripContext) => Promise<RoundtripOutcome | undefined>;
+}
+
+export const ROUNDTRIP_CHECKS: readonly RoundtripCheck[] = [
+  {
+    tool: 'create_tag',
+    domain: 'tags',
+    flow: 'create marker tag → verify via Tags re-read (deleted by the delete_tag check)',
+    appliesSurfaces: ['Mutation.createTag:applies'],
+    run: async (ctx) => {
+      const name = `${ctx.state.marker}-tag`;
+      const created = await createTag(ctx.client, { input: { name, colorName: 'BLUE1' } });
+      ctx.state.tagId = created.id;
+      ctx.registry.add({
+        kind: 'tag',
+        id: created.id,
+        label: name,
+        cleanup: () => deleteTag(ctx.client, { id: created.id }).then(() => undefined),
+      });
+      const after = (await fetchTags(ctx.client)).find((tag) => tag.id === created.id);
+      check(after, `create_tag: created id ${created.id} missing from Tags re-read`);
+      check(after.name === name, `create_tag: re-read name '${after.name}', expected '${name}'`);
+      check(
+        after.colorName === 'BLUE1',
+        `create_tag: re-read colorName '${String(after.colorName)}', expected 'BLUE1'`
+      );
+      return undefined;
+    },
+  },
+  {
+    tool: 'update_tag',
+    domain: 'tags',
+    flow: 'rename + recolor the run-created tag → verify via Tags re-read',
+    appliesSurfaces: ['Mutation.editTag:applies'],
+    run: async (ctx) => {
+      const tagId = ctx.state.tagId;
+      if (!tagId) return { skipped: 'no run-created tag (create_tag did not pass)' };
+      const name = `${ctx.state.marker}-tag-edited`;
+      await editTag(ctx.client, { id: tagId, input: { name, colorName: 'RED1' } });
+      const after = (await fetchTags(ctx.client)).find((tag) => tag.id === tagId);
+      check(after, `update_tag: tag ${tagId} missing from Tags re-read`);
+      check(
+        after.name === name,
+        `update_tag: write accepted but re-read name is '${after.name}', expected '${name}'`
+      );
+      check(
+        after.colorName === 'RED1',
+        `update_tag: write accepted but re-read colorName is '${String(after.colorName)}', expected 'RED1'`
+      );
+      return undefined;
+    },
+  },
+  {
+    tool: 'create_category',
+    domain: 'categories',
+    flow: 'create marker category → verify via Categories re-read (deleted by delete_category)',
+    appliesSurfaces: ['Mutation.createCategory:applies'],
+    run: async (ctx) => {
+      const categoryId = await ensureCategory(ctx);
+      const after = (await fetchCategories(ctx.client, { rollovers: false })).find(
+        (cat) => cat.id === categoryId
+      );
+      check(after, `create_category: created id ${categoryId} missing from Categories re-read`);
+      check(
+        after.name === `${ctx.state.marker}-cat`,
+        `create_category: re-read name '${after.name}', expected '${ctx.state.marker}-cat'`
+      );
+      check(
+        after.colorName === 'GREEN1',
+        `create_category: re-read colorName '${String(after.colorName)}', expected 'GREEN1'`
+      );
+      check(after.isExcluded === false, 'create_category: re-read isExcluded should be false');
+      return undefined;
+    },
+  },
+  {
+    tool: 'update_category',
+    domain: 'categories',
+    flow: 'rename + toggle isExcluded on the run-created category → verify via Categories re-read',
+    appliesSurfaces: ['Mutation.editCategory:applies'],
+    run: async (ctx) => {
+      const categoryId = ctx.state.categoryId;
+      if (!categoryId) return { skipped: 'no run-created category (create_category did not pass)' };
+      const name = `${ctx.state.marker}-cat-edited`;
+      await editCategory(ctx.client, { id: categoryId, input: { name, isExcluded: true } });
+      const after = (await fetchCategories(ctx.client, { rollovers: false })).find(
+        (cat) => cat.id === categoryId
+      );
+      check(after, `update_category: category ${categoryId} missing from Categories re-read`);
+      check(
+        after.name === name,
+        `update_category: write accepted but re-read name is '${after.name}', expected '${name}'`
+      );
+      check(
+        after.isExcluded === true,
+        'update_category: write accepted but re-read isExcluded is still false'
+      );
+      // Restore isExcluded=false so the budget check below behaves like a
+      // normal category (the category itself is deleted at the end either way).
+      await editCategory(ctx.client, { id: categoryId, input: { isExcluded: false } });
+      return undefined;
+    },
+  },
+  {
+    tool: 'set_budget',
+    domain: 'budgets',
+    flow: 'set default budget 100 then monthly budget 200 on the run-created category → verify via Categories budget re-read → clear both',
+    appliesSurfaces: [
+      'Mutation.editCategoryBudget:applies',
+      'Mutation.editCategoryBudgetMonthly:applies',
+    ],
+    run: async (ctx) => {
+      const categoryId = await ensureCategory(ctx);
+      const month = currentMonth();
+      try {
+        // Default branch (Mutation.editCategoryBudget).
+        await setBudget(ctx.client, { categoryId, amount: '100' });
+        let amount = budgetAmountForMonth(
+          await readSmokeCategoryBudget(ctx.client, categoryId),
+          month
+        );
+        check(
+          amount === 100,
+          `set_budget(default): re-read budget for ${month} is ${String(amount)}, expected 100`
+        );
+        // Monthly branch (Mutation.editCategoryBudgetMonthly).
+        await setBudget(ctx.client, { categoryId, amount: '200', month });
+        amount = budgetAmountForMonth(await readSmokeCategoryBudget(ctx.client, categoryId), month);
+        check(
+          amount === 200,
+          `set_budget(monthly): re-read budget for ${month} is ${String(amount)}, expected 200`
+        );
+      } finally {
+        // Revert both branches to the cleared state ('0') even if a verify
+        // failed mid-flight — the category is run-created and deleted in
+        // cleanup, but leave no budget behind if that deletion ever fails.
+        try {
+          await setBudget(ctx.client, { categoryId, amount: '0', month });
+          await setBudget(ctx.client, { categoryId, amount: '0' });
+        } catch (err: unknown) {
+          ctx.log('set_budget: WARNING — failed to clear the smoke budget', {
+            categoryId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      return undefined;
+    },
+  },
+  {
+    tool: 'create_transaction',
+    domain: 'transactions',
+    flow: 'create marker transaction (amount 100) on the first account → verify via Transactions re-read (deleted by delete_transaction)',
+    appliesSurfaces: ['Mutation.createTransaction:applies'],
+    run: async (ctx) => {
+      const txn = await ensureTxnA(ctx);
+      const after = await readTransactionById(ctx.client, ctx.state.marker, txn.id);
+      check(after, `create_transaction: created id ${txn.id} missing from Transactions re-read`);
+      check(
+        after.name === `${ctx.state.marker}-txn-a`,
+        `create_transaction: re-read name '${after.name}', expected '${ctx.state.marker}-txn-a'`
+      );
+      // Sign convention (expense vs income) is the server's business — assert
+      // magnitude so a flipped sign doesn't mask an ignored amount.
+      check(
+        Math.abs(after.amount) === 100,
+        `create_transaction: re-read |amount| ${String(Math.abs(after.amount))}, expected 100`
+      );
+      check(
+        after.categoryId === ctx.state.categoryId,
+        'create_transaction: re-read categoryId does not match the requested category'
+      );
+      check(after.type === 'REGULAR', `create_transaction: re-read type '${after.type}'`);
+      return undefined;
+    },
+  },
+  {
+    tool: 'update_transaction',
+    domain: 'transactions',
+    flow: 'rename + set note on the run-created transaction → verify via Transactions re-read',
+    appliesSurfaces: ['Mutation.editTransaction:applies'],
+    run: async (ctx) => {
+      const txn = ctx.state.txnA;
+      if (!txn) return { skipped: 'no run-created transaction (create_transaction did not pass)' };
+      const name = `${ctx.state.marker}-txn-a-edited`;
+      const note = `${ctx.state.marker} note`;
+      await editTransaction(ctx.client, {
+        id: txn.id,
+        accountId: txn.accountId,
+        itemId: txn.itemId,
+        input: { name, userNotes: note },
+      });
+      const after = await readTransactionById(ctx.client, ctx.state.marker, txn.id);
+      check(after, `update_transaction: transaction ${txn.id} missing from re-read`);
+      check(
+        after.name === name,
+        `update_transaction: write accepted but re-read name is '${after.name}', expected '${name}'`
+      );
+      check(
+        after.userNotes === note,
+        `update_transaction: write accepted but re-read userNotes is '${String(after.userNotes)}', expected '${note}'`
+      );
+      return undefined;
+    },
+  },
+  {
+    tool: 'review_transactions',
+    domain: 'transactions',
+    flow: 'capture isReviewed on the run-created transaction → flip → verify via re-read → restore original in finally',
+    appliesSurfaces: ['Mutation.editTransaction:applies'],
+    run: async (ctx) => {
+      const txn = ctx.state.txnA;
+      if (!txn) return { skipped: 'no run-created transaction (create_transaction did not pass)' };
+      const before = await readTransactionById(ctx.client, ctx.state.marker, txn.id);
+      check(before, `review_transactions: transaction ${txn.id} missing from pre-read`);
+      const original = before.isReviewed;
+      const flipped = !original;
+      try {
+        await editTransaction(ctx.client, {
+          id: txn.id,
+          accountId: txn.accountId,
+          itemId: txn.itemId,
+          input: { isReviewed: flipped },
+        });
+        const after = await readTransactionById(ctx.client, ctx.state.marker, txn.id);
+        check(
+          after?.isReviewed === flipped,
+          `review_transactions: write accepted but re-read isReviewed is ` +
+            `${String(after?.isReviewed)}, expected ${String(flipped)}`
+        );
+      } finally {
+        // Restore the captured original even when verification failed.
+        try {
+          await editTransaction(ctx.client, {
+            id: txn.id,
+            accountId: txn.accountId,
+            itemId: txn.itemId,
+            input: { isReviewed: original },
+          });
+        } catch (err: unknown) {
+          ctx.log('review_transactions: WARNING — failed to restore isReviewed', {
+            id: txn.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      return undefined;
+    },
+  },
+  {
+    tool: 'create_recurring',
+    domain: 'recurring',
+    flow: 'create recurring (MONTHLY) from the run-created transaction → verify via Recurrings re-read (deleted by delete_recurring)',
+    appliesSurfaces: ['Mutation.createRecurring:applies'],
+    run: async (ctx) => {
+      const txn = await ensureTxnA(ctx);
+      const created = await createRecurring(ctx.client, {
+        input: {
+          frequency: 'MONTHLY',
+          transaction: { accountId: txn.accountId, itemId: txn.itemId, transactionId: txn.id },
+        },
+      });
+      ctx.state.recurringId = created.id;
+      ctx.registry.add({
+        kind: 'recurring',
+        id: created.id,
+        // The server derives the recurring's name from the transaction, so it
+        // should carry the marker — but that derivation is the server's, so
+        // the label records what the echo said.
+        label: created.name,
+        cleanup: () => deleteRecurring(ctx.client, { id: created.id }).then(() => undefined),
+      });
+      const after = (await fetchRecurrings(ctx.client)).find((rec) => rec.id === created.id);
+      check(after, `create_recurring: created id ${created.id} missing from Recurrings re-read`);
+      check(
+        after.frequency.toUpperCase() === 'MONTHLY',
+        `create_recurring: re-read frequency '${after.frequency}', expected MONTHLY`
+      );
+      return undefined;
+    },
+  },
+  {
+    tool: 'update_recurring',
+    domain: 'recurring',
+    flow: 'flip the run-created recurring MONTHLY→WEEKLY → verify via Recurrings re-read',
+    appliesSurfaces: ['Mutation.editRecurring:applies'],
+    run: async (ctx) => {
+      const recurringId = ctx.state.recurringId;
+      if (!recurringId)
+        return { skipped: 'no run-created recurring (create_recurring did not pass)' };
+      await editRecurring(ctx.client, { id: recurringId, input: { frequency: 'WEEKLY' } });
+      const after = (await fetchRecurrings(ctx.client)).find((rec) => rec.id === recurringId);
+      check(after, `update_recurring: recurring ${recurringId} missing from re-read`);
+      check(
+        after.frequency.toUpperCase() === 'WEEKLY',
+        `update_recurring: write accepted but re-read frequency is '${after.frequency}', expected WEEKLY`
+      );
+      return undefined;
+    },
+  },
+  {
+    tool: 'set_recurring_state',
+    domain: 'recurring',
+    flow: 'capture state on the run-created recurring → flip ACTIVE↔PAUSED → verify via re-read → restore original in finally',
+    appliesSurfaces: ['Mutation.editRecurring:applies'],
+    run: async (ctx) => {
+      const recurringId = ctx.state.recurringId;
+      if (!recurringId)
+        return { skipped: 'no run-created recurring (create_recurring did not pass)' };
+      const before = (await fetchRecurrings(ctx.client)).find((rec) => rec.id === recurringId);
+      check(before, `set_recurring_state: recurring ${recurringId} missing from pre-read`);
+      const original = before.state.toUpperCase() as RecurringStateValue;
+      const flipped: RecurringStateValue = original === 'PAUSED' ? 'ACTIVE' : 'PAUSED';
+      try {
+        await editRecurring(ctx.client, { id: recurringId, input: { state: flipped } });
+        const after = (await fetchRecurrings(ctx.client)).find((rec) => rec.id === recurringId);
+        check(
+          after?.state.toUpperCase() === flipped,
+          `set_recurring_state: write accepted but re-read state is ` +
+            `'${String(after?.state)}', expected ${flipped}`
+        );
+      } finally {
+        // Restore the captured original even when verification failed.
+        try {
+          await editRecurring(ctx.client, { id: recurringId, input: { state: original } });
+        } catch (err: unknown) {
+          ctx.log('set_recurring_state: WARNING — failed to restore state', {
+            id: recurringId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      return undefined;
+    },
+  },
+  {
+    tool: 'add_transaction_to_recurring',
+    domain: 'recurring',
+    flow: 'create a second marker transaction → attach to the run-created recurring → verify recurringId via re-read',
+    appliesSurfaces: ['Mutation.addTransactionToRecurring:applies'],
+    run: async (ctx) => {
+      const recurringId = ctx.state.recurringId;
+      if (!recurringId)
+        return { skipped: 'no run-created recurring (create_recurring did not pass)' };
+      const txnB = await createSmokeTransaction(ctx, 'txn-b', 100);
+      await addTransactionToRecurring(ctx.client, {
+        id: txnB.id,
+        accountId: txnB.accountId,
+        itemId: txnB.itemId,
+        input: { recurringId },
+      });
+      const after = await readTransactionById(ctx.client, ctx.state.marker, txnB.id);
+      check(after, `add_transaction_to_recurring: transaction ${txnB.id} missing from re-read`);
+      check(
+        after.recurringId === recurringId,
+        `add_transaction_to_recurring: write accepted but re-read recurringId is ` +
+          `${String(after.recurringId)}, expected the smoke recurring`
+      );
+      return undefined;
+    },
+  },
+  {
+    tool: 'split_transaction',
+    domain: 'transactions',
+    flow: 'create a third marker transaction (amount 200) → split into 2×100 children → verify children via re-read (no unsplit mutation exists; parent + children are all run-created and deleted in cleanup)',
+    appliesSurfaces: ['Mutation.splitTransaction:applies'],
+    run: async (ctx) => {
+      const parent = await createSmokeTransaction(ctx, 'txn-c', 200);
+      const date = todayIso();
+      const categoryId = await ensureCategory(ctx);
+      const result = await splitTransaction(ctx.client, {
+        id: parent.id,
+        accountId: parent.accountId,
+        itemId: parent.itemId,
+        input: [
+          { name: `${ctx.state.marker}-split-a`, date, amount: 100, categoryId },
+          { name: `${ctx.state.marker}-split-b`, date, amount: 100, categoryId },
+        ],
+      });
+      for (const child of result.splitTransactions) {
+        ctx.registry.add({
+          kind: 'transaction',
+          id: child.id,
+          label: child.name,
+          cleanup: () =>
+            deleteTransaction(ctx.client, {
+              id: child.id,
+              accountId: parent.accountId,
+              itemId: parent.itemId,
+            }).then(() => undefined),
+        });
+      }
+      // Verify via RE-READ, not the mutation echo: both children must come
+      // back from the Transactions query pointing at the parent. (Copilot
+      // hides the parent in its UI after a split but does not delete it —
+      // cleanup deletes children and parent explicitly.)
+      const rows = await readTransactionsByMarker(ctx.client, ctx.state.marker);
+      const children = rows.filter((node) => node.parentId === parent.id);
+      check(
+        children.length === 2,
+        `split_transaction: re-read found ${String(children.length)} children with ` +
+          `parentId=${parent.id}, expected 2`
+      );
+      for (const child of children) {
+        check(
+          Math.abs(child.amount) === 100,
+          `split_transaction: child ${child.id} re-read |amount| ` +
+            `${String(Math.abs(child.amount))}, expected 100`
+        );
+      }
+      return undefined;
+    },
+  },
+  {
+    tool: 'delete_recurring',
+    domain: 'recurring',
+    flow: 'delete the run-created recurring → verify absence via Recurrings re-read',
+    appliesSurfaces: ['Mutation.deleteRecurring:applies'],
+    run: async (ctx) => {
+      const recurringId = ctx.state.recurringId;
+      if (!recurringId)
+        return { skipped: 'no run-created recurring (create_recurring did not pass)' };
+      await deleteRecurring(ctx.client, { id: recurringId });
+      const after = (await fetchRecurrings(ctx.client)).find((rec) => rec.id === recurringId);
+      check(
+        after === undefined,
+        `delete_recurring: recurring ${recurringId} still present on re-read`
+      );
+      ctx.registry.remove(recurringId);
+      ctx.state.recurringId = undefined;
+      return undefined;
+    },
+  },
+  {
+    tool: 'delete_transaction',
+    domain: 'transactions',
+    flow: 'delete the run-created transaction → verify absence via Transactions re-read',
+    appliesSurfaces: ['Mutation.deleteTransaction:applies'],
+    run: async (ctx) => {
+      const txn = ctx.state.txnA;
+      if (!txn) return { skipped: 'no run-created transaction (create_transaction did not pass)' };
+      await deleteTransaction(ctx.client, {
+        id: txn.id,
+        accountId: txn.accountId,
+        itemId: txn.itemId,
+      });
+      const after = await readTransactionById(ctx.client, ctx.state.marker, txn.id);
+      check(after === undefined, `delete_transaction: ${txn.id} still present on re-read`);
+      ctx.registry.remove(txn.id);
+      ctx.state.txnA = undefined;
+      return undefined;
+    },
+  },
+  {
+    tool: 'delete_tag',
+    domain: 'tags',
+    flow: 'delete the run-created tag → verify absence via Tags re-read',
+    appliesSurfaces: ['Mutation.deleteTag:applies'],
+    run: async (ctx) => {
+      const tagId = ctx.state.tagId;
+      if (!tagId) return { skipped: 'no run-created tag (create_tag did not pass)' };
+      await deleteTag(ctx.client, { id: tagId });
+      const after = (await fetchTags(ctx.client)).find((tag) => tag.id === tagId);
+      check(after === undefined, `delete_tag: tag ${tagId} still present on re-read`);
+      ctx.registry.remove(tagId);
+      ctx.state.tagId = undefined;
+      return undefined;
+    },
+  },
+  {
+    tool: 'delete_category',
+    domain: 'categories',
+    flow: 'delete the run-created category → verify absence via Categories re-read',
+    appliesSurfaces: ['Mutation.deleteCategory:applies'],
+    run: async (ctx) => {
+      const categoryId = ctx.state.categoryId;
+      if (!categoryId) return { skipped: 'no run-created category (create_category did not pass)' };
+      await deleteCategory(ctx.client, { id: categoryId });
+      const after = (await fetchCategories(ctx.client, { rollovers: false })).find(
+        (cat) => cat.id === categoryId
+      );
+      check(
+        after === undefined,
+        `delete_category: category ${categoryId} still present on re-read`
+      );
+      ctx.registry.remove(categoryId);
+      ctx.state.categoryId = undefined;
+      return undefined;
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Residue detection — shared by the pre-flight check and the final sweep
+// ---------------------------------------------------------------------------
+
+export interface ResidueRecord {
+  kind: CleanupKind;
+  id: string;
+  name: string;
+}
+
+export interface ResidueReaders {
+  tags: () => Promise<Array<{ id: string; name: string }>>;
+  categories: () => Promise<Array<{ id: string; name: string }>>;
+  recurrings: () => Promise<Array<{ id: string; name: string }>>;
+  /** Server-side matchString search for MARKER_PREFIX. */
+  transactions: () => Promise<Array<{ id: string; name: string }>>;
+}
+
+/**
+ * Recurrings are the one collection whose names the SERVER derives (from
+ * the source transaction), so a crashed prior run may have left a recurring
+ * whose name was normalized away from the raw `__smoke__` marker. The
+ * word-boundary regex catches 'Smoke 176...' style derivations without
+ * matching e.g. 'Smokehouse BBQ'.
+ */
+const RECURRING_RESIDUE_RE = /\bsmoke\b/i;
+
+export function isResidueName(kind: CleanupKind, name: string): boolean {
+  if (name.includes(MARKER_PREFIX)) return true;
+  if (kind === 'recurring') return RECURRING_RESIDUE_RE.test(name);
+  return false;
+}
+
+/** Every marker-bearing object currently visible on the server. */
+export async function collectResidue(readers: ResidueReaders): Promise<ResidueRecord[]> {
+  const sources: ReadonlyArray<[CleanupKind, ResidueReaders[keyof ResidueReaders]]> = [
+    ['tag', readers.tags],
+    ['category', readers.categories],
+    ['recurring', readers.recurrings],
+    ['transaction', readers.transactions],
+  ];
+  const residue: ResidueRecord[] = [];
+  for (const [kind, read] of sources) {
+    for (const row of await read()) {
+      if (isResidueName(kind, row.name)) residue.push({ kind, id: row.id, name: row.name });
+    }
+  }
+  return residue;
+}
+
+export function buildResidueReaders(client: GraphQLClient): ResidueReaders {
+  return {
+    tags: () => fetchTags(client),
+    categories: () => fetchCategories(client, { rollovers: false }),
+    recurrings: () => fetchRecurrings(client),
+    transactions: () => readTransactionsByMarker(client, MARKER_PREFIX),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Runner plumbing (kept here so it stays unit-testable without executing
+// scripts/smoke/roundtrip.ts, whose import runs main()).
+// ---------------------------------------------------------------------------
+
+export interface RoundtripArgs {
+  /** Print the plan and exit without auth or mutations. */
+  list: boolean;
+  /** Restrict the run to one domain's checks. */
+  only?: RoundtripDomain;
+}
+
+export function parseRoundtripArgs(argv: readonly string[]): RoundtripArgs {
+  const args: RoundtripArgs = { list: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === '--list') {
+      args.list = true;
+    } else if (arg === '--only') {
+      const value = argv[++i];
+      if (!value || !(ROUNDTRIP_DOMAINS as readonly string[]).includes(value)) {
+        throw new Error(
+          `--only requires one of: ${ROUNDTRIP_DOMAINS.join(', ')} (got '${value ?? ''}')`
+        );
+      }
+      args.only = value as RoundtripDomain;
+    } else {
+      throw new Error(`unknown argument '${arg}' (usage: roundtrip.ts [--list] [--only <domain>])`);
+    }
+  }
+  return args;
+}
+
+/** Human-readable plan, printed by --list and at the start of a real run. */
+export function formatPlan(checks: readonly RoundtripCheck[]): string {
+  const width = Math.max(...checks.map((c) => c.tool.length), 'TOOL'.length);
+  const lines = checks.map(
+    (c, i) => `  ${String(i + 1).padStart(2)}. ${c.tool.padEnd(width)}  [${c.domain}]  ${c.flow}`
+  );
+  return [`[roundtrip] Plan — ${String(checks.length)} round-trips:`, ...lines].join('\n');
+}

--- a/scripts/smoke/roundtrip.ts
+++ b/scripts/smoke/roundtrip.ts
@@ -1,0 +1,214 @@
+/**
+ * Tier-2 reversible round-trip smoke runner (issue #438, Epic B #421).
+ *
+ * !!! MUTATING !!! Sends real writes to the LIVE Copilot endpoint. This is
+ * a local, consciously-run, ATTENDED gate:
+ *   - never scheduled, never part of `bun run smoke` (Tier 1 stays
+ *     non-mutating),
+ *   - refuses to start if marker residue from a prior run exists,
+ *   - guaranteed cleanup (LIFO, in `finally`) plus a final sweep that fails
+ *     loudly with the leftover ids if anything survived.
+ *
+ * Run:  bun run smoke:roundtrip            (all 17 write tools)
+ *       bun run smoke:roundtrip -- --only tags
+ *       bun run smoke:roundtrip -- --list  (print the plan, no auth, no writes)
+ *
+ * Requires an authenticated app.copilot.money browser session; without one
+ * it fails fast before sending anything. Output logs marker-bearing
+ * synthetic names and opaque ids only — never real names or amounts
+ * (PII rules per CLAUDE.md).
+ */
+
+import { FirebaseAuth } from '../../src/core/auth/firebase-auth.js';
+import { extractRefreshToken } from '../../src/core/auth/browser-token.js';
+import { GraphQLClient } from '../../src/core/graphql/client.js';
+import { getResponseDriftStats } from '../../src/core/graphql/response-validation.js';
+import {
+  ROUNDTRIP_CHECKS,
+  CleanupRegistry,
+  buildResidueReaders,
+  collectResidue,
+  formatPlan,
+  makeMarker,
+  parseRoundtripArgs,
+  type CleanupFailure,
+  type ResidueRecord,
+  type RoundtripContext,
+} from './roundtrip-checks.js';
+
+interface RoundtripResult {
+  tool: string;
+  status: 'PASS' | 'SKIP' | 'FAIL';
+  detail?: string;
+}
+
+function log(msg: string, fields?: Record<string, unknown>): void {
+  const prefix = `[roundtrip] ${msg}`;
+  if (fields) {
+    console.error(prefix, fields);
+  } else {
+    console.error(prefix);
+  }
+}
+
+function printResidue(header: string, residue: readonly ResidueRecord[]): void {
+  console.error(`\n[roundtrip] ${header}`);
+  for (const r of residue) {
+    console.error(`  - ${r.kind} id=${r.id} name='${r.name}'`);
+  }
+}
+
+async function main(): Promise<void> {
+  let args;
+  try {
+    args = parseRoundtripArgs(process.argv.slice(2));
+  } catch (err: unknown) {
+    console.error(`[roundtrip] ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  const checks = args.only
+    ? ROUNDTRIP_CHECKS.filter((check) => check.domain === args.only)
+    : ROUNDTRIP_CHECKS;
+
+  if (args.list) {
+    console.error(formatPlan(checks));
+    console.error('\n[roundtrip] --list mode: no auth performed, no requests sent.');
+    return;
+  }
+
+  console.error(
+    '[roundtrip] !!! MUTATING SMOKE !!! — this run creates, edits, and deletes real\n' +
+      '            objects (marker-named, synthetic amounts) against the LIVE Copilot\n' +
+      '            account. Watch the per-step output below.\n'
+  );
+  console.error(formatPlan(checks));
+  console.error('');
+
+  const auth = new FirebaseAuth(() => extractRefreshToken());
+  try {
+    await auth.getIdToken();
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      '[roundtrip] FAIL — could not acquire an authenticated Copilot session, no writes were sent.\n' +
+        '        The round-trip smoke needs a logged-in app.copilot.money browser session\n' +
+        '        on this machine (it is a local attended gate, not a CI job).\n' +
+        `        Underlying error: ${message}`
+    );
+    process.exit(1);
+  }
+  const client = new GraphQLClient(auth);
+  const readers = buildResidueReaders(client);
+
+  // Pre-flight: refuse to start when a prior run left marker objects behind —
+  // a second run on top of residue makes the final sweep unattributable.
+  const preexisting = await collectResidue(readers);
+  if (preexisting.length > 0) {
+    printResidue(
+      'FAIL — pre-flight found marker residue from a prior run; refusing to start.\n' +
+        '        Delete these objects (Copilot UI or delete tools), then re-run:',
+      preexisting
+    );
+    process.exit(1);
+  }
+  log('pre-flight: no marker residue found — starting');
+
+  const ctx: RoundtripContext = {
+    client,
+    state: { marker: makeMarker() },
+    registry: new CleanupRegistry(),
+    log,
+  };
+  log(`run marker: ${ctx.state.marker}`);
+
+  const results: RoundtripResult[] = [];
+  let cleanupFailures: CleanupFailure[] = [];
+  let sweepResidue: ResidueRecord[] = [];
+  try {
+    // Sequential on purpose: later checks consume objects created by earlier
+    // ones, and one mutation at a time is what the maintainer can follow live.
+    for (const [index, check] of checks.entries()) {
+      log(`${String(index + 1)}/${String(checks.length)} ${check.tool} — ${check.flow}`);
+      try {
+        const outcome = await check.run(ctx);
+        if (outcome?.skipped) {
+          results.push({ tool: check.tool, status: 'SKIP', detail: outcome.skipped });
+          log(`${check.tool}: SKIP (${outcome.skipped})`);
+        } else {
+          results.push({ tool: check.tool, status: 'PASS' });
+          log(`${check.tool}: PASS`);
+        }
+      } catch (err: unknown) {
+        const detail = err instanceof Error ? err.message : String(err);
+        results.push({ tool: check.tool, status: 'FAIL', detail });
+        log(`${check.tool}: FAIL — ${detail}`);
+      }
+    }
+  } finally {
+    // Guaranteed cleanup of everything the run still owns, then a final
+    // sweep re-querying the server for ANY marker-bearing object.
+    log(`cleanup: ${String(ctx.registry.pending.length)} object(s) still registered`);
+    cleanupFailures = await ctx.registry.runAll(log);
+    sweepResidue = await collectResidue(readers);
+  }
+
+  // Summary.
+  const width = Math.max(...results.map((r) => r.tool.length), 'TOOL'.length);
+  console.error('\n[roundtrip] Round-trip summary:');
+  console.error(`  ${'TOOL'.padEnd(width)}  RESULT`);
+  for (const r of results) {
+    const suffix = r.status !== 'PASS' && r.detail ? `  (${r.detail})` : '';
+    console.error(`  ${r.tool.padEnd(width)}  ${r.status}${suffix}`);
+  }
+
+  // B3 response-shape drift counters come for free on every mutation this
+  // run sent (warn-mode — informational here, never a failure by itself).
+  const drift = getResponseDriftStats();
+  const driftEntries = Object.entries(drift);
+  if (driftEntries.length > 0) {
+    console.error('\n[roundtrip] Response-shape drift counters (B3 zod-warn, warn-mode):');
+    for (const [surface, count] of driftEntries) {
+      console.error(`  ${surface}: ${String(count)}`);
+    }
+  } else {
+    console.error('\n[roundtrip] Response-shape drift counters (B3 zod-warn): none');
+  }
+
+  let failed = false;
+  const failures = results.filter((r) => r.status === 'FAIL');
+  if (failures.length > 0) {
+    failed = true;
+    console.error('\n[roundtrip] FAIL — round-trip drift detected:');
+    for (const r of failures) console.error(`  - [${r.tool}] ${r.detail ?? 'unknown error'}`);
+  }
+  if (cleanupFailures.length > 0) {
+    failed = true;
+    console.error('\n[roundtrip] FAIL — cleanup could not delete these objects:');
+    for (const f of cleanupFailures) {
+      console.error(`  - ${f.kind} id=${f.id} name='${f.label}': ${f.error}`);
+    }
+  }
+  if (sweepResidue.length > 0) {
+    failed = true;
+    printResidue(
+      'FAIL — final sweep found leftover marker objects; delete them manually:',
+      sweepResidue
+    );
+  } else {
+    console.error('\n[roundtrip] final sweep: zero marker residue — cleanup verified.');
+  }
+
+  if (failed) process.exit(1);
+
+  const skipped = results.filter((r) => r.status === 'SKIP').length;
+  console.error(
+    `\n[roundtrip] PASS — ${String(results.length - skipped)}/${String(checks.length)} write ` +
+      `round-trips verified against the server${skipped > 0 ? ` (${String(skipped)} skipped)` : ''}.`
+  );
+}
+
+main().catch((err: unknown) => {
+  console.error('[roundtrip] FAIL:', err);
+  process.exit(1);
+});

--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -29,6 +29,10 @@
  *                      `Mutation.createTransaction`, `Query.accounts`
  *                      (covers the operation's existence + top-level args)
  * - `response-shape` → `Mutation.<fieldName>:response` / `Query.<fieldName>:response`
+ * - `applies`        → `Mutation.<fieldName>:applies` — the mutation's effect
+ *                      is actually persisted and visible on an independent
+ *                      re-read (not just echoed). Verified by the Tier-2
+ *                      round-trip smoke (B4, issue #438).
  *
  * How to update:
  * - Adding a write-tool param? Add (or extend) an entry whose `toolParams`
@@ -46,7 +50,13 @@ import { ALL_TIME_FRAMES } from '../core/graphql/queries/_shared.js';
 import { RESPONSE_SHAPE_RUNTIME_CHECK } from '../core/graphql/response-validation.js';
 
 /** What kind of external surface the assumption is about. */
-export const SURFACE_KINDS = ['enum', 'input-field', 'response-shape', 'operation'] as const;
+export const SURFACE_KINDS = [
+  'enum',
+  'input-field',
+  'response-shape',
+  'operation',
+  'applies',
+] as const;
 export type SurfaceKind = (typeof SURFACE_KINDS)[number];
 
 /**
@@ -146,6 +156,15 @@ const READ_SMOKE_GATED =
   'wrapper-critical fields on every run; gated by scripts/smoke/reads.ts ' +
   '(issues #439/#460)';
 
+/** B4 (#438): one reversible round-trip per write tool — every write is
+ * re-read through the corresponding query after mutating (create→verify→
+ * delete or set→verify→revert), so an accepted-but-ignored write turns the
+ * run red. MUTATING — maintainer-run attended gate, never scheduled. */
+const ROUNDTRIP_GATED =
+  'Reversible round-trip smoke: write, then verify by independent re-read, then ' +
+  'delete/revert; gated by scripts/smoke/roundtrip.ts (issue #438). ' +
+  'tests/scripts/roundtrip-coverage.test.ts ratchets the write-tool ↔ round-trip bijection';
+
 /** Read response shapes: the Tier-0 smoke spot-checks load-bearing fields,
  * but nothing validates the full hand-written interface at runtime. */
 const QUERY_RESPONSE_SHAPE_UNVERIFIED =
@@ -202,6 +221,22 @@ function gatedInputField(surface: string, toolParams?: readonly string[]): Ledge
     class: 'gated',
     evidence: FIELD_PROBE_GATED,
   });
+}
+
+/**
+ * A mutation whose persisted effect is re-verified by the Tier-2 round-trip
+ * smoke (B4, #438): the round-trip writes, RE-READS the object through the
+ * corresponding query, and asserts the written values are visible — then
+ * deletes/reverts. `name` is the Mutation field, e.g. 'createTransaction'.
+ */
+function appliesSurface(name: string): LedgerEntry {
+  return {
+    surface: `Mutation.${name}:applies`,
+    kind: 'applies',
+    oracle: 'smoke:roundtrip',
+    class: 'gated',
+    evidence: ROUNDTRIP_GATED,
+  };
 }
 
 function responseShape(name: string, overrides?: Partial<LedgerEntry>): LedgerEntry {
@@ -322,6 +357,7 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   gatedInputField('CreateTransactionInput.userNotes', ['create_transaction.note']),
   gatedInputField('CreateTransactionInput.recurringId', ['create_transaction.recurring_id']),
   responseShape('createTransaction'),
+  appliesSurface('createTransaction'),
 
   operation('editTransaction', [
     'update_transaction.transaction_id',
@@ -333,6 +369,7 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   gatedInputField('EditTransactionInput.tagIds', ['update_transaction.tag_ids']),
   gatedInputField('EditTransactionInput.isReviewed', ['review_transactions.reviewed']),
   responseShape('editTransaction'),
+  appliesSurface('editTransaction'),
 
   operation('deleteTransaction', [
     'delete_transaction.transaction_id',
@@ -340,6 +377,7 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
     'delete_transaction.item_id',
   ]),
   responseShape('deleteTransaction'),
+  appliesSurface('deleteTransaction'),
 
   operation('addTransactionToRecurring', [
     'add_transaction_to_recurring.transaction_id',
@@ -350,6 +388,7 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
     'add_transaction_to_recurring.recurring_id',
   ]),
   responseShape('addTransactionToRecurring'),
+  appliesSurface('addTransactionToRecurring'),
 
   operation('splitTransaction', [
     'split_transaction.transaction_id',
@@ -362,6 +401,7 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   gatedInputField('SplitTransactionInput.amount', ['split_transaction.splits[].amount']),
   gatedInputField('SplitTransactionInput.categoryId', ['split_transaction.splits[].category_id']),
   responseShape('splitTransaction'),
+  appliesSurface('splitTransaction'),
 
   // ----- Tags ---------------------------------------------------------------
   // No top-level args beyond the input object (covered by CreateTagInput.*).
@@ -369,14 +409,17 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   gatedInputField('CreateTagInput.name', ['create_tag.name']),
   gatedInputField('CreateTagInput.colorName', ['create_tag.color_name']),
   responseShape('createTag'),
+  appliesSurface('createTag'),
 
   operation('editTag', ['update_tag.tag_id']),
   gatedInputField('EditTagInput.name', ['update_tag.name']),
   gatedInputField('EditTagInput.colorName', ['update_tag.color_name']),
   responseShape('editTag'),
+  appliesSurface('editTag'),
 
   operation('deleteTag', ['delete_tag.tag_id']),
   responseShape('deleteTag'),
+  appliesSurface('deleteTag'),
 
   // ----- Categories ---------------------------------------------------------
   // No top-level args beyond the input object (covered by CreateCategoryInput.*).
@@ -386,6 +429,7 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   gatedInputField('CreateCategoryInput.emoji', ['create_category.emoji']),
   gatedInputField('CreateCategoryInput.isExcluded', ['create_category.is_excluded']),
   responseShape('createCategory'),
+  appliesSurface('createCategory'),
 
   operation('editCategory', ['update_category.category_id']),
   gatedInputField('EditCategoryInput.name', ['update_category.name']),
@@ -393,9 +437,11 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   gatedInputField('EditCategoryInput.emoji', ['update_category.emoji']),
   gatedInputField('EditCategoryInput.isExcluded', ['update_category.is_excluded']),
   responseShape('editCategory'),
+  appliesSurface('editCategory'),
 
   operation('deleteCategory', ['delete_category.category_id']),
   responseShape('deleteCategory'),
+  appliesSurface('deleteCategory'),
 
   // ----- Budgets ------------------------------------------------------------
   // The single set_budget MCP tool fans out to one of two mutations
@@ -411,11 +457,13 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   // stay verified-once until a budget probe lands.
   inputField('EditCategoryBudgetInput.amount', ['set_budget.amount']),
   responseShape('editCategoryBudget'),
+  appliesSurface('editCategoryBudget'),
 
   operation('editCategoryBudgetMonthly', ['set_budget.category_id']),
   inputField('EditCategoryBudgetMonthlyInput.amount', ['set_budget.amount']),
   inputField('EditCategoryBudgetMonthlyInput.month', ['set_budget.month']),
   responseShape('editCategoryBudgetMonthly'),
+  appliesSurface('editCategoryBudgetMonthly'),
 
   // ----- Recurrings ---------------------------------------------------------
   // No top-level args beyond the input object (covered by CreateRecurringInput.*).
@@ -423,6 +471,7 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   gatedInputField('CreateRecurringInput.frequency', ['create_recurring.frequency']),
   gatedInputField('CreateRecurringInput.transaction', ['create_recurring.transaction_id']),
   responseShape('createRecurring'),
+  appliesSurface('createRecurring'),
 
   operation('editRecurring', ['set_recurring_state.recurring_id', 'update_recurring.recurring_id']),
   gatedInputField('EditRecurringInput.name', ['update_recurring.name']),
@@ -438,9 +487,11 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   gatedInputField('EditRecurringInput.rule.maxAmount', ['update_recurring.rule.max_amount']),
   gatedInputField('EditRecurringInput.rule.days', ['update_recurring.rule.days']),
   responseShape('editRecurring'),
+  appliesSurface('editRecurring'),
 
   operation('deleteRecurring', ['delete_recurring.recurring_id']),
   responseShape('deleteRecurring'),
+  appliesSurface('deleteRecurring'),
 
   // ----- Accounts -----------------------------------------------------------
   // editAccount has a GraphQL wrapper (src/core/graphql/accounts.ts) but no
@@ -450,6 +501,10 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   gatedInputField('EditAccountInput.name'),
   gatedInputField('EditAccountInput.isUserHidden'),
   responseShape('editAccount'),
+  // No `applies` entry for editAccount: there is no MCP write tool for it,
+  // so the B4 round-trip suite (one round-trip PER WRITE TOOL) does not
+  // cover the wrapper. Add appliesSurface('editAccount') + a round-trip
+  // check when an update_account tool ships.
 
   // ----- Read queries (issues #439/#460) -------------------------------------
   // One operation + one response-shape entry per QUERY in

--- a/src/core/graphql/recurrings.ts
+++ b/src/core/graphql/recurrings.ts
@@ -1,5 +1,23 @@
 import type { GraphQLClient } from './client.js';
-import { CREATE_RECURRING, EDIT_RECURRING, DELETE_RECURRING } from './operations.generated.js';
+import { EDIT_RECURRING, DELETE_RECURRING } from './operations.generated.js';
+
+/**
+ * Minimal CreateRecurring selection — deliberately NOT the app's
+ * RecurringFields fragment. That fragment also selects `emoji`/`icon`, whose
+ * server-side resolvers crash with a null dereference when the new recurring
+ * derives no category (observed live 2026-06-12 against production, B4 #438):
+ * the row is inserted, then response resolution fails, so the create reports
+ * an error while it actually applied. We only read these four fields; selecting
+ * only them keeps the response resolvable for category-less recurrings.
+ */
+export const CREATE_RECURRING_MINIMAL = `mutation CreateRecurring($input: CreateRecurringInput!) {
+  createRecurring(input: $input) {
+    id
+    name
+    state
+    frequency
+  }
+}`;
 
 /** The 8 valid Copilot `RecurringFrequency` GraphQL enum values (uppercase wire form).
  * Verified against production (issue #419). Single source of truth for both
@@ -40,7 +58,7 @@ export async function createRecurring(
 ): Promise<{ id: string; name: string; state: string; frequency: string }> {
   const data = await client.mutate<{ input: CreateRecurringInput }, CreateRecurringResponse>(
     'CreateRecurring',
-    CREATE_RECURRING,
+    CREATE_RECURRING_MINIMAL,
     args
   );
   return {

--- a/tests/core/graphql/recurrings.test.ts
+++ b/tests/core/graphql/recurrings.test.ts
@@ -3,9 +3,9 @@ import {
   createRecurring,
   editRecurring,
   deleteRecurring,
+  CREATE_RECURRING_MINIMAL,
 } from '../../../src/core/graphql/recurrings.js';
 import {
-  CREATE_RECURRING,
   EDIT_RECURRING,
   DELETE_RECURRING,
 } from '../../../src/core/graphql/operations.generated.js';
@@ -30,7 +30,7 @@ describe('createRecurring', () => {
     });
     const call = (client.mutate as ReturnType<typeof mock>).mock.calls[0];
     expect(call[0]).toBe('CreateRecurring');
-    expect(call[1]).toBe(CREATE_RECURRING);
+    expect(call[1]).toBe(CREATE_RECURRING_MINIMAL);
     expect(call[2]).toEqual({
       input: {
         frequency: 'MONTHLY',

--- a/tests/scripts/roundtrip-checks.test.ts
+++ b/tests/scripts/roundtrip-checks.test.ts
@@ -204,6 +204,12 @@ describe('residue detection', () => {
     expect(isResidueName('recurring', 'Smoke 1700000000000 Txn A')).toBe(true);
     expect(isResidueName('recurring', 'Smokehouse BBQ')).toBe(false);
     expect(isResidueName('transaction', 'Smoke 1700000000000 Txn A')).toBe(false);
+    // Documented approximation: a standalone "smoke" word in a REAL
+    // recurring name false-positives, making the pre-flight refuse to
+    // start — the safe direction for an attended gate (see
+    // RECURRING_RESIDUE_RE in roundtrip-checks.ts).
+    expect(isResidueName('recurring', "Smoke's BBQ")).toBe(true);
+    expect(isResidueName('recurring', 'Smoke Shop')).toBe(true);
   });
 
   test('collectResidue reads all four collections and keeps only marker hits', async () => {
@@ -392,6 +398,70 @@ describe('review_transactions check (stubbed client)', () => {
     const outcome = await getCheck('review_transactions').run(ctx);
     expect(outcome?.skipped).toMatch(/no run-created transaction/);
     expect(calls).toEqual([]);
+  });
+});
+
+describe('set_recurring_state check (stubbed client)', () => {
+  const recurringNode = (state: string) => ({
+    id: 'rec-1',
+    name: '__smoke__1700000000000-recurring',
+    state,
+    frequency: 'MONTHLY',
+    nextPaymentAmount: null,
+    nextPaymentDate: null,
+    categoryId: null,
+    emoji: null,
+    icon: null,
+    rule: null,
+    payments: [],
+  });
+
+  const editEcho = (state: string) => ({
+    editRecurring: {
+      recurring: {
+        id: 'rec-1',
+        name: '__smoke__1700000000000-recurring',
+        categoryId: 'cat-1',
+        frequency: 'MONTHLY',
+        state,
+      },
+    },
+  });
+
+  test('flips ACTIVE→PAUSED, verifies via re-read, and restores the original', async () => {
+    let serverState = 'ACTIVE';
+    const { client, calls } = stubClient({
+      Recurrings: () => ({ recurrings: [recurringNode(serverState)] }),
+      EditRecurring: (variables) => {
+        serverState = (variables as { input: { state: string } }).input.state;
+        return editEcho(serverState);
+      },
+    });
+    const ctx = makeContext(client);
+    ctx.state.recurringId = 'rec-1';
+    const outcome = await getCheck('set_recurring_state').run(ctx);
+    expect(outcome).toBeUndefined();
+    const edits = calls.filter((call) => call.operationName === 'EditRecurring');
+    expect(edits.length).toBe(2); // flip + restore
+    expect((edits[0]!.variables as { input: { state: string } }).input.state).toBe('PAUSED');
+    expect((edits[1]!.variables as { input: { state: string } }).input.state).toBe('ACTIVE');
+    expect(serverState).toBe('ACTIVE');
+  });
+
+  test('FAILS when the write is echoed but the re-read never reflects it — and STILL restores the original', async () => {
+    const { client, calls } = stubClient({
+      // Server always reports the original state: accepted-but-ignored write.
+      Recurrings: () => ({ recurrings: [recurringNode('ACTIVE')] }),
+      EditRecurring: () => editEcho('PAUSED'),
+    });
+    const ctx = makeContext(client);
+    ctx.state.recurringId = 'rec-1';
+    await expect(getCheck('set_recurring_state').run(ctx)).rejects.toThrow(
+      /write accepted but re-read state/
+    );
+    const edits = calls.filter((call) => call.operationName === 'EditRecurring');
+    expect(edits.length).toBe(2); // flip + restore, despite the failure
+    expect((edits[1]!.variables as { input: { state: string } }).input.state).toBe('ACTIVE');
   });
 });
 

--- a/tests/scripts/roundtrip-checks.test.ts
+++ b/tests/scripts/roundtrip-checks.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Unit tests for the Tier-2 round-trip suite plumbing (issue #438).
+ *
+ * Mock-only — no auth, no network, no mutations. The live behavior of the
+ * suite is exercised exclusively by the maintainer's attended
+ * `bun run smoke:roundtrip`; these tests cover the pure helpers (cleanup
+ * registry, arg parsing, residue detection, budget resolution) and — via a
+ * stubbed GraphQLClient — the two properties the design hangs on:
+ *
+ * 1. verification is RE-READ-based: a write whose echo succeeds but whose
+ *    re-read does not reflect the value FAILS the check;
+ * 2. set→revert checks restore the captured original value even when
+ *    verification fails mid-flight.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import type { GraphQLClient } from '../../src/core/graphql/client.js';
+import {
+  ROUNDTRIP_CHECKS,
+  CleanupRegistry,
+  budgetAmountForMonth,
+  collectResidue,
+  formatPlan,
+  isResidueName,
+  makeMarker,
+  parseRoundtripArgs,
+  type ResidueReaders,
+  type RoundtripContext,
+} from '../../scripts/smoke/roundtrip-checks.js';
+
+// ---------------------------------------------------------------------------
+// Stub GraphQL client
+// ---------------------------------------------------------------------------
+
+interface RecordedCall {
+  kind: 'mutate' | 'query';
+  operationName: string;
+  variables: unknown;
+}
+
+/**
+ * Dispatches by operation name to canned handlers. Records every call so
+ * tests can assert which mutations were sent (and with what variables).
+ */
+function stubClient(handlers: Record<string, (variables: unknown) => unknown>): {
+  client: GraphQLClient;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const dispatch = (kind: 'mutate' | 'query') => {
+    return (operationName: string, _query: string, variables: unknown): Promise<unknown> => {
+      calls.push({ kind, operationName, variables });
+      const handler = handlers[operationName];
+      if (!handler) {
+        return Promise.reject(new Error(`stubClient: no handler for ${operationName}`));
+      }
+      return Promise.resolve(handler(variables));
+    };
+  };
+  const client = { mutate: dispatch('mutate'), query: dispatch('query') };
+  return { client: client as unknown as GraphQLClient, calls };
+}
+
+function makeContext(client: GraphQLClient): RoundtripContext {
+  return {
+    client,
+    state: { marker: makeMarker(1700000000000) },
+    registry: new CleanupRegistry(),
+    log: () => undefined,
+  };
+}
+
+function getCheck(tool: string) {
+  const check = ROUNDTRIP_CHECKS.find((candidate) => candidate.tool === tool);
+  if (!check) throw new Error(`no round-trip check for ${tool}`);
+  return check;
+}
+
+function transactionsPage(nodes: unknown[]): unknown {
+  return {
+    transactions: {
+      edges: nodes.map((node, i) => ({ cursor: `c${i}`, node })),
+      pageInfo: { endCursor: null, hasNextPage: false },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CleanupRegistry
+// ---------------------------------------------------------------------------
+
+describe('CleanupRegistry', () => {
+  test('runAll deletes LIFO (dependents before dependencies)', async () => {
+    const registry = new CleanupRegistry();
+    const order: string[] = [];
+    for (const id of ['first', 'second', 'third']) {
+      registry.add({
+        kind: 'tag',
+        id,
+        label: id,
+        cleanup: () => {
+          order.push(id);
+          return Promise.resolve();
+        },
+      });
+    }
+    const failures = await registry.runAll(() => undefined);
+    expect(failures).toEqual([]);
+    expect(order).toEqual(['third', 'second', 'first']);
+    expect(registry.pending).toEqual([]);
+  });
+
+  test('remove() deregisters an explicitly-deleted object', async () => {
+    const registry = new CleanupRegistry();
+    const deleted: string[] = [];
+    for (const id of ['keep', 'gone']) {
+      registry.add({
+        kind: 'transaction',
+        id,
+        label: id,
+        cleanup: () => {
+          deleted.push(id);
+          return Promise.resolve();
+        },
+      });
+    }
+    registry.remove('gone');
+    expect(registry.pending.map((item) => item.id)).toEqual(['keep']);
+    await registry.runAll(() => undefined);
+    expect(deleted).toEqual(['keep']);
+  });
+
+  test('runAll never throws: failures are collected with id + label and the rest still runs', async () => {
+    const registry = new CleanupRegistry();
+    const deleted: string[] = [];
+    registry.add({
+      kind: 'category',
+      id: 'cat-1',
+      label: '__smoke__1-cat',
+      cleanup: () => {
+        deleted.push('cat-1');
+        return Promise.resolve();
+      },
+    });
+    registry.add({
+      kind: 'recurring',
+      id: 'rec-1',
+      label: '__smoke__1-rec',
+      cleanup: () => Promise.reject(new Error('server said no')),
+    });
+    const failures = await registry.runAll(() => undefined);
+    expect(failures).toEqual([
+      { kind: 'recurring', id: 'rec-1', label: '__smoke__1-rec', error: 'server said no' },
+    ]);
+    expect(deleted).toEqual(['cat-1']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Arg parsing + plan
+// ---------------------------------------------------------------------------
+
+describe('parseRoundtripArgs', () => {
+  test('defaults: full mutating run', () => {
+    expect(parseRoundtripArgs([])).toEqual({ list: false });
+  });
+
+  test('--list and --only combine', () => {
+    expect(parseRoundtripArgs(['--list'])).toEqual({ list: true });
+    expect(parseRoundtripArgs(['--only', 'tags'])).toEqual({ list: false, only: 'tags' });
+    expect(parseRoundtripArgs(['--list', '--only', 'recurring'])).toEqual({
+      list: true,
+      only: 'recurring',
+    });
+  });
+
+  test('rejects unknown domains and unknown flags', () => {
+    expect(() => parseRoundtripArgs(['--only', 'accounts'])).toThrow(/--only requires one of/);
+    expect(() => parseRoundtripArgs(['--only'])).toThrow(/--only requires one of/);
+    expect(() => parseRoundtripArgs(['--nuke'])).toThrow(/unknown argument/);
+  });
+});
+
+describe('formatPlan', () => {
+  test('lists every check with its tool, domain, and flow', () => {
+    const plan = formatPlan(ROUNDTRIP_CHECKS);
+    expect(plan).toContain(`${ROUNDTRIP_CHECKS.length} round-trips`);
+    for (const check of ROUNDTRIP_CHECKS) {
+      expect(plan).toContain(check.tool);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Residue detection
+// ---------------------------------------------------------------------------
+
+describe('residue detection', () => {
+  test('isResidueName: marker matches everywhere; bare "smoke" only for recurrings', () => {
+    expect(isResidueName('tag', '__smoke__1700000000000-tag')).toBe(true);
+    expect(isResidueName('transaction', 'prefix __smoke__1 suffix')).toBe(true);
+    expect(isResidueName('tag', 'Groceries')).toBe(false);
+    // Server-derived recurring names may have lost the raw marker.
+    expect(isResidueName('recurring', 'Smoke 1700000000000 Txn A')).toBe(true);
+    expect(isResidueName('recurring', 'Smokehouse BBQ')).toBe(false);
+    expect(isResidueName('transaction', 'Smoke 1700000000000 Txn A')).toBe(false);
+  });
+
+  test('collectResidue reads all four collections and keeps only marker hits', async () => {
+    const readers: ResidueReaders = {
+      tags: () =>
+        Promise.resolve([
+          { id: 't1', name: 'vacation' },
+          { id: 't2', name: '__smoke__1-tag' },
+        ]),
+      categories: () => Promise.resolve([{ id: 'c1', name: 'Groceries' }]),
+      recurrings: () => Promise.resolve([{ id: 'r1', name: 'Smoke 1 Txn A' }]),
+      transactions: () => Promise.resolve([{ id: 'x1', name: '__smoke__1-txn-a' }]),
+    };
+    const residue = await collectResidue(readers);
+    expect(residue).toEqual([
+      { kind: 'tag', id: 't2', name: '__smoke__1-tag' },
+      { kind: 'recurring', id: 'r1', name: 'Smoke 1 Txn A' },
+      { kind: 'transaction', id: 'x1', name: '__smoke__1-txn-a' },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// budgetAmountForMonth
+// ---------------------------------------------------------------------------
+
+describe('budgetAmountForMonth', () => {
+  const monthly = (month: string, amount: string | null, resolvedAmount: string | null) => ({
+    unassignedRolloverAmount: null,
+    childRolloverAmount: null,
+    unassignedAmount: null,
+    resolvedAmount,
+    rolloverAmount: null,
+    childAmount: null,
+    goalAmount: null,
+    amount,
+    month,
+    id: `b-${month}`,
+  });
+
+  test('resolves from current, preferring amount over resolvedAmount', () => {
+    const budget = { current: monthly('2026-06', '200', '150'), histories: [] };
+    expect(budgetAmountForMonth(budget, '2026-06')).toBe(200);
+  });
+
+  test('falls back to resolvedAmount, then to histories, and tolerates day-suffixed months', () => {
+    const budget = {
+      current: monthly('2026-06-01', null, '100'),
+      histories: [monthly('2026-05', '200', null)],
+    };
+    expect(budgetAmountForMonth(budget, '2026-06')).toBe(100);
+    expect(budgetAmountForMonth(budget, '2026-05')).toBe(200);
+  });
+
+  test('returns undefined for missing budget, missing month, or unparseable amounts', () => {
+    expect(budgetAmountForMonth(null, '2026-06')).toBeUndefined();
+    expect(budgetAmountForMonth(undefined, '2026-06')).toBeUndefined();
+    const budget = { current: monthly('2026-06', null, null), histories: [] };
+    expect(budgetAmountForMonth(budget, '2026-06')).toBeUndefined();
+    expect(budgetAmountForMonth(budget, '2026-07')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Re-read-based verification (the accepted-but-ignored detector)
+// ---------------------------------------------------------------------------
+
+describe('create_tag check (stubbed client)', () => {
+  const created = { id: 'tag-1', name: '__smoke__1700000000000-tag', colorName: 'BLUE1' };
+
+  test('PASSES when the Tags re-read reflects the created tag, and registers cleanup', async () => {
+    const { client } = stubClient({
+      CreateTag: () => ({ createTag: created }),
+      Tags: () => ({ tags: [{ id: 'other', name: 'vacation', colorName: 'RED1' }, created] }),
+    });
+    const ctx = makeContext(client);
+    const outcome = await getCheck('create_tag').run(ctx);
+    expect(outcome).toBeUndefined();
+    expect(ctx.registry.pending).toEqual([
+      { kind: 'tag', id: 'tag-1', label: '__smoke__1700000000000-tag' },
+    ]);
+  });
+
+  test('FAILS when the mutation echo succeeds but the re-read does not contain the tag', async () => {
+    const { client } = stubClient({
+      CreateTag: () => ({ createTag: created }),
+      Tags: () => ({ tags: [] }), // write accepted but ignored
+    });
+    const ctx = makeContext(client);
+    await expect(getCheck('create_tag').run(ctx)).rejects.toThrow(/missing from Tags re-read/);
+  });
+
+  test('FAILS when the re-read shows the tag with a different value than written', async () => {
+    const { client } = stubClient({
+      CreateTag: () => ({ createTag: created }),
+      Tags: () => ({ tags: [{ ...created, colorName: 'GRAY1' }] }),
+    });
+    const ctx = makeContext(client);
+    await expect(getCheck('create_tag').run(ctx)).rejects.toThrow(/colorName/);
+  });
+});
+
+describe('review_transactions check (stubbed client)', () => {
+  const txnNode = (isReviewed: boolean) => ({
+    id: 'txn-1',
+    accountId: 'acct-1',
+    itemId: 'item-1',
+    categoryId: 'cat-1',
+    recurringId: null,
+    parentId: null,
+    isReviewed,
+    isPending: false,
+    amount: 100,
+    date: '2026-06-11',
+    name: '__smoke__1700000000000-txn-a',
+    type: 'REGULAR',
+    userNotes: null,
+    tipAmount: null,
+    suggestedCategoryIds: [],
+    isoCurrencyCode: null,
+    createdAt: 0,
+    tags: [],
+    goal: null,
+  });
+
+  const editEcho = (isReviewed: boolean) => ({
+    editTransaction: {
+      transaction: {
+        id: 'txn-1',
+        name: '__smoke__1700000000000-txn-a',
+        categoryId: 'cat-1',
+        userNotes: null,
+        isReviewed,
+        tags: [],
+      },
+    },
+  });
+
+  function contextWithTxnA(client: GraphQLClient): RoundtripContext {
+    const ctx = makeContext(client);
+    ctx.state.txnA = { id: 'txn-1', accountId: 'acct-1', itemId: 'item-1' };
+    return ctx;
+  }
+
+  test('flips isReviewed, verifies via re-read, and restores the original', async () => {
+    let serverReviewed = false;
+    const { client, calls } = stubClient({
+      Transactions: () => transactionsPage([txnNode(serverReviewed)]),
+      EditTransaction: (variables) => {
+        const input = (variables as { input: { isReviewed: boolean } }).input;
+        serverReviewed = input.isReviewed;
+        return editEcho(serverReviewed);
+      },
+    });
+    const ctx = contextWithTxnA(client);
+    const outcome = await getCheck('review_transactions').run(ctx);
+    expect(outcome).toBeUndefined();
+    const edits = calls.filter((call) => call.operationName === 'EditTransaction');
+    expect(edits.length).toBe(2); // flip + restore
+    expect((edits[1]!.variables as { input: { isReviewed: boolean } }).input.isReviewed).toBe(
+      false
+    ); // original captured BEFORE mutating
+    expect(serverReviewed).toBe(false);
+  });
+
+  test('FAILS when the write is echoed but the re-read never reflects it — and STILL restores the original', async () => {
+    const { client, calls } = stubClient({
+      // Server always reports the original value: accepted-but-ignored write.
+      Transactions: () => transactionsPage([txnNode(false)]),
+      EditTransaction: () => editEcho(true),
+    });
+    const ctx = contextWithTxnA(client);
+    await expect(getCheck('review_transactions').run(ctx)).rejects.toThrow(
+      /write accepted but re-read isReviewed/
+    );
+    const edits = calls.filter((call) => call.operationName === 'EditTransaction');
+    expect(edits.length).toBe(2); // flip + restore, despite the failure
+    expect((edits[1]!.variables as { input: { isReviewed: boolean } }).input.isReviewed).toBe(
+      false
+    );
+  });
+
+  test('skips when no run-created transaction exists (never touches user data)', async () => {
+    const { client, calls } = stubClient({});
+    const ctx = makeContext(client); // no txnA, and no handlers: any call would throw
+    const outcome = await getCheck('review_transactions').run(ctx);
+    expect(outcome?.skipped).toMatch(/no run-created transaction/);
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('delete_transaction check (stubbed client)', () => {
+  test('verifies absence via re-read and deregisters from cleanup', async () => {
+    const { client } = stubClient({
+      DeleteTransaction: () => ({ deleteTransaction: true }),
+      Transactions: () => transactionsPage([]),
+    });
+    const ctx = makeContext(client);
+    ctx.state.txnA = { id: 'txn-1', accountId: 'acct-1', itemId: 'item-1' };
+    ctx.registry.add({
+      kind: 'transaction',
+      id: 'txn-1',
+      label: 'x',
+      cleanup: () => Promise.resolve(),
+    });
+    const outcome = await getCheck('delete_transaction').run(ctx);
+    expect(outcome).toBeUndefined();
+    expect(ctx.registry.pending).toEqual([]);
+    expect(ctx.state.txnA).toBeUndefined();
+  });
+
+  test('FAILS when the delete is echoed true but the transaction is still readable', async () => {
+    const node = {
+      id: 'txn-1',
+      name: '__smoke__1700000000000-txn-a',
+      parentId: null,
+      amount: 100,
+    };
+    const { client } = stubClient({
+      DeleteTransaction: () => ({ deleteTransaction: true }),
+      Transactions: () => transactionsPage([node]),
+    });
+    const ctx = makeContext(client);
+    ctx.state.txnA = { id: 'txn-1', accountId: 'acct-1', itemId: 'item-1' };
+    await expect(getCheck('delete_transaction').run(ctx)).rejects.toThrow(
+      /still present on re-read/
+    );
+  });
+});

--- a/tests/scripts/roundtrip-coverage.test.ts
+++ b/tests/scripts/roundtrip-coverage.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Write-tool round-trip coverage ratchet (issue #438, Epic B #421).
+ *
+ * Plain unit test — no auth, no network, no mutations. Enforces that the
+ * Tier-2 round-trip suite stays a complete inventory of the write surface:
+ *
+ * (a) every write tool in the registry (`WRITE_TOOL_DEFS`) has exactly one
+ *     round-trip check in scripts/smoke/roundtrip-checks.ts — a new write
+ *     tool without a round-trip fails this test;
+ * (b) no stale checks: every check maps back to a registry write tool;
+ * (c) every check's `appliesSurfaces` entry exists in the conformance
+ *     ledger as a `kind: 'applies'` entry gated by `smoke:roundtrip`, and
+ *     every `:applies` ledger surface is claimed by at least one check
+ *     (no paper gates, no untracked verification);
+ * (d) safety invariants: the marker convention, the bulkEditTransactions
+ *     ban (source scan), and synthetic-only amounts in the checks source.
+ *
+ * Together with `tests/conformance/ledger.test.ts` (which verifies the
+ * `smoke:roundtrip` oracle script exists), this is the B4 analog of
+ * `tests/scripts/read-smoke-coverage.test.ts`.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { WRITE_TOOL_DEFS } from '../../src/tools/registry/index.js';
+import { CONFORMANCE_LEDGER } from '../../src/conformance/ledger.js';
+import {
+  ROUNDTRIP_CHECKS,
+  ROUNDTRIP_DOMAINS,
+  MARKER_PREFIX,
+  makeMarker,
+} from '../../scripts/smoke/roundtrip-checks.js';
+
+const writeToolNames = WRITE_TOOL_DEFS.map((def) => def.name);
+const appliesEntries = CONFORMANCE_LEDGER.filter((entry) => entry.kind === 'applies');
+const appliesSurfaces = new Set(appliesEntries.map((entry) => entry.surface));
+const claimedSurfaces = new Set(ROUNDTRIP_CHECKS.flatMap((check) => [...check.appliesSurfaces]));
+
+const CHECKS_SOURCE = readFileSync(
+  join(import.meta.dir, '..', '..', 'scripts', 'smoke', 'roundtrip-checks.ts'),
+  'utf8'
+);
+
+describe('round-trip coverage ratchet', () => {
+  test('sanity: the registry exposes the full write surface', () => {
+    // 17 write tools as of E1 (#446); grows as new write tools land.
+    expect(writeToolNames.length).toBeGreaterThanOrEqual(17);
+    expect(new Set(writeToolNames).size).toBe(writeToolNames.length);
+  });
+
+  test('(a) every registry write tool has exactly one round-trip check', () => {
+    for (const name of writeToolNames) {
+      const checks = ROUNDTRIP_CHECKS.filter((check) => check.tool === name);
+      expect(
+        checks.length,
+        `Write tool '${name}' must have exactly one round-trip check in ` +
+          `scripts/smoke/roundtrip-checks.ts (found ${checks.length})`
+      ).toBe(1);
+    }
+  });
+
+  test('(b) no stale checks: every check maps to a registry write tool', () => {
+    const names = new Set(writeToolNames);
+    const stale = ROUNDTRIP_CHECKS.filter((check) => !names.has(check.tool)).map(
+      (check) => check.tool
+    );
+    expect(stale, `Round-trip checks without a registry write tool: ${stale.join(', ')}`).toEqual(
+      []
+    );
+  });
+
+  test('(c) every check claims at least one applies surface that exists in the ledger', () => {
+    for (const check of ROUNDTRIP_CHECKS) {
+      expect(
+        check.appliesSurfaces.length,
+        `Check '${check.tool}' must declare the Mutation.<x>:applies surfaces it verifies`
+      ).toBeGreaterThan(0);
+      for (const surface of check.appliesSurfaces) {
+        expect(
+          surface.endsWith(':applies'),
+          `Check '${check.tool}' claims '${surface}' — applies surfaces must end in ':applies'`
+        ).toBe(true);
+        expect(
+          appliesSurfaces.has(surface),
+          `Check '${check.tool}' claims '${surface}' but the conformance ledger has no such ` +
+            "kind:'applies' entry (src/conformance/ledger.ts)"
+        ).toBe(true);
+      }
+    }
+  });
+
+  test('(c) every ledger applies surface is claimed by at least one check', () => {
+    const unclaimed = [...appliesSurfaces].filter((surface) => !claimedSurfaces.has(surface));
+    expect(
+      unclaimed,
+      `Ledger 'applies' surfaces no round-trip check claims (paper gates): ${unclaimed.join(', ')}`
+    ).toEqual([]);
+  });
+
+  test("(c) every applies entry is gated by the 'smoke:roundtrip' oracle", () => {
+    for (const entry of appliesEntries) {
+      expect(entry.oracle, `Entry '${entry.surface}' must name the round-trip oracle`).toBe(
+        'smoke:roundtrip'
+      );
+      expect(entry.class, `Entry '${entry.surface}' must be classed 'gated'`).toBe('gated');
+    }
+  });
+
+  test('(d) checks declare valid domains and unique tools', () => {
+    for (const check of ROUNDTRIP_CHECKS) {
+      expect(ROUNDTRIP_DOMAINS).toContain(check.domain);
+      expect(check.flow.length).toBeGreaterThan(0);
+    }
+    const tools = ROUNDTRIP_CHECKS.map((check) => check.tool);
+    expect(new Set(tools).size).toBe(tools.length);
+  });
+
+  test('(d) marker convention: __smoke__<timestamp>', () => {
+    expect(MARKER_PREFIX).toBe('__smoke__');
+    expect(makeMarker(1700000000000)).toBe('__smoke__1700000000000');
+    expect(makeMarker()).toMatch(/^__smoke__\d+$/);
+  });
+
+  test('(d) the round-trip suite never references bulkEditTransactions', () => {
+    expect(CHECKS_SOURCE).not.toContain('bulkEditTransactions');
+    expect(CHECKS_SOURCE).not.toContain('bulk_edit');
+  });
+
+  test('(d) all amounts in the checks source are synthetic (100/200 family)', () => {
+    // Catch a realistic figure sneaking into a created object: every numeric
+    // amount literal in the checks source must come from the synthetic set.
+    const amounts = [...CHECKS_SOURCE.matchAll(/amount:\s*(-?\d+(?:\.\d+)?)/g)].map((m) =>
+      Math.abs(parseFloat(m[1]!))
+    );
+    expect(amounts.length).toBeGreaterThan(0);
+    for (const amount of amounts) {
+      expect([100, 200]).toContain(amount);
+    }
+  });
+});


### PR DESCRIPTION
# Summary

One reversible round-trip per write tool (17/17), each verifying the write by **independent re-read** — the detector for accepted-but-ignored writes. New `bun run smoke:roundtrip` runner (separate from `bun run smoke`; Tier 1 stays non-mutating), per-write-tool `applies` ledger surfaces gated by the `smoke:roundtrip` oracle, and a coverage ratchet so a new write tool cannot ship without a round-trip. Closes #438

> **MUTATING SUITE — drafted, not executed.** Per the rules of engagement this suite was written and unit-tested mock-only; nothing here was run against the live endpoint. **The maintainer's attended `bun run smoke:roundtrip` is the merge gate for this PR.** `--list` prints the full plan without auth or writes.

## Round-trip plan (run order)

| # | tool | flow | target |
|---|------|------|--------|
| 1 | create_tag | create → verify (Tags re-read) | run-created tag |
| 2 | update_tag | rename+recolor → verify | run-created tag |
| 3 | create_category | create → verify (Categories re-read) | run-created category |
| 4 | update_category | rename+toggle isExcluded → verify → untoggle | run-created category |
| 5 | set_budget | default 100 → verify; monthly 200 → verify; clear both in finally | run-created category |
| 6 | create_transaction | create (amount 100) → verify (Transactions re-read) | new txn on first account |
| 7 | update_transaction | rename+note → verify | run-created txn |
| 8 | review_transactions | capture isReviewed → flip → verify → restore in finally | run-created txn |
| 9 | create_recurring | create MONTHLY from run-created txn → verify (Recurrings re-read) | run-created recurring |
| 10 | update_recurring | MONTHLY→WEEKLY → verify | run-created recurring |
| 11 | set_recurring_state | capture state → flip ACTIVE↔PAUSED → verify → restore in finally | run-created recurring |
| 12 | add_transaction_to_recurring | create 2nd txn → attach → verify recurringId | run-created txn + recurring |
| 13 | split_transaction | create 3rd txn (200) → split 2×100 → verify children via re-read | run-created txn |
| 14 | delete_recurring | delete → verify absence | run-created recurring |
| 15 | delete_transaction | delete → verify absence | run-created txn |
| 16 | delete_tag | delete → verify absence | run-created tag |
| 17 | delete_category | delete → verify absence | run-created category |

**No check mutates pre-existing user data.** Every mutator/deleter operates on an object the run itself created (lazy prerequisites keep that true under `--only <domain>`). The single unavoidable contact with user data: created transactions must reference a real `account_id`/`item_id` (first account from the Accounts query, same pick as the Tier-0 read smoke); they are deleted and sweep-verified in the same run.

## Safety mechanics

- Marker `__smoke__<timestamp>` on every created object; synthetic names/amounts only (100/200; a source-scan test enforces the amount set).
- **Pre-flight residue check** refuses to start if marker objects from a prior run exist.
- **Guaranteed cleanup**: LIFO `CleanupRegistry` runs in `finally` (continues past failures, reports every leftover id); checks that delete their own target deregister only after verifying absence.
- **Final sweep** re-queries tags/categories/recurrings/transactions for marker residue and fails loudly with leftover ids. Recurrings additionally match `\bsmoke\b` (case-insensitive, word-bounded) because the server derives recurring names and may normalize the raw marker away.
- Set→revert flows capture the original BEFORE mutating and restore it in `finally` even when verification fails (unit-tested with a stub client).
- B3 zod-warn drift counters are printed in the run summary (come for free on every mutation the run sends).
- `bulkEditTransactions` is never used — enforced by a source scan in the ratchet test.
- Idempotent re-run safety: per-run timestamp marker + pre-flight refusal + name-based sweep (catches residue across crashed runs, not just tracked ids).

## Tools flagged for maintainer judgment (none blocked, two caveats)

- **split_transaction**: Copilot has no unsplit mutation. The flow is still safe — parent and both children are run-created and deleted in cleanup. Caveat: Copilot hides (not deletes) split parents in its UI; if the Transactions query also hides them, a failed parent delete would be invisible to the name sweep — the cleanup failure report (with id) is the loud signal in that case.
- **set_budget / update_account class**: `set_budget` avoids touching real budgets by budgeting the run-created category. There is no `update_account` tool (the `editAccount` wrapper has no MCP tool), so no account round-trip exists — noted in the ledger with instructions for when one ships.

## Ledger entries touched (src/conformance/ledger.ts)

- New surface kind `applies` (`Mutation.<x>:applies` = "the write is persisted and visible on independent re-read").
- 16 new entries, all `gated` / oracle `smoke:roundtrip`: createTransaction, editTransaction, deleteTransaction, addTransactionToRecurring, splitTransaction, createTag, editTag, deleteTag, createCategory, editCategory, deleteCategory, editCategoryBudget, editCategoryBudgetMonthly, createRecurring, editRecurring, deleteRecurring.
- `editAccount` deliberately has no applies entry (no MCP write tool) — comment in the ledger says when to add it.
- Ratchets: `tests/scripts/roundtrip-coverage.test.ts` enforces WRITE_TOOL_DEFS ↔ checks bijection and checks ↔ `:applies` surface coverage; the existing ledger test verifies the `smoke:roundtrip` oracle script exists.

## External assumptions

All of the below are per-tool "the write actually applies and is visible on re-read" assumptions. Evidence class for every one: **unverified — live gate pending** (the drafting agent cannot run the mutating oracle; the maintainer's attended `bun run smoke:roundtrip` upgrades them to live-verified in one run):

- `Mutation.createTransaction:applies`, `Mutation.editTransaction:applies` (update_transaction + review_transactions), `Mutation.deleteTransaction:applies`, `Mutation.addTransactionToRecurring:applies`, `Mutation.splitTransaction:applies`
- `Mutation.createTag:applies`, `Mutation.editTag:applies`, `Mutation.deleteTag:applies`
- `Mutation.createCategory:applies`, `Mutation.editCategory:applies`, `Mutation.deleteCategory:applies`
- `Mutation.editCategoryBudget:applies`, `Mutation.editCategoryBudgetMonthly:applies` (both branches of set_budget)
- `Mutation.createRecurring:applies`, `Mutation.editRecurring:applies` (update_recurring + set_recurring_state), `Mutation.deleteRecurring:applies`

Secondary unverified assumptions the attended run will confirm (assertions are written to fail loudly, not silently, if wrong): which of `budget.current.amount` / `resolvedAmount` reflects a freshly-set default budget; that the Transactions `matchString` filter matches the `__smoke__` marker substring; that server-derived recurring names retain a sweep-detectable form of the marker.

## Verification

- `bun run check` green (typecheck + lint + format + version-sync + 2130 tests, including 42 new mock-only tests — no network).
- `bun run sync-manifest` clean (no tool changes).
- `bun run smoke:roundtrip -- --list` exercised locally (no auth, no writes) — plan renders correctly; invalid `--only` rejected with usage.
- NOT executed: `bun run smoke:roundtrip` (mutating) — maintainer-run merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)