### PR TITLE
fix(auth): discard foreign-project tokens instead of surfacing PROJECT_NUMBER_MISMATCH

### DIFF
--- a/src/core/auth/browser-token.ts
+++ b/src/core/auth/browser-token.ts
@@ -23,6 +23,24 @@ export interface TokenResult {
   browser: string;
 }
 
+/**
+ * All refresh-token candidates discovered across browsers, plus the list of
+ * browsers searched (for the actionable "no session" message).
+ *
+ * Why a *list*: the browser-wide `Local Storage/leveldb` fallback contains
+ * EVERY site's storage, so any other Firebase-backed site's `AMf-` refresh
+ * token shows up here too. We can't tell from disk alone which (if any)
+ * belongs to Copilot's project (copilot-production-22904) — only the
+ * securetoken exchange knows. So we surface every candidate and let the
+ * exchange in `firebase-auth.ts` discard foreign-project ones
+ * (PROJECT_NUMBER_MISMATCH) and keep trying.
+ */
+export interface TokenCandidates {
+  candidates: TokenResult[];
+  /** Browser names searched, in order — used to build the "no session" error. */
+  checked: string[];
+}
+
 /** Firebase refresh token regex: AMf- followed by 100+ URL-safe base64 chars. */
 const REFRESH_TOKEN_REGEX = /AMf-[A-Za-z0-9_-]{100,}/g;
 const COPILOT_INDEXEDDB_DIR = 'IndexedDB/https_app.copilot.money_0.indexeddb.leveldb';
@@ -134,35 +152,45 @@ export const BROWSER_CONFIGS: BrowserConfig[] = [
   },
 ];
 
+/**
+ * Extract every refresh token from a file's raw bytes.
+ *
+ * Returns ALL matches (longest first), not just the longest one: on disk we
+ * cannot tell which `AMf-` token belongs to Copilot's Firebase project, so we
+ * surface every candidate and let the securetoken exchange reject foreign
+ * ones. The longest-first ordering preserves the old "newer tokens tend to be
+ * longer" heuristic as a try-order preference, not a hard pick.
+ */
+function tokensInFile(filePath: string): string[] {
+  try {
+    const content = readFileSync(filePath, 'latin1');
+    const matches = content.match(REFRESH_TOKEN_REGEX);
+    if (!matches || matches.length === 0) return [];
+    return [...matches].sort((a, b) => b.length - a.length);
+  } catch {
+    /* Skip unreadable files */
+    return [];
+  }
+}
+
 /** Search a directory for .ldb and .log files containing refresh tokens. */
-function searchLevelDBDir(dirPath: string): string | undefined {
-  if (!existsSync(dirPath)) return undefined;
+function searchLevelDBDir(dirPath: string): string[] {
+  if (!existsSync(dirPath)) return [];
   let files: string[];
   try {
     files = readdirSync(dirPath);
   } catch {
-    return undefined;
+    return [];
   }
 
   const targetFiles = files.filter((f) => f.endsWith('.ldb') || f.endsWith('.log'));
-  for (const file of targetFiles) {
-    try {
-      const content = readFileSync(join(dirPath, file), 'latin1');
-      const matches = content.match(REFRESH_TOKEN_REGEX);
-      if (matches && matches.length > 0) {
-        // Pick the longest match — newer Firebase tokens tend to be longer
-        return matches.reduce((a, b) => (a.length >= b.length ? a : b));
-      }
-    } catch {
-      /* Skip unreadable files */
-    }
-  }
-  return undefined;
+  return targetFiles.flatMap((file) => tokensInFile(join(dirPath, file)));
 }
 
 /** Search Firefox profiles for refresh tokens. */
-function searchFirefoxProfiles(profilesDir: string): string | undefined {
-  if (!existsSync(profilesDir)) return undefined;
+function searchFirefoxProfiles(profilesDir: string): string[] {
+  if (!existsSync(profilesDir)) return [];
+  const found: string[] = [];
   try {
     const profiles = readdirSync(profilesDir, { withFileTypes: true })
       .filter((d) => d.isDirectory())
@@ -176,95 +204,123 @@ function searchFirefoxProfiles(profilesDir: string): string | undefined {
       for (const origin of origins) {
         const idbDir = join(idbBase, origin, 'idb');
         if (!existsSync(idbDir)) continue;
-        const files = readdirSync(idbDir);
-        for (const file of files) {
-          try {
-            const content = readFileSync(join(idbDir, file), 'latin1');
-            const matches = content.match(REFRESH_TOKEN_REGEX);
-            if (matches && matches.length > 0) {
-              // Pick the longest match — newer Firebase tokens tend to be longer
-              return matches.reduce((a, b) => (a.length >= b.length ? a : b));
-            }
-          } catch {
-            /* Skip */
-          }
+        for (const file of readdirSync(idbDir)) {
+          found.push(...tokensInFile(join(idbDir, file)));
         }
       }
     }
   } catch {
     /* Skip */
   }
-  return undefined;
+  return found;
 }
 
 /** Search Safari databases for refresh tokens. */
-function searchSafariDatabases(dbDir: string): string | undefined {
-  if (!existsSync(dbDir)) return undefined;
+function searchSafariDatabases(dbDir: string): string[] {
+  if (!existsSync(dbDir)) return [];
+  const found: string[] = [];
   try {
-    const searchDir = (dir: string, depth: number): string | undefined => {
-      if (depth > 4) return undefined;
+    const searchDir = (dir: string, depth: number): void => {
+      if (depth > 4) return;
       const entries = readdirSync(dir, { withFileTypes: true });
       for (const entry of entries) {
         const fullPath = join(dir, entry.name);
         if (entry.isDirectory()) {
-          const found = searchDir(fullPath, depth + 1);
-          if (found) return found;
+          searchDir(fullPath, depth + 1);
         } else if (entry.isFile()) {
           try {
             if (statSync(fullPath).size > 10_000_000) continue;
-            const content = readFileSync(fullPath, 'latin1');
-            const matches = content.match(REFRESH_TOKEN_REGEX);
-            if (matches && matches.length > 0) {
-              // Pick the longest match — newer Firebase tokens tend to be longer
-              return matches.reduce((a, b) => (a.length >= b.length ? a : b));
-            }
           } catch {
-            /* Skip */
+            continue;
           }
+          found.push(...tokensInFile(fullPath));
         }
       }
-      return undefined;
     };
-    return searchDir(dbDir, 0);
+    searchDir(dbDir, 0);
   } catch {
-    return undefined;
+    /* Skip */
   }
+  return found;
+}
+
+/** Search one browser config's paths, returning every token found. */
+function searchBrowser(browser: BrowserConfig): string[] {
+  const search: (path: string) => string[] =
+    browser.type === 'chromium'
+      ? searchLevelDBDir
+      : browser.type === 'firefox'
+        ? searchFirefoxProfiles
+        : searchSafariDatabases;
+  return browser.paths.flatMap(search);
 }
 
 /**
- * Extract a Firebase refresh token from browser local storage.
- * Searches browsers in order: the Chromium family (Chrome, Arc, Edge, Brave,
- * Vivaldi, Chromium, Opera, Opera GX), then Safari, then Firefox.
- * @param browserOverrides - Override browser configs for testing
- * @throws Error if no token is found in any browser
+ * Build the actionable "no Copilot session" error from the searched browsers.
+ * Used both when zero `AMf-` tokens exist anywhere AND when every discovered
+ * token turned out to belong to a foreign Firebase project (the exchange in
+ * firebase-auth.ts rejected them all with PROJECT_NUMBER_MISMATCH). Both states
+ * mean the same thing to the user: log in. This is AUTH_FAILED /
+ * user-action-required, never schema/API drift.
  */
-export function extractRefreshToken(browserOverrides?: BrowserConfig[]): Promise<TokenResult> {
+export function noCopilotSessionError(checked: string[]): Error {
+  return new Error(
+    `No Copilot Money session found. Searched: ${checked.join(', ')}. ` +
+      'Please log into Copilot Money at https://app.copilot.money in your browser, then try again.'
+  );
+}
+
+/**
+ * Extract ALL Firebase refresh-token candidates from browser local storage.
+ *
+ * Searches browsers in order: the Chromium family (Chrome, Arc, Edge, Brave,
+ * Vivaldi, Chromium, Opera, Opera GX), then Safari, then Firefox — and within
+ * each, every configured path. Returns every distinct `AMf-` token discovered,
+ * because the browser-wide Local Storage fallback contains other sites' tokens
+ * too; only the securetoken exchange can tell which belongs to Copilot's
+ * project. Does NOT throw on empty — returns `{ candidates: [], checked }` so
+ * the caller can attempt exchanges and build a single, consistent error.
+ *
+ * @param browserOverrides - Override browser configs for testing
+ */
+export function extractRefreshTokenCandidates(
+  browserOverrides?: BrowserConfig[]
+): Promise<TokenCandidates> {
   const browsers = browserOverrides ?? BROWSER_CONFIGS;
   const checked: string[] = [];
+  const candidates: TokenResult[] = [];
+  const seen = new Set<string>();
 
   for (const browser of browsers) {
     checked.push(browser.name);
-    for (const searchPath of browser.paths) {
-      let token: string | undefined;
-      switch (browser.type) {
-        case 'chromium':
-          token = searchLevelDBDir(searchPath);
-          break;
-        case 'firefox':
-          token = searchFirefoxProfiles(searchPath);
-          break;
-        case 'safari':
-          token = searchSafariDatabases(searchPath);
-          break;
-      }
-      if (token) return Promise.resolve({ token, browser: browser.name });
+    for (const token of searchBrowser(browser)) {
+      if (seen.has(token)) continue;
+      seen.add(token);
+      candidates.push({ token, browser: browser.name });
     }
   }
 
-  return Promise.reject(
-    new Error(
-      `No Copilot Money session found. Searched: ${checked.join(', ')}. ` +
-        'Please log into Copilot Money at https://app.copilot.money in your browser, then try again.'
-    )
-  );
+  return Promise.resolve({ candidates, checked });
+}
+
+/**
+ * Extract the first Firebase refresh-token candidate from browser storage.
+ *
+ * Thin wrapper over {@link extractRefreshTokenCandidates} that returns the
+ * first candidate and throws the actionable "no session" error when none
+ * exist. Note: this does NOT validate that the token belongs to Copilot's
+ * project — callers that need foreign-project rejection should consume the
+ * full candidate list and drive the exchange-and-discard loop (see
+ * `FirebaseAuth`). Retained for backward compatibility.
+ *
+ * @param browserOverrides - Override browser configs for testing
+ * @throws Error if no token is found in any browser
+ */
+export async function extractRefreshToken(
+  browserOverrides?: BrowserConfig[]
+): Promise<TokenResult> {
+  const { candidates, checked } = await extractRefreshTokenCandidates(browserOverrides);
+  const [first] = candidates;
+  if (!first) throw noCopilotSessionError(checked);
+  return first;
 }

--- a/src/core/auth/firebase-auth.ts
+++ b/src/core/auth/firebase-auth.ts
@@ -6,7 +6,7 @@
  * when expired (3600 second lifetime).
  */
 
-import type { TokenResult } from './browser-token.js';
+import { noCopilotSessionError, type TokenCandidates } from './browser-token.js';
 
 // Public client-side Firebase Web API key for copilot-production-22904 — intentionally
 // not a secret. Scoped by Firebase security rules; safe to commit.
@@ -15,7 +15,21 @@ const FIREBASE_API_KEY = 'AIzaSyAMgjkeOSkHj4J4rlswOkD16N3WQOoNPpk';
 const TOKEN_ENDPOINT = `https://securetoken.googleapis.com/v1/token?key=${FIREBASE_API_KEY}`;
 const EXPIRY_MARGIN_MS = 60_000;
 
-export type TokenExtractor = () => Promise<TokenResult>;
+/**
+ * Securetoken rejection code returned when a refresh token belongs to a
+ * DIFFERENT Firebase project than copilot-production-22904. The browser-wide
+ * Local Storage fallback surfaces other sites' `AMf-` tokens as candidates, so
+ * this is the expected, benign signal that "this candidate is foreign — try
+ * the next one," NOT an API/key drift. See issue #454.
+ */
+const PROJECT_NUMBER_MISMATCH = 'PROJECT_NUMBER_MISMATCH';
+
+/**
+ * Yields the discovered refresh-token candidates (each potentially from a
+ * foreign Firebase project) plus the browsers searched, so the caller can try
+ * each in turn and build the actionable "no session" error if all fail.
+ */
+export type TokenExtractor = () => Promise<TokenCandidates>;
 
 export class FirebaseAuth {
   private idToken: string | null = null;
@@ -32,21 +46,39 @@ export class FirebaseAuth {
     if (this.idToken && Date.now() < this.expiresAt) {
       return this.idToken;
     }
-    if (!this.refreshToken) {
-      const result = await this.extractToken();
-      this.refreshToken = result.token;
+    // Fast path: we already hold a Copilot-project refresh token (from a prior
+    // successful exchange) — just refresh it. The server-returned refresh token
+    // is known-good, so any failure here is a genuine error, not a foreign one.
+    if (this.refreshToken) {
+      await this.exchangeToken(this.refreshToken);
+      if (!this.idToken) throw new Error('Firebase token exchange returned no ID token');
+      return this.idToken;
     }
-    await this.exchangeToken();
-    if (!this.idToken) throw new Error('Firebase token exchange returned no ID token');
-    return this.idToken;
+
+    // Cold path: try each discovered candidate, discarding foreign-project ones
+    // (PROJECT_NUMBER_MISMATCH) and keeping the first that exchanges cleanly.
+    const { candidates, checked } = await this.extractToken();
+    for (const candidate of candidates) {
+      try {
+        await this.exchangeToken(candidate.token);
+      } catch (err) {
+        if (isForeignProjectError(err)) continue; // not Copilot's token — try next
+        throw err; // a real exchange failure for a Copilot-project token
+      }
+      if (!this.idToken) throw new Error('Firebase token exchange returned no ID token');
+      return this.idToken;
+    }
+
+    // No candidate belonged to Copilot's project (or none were found): the user
+    // is logged out. Surface the actionable message, never a raw Firebase 400.
+    throw noCopilotSessionError(checked);
   }
 
   getUserId(): string | null {
     return this.userId;
   }
 
-  private async exchangeToken(): Promise<void> {
-    const refreshToken = this.refreshToken!;
+  private async exchangeToken(refreshToken: string): Promise<void> {
     const response = await fetch(TOKEN_ENDPOINT, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -71,4 +103,14 @@ export class FirebaseAuth {
     this.userId = data.user_id;
     this.expiresAt = Date.now() + Number(data.expires_in) * 1000 - EXPIRY_MARGIN_MS;
   }
+}
+
+/**
+ * True when a token-exchange error is a PROJECT_NUMBER_MISMATCH — i.e. the
+ * refresh token belongs to a foreign Firebase project, not
+ * copilot-production-22904. Such a candidate should be discarded so the loop
+ * can try the next one, rather than failing the whole exchange.
+ */
+function isForeignProjectError(err: unknown): boolean {
+  return err instanceof Error && err.message.includes(PROJECT_NUMBER_MISMATCH);
 }

--- a/src/core/auth/firebase-auth.ts
+++ b/src/core/auth/firebase-auth.ts
@@ -16,6 +16,14 @@ const TOKEN_ENDPOINT = `https://securetoken.googleapis.com/v1/token?key=${FIREBA
 const EXPIRY_MARGIN_MS = 60_000;
 
 /**
+ * Upper bound on how many discovered refresh-token candidates we'll try to
+ * exchange. A normal browser has a handful of Firebase-backed sites; this caps
+ * the pathological case (many `AMf-` tokens in the Local Storage fallback) so a
+ * logged-out user can't trigger an unbounded run of sequential token exchanges.
+ */
+const MAX_EXCHANGE_CANDIDATES = 10;
+
+/**
  * Securetoken rejection code returned when a refresh token belongs to a
  * DIFFERENT Firebase project than copilot-production-22904. The browser-wide
  * Local Storage fallback surfaces other sites' `AMf-` tokens as candidates, so
@@ -58,7 +66,7 @@ export class FirebaseAuth {
     // Cold path: try each discovered candidate, discarding foreign-project ones
     // (PROJECT_NUMBER_MISMATCH) and keeping the first that exchanges cleanly.
     const { candidates, checked } = await this.extractToken();
-    for (const candidate of candidates) {
+    for (const candidate of candidates.slice(0, MAX_EXCHANGE_CANDIDATES)) {
       try {
         await this.exchangeToken(candidate.token);
       } catch (err) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,7 @@ import { CopilotMoneyTools } from './tools/index.js';
 import { ALL_TOOL_DEFS, TOOL_REGISTRY, type LiveToolContext } from './tools/registry/index.js';
 import { GraphQLClient } from './core/graphql/client.js';
 import { FirebaseAuth } from './core/auth/firebase-auth.js';
-import { extractRefreshToken } from './core/auth/browser-token.js';
+import { extractRefreshTokenCandidates } from './core/auth/browser-token.js';
 import { LiveCopilotDatabase, preflightLiveAuth } from './core/live-database.js';
 import { LiveTransactionsTools } from './tools/live/transactions.js';
 import { LiveAccountsTools } from './tools/live/accounts.js';
@@ -71,7 +71,7 @@ export class CopilotMoneyServer {
 
     let graphqlClient = injectedGraphqlClient;
     if ((writeEnabled || liveReadsEnabled) && !graphqlClient) {
-      const auth = new FirebaseAuth(() => extractRefreshToken());
+      const auth = new FirebaseAuth(() => extractRefreshTokenCandidates());
       graphqlClient = new GraphQLClient(auth);
     }
 
@@ -291,7 +291,7 @@ export async function runServer(
 ): Promise<void> {
   let graphqlClient: GraphQLClient | undefined;
   if (writeEnabled || liveReadsEnabled) {
-    const auth = new FirebaseAuth(() => extractRefreshToken());
+    const auth = new FirebaseAuth(() => extractRefreshTokenCandidates());
     graphqlClient = new GraphQLClient(auth);
   }
 

--- a/tests/core/auth/browser-token.test.ts
+++ b/tests/core/auth/browser-token.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import {
   extractRefreshToken,
+  extractRefreshTokenCandidates,
   BROWSER_CONFIGS,
   getChromiumProfileStoragePaths,
   type BrowserConfig,
@@ -367,5 +368,66 @@ describe('extractRefreshToken', () => {
     const result = await extractRefreshToken(overrides);
     expect(result.token).toBe(token2);
     expect(result.browser).toBe('HasToken');
+  });
+});
+
+describe('extractRefreshTokenCandidates', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'browser-token-candidates-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('yields ALL AMf- tokens found, in browser/path order, with no exchange', async () => {
+    const dir1 = join(tempDir, 'browser1');
+    const dir2 = join(tempDir, 'browser2');
+    mkdirSync(dir1, { recursive: true });
+    mkdirSync(dir2, { recursive: true });
+
+    const foreign = 'AMf-' + 'X'.repeat(150);
+    const real = 'AMf-' + 'Y'.repeat(200);
+    // First browser holds only a foreign token; second holds the real one.
+    writeFileSync(join(dir1, '000001.ldb'), `other site ${foreign}`);
+    writeFileSync(join(dir2, '000001.ldb'), `copilot ${real}`);
+
+    const overrides: BrowserConfig[] = [
+      { name: 'FirstBrowser', paths: [dir1], type: 'chromium' },
+      { name: 'SecondBrowser', paths: [dir2], type: 'chromium' },
+    ];
+
+    const { candidates, checked } = await extractRefreshTokenCandidates(overrides);
+    expect(candidates.map((c) => c.token)).toEqual([foreign, real]);
+    expect(candidates.map((c) => c.browser)).toEqual(['FirstBrowser', 'SecondBrowser']);
+    expect(checked).toEqual(['FirstBrowser', 'SecondBrowser']);
+  });
+
+  test('returns an empty candidate list (not a throw) when no token is found', async () => {
+    const ldbDir = join(tempDir, 'leveldb');
+    mkdirSync(ldbDir, { recursive: true });
+    writeFileSync(join(ldbDir, '000001.ldb'), 'no tokens here');
+
+    const overrides: BrowserConfig[] = [{ name: 'TestBrowser', paths: [ldbDir], type: 'chromium' }];
+
+    const { candidates, checked } = await extractRefreshTokenCandidates(overrides);
+    expect(candidates).toEqual([]);
+    expect(checked).toEqual(['TestBrowser']);
+  });
+
+  test('de-duplicates the same token discovered across multiple paths/files', async () => {
+    const ldbDir = join(tempDir, 'leveldb');
+    mkdirSync(ldbDir, { recursive: true });
+    const token = 'AMf-' + 'Z'.repeat(200);
+    // Same token appears in two files in the same dir.
+    writeFileSync(join(ldbDir, '000001.ldb'), token);
+    writeFileSync(join(ldbDir, '000002.ldb'), `dup ${token}`);
+
+    const overrides: BrowserConfig[] = [{ name: 'TestBrowser', paths: [ldbDir], type: 'chromium' }];
+
+    const { candidates } = await extractRefreshTokenCandidates(overrides);
+    expect(candidates.map((c) => c.token)).toEqual([token]);
   });
 });

--- a/tests/core/auth/firebase-auth.test.ts
+++ b/tests/core/auth/firebase-auth.test.ts
@@ -1,9 +1,13 @@
 import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { FirebaseAuth } from '../../../src/core/auth/firebase-auth.js';
+import type { TokenResult } from '../../../src/core/auth/browser-token.js';
 
-// Mock token extractor
+// Mock token extractor: yields a single valid candidate.
 const mockExtractor = mock(() =>
-  Promise.resolve({ token: 'AMf-fake-refresh-token', browser: 'Chrome' })
+  Promise.resolve({
+    candidates: [{ token: 'AMf-fake-refresh-token', browser: 'Chrome' }] as TokenResult[],
+    checked: ['Chrome'],
+  })
 );
 
 // Capture fetch calls
@@ -15,6 +19,25 @@ function mockFetch(response: object, status = 200) {
     fetchCalls.push({ url: String(url), options: options ?? {} });
     return Promise.resolve(
       new Response(JSON.stringify(response), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  }) as typeof fetch;
+}
+
+/**
+ * Queue distinct responses, one per fetch call (for multi-candidate exchange).
+ * Each entry is `[body, status]`; the Nth fetch returns the Nth entry.
+ */
+function mockFetchSequence(responses: [object, number][]) {
+  let i = 0;
+  globalThis.fetch = mock((url: string | URL | Request, options?: RequestInit) => {
+    fetchCalls.push({ url: String(url), options: options ?? {} });
+    const [body, status] = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
         status,
         headers: { 'Content-Type': 'application/json' },
       })
@@ -87,6 +110,75 @@ describe('FirebaseAuth', () => {
 
   test('throws on failed token exchange', async () => {
     mockFetch({ error: { message: 'INVALID_REFRESH_TOKEN' } }, 400);
+    await expect(auth.getIdToken()).rejects.toThrow('Firebase token exchange failed');
+  });
+
+  test('PROJECT_NUMBER_MISMATCH on the only candidate yields the "no session" error', async () => {
+    // The sole candidate is a foreign-project AMf- token (e.g. another site's
+    // Firebase session in the browser-wide Local Storage). Its exchange is
+    // correctly rejected with PROJECT_NUMBER_MISMATCH. The user is logged out
+    // of Copilot — surface the actionable "no session" message, NOT a raw 400.
+    mockExtractor.mockResolvedValueOnce({
+      candidates: [{ token: 'AMf-foreign-project-token', browser: 'Chrome' }],
+      checked: ['Chrome'],
+    });
+    mockFetch({ error: { message: 'PROJECT_NUMBER_MISMATCH' } }, 400);
+
+    await expect(auth.getIdToken()).rejects.toThrow('No Copilot Money session found');
+    // The misleading raw exchange error must not leak through.
+    await expect(auth.getIdToken()).rejects.not.toThrow('PROJECT_NUMBER_MISMATCH');
+  });
+
+  test('discards foreign candidates and succeeds on a valid one', async () => {
+    // Two foreign tokens precede a real Copilot session token. The first two
+    // exchanges reject with PROJECT_NUMBER_MISMATCH; the third succeeds.
+    mockExtractor.mockResolvedValueOnce({
+      candidates: [
+        { token: 'AMf-foreign-one', browser: 'Chrome' },
+        { token: 'AMf-foreign-two', browser: 'Chrome' },
+        { token: 'AMf-real-copilot-token', browser: 'Arc' },
+      ],
+      checked: ['Chrome', 'Arc'],
+    });
+    mockFetchSequence([
+      [{ error: { message: 'PROJECT_NUMBER_MISMATCH' } }, 400],
+      [{ error: { message: 'PROJECT_NUMBER_MISMATCH' } }, 400],
+      [
+        {
+          id_token: 'real-id-token',
+          refresh_token: 'AMf-real-copilot-token',
+          expires_in: '3600',
+          token_type: 'Bearer',
+          user_id: 'user123',
+        },
+        200,
+      ],
+    ]);
+
+    const token = await auth.getIdToken();
+    expect(token).toBe('real-id-token');
+    expect(fetchCalls).toHaveLength(3);
+  });
+
+  test('no candidates at all yields the "no session" error', async () => {
+    mockExtractor.mockResolvedValueOnce({ candidates: [], checked: ['Chrome', 'Safari'] });
+    // No exchange should even be attempted.
+    mockFetch({ id_token: 'should-not-be-used' }, 200);
+
+    await expect(auth.getIdToken()).rejects.toThrow('No Copilot Money session found');
+    expect(fetchCalls).toHaveLength(0);
+  });
+
+  test('a non-mismatch exchange error on a candidate is surfaced raw (not "no session")', async () => {
+    // INVALID_REFRESH_TOKEN is a genuine exchange failure for a Copilot-project
+    // token (e.g. expired/revoked), not a foreign-project token. Don't swallow
+    // it into the "logged out" message — the token WAS Copilot's.
+    mockExtractor.mockResolvedValueOnce({
+      candidates: [{ token: 'AMf-copilot-but-expired', browser: 'Chrome' }],
+      checked: ['Chrome'],
+    });
+    mockFetch({ error: { message: 'INVALID_REFRESH_TOKEN' } }, 400);
+
     await expect(auth.getIdToken()).rejects.toThrow('Firebase token exchange failed');
   });
 

--- a/tests/core/auth/firebase-auth.test.ts
+++ b/tests/core/auth/firebase-auth.test.ts
@@ -125,7 +125,10 @@ describe('FirebaseAuth', () => {
     mockFetch({ error: { message: 'PROJECT_NUMBER_MISMATCH' } }, 400);
 
     await expect(auth.getIdToken()).rejects.toThrow('No Copilot Money session found');
-    // The misleading raw exchange error must not leak through.
+    // A SECOND, independent getIdToken() call (the mockResolvedValueOnce is
+    // spent, so this uses the default single-valid-candidate extractor against
+    // the same PROJECT_NUMBER_MISMATCH fetch mock): assert the raw code never
+    // leaks on any attempt, not just that a cached error was reused.
     await expect(auth.getIdToken()).rejects.not.toThrow('PROJECT_NUMBER_MISMATCH');
   });
 
@@ -167,6 +170,23 @@ describe('FirebaseAuth', () => {
 
     await expect(auth.getIdToken()).rejects.toThrow('No Copilot Money session found');
     expect(fetchCalls).toHaveLength(0);
+  });
+
+  test('caps the exchange loop at MAX_EXCHANGE_CANDIDATES foreign tokens', async () => {
+    // Pathological case: many foreign AMf- tokens in the Local Storage fallback.
+    // The loop must bound its sequential exchanges (cap 10) rather than trying
+    // all 25, then surface the "no session" error.
+    mockExtractor.mockResolvedValueOnce({
+      candidates: Array.from({ length: 25 }, (_, i) => ({
+        token: `AMf-foreign-${i}`,
+        browser: 'Chrome',
+      })),
+      checked: ['Chrome'],
+    });
+    mockFetch({ error: { message: 'PROJECT_NUMBER_MISMATCH' } }, 400);
+
+    await expect(auth.getIdToken()).rejects.toThrow('No Copilot Money session found');
+    expect(fetchCalls).toHaveLength(10);
   });
 
   test('a non-mismatch exchange error on a candidate is surfaced raw (not "no session")', async () => {


### PR DESCRIPTION
## What

The browser token extractor surfaced foreign-project Firebase tokens as `PROJECT_NUMBER_MISMATCH` instead of the actionable "no Copilot session" message.

When no Copilot session exists in any browser, the extractor fell back to the browser-wide `Local Storage/leveldb` directory, which holds every site's storage. Any other Firebase-backed site leaves `AMf-` refresh tokens there. The old code returned the single longest match — which, with no Copilot session, is a *foreign* project's token — and the securetoken exchange correctly rejected it with `PROJECT_NUMBER_MISMATCH`. That reads like API/key drift when the real state is "the user is logged out."

## How

- `browser-token.ts`: search helpers now collect **every** `AMf-` match (longest-first as a try-order preference, not a hard pick). New `extractRefreshTokenCandidates()` returns the full de-duplicated candidate list plus the searched-browser list, and never throws on empty. `extractRefreshToken()` is kept as a thin first-candidate wrapper for backward compatibility. The "no session" message moved into a shared `noCopilotSessionError(checked)` helper.
- `firebase-auth.ts`: `TokenExtractor` now yields the candidate list. `getIdToken()` tries each candidate's exchange, **discarding `PROJECT_NUMBER_MISMATCH` (foreign-project) ones and continuing**; the first clean exchange wins. If every candidate is foreign (or none were found), it throws the existing actionable "No Copilot Money session found… log into https://app.copilot.money" message. A known-good, server-returned refresh token still takes the fast refresh path, and a genuine non-mismatch exchange failure for a Copilot-project token (e.g. `INVALID_REFRESH_TOKEN`) still surfaces raw.
- `server.ts`: both `FirebaseAuth` constructions use `extractRefreshTokenCandidates`.

## Error taxonomy

This is `AUTH_FAILED` / user-action-required, never schema/API-drift attribution (C2, #441).

## External assumptions

- **A refresh token found in browser storage belongs to Copilot's Firebase project (`copilot-production-22904`).** Previously this was implicit and unverified — the extractor *assumed* any `AMf-` token it found was Copilot's. It is now made explicit: the only way to know a token's project is the securetoken exchange, so the exchange-and-discard loop *is* the verification. The `PROJECT_NUMBER_MISMATCH` signal is treated as the benign "this candidate is foreign, try the next one" outcome, and is documented in `firebase-auth.ts`.
- `PROJECT_NUMBER_MISMATCH` is the exact securetoken rejection code for a cross-project refresh token (matched as a substring of the 400 error body).

## Ratchet

Per the issue, the unit test is the ratchet (foreign-only candidate list must produce "no session," never a raw Firebase 400):

- `firebase-auth.test.ts`: PROJECT_NUMBER_MISMATCH on the only candidate → "no session" (and the raw code does not leak); foreign candidates discarded, valid one succeeds; empty candidate list → "no session" with zero exchange attempts; a non-mismatch error surfaces raw.
- `browser-token.test.ts`: candidates returns all `AMf-` tokens in order, empty list (not throw) when none, de-dupes the same token across files.

**Conformance ledger:** the existing ledger (`src/conformance/ledger.ts`) is scoped to Copilot's *GraphQL* surface (enums / input-fields / operations / response-shapes, with smoke/runtime oracles). A *client-side* "which Firebase project does this browser token belong to" assumption has no matching surface kind or oracle category there, and bolting on a new kind for one assumption would over-engineer the ledger schema. The assumption is instead pinned by the exchange-and-discard loop and its unit tests above (a regression turns the build red), and documented inline. Flagging for the maintainer in case a future "client-assumptions" ledger section is wanted.

## Bug Response Ritual

- **Root cause:** the extractor committed to a *single* token (longest match) from the browser-wide Local Storage fallback and handed it to a single exchange attempt. With no Copilot session, that single token is a foreign project's, and there was no path to "try the next candidate" — so a benign foreign-token signal became a terminal, misattributed error.
- **Bug class:** *premature single-candidate selection over an impure/ambiguous source* — picking one item from a noisy set (other sites' tokens) before the only authority that can validate it (the exchange) gets to weigh in, with no fallback to alternatives. Adjacent class: *misattributing a benign downstream rejection as a system/API error*.
- **Detector added:** the conformance ledger's error-taxonomy discipline (C2, #441) is the standing class-level guard for "benign rejection misread as drift." For *this* bug specifically, the exchange-and-discard loop + its unit tests make "foreign token must not surface as a raw 400" a red build.
- **Siblings checked:** searched for other consumers of `extractRefreshToken` / `TokenExtractor` / single-`.token` selection (`src/core/auth/`, `src/cli.ts`, `src/server.ts`) — the only call sites were the two `FirebaseAuth` constructions in `server.ts`, both migrated. The same "pick the longest match" heuristic appeared in three search helpers (chromium / firefox / safari); all three now return full lists, so no other code path silently collapses to one token.
- **Ledger updated:** see "Ratchet" above — assumption documented + test-pinned; GraphQL ledger left unchanged by design (no fitting surface kind), maintainer flagged.

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)
