### PR TITLE
test(fixtures): opaque-ID fixture-shape gate for the name→ID bug class

### DIFF
--- a/tests/helpers/DATA_FORMATS.md
+++ b/tests/helpers/DATA_FORMATS.md
@@ -8,24 +8,25 @@ The test helper (`test-db.ts`) creates LevelDB databases with Firestore-compatib
 
 ## Collection Mappings
 
-| Test Collection | Production Collection | Notes |
-|----------------|----------------------|-------|
-| `transactions` | `transactions` | Same |
-| `accounts` | `accounts` | Same |
-| `recurring` | `recurring` | Same |
-| `budgets` | `budgets` | Same |
-| `financial_goals` | `financial_goals` | **Note: NOT `goals`** |
-| `goalHistory` | `goalHistory` | May have subcollection path |
-| `investmentPrices` | `investmentPrices` | Same |
-| `investmentSplits` | `investmentSplits` | Same |
-| `items` | `items` | Same |
-| `categories` | User subcollection | Usually `users/{userId}/categories` |
+| Test Collection    | Production Collection | Notes                               |
+| ------------------ | --------------------- | ----------------------------------- |
+| `transactions`     | `transactions`        | Same                                |
+| `accounts`         | `accounts`            | Same                                |
+| `recurring`        | `recurring`           | Same                                |
+| `budgets`          | `budgets`             | Same                                |
+| `financial_goals`  | `financial_goals`     | **Note: NOT `goals`**               |
+| `goalHistory`      | `goalHistory`         | May have subcollection path         |
+| `investmentPrices` | `investmentPrices`    | Same                                |
+| `investmentSplits` | `investmentSplits`    | Same                                |
+| `items`            | `items`               | Same                                |
+| `categories`       | User subcollection    | Usually `users/{userId}/categories` |
 
 ## Nested Structure Differences
 
 ### Goals (`financial_goals`)
 
 **Production Format:**
+
 ```json
 {
   "goal_id": "goal_abc123",
@@ -39,8 +40,8 @@ The test helper (`test-db.ts`) creates LevelDB databases with Firestore-compatib
     "type": "savings",
     "status": "active",
     "tracking_type": "automatic",
-    "tracking_type_monthly_contribution": 500.00,
-    "target_amount": 10000.00,
+    "tracking_type_monthly_contribution": 500.0,
+    "target_amount": 10000.0,
     "start_date": "2024-01-15",
     "modified_start_date": false,
     "inflates_budget": false,
@@ -50,6 +51,7 @@ The test helper (`test-db.ts`) creates LevelDB databases with Firestore-compatib
 ```
 
 **Test Format (simplified):**
+
 ```typescript
 {
   goal_id: 'goal_abc123',
@@ -95,9 +97,25 @@ Documents stored in subcollection: `users/{userId}/categories/{categoryId}`
 }
 ```
 
+## Opaque-ID invariant (issue #461)
+
+Synthetic fixtures for ID-keyed entities (`categories`, `accounts`, `recurring`,
+`tags`) **must use opaque IDs that are distinct from their display name**. A
+fixture where `id === name` (e.g. `tag_id: 'work'` for a tag named `work`) lets
+a broken `name === id` comparison pass by accident — exactly the bug class fixed
+in PR #394, where cache-mode `get_transactions` compared a user-facing tag _name_
+against opaque tag _IDs_.
+
+`assertOpaqueIds()` (in `test-db.ts`) enforces this and is wired into
+`createTestDb()`, so every LevelDB-backed fixture is validated as it is built.
+Use Firestore-shaped opaque IDs (`9qyEMnfMXknwvx9OnYhk`) or `prefix_xxxxxx`
+slugs. Plaid-taxonomy category slugs (`food_dining`) are fine — they look
+name-ish but never equal the display name (`Food & Dining`).
+
 ## Field Name Conventions
 
 All field names in production Firestore use **snake_case**:
+
 - `transaction_id` (not `transactionId`)
 - `account_id` (not `accountId`)
 - `current_balance` (not `currentBalance`)
@@ -108,6 +126,7 @@ The decoder looks for snake_case fields, so test data must use snake_case.
 
 **Production Format:**
 Firestore timestamps are stored as protobuf Timestamp messages:
+
 ```json
 {
   "created_at": {
@@ -119,6 +138,7 @@ Firestore timestamps are stored as protobuf Timestamp messages:
 
 **Test Format:**
 The test helper accepts ISO date strings which are converted:
+
 ```typescript
 {
   date: '2024-01-15',  // Converted to timestamp during encoding
@@ -130,11 +150,13 @@ The test helper accepts ISO date strings which are converted:
 To achieve full production data parity, the following enhancements are needed:
 
 ### 1. Nested Object Support in Goals
+
 ```typescript
 interface TestGoal {
   goal_id: string;
   name?: string;
-  savings?: {  // Add nested savings support
+  savings?: {
+    // Add nested savings support
     type?: string;
     status?: string;
     target_amount?: number;
@@ -145,6 +167,7 @@ interface TestGoal {
 ```
 
 ### 2. Subcollection Support
+
 ```typescript
 // Support for user subcollections
 createDocument({
@@ -155,6 +178,7 @@ createDocument({
 ```
 
 ### 3. Timestamp Field Types
+
 ```typescript
 interface TestTransaction {
   // Add proper timestamp fields
@@ -164,16 +188,18 @@ interface TestTransaction {
 ```
 
 ### 4. Reference Fields
+
 ```typescript
 // Some fields are Firestore references
 {
-  account_ref: 'projects/copilot-production/databases/(default)/documents/accounts/acc_123'
+  account_ref: 'projects/copilot-production/databases/(default)/documents/accounts/acc_123';
 }
 ```
 
 ## Usage Example
 
 Current simplified test data creation:
+
 ```typescript
 await createTransactionDb(dbPath, [
   {
@@ -186,6 +212,7 @@ await createTransactionDb(dbPath, [
 ```
 
 Future production-equivalent:
+
 ```typescript
 await createTransactionDb(dbPath, [
   {
@@ -212,6 +239,7 @@ await createTransactionDb(dbPath, [
 The decoder extracts fields from Firestore documents based on field names. See `src/core/decoder.ts` for the complete list of expected fields for each collection.
 
 Key decoder functions:
+
 - `decodeTransactions()` - Expects `amount`, `date`, various string/bool fields
 - `decodeAccounts()` - Expects `current_balance` (required), type fields
 - `decodeGoals()` - Expects nested `savings` object with amounts/dates

--- a/tests/helpers/fixture-shape.test.ts
+++ b/tests/helpers/fixture-shape.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Fixture-shape invariant gate (issue #461).
+ *
+ * Class-level ratchet for the name→ID resolution bug class fixed in PR #394.
+ * That bug — cache-mode `get_transactions` comparing a user-facing tag NAME
+ * against opaque tag IDs — went undetected for over a month because the only
+ * fixture exercising the path used a tag whose ID equaled its display name
+ * (`tag_id: 'work'` for a tag named `work`), so the broken `name === id`
+ * comparison passed by accident.
+ *
+ * The invariant: synthetic fixture documents for ID-keyed entities must use
+ * opaque IDs that are DISTINCT from their own display name. If id === name,
+ * a resolution step that should map name → id can be silently skipped and the
+ * fixture will still "pass", masking the same class of bug on sibling paths
+ * (categories, accounts, recurrings, ...).
+ *
+ * The check is enforced two ways:
+ *  1. `assertOpaqueIds()` is wired into `createTestDb()`, so EVERY LevelDB-backed
+ *     fixture is validated as it is built (see test-db.ts).
+ *  2. The unit tests below pin the helper's behavior so the gate itself can't
+ *     silently regress.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { assertOpaqueIds, ID_NAME_FIELD_PAIRS } from './test-db.js';
+
+describe('fixture-shape invariant (issue #461)', () => {
+  test('passes when ids are opaque and distinct from display names', () => {
+    expect(() =>
+      assertOpaqueIds([
+        {
+          collection: 'categories',
+          id: 'cat_8f3kq9',
+          fields: { category_id: 'cat_8f3kq9', name: 'Groceries' },
+        },
+        {
+          collection: 'accounts',
+          id: 'acc_2bz1',
+          fields: { account_id: 'acc_2bz1', name: 'Checking' },
+        },
+      ])
+    ).not.toThrow();
+  });
+
+  test('passes for Plaid-taxonomy slug ids that are not equal to the display name', () => {
+    // Plaid category ids look name-ish (`food_dining`) but never equal the
+    // human display name (`Food & Dining`), so they are legitimately opaque.
+    expect(() =>
+      assertOpaqueIds([
+        {
+          collection: 'categories',
+          id: 'food_dining',
+          fields: { category_id: 'food_dining', name: 'Food & Dining' },
+        },
+      ])
+    ).not.toThrow();
+  });
+
+  test('throws when a doc id equals its display name', () => {
+    expect(() =>
+      assertOpaqueIds([
+        {
+          collection: 'categories',
+          id: 'Groceries',
+          fields: { category_id: 'Groceries', name: 'Groceries' },
+        },
+      ])
+    ).toThrow(/id-equals-name/i);
+  });
+
+  test('throws when id equals name case-insensitively (a comparison could still match)', () => {
+    expect(() =>
+      assertOpaqueIds([
+        {
+          collection: 'accounts',
+          id: 'checking',
+          fields: { account_id: 'checking', name: 'Checking' },
+        },
+      ])
+    ).toThrow(/id-equals-name/i);
+  });
+
+  test('throws when the id field inside fields equals the name (even if doc id differs)', () => {
+    // The decoded model reads the *_id field, so an id==name there is just as
+    // dangerous as on the doc id.
+    expect(() =>
+      assertOpaqueIds([
+        {
+          collection: 'recurring',
+          id: 'rec_opaque',
+          fields: { recurring_id: 'Netflix', name: 'Netflix' },
+        },
+      ])
+    ).toThrow(/id-equals-name/i);
+  });
+
+  test('error message names the offending collection and value', () => {
+    let message = '';
+    try {
+      assertOpaqueIds([
+        {
+          collection: 'accounts',
+          id: 'Savings',
+          fields: { account_id: 'Savings', name: 'Savings' },
+        },
+      ]);
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toContain('accounts');
+    expect(message).toContain('Savings');
+  });
+
+  test('ignores documents without a name field (nothing to collide with)', () => {
+    expect(() =>
+      assertOpaqueIds([
+        {
+          collection: 'budgets',
+          // budgets have no display name; id-equals-name is not a concern
+          id: 'food_dining',
+          fields: { budget_id: 'food_dining', category_id: 'food_dining' },
+        },
+      ])
+    ).not.toThrow();
+  });
+
+  test('covers the documented name→ID-keyed collections', () => {
+    // Guards against silently dropping a collection from the invariant.
+    const collections = ID_NAME_FIELD_PAIRS.map((p) => p.collectionPrefix);
+    expect(collections).toContain('categories');
+    expect(collections).toContain('accounts');
+    expect(collections).toContain('recurring');
+    expect(collections).toContain('tags');
+  });
+});

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -141,17 +141,93 @@ export interface TestCategory {
 }
 
 /**
+ * A synthetic Firestore document as accepted by {@link createTestDb}.
+ */
+export interface TestDocument {
+  collection: string;
+  id: string;
+  fields: Record<string, unknown>;
+}
+
+/**
+ * Fixture-shape invariant config (issue #461).
+ *
+ * For each ID-keyed entity whose IDs are opaque Firestore-generated strings,
+ * lists the doc-id field and the display-name field that must NOT collide.
+ *
+ * `collectionPrefix` is matched against the leading segment of the document's
+ * collection path so subcollection paths (e.g.
+ * `financial_goals/{id}/financial_goal_history`) are handled by their root.
+ *
+ * This is the class-level ratchet for the name→ID resolution bug class fixed
+ * in PR #394: a fixture where `id === name` lets a broken `name === id`
+ * comparison pass by accident, masking the bug. Plaid-taxonomy category slugs
+ * (`food_dining`) are name-ish but never equal the display name (`Food &
+ * Dining`), so they satisfy the invariant naturally.
+ */
+export const ID_NAME_FIELD_PAIRS: ReadonlyArray<{
+  collectionPrefix: string;
+  idField: string;
+  nameField: string;
+}> = [
+  { collectionPrefix: 'categories', idField: 'category_id', nameField: 'name' },
+  { collectionPrefix: 'accounts', idField: 'account_id', nameField: 'name' },
+  { collectionPrefix: 'recurring', idField: 'recurring_id', nameField: 'name' },
+  { collectionPrefix: 'tags', idField: 'tag_id', nameField: 'name' },
+];
+
+/**
+ * Assert that synthetic fixture documents use opaque IDs distinct from their
+ * own display name (issue #461).
+ *
+ * Throws if any ID-keyed document has an ID that equals its display name
+ * (case-insensitive), on either the doc id or the in-fields `*_id`. Such
+ * fixtures mask the name→ID resolution bug class (PR #394) because a filter
+ * that skips name→id resolution still matches.
+ *
+ * Documents without a display-name field, and collections not listed in
+ * {@link ID_NAME_FIELD_PAIRS}, are ignored — there is nothing for the id to
+ * collide with.
+ */
+export function assertOpaqueIds(documents: TestDocument[]): void {
+  for (const doc of documents) {
+    const root = doc.collection.split('/')[0];
+    const pair = ID_NAME_FIELD_PAIRS.find((p) => p.collectionPrefix === root);
+    if (!pair) continue;
+
+    const name = doc.fields[pair.nameField];
+    if (typeof name !== 'string' || name.length === 0) continue;
+    const nameLower = name.toLowerCase();
+
+    const candidateIds = [doc.id, doc.fields[pair.idField]].filter(
+      (v): v is string => typeof v === 'string' && v.length > 0
+    );
+
+    for (const id of candidateIds) {
+      if (id.toLowerCase() === nameLower) {
+        throw new Error(
+          `Fixture-shape invariant violated (issue #461): document in collection ` +
+            `'${doc.collection}' has an id-equals-name shape (id='${id}', ` +
+            `${pair.nameField}='${name}'). Synthetic fixtures for ID-keyed ` +
+            `entities must use opaque IDs distinct from display names, or a ` +
+            `name→ID resolution bug (see PR #394) can be masked. Use a ` +
+            `Firestore-shaped opaque id (e.g. '9qyEMnfMXknwvx9OnYhk' or ` +
+            `'${pair.collectionPrefix}_${Math.random().toString(36).slice(2, 8)}').`
+        );
+      }
+    }
+  }
+}
+
+/**
  * Create a test database with the given documents.
  * The database is created in the specified directory.
  */
-export async function createTestDb(
-  dbPath: string,
-  documents: Array<{
-    collection: string;
-    id: string;
-    fields: Record<string, unknown>;
-  }>
-): Promise<void> {
+export async function createTestDb(dbPath: string, documents: TestDocument[]): Promise<void> {
+  // Gate fixtures on the name→ID opaque-id invariant (issue #461) before they
+  // can mask a resolution bug.
+  assertOpaqueIds(documents);
+
   // Remove existing directory if it exists
   if (fs.existsSync(dbPath)) {
     fs.rmSync(dbPath, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Closes #461 (boundary-audit finding F2).

PR #394 fixed cache-mode `get_transactions` comparing a user-facing tag **name** against opaque tag **IDs**. The bug hid for over a month because the only fixture exercising that path used a tag whose ID equaled its display name (`tag_id: 'work'` for a tag named `work`), so the broken `name === id` comparison passed by accident. That enabling condition — id-equals-name fixtures — had no gate, so nothing stopped a future fixture from re-masking the same bug class on a sibling name→ID path (categories, accounts, recurrings).

This PR adds the class-level ratchet.

## What the gate asserts

`assertOpaqueIds()` (in `tests/helpers/test-db.ts`) throws if any ID-keyed fixture document has an ID equal — case-insensitively — to its own display `name`, checking **both** the doc id and the in-fields `*_id`. The covered collections (`ID_NAME_FIELD_PAIRS`) are the entities with opaque Firestore IDs and a user-facing name: `categories`, `accounts`, `recurring`, `tags`.

It is wired into `createTestDb()`, the single funnel every LevelDB-backed fixture builder routes through, so each fixture is validated as it is built. Documents without a display-name field, and collections not in the list, are ignored (nothing for the id to collide with). Plaid-taxonomy category slugs (`food_dining`) pass naturally — they look name-ish but never equal the display name (`Food & Dining`).

`tests/helpers/fixture-shape.test.ts` pins the helper's behavior so the gate itself can't silently regress.

## Fixtures I had to fix

None — all existing builder-routed fixtures (`tests/core/decoder-leveldb.test.ts`, `tests/core/decode-stats.test.ts`, `tests/integration/mcpb-bundle.test.ts`) already use opaque IDs distinct from names, so the gate is green on the current tree. (The intentional legacy id-equals-name regression test in `tools.test.ts` injects `_tags` directly via `(db as any)._tags`, not through `createTestDb`, so it is correctly untouched.)

## Sweep findings

Swept sibling cache-mode filters for the #394 class (user-facing name compared against an opaque `*_id`). **No other instances:** every `*_id` comparison in `tools.ts`/`database.ts` compares an id-typed param against an id field, not a name. The `get_transactions` `category` filter substring-matches against `category_id` by documented design ("case-insensitive substring") — it works for Plaid slug ids and degrades for opaque user-category ids, but it is not the #394 always-fails pattern, so it is left as-is to preserve documented semantics. Noted here rather than expanding scope.

## External assumptions

None — internal test infra only.

## Test plan

- [x] `bun run check` green (2146 pass / 0 fail)
- [x] New gate red before the helper existed, green after (TDD)
- [x] Existing builder-routed fixture tests still pass under the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)