### PR TITLE
fix(live): correct get_networth_live time_frame enum to canonical TimeFrame (#494)

### DIFF
--- a/src/tools/live/networth.ts
+++ b/src/tools/live/networth.ts
@@ -28,6 +28,7 @@ import {
   fetchNetworthHistory,
   type NetworthHistoryNode,
 } from '../../core/graphql/queries/networth.js';
+import { ALL_TIME_FRAMES } from '../../core/graphql/queries/_shared.js';
 import { paginate, DEFAULT_MAX_ROWS } from '../../utils/pagination.js';
 import type { ToolSchema } from '../tools.js';
 
@@ -129,8 +130,9 @@ export function createLiveNetworthToolSchema(): ToolSchema {
       'sorted oldest→newest by date; for each row, `assets - debt` gives the net worth ' +
       'at that point in time. Both `assets` and `debt` are nullable strings — early dates ' +
       "in the user's history may have `assets: null` until backfilled. Available when " +
-      '--live-reads is on. Optional `time_frame` arg (default "YTD"; other server-supported ' +
-      'values include "ALL", "YEAR", "MONTH"). The cache holds the most-recently-requested ' +
+      '--live-reads is on. Optional `time_frame` arg (default "YTD"; accepts the canonical ' +
+      'TimeFrame values "ONE_DAY", "ONE_WEEK", "ONE_MONTH", "THREE_MONTHS", "YTD", ' +
+      '"ONE_YEAR", "ALL"). The cache holds the most-recently-requested ' +
       'time_frame; requesting a different value triggers a fresh fetch. ' +
       'Long-range responses are paginated via `max_rows` (default 500, max 5000) and ' +
       '`offset`; `total_rows` and `truncated` indicate whether older rows remain.',
@@ -139,12 +141,13 @@ export function createLiveNetworthToolSchema(): ToolSchema {
       properties: {
         time_frame: {
           type: 'string',
-          enum: ['ALL', 'YEAR', 'MONTH', 'YTD'],
+          enum: [...ALL_TIME_FRAMES],
           description:
             "TimeFrame enum passed through to the Networth query. Default 'YTD' " +
-            "(tightened from 'ALL' on 2026-05). Note: this enum is smaller than the canonical " +
-            'TimeFrame used by other live time-series tools (no ONE_DAY/ONE_WEEK/ONE_MONTH/' +
-            'THREE_MONTHS/ONE_YEAR). The Networth GraphQL endpoint accepts only these four values.',
+            "(tightened from 'ALL' on 2026-05). Networth accepts the full canonical " +
+            'TimeFrame enum (the same `ALL_TIME_FRAMES` set used by the other live ' +
+            'time-series tools); bare "MONTH"/"YEAR" are NOT valid TimeFrame members ' +
+            'and return a 400 (see #494).',
           default: DEFAULT_TIME_FRAME,
         },
         max_rows: {

--- a/tests/tools/live/networth.test.ts
+++ b/tests/tools/live/networth.test.ts
@@ -202,6 +202,18 @@ describe('createLiveNetworthToolSchema', () => {
     expect(schema.description).toMatch(/YTD/);
   });
 
+  test('time_frame enum equals the canonical TimeFrame set and excludes bogus MONTH/YEAR (#494)', async () => {
+    const { createLiveNetworthToolSchema } = await import('../../../src/tools/live/networth.js');
+    const { ALL_TIME_FRAMES } = await import('../../../src/core/graphql/queries/_shared.js');
+    const schema = createLiveNetworthToolSchema();
+    const props = schema.inputSchema.properties as Record<string, { enum?: string[] }>;
+    // Networth uses the same canonical TimeFrame GraphQL enum as the other
+    // live time-series tools — bare MONTH/YEAR are not members and 400 on use.
+    expect(props.time_frame?.enum).toEqual([...ALL_TIME_FRAMES]);
+    expect(props.time_frame?.enum).not.toContain('MONTH');
+    expect(props.time_frame?.enum).not.toContain('YEAR');
+  });
+
   test('exposes max_rows and offset pagination args', async () => {
     const { createLiveNetworthToolSchema } = await import('../../../src/tools/live/networth.js');
     const schema = createLiveNetworthToolSchema();

--- a/tests/tools/registry/live-timeframe-enum.test.ts
+++ b/tests/tools/registry/live-timeframe-enum.test.ts
@@ -24,7 +24,8 @@ function isToolEntry(v: unknown): v is ToolEntry {
     typeof v === 'object' &&
     v !== null &&
     'schema' in v &&
-    typeof (v as ToolEntry).schema?.name === 'string'
+    typeof (v as ToolEntry).schema?.name === 'string' &&
+    typeof (v as ToolEntry).schema?.inputSchema === 'object'
   );
 }
 

--- a/tests/tools/registry/live-timeframe-enum.test.ts
+++ b/tests/tools/registry/live-timeframe-enum.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Class-level detector for the #494 bug class: a live tool's `time_frame`
+ * input-schema enum drifting from the canonical, conformance-gated
+ * `ALL_TIME_FRAMES` set (e.g. by hardcoding a literal list that includes
+ * server-invalid values like bare "MONTH"/"YEAR").
+ *
+ * This gate covers the whole class — every current and future live tool that
+ * exposes a `time_frame` enum must reuse ALL_TIME_FRAMES — not just the
+ * networth instance that triggered #494.
+ */
+import { describe, expect, test } from 'bun:test';
+import * as liveRegistry from '../../../src/tools/registry/live.js';
+import { ALL_TIME_FRAMES } from '../../../src/core/graphql/queries/_shared.js';
+
+interface ToolEntry {
+  schema: {
+    name: string;
+    inputSchema: { properties?: Record<string, { enum?: string[] }> };
+  };
+}
+
+function isToolEntry(v: unknown): v is ToolEntry {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    'schema' in v &&
+    typeof (v as ToolEntry).schema?.name === 'string'
+  );
+}
+
+const toolsWithTimeFrame = Object.entries(liveRegistry)
+  .filter((e): e is [string, ToolEntry] => isToolEntry(e[1]))
+  .filter(([, t]) => t.schema.inputSchema.properties?.time_frame?.enum);
+
+describe('live tool time_frame enum conformance (#494 class detector)', () => {
+  test('guards the gate: at least one live tool exposes a time_frame enum', () => {
+    expect(toolsWithTimeFrame.length).toBeGreaterThan(0);
+  });
+
+  for (const [exportName, tool] of toolsWithTimeFrame) {
+    test(`${tool.schema.name} (${exportName}) time_frame enum equals ALL_TIME_FRAMES`, () => {
+      const en = tool.schema.inputSchema.properties!.time_frame!.enum;
+      expect(en).toEqual([...ALL_TIME_FRAMES]);
+    });
+  }
+});


### PR DESCRIPTION
# Summary

`get_networth_live` advertised the `time_frame` enum `['ALL', 'YEAR', 'MONTH', 'YTD']`, but the Networth GraphQL endpoint uses the canonical `TimeFrame` enum. Bare **`YEAR`** and **`MONTH`** are not members and return a hard `400` — 2 of the 4 advertised values were dead, and the description's "accepts only these four values" claim was false. Closes #494

## External assumptions

- **Networth accepts the full canonical `TimeFrame`** (`ONE_DAY`/`ONE_WEEK`/`ONE_MONTH`/`THREE_MONTHS`/`YTD`/`ONE_YEAR`/`ALL`); bare `MONTH`/`YEAR` are not TimeFrame members and 400. Evidence class: **probe transcript** — one-shot live probe of all values against the Networth endpoint (`ALL`/`YTD`/`ONE_DAY`/`ONE_WEEK`/`ONE_MONTH`/`THREE_MONTHS`/`ONE_YEAR` → 200; `MONTH`/`YEAR` → 400). Consistent with the existing `ALL_TIME_FRAMES` conformance gate (#439).

## Bug fix?

Root cause:       The tool schema hardcoded an enum literal `['ALL','YEAR','MONTH','YTD']` with non-existent TimeFrame members (`MONTH`/`YEAR`) instead of reusing the shared canonical set.
Bug class:        Tool input-schema enum drift — a `time_frame` enum diverging from the conformance-gated `ALL_TIME_FRAMES` by hardcoding a literal list.
Detector added:   `tests/tools/registry/live-timeframe-enum.test.ts` — iterates every live tool schema and asserts any `time_frame` enum equals `ALL_TIME_FRAMES` (class-level; verified it fails when networth's drift is reintroduced). Covers networth, balance-history, investment-prices.
Siblings checked: balance-history and investment-prices — both already use `ALL_TIME_FRAMES`; no other drift found. networth was the only offender.
Ledger updated:   n/a — the canonical set is already tracked by the TimeFrame conformance check (#439); this PR brings networth under that existing gate rather than adding a new external-assumption entry.

## Evidence (live probe)

| time_frame | result |
|---|---|
| `ALL`, `YTD`, `ONE_DAY`, `ONE_WEEK`, `ONE_MONTH`, `THREE_MONTHS`, `ONE_YEAR` | ✅ 200 |
| `MONTH`, `YEAR` | ❌ 400 (not in TimeFrame enum) |

## Change

- Replace the hardcoded literal enum with `[...ALL_TIME_FRAMES]` so it can't drift from the shared union.
- Correct the schema + tool descriptions (drop the "only these four values" claim).
- Add the class-level detector test (TDD: watched the instance test RED with the bogus list, then GREEN; verified the detector catches reintroduced drift).

`bun run check` green (2182 pass / 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)