### PR TITLE
chore(release): 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-06-14
+
+### Fixed
+
+- **`get_networth_live` `time_frame` enum** now matches the canonical `TimeFrame` the Networth endpoint actually accepts (`ONE_DAY` / `ONE_WEEK` / `ONE_MONTH` / `THREE_MONTHS` / `YTD` / `ONE_YEAR` / `ALL`). The previously-advertised bare `MONTH` / `YEAR` were not valid `TimeFrame` members and returned a `400`; the enum now reuses the shared `ALL_TIME_FRAMES` constant, so the documented values all work, and a class-level test gates every live tool's `time_frame` enum against drift ([#495](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/pull/495)). Fixes [#494](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/494).
+
 ## [2.2.1] - 2026-06-14
 
 Write-path capability additions plus a repo-wide "boundary hardening" program: every assumption this server makes about Copilot's GraphQL API is now inventoried and re-verified by an oracle (live conformance smokes, runtime response validation, reversible write round-trips, and a weekly scheduled drift check), so API drift surfaces as a red build instead of a confusing user-facing failure. See [`docs/CONFORMANCE_ARCHITECTURE.md`](docs/CONFORMANCE_ARCHITECTURE.md).

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "copilot-money-mcp",
   "display_name": "Copilot Money MCP Server",
   "description": "Query your personal finances with AI using local Copilot Money data. 14 read-only tools for transactions, investments, budgets, goals, and more.",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "icon": "icon.png",
   "author": {
     "name": "Ignacio Hermosilla",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "copilot-money-mcp",
   "mcpName": "io.github.ignaciohermosillacornejo/copilot-money-mcp",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "MCP server for Copilot Money — query personal finances locally (14 cache-mode read tools), opt into GraphQL-backed live reads with --live-reads (21 read tools: 8 cache + 13 live), and manage data via Copilot's GraphQL API (17 write tools, opt-in with --write)",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/ignaciohermosillacornejo/copilot-money-mcp#readme",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "copilot-money-mcp",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
# Summary

Release **2.3.0**. Bumps all four version fields (package.json, server.json#version, server.json#packages[npm].version, manifest.json) and adds the CHANGELOG entry.

⚠️ **Merging to `main` fires the auto-release**: .mcpb build + GitHub release `v2.3.0` + npm / MCP-registry publish.

## External assumptions

None — version/CHANGELOG bump only; no new assumptions about Copilot's API/data.

## What's in this release

- **`get_networth_live` `time_frame` enum fix** ([#495](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/pull/495), Fixes [#494](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/494)) — bogus bare `MONTH`/`YEAR` (which 400'd) replaced with the canonical `ALL_TIME_FRAMES`; class-level detector added to gate every live tool's `time_frame` enum against future drift.

## Verification

- `bun run check:version-sync` → "Versions in sync: 2.3.0".

🤖 Generated with [Claude Code](https://claude.com/claude-code)