### PR TITLE
chore: resolve audit nits #479, #480, #481

### DIFF
--- a/scripts/check-pr-sections.sh
+++ b/scripts/check-pr-sections.sh
@@ -18,7 +18,7 @@
 # placeholder text never counts as a real answer.
 #
 # This logic lives in a script (not inline YAML) so it can be unit-tested
-# locally: see tests/check-pr-sections.test.sh.
+# locally: see tests/scripts/check-pr-sections.test.ts.
 
 set -euo pipefail
 
@@ -61,7 +61,7 @@ body="$(printf '%s' "$raw_body" | perl -0777 -pe 's/<!--.*?-->//gs')"
 # trailing whitespace after the title.
 section="$(
   printf '%s\n' "$body" | awk -v hdr="$REQUIRED_HEADER" '
-    BEGIN { want = "^## +" tolower(hdr) " *$"; capturing = 0 }
+    BEGIN { want = "^##[ \t]+" tolower(hdr) "[ \t]*$"; capturing = 0 }
     {
       line = $0
       stripped = line

--- a/tests/helpers/fixture-shape.test.ts
+++ b/tests/helpers/fixture-shape.test.ts
@@ -111,17 +111,33 @@ describe('fixture-shape invariant (issue #461)', () => {
     expect(message).toContain('Savings');
   });
 
-  test('ignores documents without a name field (nothing to collide with)', () => {
+  test('ignores collections not in ID_NAME_FIELD_PAIRS', () => {
+    // 'budgets' is not a name→ID resolution surface (no entry in
+    // ID_NAME_FIELD_PAIRS), so the gate doesn't inspect it — even though the
+    // id happens to equal the category_id here.
     expect(() =>
       assertOpaqueIds([
         {
           collection: 'budgets',
-          // budgets have no display name; id-equals-name is not a concern
           id: 'food_dining',
           fields: { budget_id: 'food_dining', category_id: 'food_dining' },
         },
       ])
     ).not.toThrow();
+  });
+
+  test('throws for a tag doc whose id equals its name', () => {
+    // tags are in ID_NAME_FIELD_PAIRS (the #394 bug was the tag filter);
+    // pin that the gate actually fires for them, not just categories/accounts.
+    expect(() =>
+      assertOpaqueIds([
+        {
+          collection: 'tags',
+          id: 'vacation',
+          fields: { tag_id: 'vacation', name: 'vacation' },
+        },
+      ])
+    ).toThrow(/id-equals-name/i);
   });
 
   test('covers the documented name→ID-keyed collections', () => {

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -212,7 +212,7 @@ export function assertOpaqueIds(documents: TestDocument[]): void {
             `entities must use opaque IDs distinct from display names, or a ` +
             `name→ID resolution bug (see PR #394) can be masked. Use a ` +
             `Firestore-shaped opaque id (e.g. '9qyEMnfMXknwvx9OnYhk' or ` +
-            `'${pair.collectionPrefix}_${Math.random().toString(36).slice(2, 8)}').`
+            `'${pair.collectionPrefix}_a1b2c3').`
         );
       }
     }

--- a/tests/unit/update-transaction.test.ts
+++ b/tests/unit/update-transaction.test.ts
@@ -1,11 +1,11 @@
 /**
  * Unit tests for the update_transaction tool (GraphQL-based).
  *
- * Supported fields: name, category_id, note, and tag_ids via GraphQL's
- * EditTransaction mutation. Legacy fields (excluded, internal_transfer,
- * goal_id) were removed from the schema when the backend was migrated to
- * GraphQL; they now hit the defense-in-depth "unknown field" check in
- * updateTransaction.
+ * Supported fields: name, category_id, note, tag_ids, type, and reviewed via
+ * GraphQL's EditTransaction mutation. Legacy fields (excluded,
+ * internal_transfer, goal_id) were removed from the schema when the backend
+ * was migrated to GraphQL; they now hit the defense-in-depth "unknown field"
+ * check in updateTransaction.
  *
  * Covers: per-field mapping, multi-field atomic dispatch, argument
  * validation, referential integrity checks, unknown-field rejection.


### PR DESCRIPTION
# Summary

Resolves the three PR-review audit follow-ups auto-filed from #475/#476/#477 — all small, all in one batch per the repo's nit-batching convention. Closes #479. Closes #480. Closes #481.

## External assumptions

None — internal test/script/doc cleanups; no assumptions about Copilot's API.

## What

- **#479** (`scripts/check-pr-sections.sh`): fix the stale unit-test path in the header comment (`tests/scripts/check-pr-sections.test.ts`), and make the awk header pattern tab-tolerant (`^##[ \t]+ … [ \t]*$`) so it matches the grep existence check — a tab-indented header now reports "missing" consistently instead of "section empty". Verified both space- and tab-indented headers pass the script.
- **#480** (`tests/unit/update-transaction.test.ts`): refresh the file-level JSDoc to list `type` and `reviewed` (stale since #415/#416; the source-file JSDoc was already fixed).
- **#481** (`tests/helpers/fixture-shape.test.ts`, `tests/helpers/test-db.ts`): rename the budgets test + comment to the accurate reason (collection not in `ID_NAME_FIELD_PAIRS`, not "no name field"); add a tags `id === name` throw-case test (tags were the original #394 bug class but had no concrete throw test); make the error-message example id static instead of `Math.random()`.

## Verification

- `bun run check` green (2197 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)