### PR TITLE
feat(write): resolve routing ids live-first via meta index; drop LevelDB from live-mode resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,14 @@ COPILOT_CACHE_TTL_MINUTES=0 copilot-money-mcp
 
 You can also refresh manually using the `refresh_database` tool.
 
+### Write Resolution Window
+
+Write tools resolve account/item ids for a transaction id via a live window fetch when the in-memory index (fed by live reads) misses. Default window: 13 months. Raise it to edit older transactions:
+
+```bash
+COPILOT_WRITE_RESOLVE_WINDOW_MONTHS=30 copilot-money-mcp --write
+```
+
 ### Decode Timeout
 
 For large databases (500MB+), increase the decode timeout (default: 90 seconds):

--- a/README.md
+++ b/README.md
@@ -171,17 +171,14 @@ COPILOT_CACHE_TTL_MINUTES=10 copilot-money-mcp
 
 # Disable caching (always reload from disk)
 COPILOT_CACHE_TTL_MINUTES=0 copilot-money-mcp
+
+# Write tools resolve account/item ids for a transaction id via a live
+# window fetch when the in-memory index (fed by live reads) misses.
+# Default window: 13 months. Raise it to edit older transactions:
+COPILOT_WRITE_RESOLVE_WINDOW_MONTHS=30 copilot-money-mcp --write
 ```
 
 You can also refresh manually using the `refresh_database` tool.
-
-### Write Resolution Window
-
-Write tools resolve account/item ids for a transaction id via a live window fetch when the in-memory index (fed by live reads) misses. Default window: 13 months. Raise it to edit older transactions:
-
-```bash
-COPILOT_WRITE_RESOLVE_WINDOW_MONTHS=30 copilot-money-mcp --write
-```
 
 ### Decode Timeout
 

--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -374,6 +374,18 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   gatedInputField('EditTransactionInput.type', ['update_transaction.type']),
   responseShape('editTransaction'),
   appliesSurface('editTransaction'),
+  {
+    surface: 'Mutation.editTransaction:routing',
+    kind: 'operation',
+    oracle: null,
+    class: 'verified-once',
+    evidence:
+      'Live probe 2026-07-05: EditTransaction validates the full (id, accountId, itemId) ' +
+      'binding, not mere existence — fabricated accountId → "accountId … Not Found"; ' +
+      'real-but-wrong pair → "Transaction not found" (server scopes the txn lookup under ' +
+      'account/item); correct pair → edit applied. Routing ids therefore cannot be ' +
+      'defaulted or faked; resolveTransactionMeta must supply the true pair.',
+  },
 
   operation('deleteTransaction', [
     'delete_transaction.transaction_id',

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -90,6 +90,15 @@ export class LiveCopilotDatabase {
   // who need a fresh snapshot can use refresh_cache with scope='holdings'.
   private readonly holdingsCache: SnapshotCache<HoldingNode>;
   private readonly transactionsWindowCache: TransactionWindowCache<TransactionNode>;
+  /**
+   * Append-only id → (accountId, itemId) index fed by every live
+   * transaction fetch. The mapping is immutable server-side (a transaction
+   * never moves accounts; Plaid pending→posted replaces the id itself), so
+   * entries are never invalidated, evicted, or TTL'd. Write tools use this
+   * to resolve mutation routing ids without a network fetch (~100
+   * bytes/entry; a full history is a few MB).
+   */
+  private readonly txnMetaIndex = new Map<string, { accountId: string; itemId: string }>();
 
   constructor(
     private readonly graphql: GraphQLClient,
@@ -192,6 +201,12 @@ export class LiveCopilotDatabase {
       },
       { startDate: monthStart }
     );
+    // Feed the append-only id→(accountId,itemId) index from the raw page
+    // rows — pre-trim, because leaked tail rows are real transactions too
+    // and their routing ids are just as valid.
+    for (const r of rawRows) {
+      this.txnMetaIndex.set(r.id, { accountId: r.accountId, itemId: r.itemId });
+    }
     // Trim leaked tail-page rows that fall outside this month's window.
     // `paginateTransactions` early-exits AFTER appending a page, so the
     // trailing edge of the last page can dip into the previous month.
@@ -422,6 +437,24 @@ export class LiveCopilotDatabase {
     return this.transactionsWindowCache;
   }
 
+  /** Feed the meta index for a transaction learned outside a month fetch
+   *  (e.g. the create_transaction response). */
+  indexTransactionMeta(id: string, meta: { accountId: string; itemId: string }): void {
+    this.txnMetaIndex.set(id, meta);
+  }
+
+  /** Resolve routing ids for the given transaction ids from the in-memory
+   *  index. Returns only the ids present; callers treat absence as
+   *  "not seen by any live fetch this session". */
+  lookupTransactionMeta(ids: string[]): Map<string, { accountId: string; itemId: string }> {
+    const out = new Map<string, { accountId: string; itemId: string }>();
+    for (const id of ids) {
+      const m = this.txnMetaIndex.get(id);
+      if (m) out.set(id, m);
+    }
+    return out;
+  }
+
   // ── Phase 2: write-through patch methods ─────────────────────────────────
 
   /**
@@ -440,6 +473,9 @@ export class LiveCopilotDatabase {
     }
     if (!existing) return;
     const merged: TransactionNode = { ...existing, ...fields, id };
+    // Keep the meta index consistent with the invariant "any row this class
+    // has seen is indexed" (redundant for ingested rows, cheap insurance).
+    this.txnMetaIndex.set(id, { accountId: merged.accountId, itemId: merged.itemId });
     this.transactionsWindowCache.upsert(merged);
   }
 

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -203,9 +203,12 @@ export class LiveCopilotDatabase {
     );
     // Feed the append-only id→(accountId,itemId) index from the raw page
     // rows — pre-trim, because leaked tail rows are real transactions too
-    // and their routing ids are just as valid.
+    // and their routing ids are just as valid. Guard against drifted
+    // responses with null/empty routing ids (see review finding).
     for (const r of rawRows) {
-      this.txnMetaIndex.set(r.id, { accountId: r.accountId, itemId: r.itemId });
+      if (r.accountId && r.itemId) {
+        this.txnMetaIndex.set(r.id, { accountId: r.accountId, itemId: r.itemId });
+      }
     }
     // Trim leaked tail-page rows that fall outside this month's window.
     // `paginateTransactions` early-exits AFTER appending a page, so the
@@ -478,7 +481,10 @@ export class LiveCopilotDatabase {
     // Merging `fields` cannot change the routing ids: it is
     // Partial<Transaction> (snake_case account_id/item_id, not the node's
     // camelCase keys), and the ids are server-immutable regardless.
-    this.txnMetaIndex.set(id, { accountId: merged.accountId, itemId: merged.itemId });
+    // Guard against drifted responses with null/empty routing ids (review finding).
+    if (merged.accountId && merged.itemId) {
+      this.txnMetaIndex.set(id, { accountId: merged.accountId, itemId: merged.itemId });
+    }
     this.transactionsWindowCache.upsert(merged);
   }
 

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -475,6 +475,9 @@ export class LiveCopilotDatabase {
     const merged: TransactionNode = { ...existing, ...fields, id };
     // Keep the meta index consistent with the invariant "any row this class
     // has seen is indexed" (redundant for ingested rows, cheap insurance).
+    // Merging `fields` cannot change the routing ids: it is
+    // Partial<Transaction> (snake_case account_id/item_id, not the node's
+    // camelCase keys), and the ids are server-immutable regardless.
     this.txnMetaIndex.set(id, { accountId: merged.accountId, itemId: merged.itemId });
     this.transactionsWindowCache.upsert(merged);
   }

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2413,34 +2413,60 @@ export class CopilotMoneyTools {
   }
 
   /**
-   * Resolve accountId/itemId for a set of transaction ids — required to build
-   * EditTransaction mutations. Prefers the local LevelDB cache; for ids not
-   * present (or missing account/item) locally, falls back to a single live
-   * GraphQL window fetch so write tools can edit any transaction the API
-   * exposes, not just the subset the local cache holds. (The local cache only
-   * auto-fetches ~30 days and Firestore LRU-evicts older docs, so cache-only
-   * resolution silently fails for older transactions.) The live window defaults
-   * to the last 13 months and is overridable via the
-   * COPILOT_WRITE_RESOLVE_WINDOW_MONTHS env var. Returns a map of only the ids
-   * that resolved; callers treat absence as "not found".
+   * Resolve accountId/itemId routing ids for a set of transaction ids —
+   * required by EditTransaction/CreateRecurring mutations (the server
+   * validates the full binding; see the Mutation.editTransaction:routing
+   * ledger entry).
+   *
+   * Live mode (liveDb present — all production writes, since --write
+   * implies --live-reads): ① the in-memory meta index fed by every live
+   * read (O(1), no network) → ② one windowed live fetch for ids the index
+   * misses (default 13 months, COPILOT_WRITE_RESOLVE_WINDOW_MONTHS
+   * overrides; the fetch itself re-feeds the index via fetchMonth). The
+   * local LevelDB cache is deliberately NOT consulted: README's contract
+   * is that writes resolve against the live GraphQL surface, and the
+   * desktop app's cache may belong to a different login than the browser
+   * session token.
+   *
+   * Degraded mode (no liveDb — unit tests / hypothetical configs): the
+   * local LevelDB cache is the only resolver, as before.
+   *
+   * Returns the resolved map plus liveWindowMonths (null iff no live fetch
+   * could be attempted) so callers can compose an honest not-found error.
    */
   private async resolveTransactionMeta(
     ids: string[]
-  ): Promise<Map<string, { accountId: string; itemId: string }>> {
+  ): Promise<{
+    meta: Map<string, { accountId: string; itemId: string }>;
+    liveWindowMonths: number | null;
+  }> {
     const out = new Map<string, { accountId: string; itemId: string }>();
-    const local = await this.db.getAllTransactions();
-    const localById = new Map(local.map((t) => [t.transaction_id, t]));
+
+    if (!this.liveDb) {
+      const local = await this.db.getAllTransactions();
+      const localById = new Map(local.map((t) => [t.transaction_id, t]));
+      for (const id of ids) {
+        const t = localById.get(id);
+        if (t?.account_id && t?.item_id) {
+          out.set(id, { accountId: t.account_id, itemId: t.item_id });
+        }
+      }
+      return { meta: out, liveWindowMonths: null };
+    }
+
+    const indexed = this.liveDb.lookupTransactionMeta(ids);
     const missing: string[] = [];
     for (const id of ids) {
-      const t = localById.get(id);
-      if (t?.account_id && t?.item_id) {
-        out.set(id, { accountId: t.account_id, itemId: t.item_id });
+      const m = indexed.get(id);
+      if (m) {
+        out.set(id, m);
       } else {
         missing.push(id);
       }
     }
-    if (missing.length > 0 && this.liveDb) {
-      const months = Number(process.env.COPILOT_WRITE_RESOLVE_WINDOW_MONTHS) || 13;
+
+    const months = CopilotMoneyTools.resolveWindowMonths();
+    if (missing.length > 0) {
       const to = new Date().toISOString().slice(0, 10);
       const fromDate = new Date();
       fromDate.setMonth(fromDate.getMonth() - months);
@@ -2449,12 +2475,44 @@ export class CopilotMoneyTools {
       const liveById = new Map(live.rows.map((n) => [n.id, n]));
       for (const id of missing) {
         const n = liveById.get(id);
-        if (n?.accountId && n?.itemId) {
-          out.set(id, { accountId: n.accountId, itemId: n.itemId });
-        }
+        if (n) out.set(id, { accountId: n.accountId, itemId: n.itemId });
       }
     }
-    return out;
+    return { meta: out, liveWindowMonths: months };
+  }
+
+  /**
+   * Window size for the live resolution fetch. Mirrors the
+   * getCacheTTLMs() env-parse convention (src/core/database.ts): explicit
+   * positive integer wins, anything else falls back to the default.
+   */
+  private static resolveWindowMonths(): number {
+    const envValue = process.env.COPILOT_WRITE_RESOLVE_WINDOW_MONTHS;
+    if (envValue !== undefined) {
+      const months = parseInt(envValue, 10);
+      if (!isNaN(months) && months > 0) return months;
+    }
+    return 13;
+  }
+
+  /**
+   * Compose the not-found error for unresolved write targets. The window
+   * suffix appears only when a live fetch was actually attempted
+   * (liveWindowMonths non-null) — three distinct failures otherwise share
+   * one string: typo'd id, out-of-window id, and the server's own
+   * wrong-routing error (verified byte-identical by the 2026-07-05 probe).
+   */
+  private static transactionsNotFoundMessage(
+    missing: string[],
+    liveWindowMonths: number | null
+  ): string {
+    const base = `Transaction${missing.length > 1 ? 's' : ''} not found: ${missing.join(', ')}`;
+    if (liveWindowMonths === null) return base;
+    return (
+      `${base} — not found in the last ${liveWindowMonths} months of live data. ` +
+      `If the transaction is older, raise COPILOT_WRITE_RESOLVE_WINDOW_MONTHS; ` +
+      `if it should be recent, verify the id.`
+    );
   }
 
   /**
@@ -2517,10 +2575,14 @@ export class CopilotMoneyTools {
     // Prefers the local cache; falls back to a live GraphQL window fetch so we
     // can edit any transaction the API exposes — not just the subset the local
     // cache happens to hold. See resolveTransactionMeta().
-    const metaMap = await this.resolveTransactionMeta([transaction_id]);
+    const { meta: metaMap, liveWindowMonths } = await this.resolveTransactionMeta([
+      transaction_id,
+    ]);
     const meta = metaMap.get(transaction_id);
     if (!meta) {
-      throw new Error(`Transaction not found: ${transaction_id}`);
+      throw new Error(
+        CopilotMoneyTools.transactionsNotFoundMessage([transaction_id], liveWindowMonths)
+      );
     }
     const resolvedAccountId = meta.accountId;
     const resolvedItemId = meta.itemId;
@@ -3161,10 +3223,10 @@ export class CopilotMoneyTools {
 
     // Resolve account/item ids for all targets (local cache first, live
     // fallback for older transactions). See resolveTransactionMeta().
-    const metaMap = await this.resolveTransactionMeta(transaction_ids);
+    const { meta: metaMap, liveWindowMonths } = await this.resolveTransactionMeta(transaction_ids);
     const missing = transaction_ids.filter((id) => !metaMap.has(id));
     if (missing.length > 0) {
-      throw new Error(`Transactions not found: ${missing.join(', ')}`);
+      throw new Error(CopilotMoneyTools.transactionsNotFoundMessage(missing, liveWindowMonths));
     }
 
     // Bounded concurrency: never more than CONCURRENCY in flight at once.

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2434,9 +2434,7 @@ export class CopilotMoneyTools {
    * Returns the resolved map plus liveWindowMonths (null iff no live fetch
    * could be attempted) so callers can compose an honest not-found error.
    */
-  private async resolveTransactionMeta(
-    ids: string[]
-  ): Promise<{
+  private async resolveTransactionMeta(ids: string[]): Promise<{
     meta: Map<string, { accountId: string; itemId: string }>;
     liveWindowMonths: number | null;
   }> {
@@ -2475,7 +2473,9 @@ export class CopilotMoneyTools {
       const liveById = new Map(live.rows.map((n) => [n.id, n]));
       for (const id of missing) {
         const n = liveById.get(id);
-        if (n) out.set(id, { accountId: n.accountId, itemId: n.itemId });
+        if (n?.accountId && n?.itemId) {
+          out.set(id, { accountId: n.accountId, itemId: n.itemId });
+        }
       }
     }
     return { meta: out, liveWindowMonths: months };
@@ -2574,9 +2574,7 @@ export class CopilotMoneyTools {
     // Resolve the transaction's accountId/itemId for the GraphQL mutation —
     // live-first via the meta index / windowed fetch; local cache only in
     // degraded (no-liveDb) mode. See resolveTransactionMeta().
-    const { meta: metaMap, liveWindowMonths } = await this.resolveTransactionMeta([
-      transaction_id,
-    ]);
+    const { meta: metaMap, liveWindowMonths } = await this.resolveTransactionMeta([transaction_id]);
     const meta = metaMap.get(transaction_id);
     if (!meta) {
       throw new Error(

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2571,10 +2571,9 @@ export class CopilotMoneyTools {
 
     validateDocId(transaction_id, 'transaction_id');
 
-    // Resolve the transaction's accountId/itemId for the GraphQL mutation.
-    // Prefers the local cache; falls back to a live GraphQL window fetch so we
-    // can edit any transaction the API exposes — not just the subset the local
-    // cache happens to hold. See resolveTransactionMeta().
+    // Resolve the transaction's accountId/itemId for the GraphQL mutation —
+    // live-first via the meta index / windowed fetch; local cache only in
+    // degraded (no-liveDb) mode. See resolveTransactionMeta().
     const { meta: metaMap, liveWindowMonths } = await this.resolveTransactionMeta([
       transaction_id,
     ]);
@@ -2833,6 +2832,10 @@ export class CopilotMoneyTools {
         internal_transfer: tx.type === 'INTERNAL_TRANSFER',
         is_manual: true,
       };
+
+      // Feed the live meta index so an immediate follow-up write on the new
+      // transaction resolves without a network fetch.
+      this.liveDb?.indexTransactionMeta(tx.id, { accountId: tx.accountId, itemId: tx.itemId });
 
       return {
         success: true,
@@ -3221,8 +3224,9 @@ export class CopilotMoneyTools {
       validateDocId(id, 'transaction_id');
     }
 
-    // Resolve account/item ids for all targets (local cache first, live
-    // fallback for older transactions). See resolveTransactionMeta().
+    // Resolve account/item ids for all targets — live-first via the meta
+    // index / windowed fetch; local cache only in degraded (no-liveDb)
+    // mode. See resolveTransactionMeta().
     const { meta: metaMap, liveWindowMonths } = await this.resolveTransactionMeta(transaction_ids);
     const missing = transaction_ids.filter((id) => !metaMap.has(id));
     if (missing.length > 0) {
@@ -3647,12 +3651,15 @@ export class CopilotMoneyTools {
       );
     }
 
-    const all = await this.db.getAllTransactions();
-    const txn = all.find((t) => t.transaction_id === args.transaction_id);
-    if (!txn) throw new Error(`Transaction not found: ${args.transaction_id}`);
-    if (!txn.account_id || !txn.item_id) {
+    // Resolve routing ids the same way update_transaction does — live-first
+    // in live mode, local cache only in degraded mode. See
+    // resolveTransactionMeta(). Fixes the class bug where a transaction
+    // older than the local cache window could not be made recurring.
+    const { meta, liveWindowMonths } = await this.resolveTransactionMeta([args.transaction_id]);
+    const txnMeta = meta.get(args.transaction_id);
+    if (!txnMeta) {
       throw new Error(
-        `Transaction ${args.transaction_id} missing account_id or item_id in local cache`
+        CopilotMoneyTools.transactionsNotFoundMessage([args.transaction_id], liveWindowMonths)
       );
     }
 
@@ -3662,8 +3669,8 @@ export class CopilotMoneyTools {
           // Validated against RECURRING_FREQUENCIES above, so the widening cast is safe.
           frequency: args.frequency as RecurringFrequency,
           transaction: {
-            accountId: txn.account_id,
-            itemId: txn.item_id,
+            accountId: txnMeta.accountId,
+            itemId: txnMeta.itemId,
             transactionId: args.transaction_id,
           },
         },

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2478,6 +2478,11 @@ export class CopilotMoneyTools {
         }
       }
     }
+    // liveWindowMonths is non-null here even when no fetch ran
+    // (missing.length === 0). Safe by invariant: callers only compose the
+    // window error for ids absent from `meta`, and an empty `missing` means
+    // every requested id IS in `meta` — the error path is unreachable
+    // without an attempted fetch.
     return { meta: out, liveWindowMonths: months };
   }
 

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -1027,4 +1027,21 @@ describe('transaction meta index', () => {
     );
     expect(live.lookupTransactionMeta(['nope']).size).toBe(0);
   });
+
+  test('rows with empty routing ids are not indexed (drift guard)', async () => {
+    const bad = { ...metaNode('meta-bad', '2025-01-16', '', 'item-X') };
+    const good = metaNode('meta-good', '2025-01-17', 'acct-C', 'item-C');
+    const page = metaPage([good, bad as ReturnType<typeof metaNode>]);
+    const client = {
+      mutate: mock(),
+      query: mock(() => Promise.resolve({ transactions: page })),
+    } as unknown as GraphQLClient;
+    const live = new LiveCopilotDatabase(client, {} as CopilotDatabase);
+
+    await live.getTransactions({ from: '2025-01-01', to: '2025-01-31' });
+
+    const found = live.lookupTransactionMeta(['meta-good', 'meta-bad']);
+    expect(found.has('meta-good')).toBe(true);
+    expect(found.has('meta-bad')).toBe(false);
+  });
 });

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -960,3 +960,71 @@ describe('LiveCopilotDatabase — logReadCall', () => {
     }
   });
 });
+
+describe('transaction meta index', () => {
+  function metaNode(id: string, date: string, accountId: string, itemId: string) {
+    return {
+      id,
+      accountId,
+      itemId,
+      categoryId: 'c1',
+      recurringId: null,
+      parentId: null,
+      isReviewed: false,
+      isPending: false,
+      amount: 10,
+      date,
+      name: `tx-${id}`,
+      type: 'REGULAR' as const,
+      userNotes: null,
+      tipAmount: null,
+      suggestedCategoryIds: [],
+      isoCurrencyCode: null,
+      createdAt: 1,
+      tags: [],
+      goal: null,
+    };
+  }
+
+  function metaPage(nodes: ReturnType<typeof metaNode>[]): TransactionsPage {
+    return {
+      edges: nodes.map((n) => ({ cursor: `c-${n.id}`, node: n })),
+      pageInfo: { endCursor: null, hasNextPage: false },
+    };
+  }
+
+  test('getTransactions feeds the index; lookupTransactionMeta resolves fetched ids', async () => {
+    const page = metaPage([metaNode('meta-t1', '2025-01-15', 'acct-A', 'item-A')]);
+    const client = {
+      mutate: mock(),
+      query: mock(() => Promise.resolve({ transactions: page })),
+    } as unknown as GraphQLClient;
+    const live = new LiveCopilotDatabase(client, {} as CopilotDatabase);
+
+    await live.getTransactions({ from: '2025-01-01', to: '2025-01-31' });
+
+    const found = live.lookupTransactionMeta(['meta-t1', 'meta-unknown']);
+    expect(found.get('meta-t1')).toEqual({ accountId: 'acct-A', itemId: 'item-A' });
+    expect(found.has('meta-unknown')).toBe(false);
+  });
+
+  test('indexTransactionMeta feeds the index directly', () => {
+    const live = new LiveCopilotDatabase(
+      { mutate: mock(), query: mock() } as unknown as GraphQLClient,
+      {} as CopilotDatabase
+    );
+    live.indexTransactionMeta('meta-t2', { accountId: 'acct-B', itemId: 'item-B' });
+    expect(live.lookupTransactionMeta(['meta-t2']).get('meta-t2')).toEqual({
+      accountId: 'acct-B',
+      itemId: 'item-B',
+    });
+  });
+
+  test('lookupTransactionMeta returns an empty map for unknown ids', () => {
+    const live = new LiveCopilotDatabase(
+      { mutate: mock(), query: mock() } as unknown as GraphQLClient,
+      {} as CopilotDatabase
+    );
+    expect(live.lookupTransactionMeta(['nope']).size).toBe(0);
+  });
+});

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -2928,7 +2928,7 @@ describe('reviewTransactions', () => {
     const client = createMockGraphQLClient({});
     tools = new CopilotMoneyTools(mockDb, client);
     await expect(tools.reviewTransactions({ transaction_ids: ['nonexistent'] })).rejects.toThrow(
-      'Transactions not found: nonexistent'
+      'Transaction not found: nonexistent'
     );
   });
 

--- a/tests/tools/write-tools-phase3.test.ts
+++ b/tests/tools/write-tools-phase3.test.ts
@@ -200,7 +200,10 @@ describe('createRecurring', () => {
     expect(client._calls).toHaveLength(0);
   });
 
-  test('throws when transaction is missing account_id or item_id', async () => {
+  test('locally-incomplete transaction is unresolved (no live fallback here) and throws not-found', async () => {
+    // txn-orphan lacks account_id/item_id and there is no liveDb, so
+    // resolution finds nothing — the old "missing account_id or item_id"
+    // message is retired in favor of the resolver's not-found contract.
     (mockDb as any)._transactions = [
       { transaction_id: 'txn-orphan', amount: 10, date: '2024-01-01', name: 'Orphan' },
     ];
@@ -210,7 +213,7 @@ describe('createRecurring', () => {
 
     await expect(
       tools.createRecurring({ transaction_id: 'txn-orphan', frequency: 'MONTHLY' })
-    ).rejects.toThrow('missing account_id or item_id');
+    ).rejects.toThrow('Transaction not found: txn-orphan');
     expect(client._calls).toHaveLength(0);
   });
 

--- a/tests/unit/resolve-transaction-meta.test.ts
+++ b/tests/unit/resolve-transaction-meta.test.ts
@@ -161,9 +161,9 @@ describe('resolveTransactionMeta v2 — live mode', () => {
 
     const { liveDb: emptyLive } = stubLiveDb({});
     const tools2 = new CopilotMoneyTools(makeDb(), createMockGraphQLClient({}), emptyLive);
-    await expect(
-      tools2.reviewTransactions({ transaction_ids: ['tX', 'tY'] })
-    ).rejects.toThrow(/Transactions not found: tX, tY.*last 13 months/);
+    await expect(tools2.reviewTransactions({ transaction_ids: ['tX', 'tY'] })).rejects.toThrow(
+      /Transactions not found: tX, tY.*last 13 months/
+    );
   });
 
   test('env var override is honored; garbage/zero/negative fall back to 13', async () => {

--- a/tests/unit/resolve-transaction-meta.test.ts
+++ b/tests/unit/resolve-transaction-meta.test.ts
@@ -218,3 +218,87 @@ describe('resolveTransactionMeta v2 — degraded mode (no liveDb)', () => {
     expect(msg).not.toMatch(/COPILOT_WRITE_RESOLVE_WINDOW_MONTHS/);
   });
 });
+
+describe('createRecurring uses resolveTransactionMeta', () => {
+  test('uncached id resolves via live fetch; mutation receives the triple', async () => {
+    const client = createMockGraphQLClient({
+      CreateRecurring: {
+        createRecurring: { id: 'rec-1', name: 'n', state: 'ACTIVE', frequency: 'MONTHLY' },
+      },
+    });
+    const { liveDb } = stubLiveDb({
+      liveRows: [{ id: 'tOld', accountId: 'acct-9', itemId: 'item-9' }],
+    });
+    (liveDb as any).patchLiveRecurringUpsert = () => {};
+    const tools = new CopilotMoneyTools(makeDb(), client, liveDb);
+
+    await tools.createRecurring({ transaction_id: 'tOld', frequency: 'MONTHLY' });
+
+    const call = client._calls.find((c) => c.op === 'CreateRecurring')!;
+    expect((call.variables as any).input.transaction).toEqual({
+      accountId: 'acct-9',
+      itemId: 'item-9',
+      transactionId: 'tOld',
+    });
+  });
+
+  test('unresolvable id gets the honest window error', async () => {
+    const client = createMockGraphQLClient({});
+    const { liveDb } = stubLiveDb({});
+    const tools = new CopilotMoneyTools(makeDb(), client, liveDb);
+
+    await expect(
+      tools.createRecurring({ transaction_id: 'tGone', frequency: 'MONTHLY' })
+    ).rejects.toThrow(/Transaction not found: tGone.*last 13 months/);
+    expect(client._calls).toHaveLength(0);
+  });
+});
+
+describe('createTransaction feeds the meta index', () => {
+  test('created id becomes resolvable without a fetch', async () => {
+    const client = createMockGraphQLClient({
+      CreateTransaction: {
+        createTransaction: {
+          id: 'tNew',
+          name: 'Synthetic',
+          date: '2026-07-01',
+          amount: 100,
+          categoryId: 'c1',
+          type: 'REGULAR',
+          accountId: 'acct-5',
+          itemId: 'item-5',
+          isPending: false,
+          isReviewed: true,
+          createdAt: 1,
+          recurringId: null,
+          userNotes: null,
+          tipAmount: null,
+          suggestedCategoryIds: [],
+          tags: [],
+          goal: null,
+        },
+      },
+    });
+    const indexTransactionMeta = mock();
+    const { liveDb } = stubLiveDb({});
+    (liveDb as any).indexTransactionMeta = indexTransactionMeta;
+    const db = makeDb();
+    (db as any)._userCategories = [{ category_id: 'c1', name: 'Synthetic Cat' }];
+    const tools = new CopilotMoneyTools(db, client, liveDb);
+
+    await tools.createTransaction({
+      account_id: 'acct-5',
+      item_id: 'item-5',
+      name: 'Synthetic',
+      date: '2026-07-01',
+      amount: 100,
+      category_id: 'c1',
+      type: 'REGULAR',
+    });
+
+    expect(indexTransactionMeta).toHaveBeenCalledWith('tNew', {
+      accountId: 'acct-5',
+      itemId: 'item-5',
+    });
+  });
+});

--- a/tests/unit/resolve-transaction-meta.test.ts
+++ b/tests/unit/resolve-transaction-meta.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Resolution-order tests for resolveTransactionMeta v2 (write-tool routing
+ * ids). Live mode resolves: ① liveDb meta index → ② windowed live fetch →
+ * ③ honest window error. LevelDB is NOT consulted when liveDb is present;
+ * it remains the sole resolver in degraded mode (no liveDb).
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { CopilotMoneyTools } from '../../src/tools/tools.js';
+import { CopilotDatabase } from '../../src/core/database.js';
+import type { LiveCopilotDatabase } from '../../src/core/live-database.js';
+import { createMockGraphQLClient } from '../helpers/mock-graphql.js';
+
+function echoEdit(vars: any) {
+  return {
+    editTransaction: {
+      transaction: {
+        id: vars.id,
+        name: 'n',
+        categoryId: 'c1',
+        userNotes: null,
+        isReviewed: vars.input.isReviewed ?? false,
+        type: 'REGULAR',
+        tags: [],
+      },
+    },
+  };
+}
+
+function makeDb(transactions: unknown[] = []) {
+  const db = new CopilotDatabase('/nonexistent');
+  (db as any).dbPath = '/fake';
+  (db as any)._transactions = transactions;
+  (db as any)._userCategories = [];
+  (db as any)._tags = [];
+  (db as any)._goals = [];
+  return db;
+}
+
+/** Stub liveDb: `indexed` backs lookupTransactionMeta; `liveRows` backs the
+ *  windowed getTransactions fetch. Returns the spy so tests can assert
+ *  whether the network fallback fired. */
+function stubLiveDb(overrides: {
+  indexed?: Record<string, { accountId: string; itemId: string }>;
+  liveRows?: Array<{ id: string; accountId: string; itemId: string }>;
+}) {
+  const getTransactions = mock(() =>
+    Promise.resolve({
+      rows: overrides.liveRows ?? [],
+      oldest_fetched_at: 0,
+      newest_fetched_at: 0,
+      hit: false,
+    })
+  );
+  const liveDb = {
+    lookupTransactionMeta: (ids: string[]) => {
+      const out = new Map<string, { accountId: string; itemId: string }>();
+      for (const id of ids) {
+        const m = overrides.indexed?.[id];
+        if (m) out.set(id, m);
+      }
+      return out;
+    },
+    getTransactions,
+    patchLiveTransaction: () => {}, // no-op for tests
+  } as unknown as LiveCopilotDatabase;
+  return { liveDb, getTransactions };
+}
+
+const ORIGINAL_ENV = process.env.COPILOT_WRITE_RESOLVE_WINDOW_MONTHS;
+beforeEach(() => {
+  delete process.env.COPILOT_WRITE_RESOLVE_WINDOW_MONTHS;
+});
+afterEach(() => {
+  if (ORIGINAL_ENV === undefined) delete process.env.COPILOT_WRITE_RESOLVE_WINDOW_MONTHS;
+  else process.env.COPILOT_WRITE_RESOLVE_WINDOW_MONTHS = ORIGINAL_ENV;
+});
+
+describe('resolveTransactionMeta v2 — live mode', () => {
+  test('index hit: no live fetch, mutation receives the indexed triple', async () => {
+    const client = createMockGraphQLClient({ EditTransaction: echoEdit as any });
+    const { liveDb, getTransactions } = stubLiveDb({
+      indexed: { tA: { accountId: 'acct-1', itemId: 'item-1' } },
+    });
+    const tools = new CopilotMoneyTools(makeDb(), client, liveDb);
+
+    await tools.updateTransaction({ transaction_id: 'tA', reviewed: true });
+
+    expect(getTransactions).toHaveBeenCalledTimes(0);
+    const call = client._calls.find((c) => c.op === 'EditTransaction')!;
+    expect((call.variables as any).accountId).toBe('acct-1');
+    expect((call.variables as any).itemId).toBe('item-1');
+  });
+
+  test('index miss: windowed fetch resolves the triple (the #498-owed test)', async () => {
+    const client = createMockGraphQLClient({ EditTransaction: echoEdit as any });
+    const { liveDb, getTransactions } = stubLiveDb({
+      liveRows: [{ id: 'tOld', accountId: 'acct-2', itemId: 'item-2' }],
+    });
+    const tools = new CopilotMoneyTools(makeDb(), client, liveDb);
+
+    await tools.updateTransaction({ transaction_id: 'tOld', reviewed: true });
+
+    expect(getTransactions).toHaveBeenCalledTimes(1);
+    const call = client._calls.find((c) => c.op === 'EditTransaction')!;
+    expect((call.variables as any).accountId).toBe('acct-2');
+    expect((call.variables as any).itemId).toBe('item-2');
+  });
+
+  test('LevelDB is NOT consulted in live mode', async () => {
+    // The row exists in the local cache with valid ids, but liveDb knows
+    // nothing about it → v2 must fail with the window error, proving the
+    // local cache was skipped.
+    const client = createMockGraphQLClient({});
+    const { liveDb } = stubLiveDb({});
+    const tools = new CopilotMoneyTools(
+      makeDb([
+        {
+          transaction_id: 'tLocal',
+          amount: 100,
+          date: '2026-06-01',
+          name: 'Synthetic',
+          account_id: 'acct-3',
+          item_id: 'item-3',
+        },
+      ]),
+      client,
+      liveDb
+    );
+
+    await expect(
+      tools.updateTransaction({ transaction_id: 'tLocal', reviewed: true })
+    ).rejects.toThrow(/last 13 months/);
+    expect(client._calls).toHaveLength(0);
+  });
+
+  test('unresolved after fetch: honest error names the window and the env var', async () => {
+    const client = createMockGraphQLClient({});
+    const { liveDb } = stubLiveDb({});
+    const tools = new CopilotMoneyTools(makeDb(), client, liveDb);
+
+    await expect(
+      tools.updateTransaction({ transaction_id: 'tGone', reviewed: true })
+    ).rejects.toThrow(/COPILOT_WRITE_RESOLVE_WINDOW_MONTHS/);
+    await expect(
+      tools.updateTransaction({ transaction_id: 'tGone', reviewed: true })
+    ).rejects.toThrow(/Transaction not found: tGone/);
+  });
+
+  test('bulk review: mixed index/fetch resolution, one fetch total; honest bulk error', async () => {
+    const client = createMockGraphQLClient({ EditTransaction: echoEdit as any });
+    const { liveDb, getTransactions } = stubLiveDb({
+      indexed: { tA: { accountId: 'acct-1', itemId: 'item-1' } },
+      liveRows: [{ id: 'tB', accountId: 'acct-2', itemId: 'item-2' }],
+    });
+    const tools = new CopilotMoneyTools(makeDb(), client, liveDb);
+
+    const result = await tools.reviewTransactions({ transaction_ids: ['tA', 'tB'] });
+    expect(result.reviewed_count).toBe(2);
+    expect(getTransactions).toHaveBeenCalledTimes(1);
+
+    const { liveDb: emptyLive } = stubLiveDb({});
+    const tools2 = new CopilotMoneyTools(makeDb(), createMockGraphQLClient({}), emptyLive);
+    await expect(
+      tools2.reviewTransactions({ transaction_ids: ['tX', 'tY'] })
+    ).rejects.toThrow(/Transactions not found: tX, tY.*last 13 months/);
+  });
+
+  test('env var override is honored; garbage/zero/negative fall back to 13', async () => {
+    const client = createMockGraphQLClient({});
+    const { liveDb } = stubLiveDb({});
+    const tools = new CopilotMoneyTools(makeDb(), client, liveDb);
+
+    process.env.COPILOT_WRITE_RESOLVE_WINDOW_MONTHS = '30';
+    await expect(
+      tools.updateTransaction({ transaction_id: 'tGone', reviewed: true })
+    ).rejects.toThrow(/last 30 months/);
+
+    for (const bad of ['-5', '0', 'garbage']) {
+      process.env.COPILOT_WRITE_RESOLVE_WINDOW_MONTHS = bad;
+      await expect(
+        tools.updateTransaction({ transaction_id: 'tGone', reviewed: true })
+      ).rejects.toThrow(/last 13 months/);
+    }
+  });
+});
+
+describe('resolveTransactionMeta v2 — degraded mode (no liveDb)', () => {
+  test('resolves from LevelDB; message stays the plain not-found (no env-var hint)', async () => {
+    const client = createMockGraphQLClient({ EditTransaction: echoEdit as any });
+    const tools = new CopilotMoneyTools(
+      makeDb([
+        {
+          transaction_id: 'tLocal',
+          amount: 100,
+          date: '2026-06-01',
+          name: 'Synthetic',
+          account_id: 'acct-3',
+          item_id: 'item-3',
+        },
+      ]),
+      client
+    );
+
+    await tools.updateTransaction({ transaction_id: 'tLocal', reviewed: true });
+    const call = client._calls.find((c) => c.op === 'EditTransaction')!;
+    expect((call.variables as any).accountId).toBe('acct-3');
+
+    await expect(
+      tools.updateTransaction({ transaction_id: 'tMissing', reviewed: true })
+    ).rejects.toThrow('Transaction not found: tMissing');
+    let msg = '';
+    try {
+      await tools.updateTransaction({ transaction_id: 'tMissing', reviewed: true });
+    } catch (e) {
+      msg = (e as Error).message;
+    }
+    expect(msg).not.toMatch(/COPILOT_WRITE_RESOLVE_WINDOW_MONTHS/);
+  });
+});

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -28,6 +28,7 @@
     "tests/tools/unit-coverage-gaps.test.ts",
     "tests/tools/write-tools-phase3.test.ts",
     "tests/tools/write-tools.test.ts",
+    "tests/unit/resolve-transaction-meta.test.ts",
     "tests/unit/update-transaction.test.ts"
   ],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Problem

Write tools need a transaction's `(accountId, itemId)` to build `EditTransaction`/`CreateRecurring` mutations — the server validates the full binding (live-probed, see External assumptions). After #498, resolution went local-LevelDB-first with a 13-month live-window fallback. Three residual problems:

1. **The server re-derived facts it had already served.** Every live read returns full nodes (routing ids included), then forgot them — a write on a just-read transaction paid a fresh multi-second window fetch.
2. **LevelDB in the live-mode write path contradicted the README contract** ("writes resolve transaction metadata against the live GraphQL surface") and mixed in the desktop app's cache, which isn't guaranteed to match the browser-session identity.
3. **Misleading errors**: an id outside the resolve window threw the generic `Transaction not found` — byte-identical to the server's own wrong-routing error and the typo'd-id error.

`create_recurring` had the same cache-only resolution bug class: a transaction older than the local cache window couldn't be made recurring.

## Fix

- **Append-only meta index** (`Map<id, {accountId, itemId}>`) on `LiveCopilotDatabase`, fed at the `fetchMonth` chokepoint (pre-trim rows), by `patchLiveTransaction`, and by the `create_transaction` response. The mapping is immutable server-side, so the index needs no TTL/invalidation.
- **`resolveTransactionMeta` v2**: live mode resolves index → one windowed live fetch (default 13mo, `COPILOT_WRITE_RESOLVE_WINDOW_MONTHS` overrides, now parseInt-validated) → honest error naming the window and the env var. LevelDB is no longer consulted in live mode; it remains the sole resolver in degraded (no-liveDb) configs.
- **`create_recurring` adopts the resolver** (class fix); `update_transaction`/`review_transactions` keep their contracts.
- **Conformance ledger** gains `Mutation.editTransaction:routing` (verified-once) + README documents the env var.

## Deviations from spec worth naming

- Bulk review with exactly **one** missing id now says `Transaction not found: <id>` (singular) — the old always-plural wording was a v1 hardcode; one test expectation updated (`tests/tools/tools.test.ts`). No non-test consumer matches the plural string (verified by grep).
- `create_recurring`'s old `missing account_id or item_id in local cache` message is retired in favor of the resolver's not-found contract.

## External assumptions

- **`Mutation.editTransaction:routing`** (NEW, verified-once, ledger entry in this PR): the server validates the full `(id, accountId, itemId)` binding, not mere existence. Evidence: three-arm live probe 2026-07-05 — fabricated ids → `accountId … Not Found`; real-but-wrong account pair → `Transaction not found`; correct pair → edit applied.
- No other new assumptions: the windowed fetch reuses the existing `Transactions` query surface; `TransactionNode.accountId/itemId` field shapes unchanged. A hardening commit guards the fallback against null routing ids in (unvalidated) read responses.

## Testing

- `bun run check` green: 2215 tests (2195 pass / 20 skip / 0 fail), typecheck, lint, format, version-sync, server-json; `sync-manifest` reports no manifest change (no tool schemas touched).
- New unit coverage: index population via real `fetchMonth`; resolution order (index hit ⇒ zero fetches); windowed-fallback resolution (the test #498 owed); LevelDB-not-consulted-in-live-mode (adversarial); honest window error single+bulk; env-var override/garbage/zero/negative; `create_recurring` triple wiring; `create_transaction` index feed.
- **Live smoke (run, read-only)**: `[1] read 67 rows` from an 8-month-old window; `[2] index resolution: 1ms, match=true -> PASS` (no second fetch); `[3] cold miss handled, window=13 -> PASS`.

## Follow-ups (issues to be filed on merge)

- `split_transaction`'s full-parent-row LevelDB read (needs full nodes, not the triple — own design).
- Reference-data validation reads (categories/tags) against live caches in live mode.
- Persistent on-disk id-index (cross-session endgame).
- Read-shape validation for `Transactions` responses — `accountId`/`itemId` are now mutation-routing inputs, the highest-value read fields to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)