### PR TITLE
feat(update_transaction): expose reviewed (isReviewed) as a writable field

### DIFF
--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -367,7 +367,10 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   gatedInputField('EditTransactionInput.categoryId', ['update_transaction.category_id']),
   gatedInputField('EditTransactionInput.userNotes', ['update_transaction.note']),
   gatedInputField('EditTransactionInput.tagIds', ['update_transaction.tag_ids']),
-  gatedInputField('EditTransactionInput.isReviewed', ['review_transactions.reviewed']),
+  gatedInputField('EditTransactionInput.isReviewed', [
+    'review_transactions.reviewed',
+    'update_transaction.reviewed',
+  ]),
   gatedInputField('EditTransactionInput.type', ['update_transaction.type']),
   responseShape('editTransaction'),
   appliesSurface('editTransaction'),

--- a/src/tools/registry/transactions.ts
+++ b/src/tools/registry/transactions.ts
@@ -406,16 +406,19 @@ export const updateTransactionTool = defineTool({
   schema: {
     name: 'update_transaction',
     description:
-      "Update a single transaction's name, category, note, tags, or type. Pass transaction_id " +
-      'plus any combination of name, category_id, note, tag_ids, or type — only specified fields ' +
-      'are changed. Pass note="" to clear the note. Pass tag_ids=[] to clear all tags. `type` sets ' +
-      'the high-level classification (REGULAR, INCOME, or INTERNAL_TRANSFER) — use ' +
-      'INTERNAL_TRANSFER to exclude internal/transfer mechanics from spending. Setting type to ' +
-      "INCOME or INTERNAL_TRANSFER clears the transaction's category (Copilot does this " +
-      'server-side), so category_id cannot be combined with those two types — pass the type alone, ' +
-      'or use REGULAR to keep/set a category. At least one mutable field must be provided besides ' +
-      'transaction_id. Other fields (excluded, internal_transfer, goal_id) are not writable ' +
-      'through the GraphQL API and were removed from this tool when the backend was migrated.',
+      "Update a single transaction's name, category, note, tags, type, or reviewed-state. Pass " +
+      'transaction_id plus any combination of name, category_id, note, tag_ids, type, or reviewed ' +
+      '— only specified fields are changed. Pass note="" to clear the note. Pass tag_ids=[] to ' +
+      'clear all tags. `type` sets the high-level classification (REGULAR, INCOME, or ' +
+      'INTERNAL_TRANSFER) — use INTERNAL_TRANSFER to exclude internal/transfer mechanics from ' +
+      "spending. Setting type to INCOME or INTERNAL_TRANSFER clears the transaction's category " +
+      '(Copilot does this server-side), so category_id cannot be combined with those two types — ' +
+      'pass the type alone, or use REGULAR to keep/set a category. `reviewed` marks a single ' +
+      'transaction reviewed (true) or un-reviewed (false), and can be set inline with other edits ' +
+      '— use review_transactions instead for bulk/filter-based review. At least one mutable field ' +
+      'must be provided besides transaction_id. Other fields (excluded, internal_transfer, ' +
+      'goal_id) are not writable through the GraphQL API and were removed from this tool when the ' +
+      'backend was migrated.',
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -447,6 +450,12 @@ export const updateTransactionTool = defineTool({
           description:
             'High-level classification. INTERNAL_TRANSFER excludes the transaction from spending. ' +
             'INCOME/INTERNAL_TRANSFER clear the category server-side — do not pass category_id with them.',
+        },
+        reviewed: {
+          type: 'boolean',
+          description:
+            'Mark this transaction reviewed (true) or un-reviewed (false). For bulk/filter-based ' +
+            'review across many transactions, use review_transactions instead.',
         },
       },
       required: ['transaction_id'],

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2428,6 +2428,7 @@ export class CopilotMoneyTools {
     note?: string;
     tag_ids?: string[];
     type?: TransactionType;
+    reviewed?: boolean;
   }): Promise<{
     success: true;
     transaction_id: string;
@@ -2446,6 +2447,7 @@ export class CopilotMoneyTools {
       'note',
       'tag_ids',
       'type',
+      'reviewed',
     ]);
     for (const key of Object.keys(args)) {
       if (!allowedKeys.has(key)) {
@@ -2521,6 +2523,13 @@ export class CopilotMoneyTools {
         );
       }
     }
+    if ('reviewed' in args && args.reviewed !== undefined) {
+      if (typeof args.reviewed !== 'boolean') {
+        throw new Error(
+          `update_transaction: reviewed must be a boolean. Got: ${String(args.reviewed)}`
+        );
+      }
+    }
     // Map MCP fields → EditTransaction input shape.
     const input: {
       name?: string;
@@ -2536,6 +2545,7 @@ export class CopilotMoneyTools {
     if ('note' in args && args.note !== undefined) input.userNotes = args.note;
     if ('tag_ids' in args && args.tag_ids !== undefined) input.tagIds = args.tag_ids;
     if ('type' in args && args.type !== undefined) input.type = args.type;
+    if ('reviewed' in args && args.reviewed !== undefined) input.isReviewed = args.reviewed;
 
     if (!txn.account_id || !txn.item_id) {
       throw new Error(`Transaction ${transaction_id} missing account_id or item_id in local cache`);
@@ -2567,6 +2577,7 @@ export class CopilotMoneyTools {
         patch.category_id = args.category_id;
       if ('note' in args && args.note !== undefined) patch.user_note = args.note;
       if ('tag_ids' in args && args.tag_ids !== undefined) patch.tag_ids = args.tag_ids;
+      if ('reviewed' in args && args.reviewed !== undefined) patch.user_reviewed = args.reviewed;
       // `type` itself isn't mirrored into the cache: the local Transaction model
       // stores Plaid's `transaction_type`/`plaid_transaction_type`, not Copilot's
       // REGULAR/INCOME/INTERNAL_TRANSFER classification, so there's no field to

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2415,11 +2415,14 @@ export class CopilotMoneyTools {
   /**
    * Update one or more fields on a transaction in a single atomic write.
    *
-   * Supported fields: category_id, note, tag_ids. Omitted fields are preserved.
-   * note="" clears the note. tag_ids=[] clears all tags. Other legacy fields
-   * (name, excluded, internal_transfer, goal_id) are not writable through the
-   * GraphQL EditTransaction mutation and were removed from this tool when the
-   * backend was migrated.
+   * Supported fields: name, category_id, note, tag_ids, type, reviewed.
+   * Omitted fields are preserved. note="" clears the note. tag_ids=[] clears
+   * all tags. type=INCOME/INTERNAL_TRANSFER clears the category server-side
+   * (so category_id can't be combined with them). reviewed sets the
+   * reviewed-state of a single transaction. Other legacy fields (excluded,
+   * internal_transfer, goal_id) are not writable through the GraphQL
+   * EditTransaction mutation and were removed from this tool when the backend
+   * was migrated.
    */
   async updateTransaction(args: {
     transaction_id: string;

--- a/tests/unit/update-transaction.test.ts
+++ b/tests/unit/update-transaction.test.ts
@@ -436,4 +436,18 @@ describe('updateTransaction — reviewed (#416)', () => {
     ).rejects.toThrow(/reviewed must be a boolean/i);
     expect(client._calls).toHaveLength(0);
   });
+
+  test('reviewed combined with type: both merge into one call, neither blocks the other', async () => {
+    const { tools, client } = makeTools();
+    const result = await tools.updateTransaction({
+      transaction_id: 'txn1',
+      type: 'INCOME',
+      reviewed: true,
+    });
+    expect(client._calls).toHaveLength(1);
+    const input = (client._calls[0] as any).variables.input;
+    expect(input.type).toBe('INCOME');
+    expect(input.isReviewed).toBe(true);
+    expect(result.updated.sort()).toEqual(['reviewed', 'type']);
+  });
 });

--- a/tests/unit/update-transaction.test.ts
+++ b/tests/unit/update-transaction.test.ts
@@ -388,3 +388,52 @@ describe('updateTransaction — type (#415)', () => {
     expect(cached?.category_id).toBe('');
   });
 });
+
+describe('updateTransaction — reviewed (#416)', () => {
+  test('reviewed=true: dispatches with isReviewed input, response maps back to "reviewed"', async () => {
+    const { tools, client } = makeTools();
+    const result = await tools.updateTransaction({ transaction_id: 'txn1', reviewed: true });
+    expect(client._calls).toHaveLength(1);
+    const call = client._calls[0] as any;
+    expect(call.op).toBe('EditTransaction');
+    expect(call.variables.input.isReviewed).toBe(true);
+    expect(result.updated).toEqual(['reviewed']);
+  });
+
+  test('reviewed=false: dispatches with isReviewed=false (un-review a single transaction)', async () => {
+    const { tools, client } = makeTools();
+    const result = await tools.updateTransaction({ transaction_id: 'txn1', reviewed: false });
+    expect(client._calls).toHaveLength(1);
+    expect((client._calls[0] as any).variables.input.isReviewed).toBe(false);
+    expect(result.updated).toEqual(['reviewed']);
+  });
+
+  test('reviewed: optimistic cache patches user_reviewed', async () => {
+    const { tools, mockDb } = makeTools();
+    await tools.updateTransaction({ transaction_id: 'txn1', reviewed: true });
+    const cached = (await mockDb.getTransactions()).find((t) => t.transaction_id === 'txn1');
+    expect(cached?.user_reviewed).toBe(true);
+  });
+
+  test('reviewed combined with category_id: one merged EditTransaction call', async () => {
+    const { tools, client } = makeTools();
+    const result = await tools.updateTransaction({
+      transaction_id: 'txn1',
+      reviewed: true,
+      category_id: 'groceries',
+    });
+    expect(client._calls).toHaveLength(1);
+    const input = (client._calls[0] as any).variables.input;
+    expect(input.isReviewed).toBe(true);
+    expect(input.categoryId).toBe('groceries');
+    expect(result.updated.sort()).toEqual(['category_id', 'reviewed']);
+  });
+
+  test('reviewed: non-boolean value throws, no write', async () => {
+    const { tools, client } = makeTools();
+    await expect(
+      tools.updateTransaction({ transaction_id: 'txn1', reviewed: 'yes' as any })
+    ).rejects.toThrow(/reviewed must be a boolean/i);
+    expect(client._calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #414 / sibling of #415. Adds `reviewed` (boolean) as a **writable input** on `update_transaction`.

`isReviewed` was already declared on `EditTransactionInput` and the tool already mapped it **back** in its response (`isReviewed → reviewed`); the only gap was that it wasn't accepted as **input**. This closes that gap so an agent can:

- **un-review** a single transaction (previously impossible — `review_transactions` is bulk/filter-based), and
- set reviewed-state **inline** with a category/note/type change in one call instead of two round-trips.

Mirrors the `type` field pattern from #415 exactly.

## Changes

- **Handler** (`src/tools/tools.ts`): `reviewed?: boolean` param, added to `allowedKeys`, boolean validation before any write, mapped `reviewed → input.isReviewed`, optimistic cache patch of `user_reviewed` (the local `Transaction` model field — same field `review_transactions` patches).
- **Registry** (`src/tools/registry/transactions.ts`): `reviewed` boolean property + description; tool description points agents at `review_transactions` for bulk vs `update_transaction.reviewed` for inline single edits.
- **Ledger** (`src/conformance/ledger.ts`): added `update_transaction.reviewed` to the existing `EditTransactionInput.isReviewed` `gatedInputField` `toolParams` (no duplicate entry).
- **Tests** (`tests/unit/update-transaction.test.ts`): dispatch sets `isReviewed` (true/false), response maps back to `reviewed`, optimistic `user_reviewed` cache patch, combined-with-category merged dispatch, non-boolean rejection. TDD: written failing first, confirmed red, then green.

## External assumptions

- `EditTransactionInput.isReviewed` is a real, server-accepted input field. **Evidence class: gated.** It is gated by the B2 field probe (auto-derived from the conformance ledger) and exercised by the `review_transactions` B4 round-trip. This PR only adds a second tool param to the same already-gated field; the GraphQL surface is unchanged.
- No new live gate is required. Maintainer can run `bun run smoke` to re-confirm.

## Verification

- `bun run check` green (typecheck + lint + format + 2163 tests, 0 fail).
- `bun run sync-manifest` clean.

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)