### PR TITLE
fix(write): consult fed stores after windowed fetch, not date-filtered rows

### DIFF
--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2465,13 +2465,14 @@ export class CopilotMoneyTools {
 
     const { from, to, months } = CopilotMoneyTools.writeResolveWindow();
     if (missing.length > 0) {
-      const live = await this.liveDb.getTransactions({ from, to });
-      const liveById = new Map(live.rows.map((n) => [n.id, n]));
-      for (const id of missing) {
-        const n = liveById.get(id);
-        if (n?.accountId && n?.itemId) {
-          out.set(id, { accountId: n.accountId, itemId: n.itemId });
-        }
+      // Consult the meta index the fetch just fed rather than scanning the
+      // date-filtered return value: fetchMonth feeds the index with the FULL
+      // pre-trim month, so this also resolves same-month future-dated
+      // transactions the rows scan missed (#513). The empty-routing-id guard
+      // is enforced at the feed, so indexed entries are always valid.
+      await this.liveDb.getTransactions({ from, to });
+      for (const [id, m] of this.liveDb.lookupTransactionMeta(missing)) {
+        out.set(id, m);
       }
     }
     // liveWindowMonths is non-null here even when no fetch ran
@@ -2561,8 +2562,11 @@ export class CopilotMoneyTools {
         liveWindowMonths: months,
       };
     }
-    const live = await this.liveDb.getTransactions({ from, to });
-    const n = live.rows.find((r) => r.id === id);
+    await this.liveDb.getTransactions({ from, to });
+    // Consult the window cache the fetch just fed rather than the
+    // date-filtered return value — it holds same-month future-dated rows the
+    // rows scan would miss (#513).
+    const n = this.liveDb.lookupTransactionNodes([id]).get(id);
     if (!n) return { snapshot: null, liveWindowMonths: months };
     return {
       snapshot: { amount: n.amount, date: n.date, name: n.name },

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2562,11 +2562,14 @@ export class CopilotMoneyTools {
         liveWindowMonths: months,
       };
     }
-    await this.liveDb.getTransactions({ from, to });
-    // Consult the window cache the fetch just fed rather than the
-    // date-filtered return value — it holds same-month future-dated rows the
-    // rows scan would miss (#513).
-    const n = this.liveDb.lookupTransactionNodes([id]).get(id);
+    const live = await this.liveDb.getTransactions({ from, to });
+    // Cache-first: the window cache holds same-month future-dated rows the
+    // date-filtered return value misses (#513). Rows-fallback: unlike the
+    // append-only meta index resolveTransactionMeta reads, the window cache
+    // LRU-evicts per ingest, so a very large window can evict early months
+    // before the fetch returns — the in-hand rows are immune to that.
+    const n =
+      this.liveDb.lookupTransactionNodes([id]).get(id) ?? live.rows.find((r) => r.id === id);
     if (!n) return { snapshot: null, liveWindowMonths: months };
     return {
       snapshot: { amount: n.amount, date: n.date, name: n.name },

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -1074,4 +1074,29 @@ describe('transaction meta index', () => {
     );
     expect(live.lookupTransactionNodes(['anything']).size).toBe(0);
   });
+
+  test('rows dated after the requested range still land in the index and window cache (#513)', async () => {
+    // Range ends Jan 20 but the page contains a Jan 25 row: it is excluded
+    // from the RETURNED rows (date filter) yet fed to the meta index
+    // (pre-trim) and stored in the month bucket (within month boundary) —
+    // the asymmetry the write-resolvers rely on after their fallback fetch.
+    const page = metaPage([
+      metaNode('in-range', '2025-01-15', 'acct-A', 'item-A'),
+      metaNode('future-ish', '2025-01-25', 'acct-B', 'item-B'),
+    ]);
+    const client = {
+      mutate: mock(),
+      query: mock(() => Promise.resolve({ transactions: page })),
+    } as unknown as GraphQLClient;
+    const live = new LiveCopilotDatabase(client, {} as CopilotDatabase);
+
+    const result = await live.getTransactions({ from: '2025-01-01', to: '2025-01-20' });
+
+    expect(result.rows.map((r) => r.id)).toEqual(['in-range']);
+    expect(live.lookupTransactionMeta(['future-ish']).get('future-ish')).toEqual({
+      accountId: 'acct-B',
+      itemId: 'item-B',
+    });
+    expect(live.lookupTransactionNodes(['future-ish']).has('future-ish')).toBe(true);
+  });
 });

--- a/tests/unit/resolve-transaction-meta.test.ts
+++ b/tests/unit/resolve-transaction-meta.test.ts
@@ -37,32 +37,48 @@ function makeDb(transactions: unknown[] = []) {
   return db;
 }
 
-/** Stub liveDb: `indexed` backs lookupTransactionMeta; `liveRows` backs the
- *  windowed getTransactions fetch. Returns the spy so tests can assert
- *  whether the network fallback fired. */
+/** Stub liveDb: `indexed` backs lookupTransactionMeta from the start;
+ *  `liveRows` backs the windowed getTransactions RETURN VALUE and — like the
+ *  real fetchMonth feed — becomes visible via lookupTransactionMeta once the
+ *  fetch has run; `storeOnlyRows` simulates rows the fetch feeds to the store
+ *  but does NOT return (same-month future-dated rows; #513). Returns the
+ *  getTransactions spy so tests can assert whether the fallback fired. */
 function stubLiveDb(overrides: {
   indexed?: Record<string, { accountId: string; itemId: string }>;
   liveRows?: Array<{ id: string; accountId: string; itemId: string }>;
+  storeOnlyRows?: Array<{ id: string; accountId: string; itemId: string }>;
 }) {
-  const getTransactions = mock(() =>
-    Promise.resolve({
+  let fetched = false;
+  const getTransactions = mock(() => {
+    fetched = true;
+    return Promise.resolve({
       rows: overrides.liveRows ?? [],
       oldest_fetched_at: 0,
       newest_fetched_at: 0,
       hit: false,
-    })
-  );
-  const liveDb = {
-    lookupTransactionMeta: (ids: string[]) => {
-      const out = new Map<string, { accountId: string; itemId: string }>();
-      for (const id of ids) {
-        const m = overrides.indexed?.[id];
-        if (m) out.set(id, m);
+    });
+  });
+  const lookupTransactionMeta = (ids: string[]) => {
+    const out = new Map<string, { accountId: string; itemId: string }>();
+    for (const id of ids) {
+      const m = overrides.indexed?.[id];
+      if (m) {
+        out.set(id, m);
+        continue;
       }
-      return out;
-    },
+      if (fetched) {
+        const r = [...(overrides.liveRows ?? []), ...(overrides.storeOnlyRows ?? [])].find(
+          (n) => n.id === id
+        );
+        if (r?.accountId && r?.itemId) out.set(id, { accountId: r.accountId, itemId: r.itemId });
+      }
+    }
+    return out;
+  };
+  const liveDb = {
+    lookupTransactionMeta,
     getTransactions,
-    patchLiveTransaction: () => {}, // no-op for tests
+    patchLiveTransaction: () => {},
   } as unknown as LiveCopilotDatabase;
   return { liveDb, getTransactions };
 }
@@ -182,6 +198,24 @@ describe('resolveTransactionMeta v2 — live mode', () => {
         tools.updateTransaction({ transaction_id: 'tGone', reviewed: true })
       ).rejects.toThrow(/last 13 months/);
     }
+  });
+
+  test('same-month future-dated id resolves on the FIRST call (#513)', async () => {
+    // The row is fed to the meta index by the fetch but NOT present in the
+    // date-filtered return value — the pre-#513 code threw the window error
+    // here and only succeeded on retry.
+    const client = createMockGraphQLClient({ EditTransaction: echoEdit as any });
+    const { liveDb, getTransactions } = stubLiveDb({
+      storeOnlyRows: [{ id: 'tFuture', accountId: 'acct-F', itemId: 'item-F' }],
+    });
+    const tools = new CopilotMoneyTools(makeDb(), client, liveDb);
+
+    await tools.updateTransaction({ transaction_id: 'tFuture', reviewed: true });
+
+    expect(getTransactions).toHaveBeenCalledTimes(1);
+    const call = client._calls.find((c) => c.op === 'EditTransaction')!;
+    expect((call.variables as any).accountId).toBe('acct-F');
+    expect((call.variables as any).itemId).toBe('item-F');
   });
 });
 

--- a/tests/unit/split-transaction-resolution.test.ts
+++ b/tests/unit/split-transaction-resolution.test.ts
@@ -70,25 +70,41 @@ function makeDb(transactions: unknown[] = []) {
   return db;
 }
 
-function stubLiveDb(overrides: { cachedNodes?: TransactionNode[]; liveRows?: TransactionNode[] }) {
-  const getTransactions = mock(() =>
-    Promise.resolve({
+/** Stub liveDb: `cachedNodes` back lookupTransactionNodes from the start;
+ *  `liveRows` back the windowed getTransactions RETURN VALUE and — like the
+ *  real ingestMonth — become visible via lookupTransactionNodes once the
+ *  fetch has run; `storeOnlyNodes` simulate same-month future-dated rows the
+ *  fetch stores but does not return (#513). */
+function stubLiveDb(overrides: {
+  cachedNodes?: TransactionNode[];
+  liveRows?: TransactionNode[];
+  storeOnlyNodes?: TransactionNode[];
+}) {
+  let fetched = false;
+  const getTransactions = mock(() => {
+    fetched = true;
+    return Promise.resolve({
       rows: overrides.liveRows ?? [],
       oldest_fetched_at: 0,
       newest_fetched_at: 0,
       hit: false,
-    })
-  );
+    });
+  });
   const indexTransactionMeta = mock();
+  const lookupTransactionNodes = (ids: string[]) => {
+    const pool = [
+      ...(overrides.cachedNodes ?? []),
+      ...(fetched ? [...(overrides.liveRows ?? []), ...(overrides.storeOnlyNodes ?? [])] : []),
+    ];
+    const out = new Map<string, TransactionNode>();
+    for (const id of ids) {
+      const n = pool.find((c) => c.id === id);
+      if (n) out.set(id, n);
+    }
+    return out;
+  };
   const liveDb = {
-    lookupTransactionNodes: (ids: string[]) => {
-      const out = new Map<string, TransactionNode>();
-      for (const id of ids) {
-        const n = (overrides.cachedNodes ?? []).find((c) => c.id === id);
-        if (n) out.set(id, n);
-      }
-      return out;
-    },
+    lookupTransactionNodes,
     lookupTransactionMeta: () => new Map(),
     getTransactions,
     indexTransactionMeta,
@@ -245,6 +261,26 @@ describe('splitTransaction parent resolution — live mode', () => {
         ], // sums to the stale 100
       })
     ).rejects.toThrow(/Parent=120/);
+  });
+
+  test('same-month future-dated parent resolves on the FIRST call (#513)', async () => {
+    const client = createMockGraphQLClient(SPLIT_RESPONSE);
+    const { liveDb, getTransactions } = stubLiveDb({
+      storeOnlyNodes: [node('parent-1', 120, '2025-10-30', 'Future Parent')],
+    });
+    const tools = new CopilotMoneyTools(makeDb(), client, liveDb);
+
+    const result = await tools.splitTransaction({
+      transaction_id: 'parent-1',
+      account_id: 'acct-P',
+      item_id: 'item-P',
+      splits: VALID_SPLITS,
+    });
+
+    expect(result.success).toBe(true);
+    expect(getTransactions).toHaveBeenCalledTimes(1);
+    const sent = (client._calls[0]!.variables as any).input;
+    expect(sent[0].name).toBe('Future Parent');
   });
 });
 

--- a/tests/unit/split-transaction-resolution.test.ts
+++ b/tests/unit/split-transaction-resolution.test.ts
@@ -74,11 +74,14 @@ function makeDb(transactions: unknown[] = []) {
  *  `liveRows` back the windowed getTransactions RETURN VALUE and — like the
  *  real ingestMonth — become visible via lookupTransactionNodes once the
  *  fetch has run; `storeOnlyNodes` simulate same-month future-dated rows the
- *  fetch stores but does not return (#513). */
+ *  fetch stores but does not return (#513); `evictedIds` are nodes present in
+ *  liveRows/storeOnlyNodes but excluded from the lookupTransactionNodes pool
+ *  (modeling LRU eviction mid-fetch). */
 function stubLiveDb(overrides: {
   cachedNodes?: TransactionNode[];
   liveRows?: TransactionNode[];
   storeOnlyNodes?: TransactionNode[];
+  evictedIds?: string[];
 }) {
   let fetched = false;
   const getTransactions = mock(() => {
@@ -99,7 +102,7 @@ function stubLiveDb(overrides: {
     const out = new Map<string, TransactionNode>();
     for (const id of ids) {
       const n = pool.find((c) => c.id === id);
-      if (n) out.set(id, n);
+      if (n && !(overrides.evictedIds ?? []).includes(id)) out.set(id, n);
     }
     return out;
   };
@@ -281,6 +284,27 @@ describe('splitTransaction parent resolution — live mode', () => {
     expect(getTransactions).toHaveBeenCalledTimes(1);
     const sent = (client._calls[0]!.variables as any).input;
     expect(sent[0].name).toBe('Future Parent');
+  });
+
+  test('parent evicted from the window cache mid-fetch still resolves via returned rows', async () => {
+    const client = createMockGraphQLClient(SPLIT_RESPONSE);
+    const { liveDb, getTransactions } = stubLiveDb({
+      liveRows: [node('parent-1', 120, '2025-10-05', 'Evicted Parent')],
+      evictedIds: ['parent-1'],
+    });
+    const tools = new CopilotMoneyTools(makeDb(), client, liveDb);
+
+    const result = await tools.splitTransaction({
+      transaction_id: 'parent-1',
+      account_id: 'acct-P',
+      item_id: 'item-P',
+      splits: VALID_SPLITS,
+    });
+
+    expect(result.success).toBe(true);
+    expect(getTransactions).toHaveBeenCalledTimes(1);
+    const sent = (client._calls[0]!.variables as any).input;
+    expect(sent[0].name).toBe('Evicted Parent');
   });
 });
 


### PR DESCRIPTION
## Problem

Both windowed write-resolvers (`resolveTransactionMeta`, `resolveParentSnapshot`) scanned the **date-filtered** rows returned by `liveDb.getTransactions({from, to})` after their fallback fetch — but the fetch feeds the meta index with the full **pre-trim** month and the window cache with everything inside the month boundary, future dates included. A same-month future-dated transaction (e.g. manually created) was excluded from the returned rows yet present in both stores: the first call threw the honest window error (with a misleading "if it is older, raise the window" hint for a *future* date) while an immediate retry succeeded via the warm stores.

## Fix

Consult the store the fetch just fed instead of scanning the filtered return value:

- `resolveTransactionMeta`: post-fetch, resolve remaining ids via `lookupTransactionMeta(missing)` (the empty-routing-id guard is enforced at the feed, so indexed entries are always valid).
- `resolveParentSnapshot`: post-fetch, `lookupTransactionNodes([id])` — **cache-first with a fallback to the in-hand rows**: unlike the append-only meta index, the window cache LRU-evicts per ingest, so a pathologically large resolve window could evict early months before the fetch returns; the rows fallback restores the eviction immunity the old scan had (final-review finding, regression-tested via an eviction-simulating stub knob).

First call and retry are now consistent by construction. Test stubs became stateful to mirror the real fetch-feeds-store behavior (existing assertions untouched); an integration test on the real `LiveCopilotDatabase` documents the store-vs-return asymmetry the fix relies on.

## External assumptions

None — same fetch, same ledgered surfaces; only the post-fetch lookup source changed.

## Bug fix?

Yes — Bug Response Ritual:
- **Root cause:** post-fetch resolution scanned the date-filtered return value instead of the stores the fetch feeds.
- **Bug class:** fetch-return vs fed-store asymmetry in windowed resolution.
- **Detector added:** first-call future-dated regression tests on both resolvers, an eviction-fallback regression test, and a store-vs-return integration test on the real LiveCopilotDatabase.
- **Siblings checked:** both members of the class fixed here. The live read tools' `singleTransactionLookup` also scans date-filtered rows but is NOT in the class: its range is caller-supplied and period parsing returns full calendar months, so same-month future dates survive its filter and "not found in your range" is honest. `refresh_cache` only invalidates. No other `getTransactions` consumers exist.
- **Ledger updated:** no change — no new external assumption.

## Testing

- `bun run check` green: 2227 tests, 0 fail; `sync-manifest` no-op.
- Live smoke (run, non-mutating): `[1] read 67 rows`; `[2] meta resolution match=true -> PASS`; `[3] snapshot resolution match=true -> PASS`.

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)