### PR TITLE
ci: require the External assumptions section in PR bodies

### DIFF
--- a/.github/workflows/required-sections.yml
+++ b/.github/workflows/required-sections.yml
@@ -1,0 +1,36 @@
+name: Required PR Sections
+
+# Enforces that PR bodies keep the sections the template marks as mandatory:
+#   - "## External assumptions" (with a non-empty answer — "None" is valid)
+#   - the Bug Response Ritual fields when the title is a `fix:` PR
+#
+# Lightweight by design: one job, no checkout of code dependencies, no network
+# beyond reading the PR event payload. Re-runs on body/title edits so clearing
+# a section can't sneak past after the initial green check.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  required-sections:
+    name: Check required PR sections
+    runs-on: ubuntu-latest
+    # Bots (Dependabot, etc.) open PRs that don't use the human template, so
+    # holding them to it would only produce noise. Skip any `[bot]` actor.
+    if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Check required sections
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Pass the body via stdin (never via an arg or inline expansion) so
+          # arbitrary content — backticks, $(...), quotes — can't be interpreted
+          # by the shell.
+          printf '%s' "$PR_BODY" | bash scripts/check-pr-sections.sh -

--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,7 @@ scripts/*
 !scripts/scheduled-smoke.ts
 !scripts/install-scheduled-smoke.sh
 !scripts/uninstall-scheduled-smoke.sh
+!scripts/check-pr-sections.sh
 # License-check scratch directory (created by CI license gate)
 .license-check/
 # Generated test fixtures

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,6 +192,14 @@ entry with a comment.
 5. Push and open a Pull Request — fill every section of the PR template,
    including "External assumptions" (see `.github/PULL_REQUEST_TEMPLATE.md`)
 
+The **Required PR Sections** check (`.github/workflows/required-sections.yml`)
+enforces this: a PR fails CI unless its body contains a non-empty
+`## External assumptions` section (write `None` if there are no new
+assumptions), and `fix:`-titled PRs must additionally include every Bug
+Response Ritual field below. The matching logic lives in
+`scripts/check-pr-sections.sh` and is covered by
+`tests/scripts/check-pr-sections.test.ts`.
+
 ## Bug Response Ritual
 
 Every bug-fix PR ratchets the system: fix the **class**, not just the instance.

--- a/scripts/check-pr-sections.sh
+++ b/scripts/check-pr-sections.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# check-pr-sections.sh — enforce required PR-body sections.
+#
+# Reads the PR body from the file named by $1 (or stdin if no arg) and the PR
+# title from $PR_TITLE. Exits 0 when the body satisfies the gate, non-zero with
+# a ::error:: annotation otherwise.
+#
+# Rules:
+#   1. The body must contain a `## External assumptions` header followed by a
+#      non-empty answer (the PR template ships "None" as the explicit default,
+#      so an empty section is a deletion, not an omission).
+#   2. If the PR title starts with `fix:` (a bug-fix per Conventional Commits),
+#      the body must also contain every Bug Response Ritual field label from
+#      CONTRIBUTING.md.
+#
+# HTML comments are stripped before matching so the template's commented-out
+# placeholder text never counts as a real answer.
+#
+# This logic lives in a script (not inline YAML) so it can be unit-tested
+# locally: see tests/check-pr-sections.test.sh.
+
+set -euo pipefail
+
+REQUIRED_HEADER='External assumptions'
+
+# Ritual field labels (kept in sync with CONTRIBUTING.md "Bug Response Ritual").
+RITUAL_FIELDS=(
+  'Root cause:'
+  'Bug class:'
+  'Detector added:'
+  'Siblings checked:'
+  'Ledger updated:'
+)
+
+fail() {
+  # GitHub Actions surfaces ::error:: lines in the checks UI / annotations.
+  echo "::error::$1" >&2
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# --- read body -------------------------------------------------------------
+if [ "$#" -ge 1 ] && [ "$1" != "-" ]; then
+  raw_body="$(cat -- "$1")"
+else
+  raw_body="$(cat)"
+fi
+
+title="${PR_TITLE:-}"
+
+# --- strip HTML comments ---------------------------------------------------
+# Use perl for a multiline, non-greedy strip of <!-- ... --> blocks so that a
+# commented-out template section can't masquerade as a filled-in answer.
+body="$(printf '%s' "$raw_body" | perl -0777 -pe 's/<!--.*?-->//gs')"
+
+# --- check 1: External assumptions ----------------------------------------
+# Extract the text from the `## External assumptions` header up to (but not
+# including) the next `## ` header or end of body, then test that something
+# non-whitespace remains. Header match is case-insensitive and tolerates
+# trailing whitespace after the title.
+section="$(
+  printf '%s\n' "$body" | awk -v hdr="$REQUIRED_HEADER" '
+    BEGIN { want = tolower("## " hdr); capturing = 0 }
+    {
+      line = $0
+      stripped = line
+      sub(/[ \t\r]+$/, "", stripped)        # rstrip
+      lower = tolower(stripped)
+      if (capturing && line ~ /^##[ \t]/) { capturing = 0 }
+      if (lower == want) { capturing = 1; next }
+      if (capturing) { print line }
+    }
+  '
+)"
+
+if ! printf '%s\n' "$body" | grep -qiE '^##[[:space:]]+External assumptions[[:space:]]*$'; then
+  fail "PR body is missing the required '## External assumptions' section. \
+Restore it from .github/PULL_REQUEST_TEMPLATE.md (use 'None' if there are no new assumptions)."
+fi
+
+if ! printf '%s' "$section" | grep -qE '[^[:space:]]'; then
+  fail "The '## External assumptions' section is empty. \
+List new Copilot API/data assumptions and their evidence class, or write 'None'."
+fi
+
+echo "OK: '## External assumptions' section present and non-empty."
+
+# --- check 2: Bug Response Ritual (fix: PRs only) -------------------------
+# Match a Conventional-Commits bug-fix prefix: fix, fix(scope), fix!, etc.
+if printf '%s' "$title" | grep -qiE '^fix(\([^)]*\))?!?:'; then
+  echo "Title is a 'fix:' PR — checking Bug Response Ritual fields."
+  missing=()
+  for field in "${RITUAL_FIELDS[@]}"; do
+    if ! printf '%s' "$body" | grep -qiF "$field"; then
+      missing+=("$field")
+    fi
+  done
+  if [ "${#missing[@]}" -gt 0 ]; then
+    fail "'fix:' PR is missing Bug Response Ritual field(s): ${missing[*]} \
+(see CONTRIBUTING.md → 'Bug Response Ritual'; fill every line, fix the class not the instance)."
+  fi
+  echo "OK: all Bug Response Ritual fields present."
+else
+  echo "Title is not a 'fix:' PR — skipping Bug Response Ritual check."
+fi
+
+echo "All required-section checks passed."

--- a/scripts/check-pr-sections.sh
+++ b/scripts/check-pr-sections.sh
@@ -61,14 +61,14 @@ body="$(printf '%s' "$raw_body" | perl -0777 -pe 's/<!--.*?-->//gs')"
 # trailing whitespace after the title.
 section="$(
   printf '%s\n' "$body" | awk -v hdr="$REQUIRED_HEADER" '
-    BEGIN { want = tolower("## " hdr); capturing = 0 }
+    BEGIN { want = "^## +" tolower(hdr) " *$"; capturing = 0 }
     {
       line = $0
       stripped = line
       sub(/[ \t\r]+$/, "", stripped)        # rstrip
       lower = tolower(stripped)
       if (capturing && line ~ /^##[ \t]/) { capturing = 0 }
-      if (lower == want) { capturing = 1; next }
+      if (lower ~ want) { capturing = 1; next }
       if (capturing) { print line }
     }
   '

--- a/tests/scripts/check-pr-sections.test.ts
+++ b/tests/scripts/check-pr-sections.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Behavioural tests for scripts/check-pr-sections.sh — the logic behind the
+ * "Required PR Sections" CI gate (.github/workflows/required-sections.yml,
+ * issue #463).
+ *
+ * The workflow can't be run as a real `pull_request` event locally, so we test
+ * the matching logic directly: feed sample PR bodies to the script via stdin
+ * and assert on its exit code. This is the same script the workflow invokes,
+ * so green here means the gate's decision logic is covered.
+ */
+import { describe, expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = fileURLToPath(new URL('../../scripts/check-pr-sections.sh', import.meta.url));
+
+async function runCheck(
+  body: string,
+  title = 'feat: something'
+): Promise<{ code: number; stderr: string; stdout: string }> {
+  const proc = Bun.spawn(['bash', SCRIPT, '-'], {
+    stdin: new TextEncoder().encode(body),
+    env: { ...process.env, PR_TITLE: title },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  return { code, stderr, stdout };
+}
+
+const FILLED_ASSUMPTIONS = `# Summary
+
+Does a thing. Closes #1.
+
+## External assumptions
+
+None
+`;
+
+describe('External assumptions gate', () => {
+  test('passes when the section has a non-empty answer', async () => {
+    const { code } = await runCheck(FILLED_ASSUMPTIONS);
+    expect(code).toBe(0);
+  });
+
+  test('passes with substantive prose under the header', async () => {
+    const body = `## External assumptions
+
+Assumes RecurringFrequency includes WEEKLY (probe transcript, PR #123).
+`;
+    const { code } = await runCheck(body);
+    expect(code).toBe(0);
+  });
+
+  test('fails when the header is missing entirely', async () => {
+    const body = `# Summary
+
+No required section here.
+`;
+    const { code, stderr } = await runCheck(body);
+    expect(code).not.toBe(0);
+    expect(stderr).toContain('External assumptions');
+  });
+
+  test('fails when the section is present but empty', async () => {
+    const body = `## External assumptions
+
+## Next section
+`;
+    const { code, stderr } = await runCheck(body);
+    expect(code).not.toBe(0);
+    expect(stderr).toContain('empty');
+  });
+
+  test('fails when the only content is an HTML comment (deleted answer)', async () => {
+    const body = `## External assumptions
+
+<!-- forgot to fill this in -->
+`;
+    const { code } = await runCheck(body);
+    expect(code).not.toBe(0);
+  });
+
+  test('header match is case-insensitive', async () => {
+    const body = `## EXTERNAL ASSUMPTIONS
+
+None
+`;
+    const { code } = await runCheck(body);
+    expect(code).toBe(0);
+  });
+
+  test('stops capturing at the next ## header', async () => {
+    // Empty assumptions section followed by a populated later section must fail
+    // (later content must not leak into the assumptions check).
+    const body = `## External assumptions
+
+## Bug fix?
+
+Root cause: x
+`;
+    const { code, stderr } = await runCheck(body);
+    expect(code).not.toBe(0);
+    expect(stderr).toContain('empty');
+  });
+
+  test('shell metacharacters in the body are not interpreted', async () => {
+    const body = '## External assumptions\n\n`rm -rf /` $(whoami) "quotes" \'more\'\n';
+    const { code } = await runCheck(body);
+    expect(code).toBe(0);
+  });
+});
+
+const RITUAL = `Root cause: a
+Bug class: b
+Detector added: c
+Siblings checked: d
+Ledger updated: e`;
+
+describe('Bug Response Ritual gate (fix: PRs)', () => {
+  test('fix: PR with all ritual fields passes', async () => {
+    const body = `## External assumptions
+
+None
+
+## Bug fix?
+
+${RITUAL}
+`;
+    const { code } = await runCheck(body, 'fix: correct enum mapping');
+    expect(code).toBe(0);
+  });
+
+  test('fix: PR missing a ritual field fails', async () => {
+    const body = `## External assumptions
+
+None
+
+## Bug fix?
+
+Root cause: a
+Bug class: b
+`;
+    const { code, stderr } = await runCheck(body, 'fix: correct enum mapping');
+    expect(code).not.toBe(0);
+    expect(stderr).toContain('Bug Response Ritual');
+  });
+
+  test('fix: PR with ritual fields only inside an HTML comment fails', async () => {
+    const body = `## External assumptions
+
+None
+
+<!--
+${RITUAL}
+-->
+`;
+    const { code } = await runCheck(body, 'fix: stale comment template');
+    expect(code).not.toBe(0);
+  });
+
+  test('non-fix PR is not held to the ritual', async () => {
+    const { code } = await runCheck(FILLED_ASSUMPTIONS, 'chore: tidy');
+    expect(code).toBe(0);
+  });
+
+  test('scoped fix(scope): prefix is recognized', async () => {
+    const body = `## External assumptions
+
+None
+
+${RITUAL}
+`;
+    const { code } = await runCheck(body, 'fix(decoder): handle null');
+    expect(code).toBe(0);
+  });
+
+  test('breaking fix!: prefix is recognized', async () => {
+    const body = `## External assumptions
+
+None
+`;
+    const { code, stderr } = await runCheck(body, 'fix!: drop legacy field');
+    expect(code).not.toBe(0);
+    expect(stderr).toContain('Bug Response Ritual');
+  });
+
+  test('"fix" not used as a conventional-commit prefix is ignored', async () => {
+    // "fixture" should not trip the ritual check.
+    const { code } = await runCheck(FILLED_ASSUMPTIONS, 'test: add fixture');
+    expect(code).toBe(0);
+  });
+});


### PR DESCRIPTION
# Summary

Enforces the PR template's mandatory sections in CI. A lightweight
`pull_request` workflow (`required-sections.yml`) fails the check when a PR
body drops the `## External assumptions` section (the template says it must
never be deleted, but nothing enforced it), and when a `fix:`-titled PR omits
the Bug Response Ritual fields from CONTRIBUTING.md. Closes #463.

## External assumptions

None — this is CI tooling. It makes no assumptions about Copilot's
API/data, enum values, input fields, operation signatures, or response
shapes; it only reads the GitHub PR event payload.

## What's in this PR

- `.github/workflows/required-sections.yml` — one job, no code deps, runs on
  `pull_request` (`opened`/`edited`/`synchronize`/`reopened`) so body/title
  edits re-trigger. `permissions: pull-requests: read`. Bot PRs (any `[bot]`
  actor, e.g. Dependabot) are skipped via the job `if:` since they don't use
  the human template.
- `scripts/check-pr-sections.sh` — the matching logic, factored out of the
  YAML so it's unit-testable. The PR body is passed via **stdin** (never an
  arg or inline expansion), so backticks / `$(...)` / quotes in a body can't
  be interpreted by the shell. HTML comments are stripped before matching so
  the template's commented-out placeholders never count as a filled answer.
- `tests/scripts/check-pr-sections.test.ts` — 15 behavioural tests covering
  present/empty/missing sections, case-insensitivity, comment-only content,
  shell-metacharacter safety, and the `fix:` / `fix(scope):` / `fix!:` ritual
  cases. Runs under `bun test`, so `bun run check` covers it.
- CONTRIBUTING.md + .gitignore — document the gate; allowlist the new script
  (the repo ignores `scripts/*` by default).

## Verification

- `actionlint .github/workflows/required-sections.yml` — clean.
- `bun run check` — green (typecheck, lint, format, 2153 tests pass).
- Self-tested the script against the real PR template: passes for `feat:`,
  and a `fix:`-titled PR using the un-filled template correctly fails (ritual
  fields are only in HTML comments until a bug-fix author uncomments them).

## Notes

The `fix:` Bug Response Ritual check shipped as part of this PR (the issue
listed it as a "consider"). It's clean because the ritual field labels are
unambiguous and the comment-stripping makes the un-filled template behave
correctly — a bug-fix author must uncomment and fill the fields for the
check to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
