### PR TITLE
chore(deps): move graphql to devDependencies only (#491)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.2.0",
         "classic-level": "^3.0.0",
-        "graphql": "^16.14.2",
         "protobufjs": "^8.6.3",
         "zod": "^4.3.5"
       },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.2.0",
     "classic-level": "^3.0.0",
-    "graphql": "^16.14.2",
     "protobufjs": "^8.6.3",
     "zod": "^4.3.5"
   },


### PR DESCRIPTION
# Summary

Resolves audit follow-up #491 (from PR #490's review). Closes #491.

`graphql` was listed in **both** `dependencies` and `devDependencies`. It is imported only by `scripts/generate-graphql-operations.ts` and a few tests (`parse`/`print`/`visit`) — never under `src/` (the runtime GraphQL client talks to the endpoint with raw `fetch`). So it's a build/dev-time dependency and is dropped from `dependencies`.

## External assumptions

None — dependency classification only.

## Verification

- Grep confirms zero `graphql` imports under `src/`.
- `npm ls graphql --omit=dev` → not in the production tree (so the `.mcpb` bundle / license-check production install no longer pull it).
- `bun run check` green (2197 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)