### PR TITLE
chore: resolve audit nits #453, #462, #468

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,12 @@ bun install          # Install dependencies
 bun test             # Run tests
 bun run build        # Build for production
 bun run pack:mcpb    # Create .mcpb bundle for Claude Desktop
-bun run check        # Run typecheck + lint + format:check + test
+bun run check        # typecheck + lint + format:check + check:version-sync + check:server-json + bun test --bail
 bun run fix          # Run lint:fix + format
 ```
+
+> `bun run check` does NOT run `check:skills` (the `skills/` linter). Run
+> `bun run check:skills` separately when touching anything under `skills/`.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,10 @@ bun test               # Run tests
 bun run build          # Build for production
 bun run pack:mcpb      # Create read-only .mcpb bundle for Claude Desktop
 bun run pack:mcpb:write # Create writes-enabled .mcpb bundle (local self-install only)
-bun run check          # Run typecheck + lint + format:check + test
+bun run check          # typecheck + lint + format:check + check:version-sync + check:server-json + bun test --bail
 bun run fix            # Run lint:fix + format
 bun run sync-manifest  # Verify manifest.json matches code
+bun run check:skills   # Lint skills/ (NOT part of `check` — run separately for skills work)
 ```
 
 #### Writes-enabled bundle (local-only)
@@ -148,7 +149,7 @@ Tests mirror the `src/` structure in `tests/`. The synthetic test DB is generate
 
 - Use `(db as any)._fieldName = [...]` to inject mock data in `beforeEach`
 - Write tool tests need a mock `GraphQLClient` — use `createMockGraphQLClient` from `tests/helpers/mock-graphql.ts`
-- Run `bun run check` before submitting to catch typecheck, lint, and format issues
+- Run `bun run check` before submitting to catch typecheck, lint, format, version-sync, server-json, and test failures (run `bun run check:skills` too if you touched `skills/` — it is not part of `check`)
 
 ### License check
 

--- a/tests/core/decode-stats.test.ts
+++ b/tests/core/decode-stats.test.ts
@@ -56,6 +56,21 @@ const ITEM_DOC = {
   },
 };
 
+// Valid transaction carrying one extra field the processor neither consumes
+// nor ignores. It passes Zod (so it is NOT dropped) but trips
+// warnUnreadFields, giving unread_field_warnings > 0 with zero drops.
+const UNREAD_FIELD_TXN = {
+  collection: 'transactions',
+  id: 'txn_unread',
+  fields: {
+    transaction_id: 'txn_unread',
+    amount: 300,
+    date: '2024-01-16',
+    name: 'Synthetic Unread Field',
+    copilot_future_field: 'value the decoder does not read yet',
+  },
+};
+
 let warnSpy: ReturnType<typeof spyOn>;
 
 beforeEach(() => {
@@ -148,6 +163,32 @@ describe('decode_health on the tool surface', () => {
     const status = await tools.getConnectionStatus();
     expect(status.decode_health.status).toBe('ok');
     expect(status.decode_health.collections).toBeUndefined();
+  }, 30_000);
+
+  test('unread-only data reports ok status WITH a per-collection breakdown', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'tool-unread-db');
+    await createTestDb(dbPath, [VALID_TXN, UNREAD_FIELD_TXN, ITEM_DOC]);
+
+    const tools = new CopilotMoneyTools(new CopilotDatabase(dbPath));
+    const info = await tools.getCacheInfo();
+
+    // Nothing dropped: both transactions survive.
+    expect(info.transaction_count).toBe(2);
+    // Status stays 'ok' because there are zero drops...
+    expect(info.decode_health.status).toBe('ok');
+    // ...but the note and collections field surface the unread field.
+    expect(info.decode_health.note).toContain('not yet read by the decoder');
+    expect(info.decode_health.note).toContain('No data was dropped');
+    // Per-collection breakdown is present (unlike the terse zero-warning case)
+    // and includes only the flagged collection with dropped === 0.
+    expect(info.decode_health.collections).toEqual({
+      transactions: { decoded: 2, dropped: 0, unread_field_warnings: 1 },
+    });
+
+    const status = await tools.getConnectionStatus();
+    expect(status.decode_health.status).toBe('ok');
+    expect(status.decode_health.collections?.transactions?.unread_field_warnings).toBe(1);
+    expect(status.decode_health.collections?.transactions?.dropped).toBe(0);
   }, 30_000);
 
   test('injected (non-decoded) data reports unknown decode health', async () => {

--- a/tests/scripts/scheduled-smoke-e2e.test.ts
+++ b/tests/scripts/scheduled-smoke-e2e.test.ts
@@ -35,10 +35,26 @@ function runWithStubSmoke(smokeScript: string): {
   process.env.COPILOT_MCP_SMOKE_STATUS_PATH = statusPath;
   process.env.COPILOT_MCP_SMOKE_QUIET = '1';
   const exitCode = runScheduledSmoke();
-  return {
-    exitCode,
-    status: JSON.parse(readFileSync(statusPath, 'utf-8')) as Record<string, unknown>,
-  };
+  let raw: string;
+  try {
+    raw = readFileSync(statusPath, 'utf-8');
+  } catch (err) {
+    throw new Error(
+      `Expected runScheduledSmoke() to write a status file at ${statusPath}, ` +
+        `but it could not be read (exitCode=${exitCode}). The runner likely ` +
+        `exited before writing status. Underlying error: ${String(err)}`
+    );
+  }
+  let status: Record<string, unknown>;
+  try {
+    status = JSON.parse(raw) as Record<string, unknown>;
+  } catch (err) {
+    throw new Error(
+      `Status file at ${statusPath} is not valid JSON (exitCode=${exitCode}). ` +
+        `Contents: ${JSON.stringify(raw)}. Parse error: ${String(err)}`
+    );
+  }
+  return { exitCode, status };
 }
 
 describe('scheduled-smoke runner (full flow, stub smoke)', () => {


### PR DESCRIPTION
# Summary

Batch cleanup resolving three LOW-severity audit follow-ups. Docs/test-only; no production code or behavior changes.

- **#453** — add a decode-stats test for the `getDecodeHealth()` `ok with collections` branch (`totalUnread > 0`, `totalDropped === 0`). A valid transaction carrying one unread field surfaces `unread_field_warnings` while staying decoded, so status is `ok` but the per-collection breakdown is present.
- **#462** — fix the stale `bun run check` description in CLAUDE.md and CONTRIBUTING.md to match `package.json` (adds `check:version-sync`, `check:server-json`, `bun test --bail`) and note that `check:skills` is NOT part of `check` and must be run separately for skills work.
- **#468** — wrap the status-file read/parse in `tests/scripts/scheduled-smoke-e2e.test.ts` in try/catch blocks that throw diagnostic messages if `runScheduledSmoke()` exits before writing a valid status file.

Closes #453
Closes #462
Closes #468

## External assumptions

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
