### PR TITLE
chore(auth): document why extractRefreshTokenCandidates isn't async (#482)

### DIFF
--- a/src/core/auth/browser-token.ts
+++ b/src/core/auth/browser-token.ts
@@ -283,6 +283,11 @@ export function noCopilotSessionError(checked: string[]): Error {
  *
  * @param browserOverrides - Override browser configs for testing
  */
+// Returns a Promise (the TokenExtractor contract is async) but the body is
+// fully synchronous — all browser reads are sync readFileSync. It is NOT
+// declared `async` on purpose: `async` with no `await` trips
+// @typescript-eslint/require-await, so the explicit Promise.resolve() is the
+// lint-clean way to satisfy the async signature. (Reviewed: #482.)
 export function extractRefreshTokenCandidates(
   browserOverrides?: BrowserConfig[]
 ): Promise<TokenCandidates> {


### PR DESCRIPTION
# Summary

Resolves audit follow-up #482 (from PR #478's review). Closes #482.

The review suggested declaring `extractRefreshTokenCandidates` as `async` and dropping the `Promise.resolve()` wrapper. That suggestion isn't implementable lint-clean: the function body is fully synchronous (all browser reads are `readFileSync`), so `async` with no `await` trips `@typescript-eslint/require-await`. The explicit `Promise.resolve()` is the deliberate, lint-clean way to satisfy the async `TokenExtractor` contract. Resolved by documenting that rationale inline so the pattern isn't re-flagged, rather than churning the signature.

## External assumptions

None — internal comment/style only.

## Verification

- `bun run check` green (2197 tests), incl. the `require-await` lint rule that the literal suggestion would have violated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)