### PR TITLE
feat(reads): warn-and-skip shape validation for Transactions nodes; gate the ledger entry

### DIFF
--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -47,7 +47,12 @@ import { TRANSACTION_TYPES } from '../core/graphql/transactions.js';
 import { RECURRING_FREQUENCIES, RECURRING_STATE_VALUES } from '../core/graphql/recurrings.js';
 import { COLOR_NAMES } from '../core/graphql/colors.js';
 import { ALL_TIME_FRAMES } from '../core/graphql/queries/_shared.js';
-import { RESPONSE_SHAPE_RUNTIME_CHECK } from '../core/graphql/response-validation.js';
+import {
+  RESPONSE_SHAPE_RUNTIME_CHECK,
+  RUNTIME_CHECK_NAMES,
+} from '../core/graphql/response-validation.js';
+export { RUNTIME_CHECK_NAMES };
+import { TRANSACTIONS_READ_SHAPE_RUNTIME_CHECK } from '../core/graphql/read-validation.js';
 
 /** What kind of external surface the assumption is about. */
 export const SURFACE_KINDS = [
@@ -84,13 +89,16 @@ export type ConformanceOracle = `smoke:${string}` | `runtime:${string}`;
 
 /**
  * Registered always-on runtime checks that `runtime:<name>` oracles may
- * reference.
+ * reference. Defined in src/core/graphql/response-validation.ts and
+ * re-exported here for backward compatibility.
  * - `zod-warn` (B3, #437): every mutation response is validated warn-mode
- *   against a Zod schema mirroring the hand-written response interface
- *   (src/core/graphql/response-validation.ts); drift logs a structured
- *   warning and increments a per-surface counter, never failing the call.
+ *   against a Zod schema mirroring the hand-written response interface;
+ *   drift logs a structured warning and increments a per-surface counter.
+ * - `transactions-read-shape` (#512): per-node Zod validation for the
+ *   Transactions read query; invalid nodes are dropped, counted, and
+ *   surfaced via _dropped_invalid_rows.
  */
-export const RUNTIME_CHECK_NAMES: readonly string[] = [RESPONSE_SHAPE_RUNTIME_CHECK];
+// RUNTIME_CHECK_NAMES is imported from response-validation.ts and re-exported above.
 
 export interface LedgerEntry {
   /** External assumption surface (see naming convention above). Unique. */
@@ -256,7 +264,9 @@ function responseShape(name: string, overrides?: Partial<LedgerEntry>): LedgerEn
  * Query field, e.g. 'accounts'. The companion `queryResponseShape` entry
  * tracks the hand-written response interface separately (still unverified:
  * B3's warn-mode Zod validation (#437) covers MUTATION responses only, not
- * the read wrappers).
+ * the read wrappers — exception: Query.transactions:response is now
+ * runtime-gated via the transactions-read-shape check (#512); other read
+ * response shapes remain unverified).
  */
 function queryOperation(name: string): LedgerEntry {
   return {
@@ -538,7 +548,16 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   queryOperation('account'),
   queryResponseShape('account'),
   queryOperation('transactions'),
-  queryResponseShape('transactions'),
+  {
+    surface: 'Query.transactions:response',
+    kind: 'response-shape',
+    oracle: `runtime:${TRANSACTIONS_READ_SHAPE_RUNTIME_CHECK}`,
+    class: 'gated',
+    evidence:
+      'Per-node Zod validation at fetchTransactionsPage (warn-and-skip, #512): ' +
+      'invalid nodes are dropped from rows and all cache/index feeds, counted, and ' +
+      'surfaced via _dropped_invalid_rows + a deduped stderr warning.',
+  },
   queryOperation('categories'),
   queryResponseShape('categories'),
   queryOperation('tags'),

--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -51,8 +51,8 @@ import {
   RESPONSE_SHAPE_RUNTIME_CHECK,
   RUNTIME_CHECK_NAMES,
 } from '../core/graphql/response-validation.js';
-export { RUNTIME_CHECK_NAMES };
 import { TRANSACTIONS_READ_SHAPE_RUNTIME_CHECK } from '../core/graphql/read-validation.js';
+export { RUNTIME_CHECK_NAMES };
 
 /** What kind of external surface the assumption is about. */
 export const SURFACE_KINDS = [

--- a/src/core/graphql/queries/transactions.ts
+++ b/src/core/graphql/queries/transactions.ts
@@ -8,6 +8,7 @@
 
 import type { GraphQLClient } from '../client.js';
 import { TRANSACTIONS } from '../operations.generated.js';
+import { stripInvalidTransactionNodes, type InvalidNodeInfo } from '../read-validation.js';
 
 /**
  * TransactionType enum accepted by the read-side TransactionFilter.
@@ -228,12 +229,15 @@ export interface TransactionsResponse {
  */
 export async function fetchTransactionsPage(
   client: GraphQLClient,
-  args: FetchTransactionsArgs
+  args: FetchTransactionsArgs,
+  onInvalidNode?: (info: InvalidNodeInfo) => void
 ): Promise<TransactionsPage> {
   const data = await client.query<FetchTransactionsArgs, TransactionsResponse>(
     'Transactions',
     TRANSACTIONS,
     args
   );
-  return data.transactions;
+  // Warn-and-skip read-shape validation (#512): invalid nodes never reach
+  // rows, the window cache, or the meta index.
+  return stripInvalidTransactionNodes(data.transactions, onInvalidNode);
 }

--- a/src/core/graphql/queries/transactions.ts
+++ b/src/core/graphql/queries/transactions.ts
@@ -8,7 +8,11 @@
 
 import type { GraphQLClient } from '../client.js';
 import { TRANSACTIONS } from '../operations.generated.js';
-import { stripInvalidTransactionNodes, type InvalidNodeInfo } from '../read-validation.js';
+import {
+  stripInvalidTransactionNodes,
+  warnReadShapeDrift,
+  type InvalidNodeInfo,
+} from '../read-validation.js';
 
 /**
  * TransactionType enum accepted by the read-side TransactionFilter.
@@ -238,6 +242,10 @@ export async function fetchTransactionsPage(
     args
   );
   // Warn-and-skip read-shape validation (#512): invalid nodes never reach
-  // rows, the window cache, or the meta index.
-  return stripInvalidTransactionNodes(data.transactions, onInvalidNode);
+  // rows, the window cache, or the meta index. Default the callback so
+  // callback-less callers (smoke scripts, preflight) still surface drift.
+  return stripInvalidTransactionNodes(
+    data.transactions,
+    onInvalidNode ?? ((info) => warnReadShapeDrift('Transactions', info))
+  );
 }

--- a/src/core/graphql/read-validation.ts
+++ b/src/core/graphql/read-validation.ts
@@ -66,7 +66,8 @@ export function stripInvalidTransactionNodes(
     if (parsed.success) return true;
     const fields = [...new Set(parsed.error.issues.map((i) => String(i.path[0])))];
     const rawId = (edge.node as { id?: unknown })?.id;
-    const id = typeof rawId === 'string' && rawId.length > 0 && !fields.includes('id') ? rawId : null;
+    const id =
+      typeof rawId === 'string' && rawId.length > 0 && !fields.includes('id') ? rawId : null;
     onInvalidNode?.({ id, fields });
     return false;
   });

--- a/src/core/graphql/read-validation.ts
+++ b/src/core/graphql/read-validation.ts
@@ -1,0 +1,95 @@
+/**
+ * Read-shape validation (#512): warn-and-skip per-node validation for
+ * GraphQL READ responses. Mutations are covered by response-validation.ts;
+ * this module covers reads whose nodes feed write-critical state — today
+ * only the Transactions query, whose accountId/itemId flow into
+ * EditTransaction/CreateRecurring variables via the meta index (#508).
+ *
+ * Policy (design 2026-07-06): a malformed node must never brick reads or
+ * poison writes — it is dropped from the returned page (and therefore from
+ * the window cache and meta index, which are fed downstream of this strip),
+ * counted, and surfaced via _dropped_invalid_rows plus a deduped stderr
+ * warning. Strict only on write-critical fields; unknown extra fields and
+ * unrecognized enum values never fail a node.
+ */
+
+import { z } from 'zod';
+import type { TransactionsPage } from './queries/transactions.js';
+
+/** Registered in RUNTIME_CHECK_NAMES; the Query.transactions:response
+ *  ledger entry's oracle is `runtime:${this}`. */
+export const TRANSACTIONS_READ_SHAPE_RUNTIME_CHECK = 'transactions-read-shape' as const;
+
+export interface InvalidNodeInfo {
+  /** The node's id when itself readable, else null. */
+  id: string | null;
+  /** The strict fields that failed validation. */
+  fields: string[];
+}
+
+// Strict on write-critical fields; everything else typed-permissive per the
+// TransactionNode interface. looseObject(): unknown extra fields are fine.
+const transactionNodeSchema = z.looseObject({
+  id: z.string().min(1),
+  accountId: z.string().min(1),
+  itemId: z.string().min(1),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  amount: z.number().finite(),
+  name: z.string(),
+  categoryId: z.string().nullable(),
+  recurringId: z.string().nullable(),
+  parentId: z.string().nullable(),
+  isReviewed: z.boolean(),
+  isPending: z.boolean(),
+  type: z.string(),
+  userNotes: z.string().nullable(),
+  tipAmount: z.number().nullable(),
+  suggestedCategoryIds: z.array(z.string()),
+  isoCurrencyCode: z.string().nullable(),
+  createdAt: z.number(),
+  tags: z.array(z.looseObject({ id: z.string() })),
+  goal: z.unknown().nullable(),
+});
+
+/**
+ * Return the page with invalid nodes removed. Valid nodes are returned as
+ * the ORIGINAL objects (validation only — no transformation). Each removal
+ * invokes onInvalidNode with the node id (when readable) and the failed
+ * strict fields.
+ */
+export function stripInvalidTransactionNodes(
+  page: TransactionsPage,
+  onInvalidNode?: (info: InvalidNodeInfo) => void
+): TransactionsPage {
+  const edges = page.edges.filter((edge) => {
+    const parsed = transactionNodeSchema.safeParse(edge.node);
+    if (parsed.success) return true;
+    const fields = [...new Set(parsed.error.issues.map((i) => String(i.path[0])))];
+    const rawId = (edge.node as { id?: unknown })?.id;
+    const id = typeof rawId === 'string' && rawId.length > 0 && !fields.includes('id') ? rawId : null;
+    onInvalidNode?.({ id, fields });
+    return false;
+  });
+  if (edges.length === page.edges.length) return page;
+  return { edges, pageInfo: page.pageInfo };
+}
+
+// Dedupe stderr warnings per (op, failed-field set) so a drifted server
+// can't spam one line per row.
+const warned = new Set<string>();
+
+/** Test hook — dedupe state is module-level. */
+export function __resetReadShapeWarnDedupe(): void {
+  warned.clear();
+}
+
+export function warnReadShapeDrift(op: string, info: InvalidNodeInfo): void {
+  const key = `${op}:${[...info.fields].sort().join(',')}`;
+  if (warned.has(key)) return;
+  warned.add(key);
+  console.warn(
+    `[copilot-money-mcp] read-shape drift: ${op} node ${info.id ?? '<unreadable id>'} dropped ` +
+      `(invalid ${info.fields.join(', ')}) — see Query.transactions:response in the conformance ledger ` +
+      `(src/conformance/ledger.ts). Further identical drops this session are counted but not logged.`
+  );
+}

--- a/src/core/graphql/read-validation.ts
+++ b/src/core/graphql/read-validation.ts
@@ -64,7 +64,11 @@ export function stripInvalidTransactionNodes(
   const edges = page.edges.filter((edge) => {
     const parsed = transactionNodeSchema.safeParse(edge.node);
     if (parsed.success) return true;
-    const fields = [...new Set(parsed.error.issues.map((i) => String(i.path[0])))];
+    const fields = [
+      ...new Set(
+        parsed.error.issues.map((i) => (i.path[0] != null ? String(i.path[0]) : '<root>'))
+      ),
+    ];
     const rawId = (edge.node as { id?: unknown })?.id;
     const id =
       typeof rawId === 'string' && rawId.length > 0 && !fields.includes('id') ? rawId : null;

--- a/src/core/graphql/read-validation.ts
+++ b/src/core/graphql/read-validation.ts
@@ -27,8 +27,15 @@ export interface InvalidNodeInfo {
   fields: string[];
 }
 
-// Strict on write-critical fields; everything else typed-permissive per the
-// TransactionNode interface. looseObject(): unknown extra fields are fine.
+// Strict on write-critical fields (id/accountId/itemId/date/amount/name:
+// value constraints); everything else typed-permissive per the
+// TransactionNode interface. "Typed-permissive" means permissive on VALUE
+// (any string satisfies `type`, unknown extra fields pass), but PRESENCE of
+// every listed field is still required: the fragment selects them, and a
+// node missing a typed field would leak `undefined` into downstream
+// sorting/filters — a visible drop (counter + warning) is safer than
+// silent undefined propagation. looseObject(): unknown extra fields are
+// fine, never a failure.
 const transactionNodeSchema = z.looseObject({
   id: z.string().min(1),
   accountId: z.string().min(1),
@@ -47,8 +54,11 @@ const transactionNodeSchema = z.looseObject({
   suggestedCategoryIds: z.array(z.string()),
   isoCurrencyCode: z.string().nullable(),
   createdAt: z.number(),
+  // A tag missing `id` drops the whole node deliberately: tag ids from
+  // reads round-trip into update_transaction.tag_ids write params, so a
+  // malformed tag is write-relevant drift, not cosmetic.
   tags: z.array(z.looseObject({ id: z.string() })),
-  goal: z.unknown().nullable(),
+  goal: z.unknown(),
 });
 
 /**

--- a/src/core/graphql/response-validation.ts
+++ b/src/core/graphql/response-validation.ts
@@ -29,12 +29,18 @@
 
 import { z, type ZodType } from 'zod';
 import { TRANSACTION_TYPES } from './transactions.js';
+import { TRANSACTIONS_READ_SHAPE_RUNTIME_CHECK } from './read-validation.js';
 
 /**
  * Name of this runtime check as registered in the ledger's
  * RUNTIME_CHECK_NAMES. `runtime:zod-warn` oracles point here.
  */
 export const RESPONSE_SHAPE_RUNTIME_CHECK = 'zod-warn' as const;
+
+export const RUNTIME_CHECK_NAMES: readonly string[] = [
+  RESPONSE_SHAPE_RUNTIME_CHECK,
+  TRANSACTIONS_READ_SHAPE_RUNTIME_CHECK,
+];
 
 // ---------------------------------------------------------------------------
 // Schemas — mirror the response interfaces in the per-domain modules.

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -29,6 +29,7 @@ import {
   type TransactionNode,
   type TransactionSortInput,
 } from './graphql/queries/transactions.js';
+import { warnReadShapeDrift } from './graphql/read-validation.js';
 import { getMonthRange, monthsCovered } from '../utils/date.js';
 import { pLimit } from '../utils/concurrency.js';
 import { InFlightRegistry, SnapshotCache, TransactionWindowCache } from './cache/index.js';
@@ -99,6 +100,13 @@ export class LiveCopilotDatabase {
    * bytes/entry; a full history is a few MB).
    */
   private readonly txnMetaIndex = new Map<string, { accountId: string; itemId: string }>();
+
+  /** Session-total Transactions nodes dropped by read-shape validation (#512). */
+  private droppedInvalidRows = 0;
+
+  getDroppedInvalidRows(): number {
+    return this.droppedInvalidRows;
+  }
 
   constructor(
     private readonly graphql: GraphQLClient,
@@ -187,17 +195,31 @@ export class LiveCopilotDatabase {
     month: string,
     sort: TransactionSortInput[],
     pageSize: number
-  ): Promise<{ rows: TransactionNode[]; fetched_at: number; pages: number }> {
+  ): Promise<{
+    rows: TransactionNode[];
+    fetched_at: number;
+    pages: number;
+    droppedInvalid: number;
+  }> {
     const year = Number(month.slice(0, 4));
     const m = Number(month.slice(5, 7));
     const [monthStart, monthEnd] = getMonthRange(year, m);
     const filter = buildTransactionFilter({ startDate: monthStart, endDate: monthEnd });
     const fetched_at = Date.now();
     let pages = 0;
+    let droppedInvalid = 0;
     const rawRows = await paginateTransactions(
       async (after) => {
         pages += 1;
-        return fetchTransactionsPage(this.graphql, { first: pageSize, after, filter, sort });
+        return fetchTransactionsPage(
+          this.graphql,
+          { first: pageSize, after, filter, sort },
+          (info) => {
+            droppedInvalid += 1;
+            this.droppedInvalidRows += 1;
+            warnReadShapeDrift('Transactions', info);
+          }
+        );
       },
       { startDate: monthStart }
     );
@@ -217,7 +239,7 @@ export class LiveCopilotDatabase {
     // get double-counted on subsequent full-range queries.
     const rows = rawRows.filter((r) => r.date >= monthStart && r.date <= monthEnd);
     this.transactionsWindowCache.ingestMonth(month, rows, fetched_at);
-    return { rows, fetched_at, pages };
+    return { rows, fetched_at, pages, droppedInvalid };
   }
 
   logReadCall(log: {
@@ -231,6 +253,7 @@ export class LiveCopilotDatabase {
     month?: string;
     from_to_months?: number;
     fetched_months?: number;
+    dropped_invalid_rows?: number;
   }): void {
     if (!this.verbose) return;
     const parts = [
@@ -245,6 +268,9 @@ export class LiveCopilotDatabase {
       log.from_to_months !== undefined ? `from_to_months=${log.from_to_months}` : null,
       log.fetched_months !== undefined ? `fetched_months=${log.fetched_months}` : null,
       log.staleness_ms !== undefined ? `staleness_ms=${log.staleness_ms ?? 'null'}` : null,
+      log.dropped_invalid_rows !== undefined
+        ? `dropped_invalid_rows=${log.dropped_invalid_rows}`
+        : null,
     ].filter(Boolean);
     console.error(parts.join(' '));
   }
@@ -270,6 +296,7 @@ export class LiveCopilotDatabase {
     oldest_fetched_at: number;
     newest_fetched_at: number;
     hit: boolean;
+    dropped_invalid_rows: number;
   }> {
     if (!range.from || !range.to) {
       throw new Error(
@@ -302,7 +329,12 @@ export class LiveCopilotDatabase {
     );
 
     const failures: Array<{ month: string; reason: unknown }> = [];
-    const successes: Array<{ month: string; rows: TransactionNode[]; fetched_at: number }> = [];
+    const successes: Array<{
+      month: string;
+      rows: TransactionNode[];
+      fetched_at: number;
+      droppedInvalid: number;
+    }> = [];
     for (let i = 0; i < settled.length; i += 1) {
       const s = settled[i]!;
       if (s.status === 'fulfilled') {
@@ -316,6 +348,11 @@ export class LiveCopilotDatabase {
         .map((f) => `${f.month}: ${(f.reason as Error)?.message ?? String(f.reason)}`)
         .join('; ');
       throw new Error(`Failed to fetch months: ${summary}`);
+    }
+
+    let totalDropped = 0;
+    for (const s of successes) {
+      totalDropped += s.droppedInvalid;
     }
 
     const freshRows = successes.flatMap((s) => s.rows);
@@ -348,9 +385,16 @@ export class LiveCopilotDatabase {
       cache_hit: hit,
       from_to_months: allMonths.length,
       fetched_months: toFetch.length,
+      dropped_invalid_rows: totalDropped,
     });
 
-    return { rows: merged, oldest_fetched_at: oldest, newest_fetched_at: newest, hit };
+    return {
+      rows: merged,
+      oldest_fetched_at: oldest,
+      newest_fetched_at: newest,
+      hit,
+      dropped_invalid_rows: totalDropped,
+    };
   }
 
   // ── Phase 2: cache accessors ──────────────────────────────────────────────

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -296,6 +296,10 @@ export class LiveCopilotDatabase {
     oldest_fetched_at: number;
     newest_fetched_at: number;
     hit: boolean;
+    /** Invalid nodes dropped by read-shape validation during THIS call's
+     *  fetches. Under in-flight coalescing, concurrent callers sharing a
+     *  month fetch may each report that month's drops; the session total
+     *  (getDroppedInvalidRows) counts each drop exactly once. */
     dropped_invalid_rows: number;
   }> {
     if (!range.from || !range.to) {
@@ -385,7 +389,7 @@ export class LiveCopilotDatabase {
       cache_hit: hit,
       from_to_months: allMonths.length,
       fetched_months: toFetch.length,
-      dropped_invalid_rows: totalDropped,
+      ...(totalDropped > 0 ? { dropped_invalid_rows: totalDropped } : {}),
     });
 
     return {

--- a/src/tools/live/transactions.ts
+++ b/src/tools/live/transactions.ts
@@ -91,6 +91,7 @@ export interface GetTransactionsLiveResult extends PageResult {
   _cache_oldest_fetched_at: string;
   _cache_newest_fetched_at: string;
   _cache_hit: boolean;
+  _dropped_invalid_rows?: number;
 }
 
 const UNSUPPORTED_KEYS = ['city', 'lat', 'lon', 'radius_km', 'region', 'country'] as const;
@@ -132,6 +133,7 @@ export class LiveTransactionsTools {
       oldest_fetched_at,
       newest_fetched_at,
       hit,
+      dropped_invalid_rows,
     } = await this.live.getTransactions({ from: start_date, to: end_date });
 
     const filtered = await this.postFilter(nodes, opts);
@@ -141,6 +143,7 @@ export class LiveTransactionsTools {
       _cache_oldest_fetched_at: new Date(oldest_fetched_at).toISOString(),
       _cache_newest_fetched_at: new Date(newest_fetched_at).toISOString(),
       _cache_hit: hit,
+      ...(dropped_invalid_rows > 0 ? { _dropped_invalid_rows: dropped_invalid_rows } : {}),
     };
   }
 
@@ -160,6 +163,7 @@ export class LiveTransactionsTools {
       oldest_fetched_at,
       newest_fetched_at,
       hit,
+      dropped_invalid_rows,
     } = await this.live.getTransactions({ from: start_date, to: end_date });
     const fetchedAtIso = new Date(oldest_fetched_at).toISOString();
     const newestIso = new Date(newest_fetched_at).toISOString();
@@ -179,6 +183,7 @@ export class LiveTransactionsTools {
         _cache_oldest_fetched_at: fetchedAtIso,
         _cache_newest_fetched_at: newestIso,
         _cache_hit: hit,
+        ...(dropped_invalid_rows > 0 ? { _dropped_invalid_rows: dropped_invalid_rows } : {}),
       };
     }
     const enriched = await this.enrich([match]);
@@ -191,6 +196,7 @@ export class LiveTransactionsTools {
       _cache_oldest_fetched_at: fetchedAtIso,
       _cache_newest_fetched_at: newestIso,
       _cache_hit: hit,
+      ...(dropped_invalid_rows > 0 ? { _dropped_invalid_rows: dropped_invalid_rows } : {}),
     };
   }
 

--- a/tests/core/graphql/read-validation.test.ts
+++ b/tests/core/graphql/read-validation.test.ts
@@ -10,10 +10,12 @@ import {
   warnReadShapeDrift,
   __resetReadShapeWarnDedupe,
 } from '../../../src/core/graphql/read-validation.js';
-import type {
-  TransactionsPage,
-  TransactionNode,
+import {
+  fetchTransactionsPage,
+  type TransactionsPage,
+  type TransactionNode,
 } from '../../../src/core/graphql/queries/transactions.js';
+import type { GraphQLClient } from '../../../src/core/graphql/client.js';
 
 function goodNode(id: string, extra?: Record<string, unknown>): TransactionNode {
   return {
@@ -105,6 +107,32 @@ describe('warnReadShapeDrift dedupe', () => {
       expect(first).toContain('Transactions');
       expect(first).toContain('accountId');
       expect(first).toContain('Query.transactions:response');
+    } finally {
+      console.warn = orig;
+    }
+  });
+});
+
+describe('fetchTransactionsPage default callback', () => {
+  test('fetchTransactionsPage without a callback still warns on drops (#512 default)', async () => {
+    const spy = mock();
+    const orig = console.warn;
+    console.warn = spy as unknown as typeof console.warn;
+    try {
+      __resetReadShapeWarnDedupe();
+      const bad = goodNode('bad-default', { accountId: '' });
+      const client = {
+        query: mock(() => Promise.resolve({ transactions: page([bad]) })),
+        mutate: mock(),
+      } as unknown as GraphQLClient;
+      const result = await fetchTransactionsPage(client, {
+        first: 25,
+        after: null,
+        filter: null,
+        sort: [],
+      });
+      expect(result.edges).toHaveLength(0);
+      expect(spy).toHaveBeenCalledTimes(1);
     } finally {
       console.warn = orig;
     }

--- a/tests/core/graphql/read-validation.test.ts
+++ b/tests/core/graphql/read-validation.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Read-shape validation for Transactions pages (#512, warn-and-skip).
+ * Invalid nodes are stripped at the page boundary; valid nodes pass through
+ * unchanged; warnings dedupe per (op, failed-field set).
+ */
+
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
+import {
+  stripInvalidTransactionNodes,
+  warnReadShapeDrift,
+  __resetReadShapeWarnDedupe,
+} from '../../../src/core/graphql/read-validation.js';
+import type {
+  TransactionsPage,
+  TransactionNode,
+} from '../../../src/core/graphql/queries/transactions.js';
+
+function goodNode(id: string, extra?: Record<string, unknown>): TransactionNode {
+  return {
+    id,
+    accountId: 'acct-1',
+    itemId: 'item-1',
+    categoryId: 'c1',
+    recurringId: null,
+    parentId: null,
+    isReviewed: false,
+    isPending: false,
+    amount: 10,
+    date: '2025-01-15',
+    name: `tx-${id}`,
+    type: 'REGULAR',
+    userNotes: null,
+    tipAmount: null,
+    suggestedCategoryIds: [],
+    isoCurrencyCode: null,
+    createdAt: 1,
+    tags: [],
+    goal: null,
+    ...(extra ?? {}),
+  } as TransactionNode;
+}
+
+function page(nodes: TransactionNode[]): TransactionsPage {
+  return {
+    edges: nodes.map((n) => ({ cursor: `c-${n.id}`, node: n })),
+    pageInfo: { endCursor: null, hasNextPage: false },
+  };
+}
+
+beforeEach(() => __resetReadShapeWarnDedupe());
+
+describe('stripInvalidTransactionNodes', () => {
+  test('clean page passes through with identical nodes and pageInfo', () => {
+    const n1 = goodNode('t1');
+    const input = page([n1, goodNode('t2')]);
+    const drops: unknown[] = [];
+    const out = stripInvalidTransactionNodes(input, (i) => drops.push(i));
+    expect(out.edges).toHaveLength(2);
+    expect(out.edges[0]!.node).toBe(n1); // original object, untransformed
+    expect(out.pageInfo).toEqual(input.pageInfo);
+    expect(drops).toHaveLength(0);
+  });
+
+  test.each([
+    ['empty accountId', { accountId: '' }, 'accountId'],
+    ['missing itemId', { itemId: undefined as unknown as string }, 'itemId'],
+    ['malformed date', { date: '2025-1-5' }, 'date'],
+    ['non-finite amount', { amount: Number.NaN }, 'amount'],
+    ['non-string name', { name: 42 as unknown as string }, 'name'],
+  ])('drops node with %s and reports the field', (_label, patch, field) => {
+    const bad = goodNode('bad', patch);
+    const drops: Array<{ id: string | null; fields: string[] }> = [];
+    const out = stripInvalidTransactionNodes(page([goodNode('ok'), bad]), (i) => drops.push(i));
+    expect(out.edges.map((e) => e.node.id)).toEqual(['ok']);
+    expect(drops).toHaveLength(1);
+    expect(drops[0]!.id).toBe('bad');
+    expect(drops[0]!.fields).toContain(field);
+  });
+
+  test('unknown extra fields never fail a node; new type enum values pass', () => {
+    const weird = goodNode('t3', { some_future_field: { nested: true }, type: 'FUTURE_TYPE' });
+    const out = stripInvalidTransactionNodes(page([weird]));
+    expect(out.edges).toHaveLength(1);
+  });
+
+  test('node with unreadable id reports id: null', () => {
+    const bad = goodNode('x', { id: '' });
+    const drops: Array<{ id: string | null }> = [];
+    stripInvalidTransactionNodes(page([bad]), (i) => drops.push(i));
+    expect(drops[0]!.id).toBe(null);
+  });
+});
+
+describe('warnReadShapeDrift dedupe', () => {
+  test('identical (op, field-set) warns once; different set warns again', () => {
+    const spy = mock();
+    const orig = console.warn;
+    console.warn = spy as unknown as typeof console.warn;
+    try {
+      warnReadShapeDrift('Transactions', { id: 'a', fields: ['accountId'] });
+      warnReadShapeDrift('Transactions', { id: 'b', fields: ['accountId'] });
+      warnReadShapeDrift('Transactions', { id: 'c', fields: ['date'] });
+      expect(spy).toHaveBeenCalledTimes(2);
+      const first = String(spy.mock.calls[0]![0]);
+      expect(first).toContain('Transactions');
+      expect(first).toContain('accountId');
+      expect(first).toContain('Query.transactions:response');
+    } finally {
+      console.warn = orig;
+    }
+  });
+});

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -1029,20 +1029,26 @@ describe('transaction meta index', () => {
   });
 
   test('rows with empty routing ids are not indexed (drift guard)', async () => {
-    const bad = { ...metaNode('meta-bad', '2025-01-16', '', 'item-X') };
-    const good = metaNode('meta-good', '2025-01-17', 'acct-C', 'item-C');
-    const page = metaPage([good, bad as ReturnType<typeof metaNode>]);
-    const client = {
-      mutate: mock(),
-      query: mock(() => Promise.resolve({ transactions: page })),
-    } as unknown as GraphQLClient;
-    const live = new LiveCopilotDatabase(client, {} as CopilotDatabase);
+    const origWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const bad = { ...metaNode('meta-bad', '2025-01-16', '', 'item-X') };
+      const good = metaNode('meta-good', '2025-01-17', 'acct-C', 'item-C');
+      const page = metaPage([good, bad as ReturnType<typeof metaNode>]);
+      const client = {
+        mutate: mock(),
+        query: mock(() => Promise.resolve({ transactions: page })),
+      } as unknown as GraphQLClient;
+      const live = new LiveCopilotDatabase(client, {} as CopilotDatabase);
 
-    await live.getTransactions({ from: '2025-01-01', to: '2025-01-31' });
+      await live.getTransactions({ from: '2025-01-01', to: '2025-01-31' });
 
-    const found = live.lookupTransactionMeta(['meta-good', 'meta-bad']);
-    expect(found.has('meta-good')).toBe(true);
-    expect(found.has('meta-bad')).toBe(false);
+      const found = live.lookupTransactionMeta(['meta-good', 'meta-bad']);
+      expect(found.has('meta-good')).toBe(true);
+      expect(found.has('meta-bad')).toBe(false);
+    } finally {
+      console.warn = origWarn;
+    }
   });
 
   test('lookupTransactionNodes returns full cached rows by id', async () => {

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -1075,6 +1075,36 @@ describe('transaction meta index', () => {
     expect(live.lookupTransactionNodes(['anything']).size).toBe(0);
   });
 
+  test('invalid nodes are dropped from rows AND feeds, counted, surfaced (#512)', async () => {
+    const badNode = { ...metaNode('bad-1', '2025-01-16', '', 'item-X') }; // empty accountId
+    const page = metaPage([metaNode('ok-1', '2025-01-15', 'acct-A', 'item-A'), badNode]);
+    const client = {
+      mutate: mock(),
+      query: mock(() => Promise.resolve({ transactions: page })),
+    } as unknown as GraphQLClient;
+    const live = new LiveCopilotDatabase(client, {} as CopilotDatabase);
+
+    const result = await live.getTransactions({ from: '2025-01-01', to: '2025-01-31' });
+
+    expect(result.rows.map((r) => r.id)).toEqual(['ok-1']);
+    expect(result.dropped_invalid_rows).toBe(1);
+    expect(live.lookupTransactionMeta(['bad-1']).size).toBe(0);
+    expect(live.lookupTransactionNodes(['bad-1']).size).toBe(0);
+    expect(live.getDroppedInvalidRows()).toBe(1);
+  });
+
+  test('clean fetch reports zero drops (#512)', async () => {
+    const page = metaPage([metaNode('ok-2', '2025-02-15', 'acct-A', 'item-A')]);
+    const client = {
+      mutate: mock(),
+      query: mock(() => Promise.resolve({ transactions: page })),
+    } as unknown as GraphQLClient;
+    const live = new LiveCopilotDatabase(client, {} as CopilotDatabase);
+
+    const result = await live.getTransactions({ from: '2025-02-01', to: '2025-02-28' });
+    expect(result.dropped_invalid_rows).toBe(0);
+  });
+
   test('rows dated after the requested range still land in the index and window cache (#513)', async () => {
     // Range ends Jan 20 but the page contains a Jan 25 row: it is excluded
     // from the RETURNED rows (date filter) yet fed to the meta index

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -1099,6 +1099,30 @@ describe('transaction meta index', () => {
     expect(live.getDroppedInvalidRows()).toBe(1);
   });
 
+  test('session drop counter accumulates across separate fetches (#512)', async () => {
+    const badA = { ...metaNode('bad-a', '2025-01-16', '', 'item-X') };
+    const badB = { ...metaNode('bad-b', '2025-02-16', '', 'item-X') };
+    const pages = [metaPage([badA]), metaPage([badB])];
+    let i = 0;
+    const client = {
+      mutate: mock(),
+      query: mock(() => Promise.resolve({ transactions: pages[i++] })),
+    } as unknown as GraphQLClient;
+    const live = new LiveCopilotDatabase(client, {} as CopilotDatabase);
+
+    const origWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const r1 = await live.getTransactions({ from: '2025-01-01', to: '2025-01-31' });
+      const r2 = await live.getTransactions({ from: '2025-02-01', to: '2025-02-28' });
+      expect(r1.dropped_invalid_rows).toBe(1);
+      expect(r2.dropped_invalid_rows).toBe(1);
+      expect(live.getDroppedInvalidRows()).toBe(2);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
   test('clean fetch reports zero drops (#512)', async () => {
     const page = metaPage([metaNode('ok-2', '2025-02-15', 'acct-A', 'item-A')]);
     const client = {

--- a/tests/scripts/read-checks.test.ts
+++ b/tests/scripts/read-checks.test.ts
@@ -62,7 +62,32 @@ function validResponses(): Record<string, unknown> {
     Account: { account: { id: 'acc-1' } },
     Transactions: {
       transactions: {
-        edges: [{ cursor: 'c1', node: { id: 'txn-1', amount: 5, date: '2026-06-01' } }],
+        edges: [
+          {
+            cursor: 'c1',
+            node: {
+              id: 'txn-1',
+              accountId: 'acc-1',
+              itemId: 'item-1',
+              amount: 5,
+              date: '2026-06-01',
+              name: 'Test',
+              categoryId: null,
+              recurringId: null,
+              parentId: null,
+              isReviewed: false,
+              isPending: false,
+              type: 'REGULAR',
+              userNotes: null,
+              tipAmount: null,
+              suggestedCategoryIds: [],
+              isoCurrencyCode: null,
+              createdAt: 0,
+              tags: [],
+              goal: null,
+            },
+          },
+        ],
         pageInfo: {
           endCursor: 'c1',
           hasNextPage: false,

--- a/tests/scripts/roundtrip-checks.test.ts
+++ b/tests/scripts/roundtrip-checks.test.ts
@@ -486,11 +486,28 @@ describe('delete_transaction check (stubbed client)', () => {
   });
 
   test('FAILS when the delete is echoed true but the transaction is still readable', async () => {
+    // Node must pass stripInvalidTransactionNodes (Task 1, #512) so it survives
+    // the re-read and triggers the "still present" detection.
     const node = {
       id: 'txn-1',
+      accountId: 'acct-1',
+      itemId: 'item-1',
+      date: '2023-11-14',
       name: '__smoke__1700000000000-txn-a',
       parentId: null,
       amount: 100,
+      categoryId: null,
+      recurringId: null,
+      isReviewed: false,
+      isPending: false,
+      type: 'REGULAR',
+      userNotes: null,
+      tipAmount: null,
+      suggestedCategoryIds: [],
+      isoCurrencyCode: null,
+      createdAt: 1700000000000,
+      tags: [],
+      goal: null,
     };
     const { client } = stubClient({
       DeleteTransaction: () => ({ deleteTransaction: true }),

--- a/tests/tools/live/transactions.test.ts
+++ b/tests/tools/live/transactions.test.ts
@@ -784,6 +784,72 @@ describe('LiveTransactionsTools — hsa_eligible filter', () => {
   });
 });
 
+describe('LiveTransactionsTools — _dropped_invalid_rows field', () => {
+  test('get_transactions_live surfaces _dropped_invalid_rows only when > 0 (#512)', async () => {
+    const { LiveCopilotDatabase: LiveDB } = await import('../../../src/core/live-database.js');
+    type GQLClient = import('../../../src/core/graphql/client.js').GraphQLClient;
+    type CopilotDB = import('../../../src/core/database.js').CopilotDatabase;
+
+    // ── Dirty page: one valid node + one node with empty accountId ──────────
+    const dirtyPage = {
+      edges: [
+        {
+          cursor: 'c1',
+          node: mkNode({ id: 'valid-1', date: '2025-01-15', accountId: 'a1', itemId: 'i1' }),
+        },
+        {
+          cursor: 'c2',
+          node: mkNode({ id: 'bad-1', date: '2025-01-16', accountId: '', itemId: 'i1' }),
+        },
+      ],
+      pageInfo: { endCursor: null, hasNextPage: false },
+    };
+    const dirtyClient = {
+      mutate: mock(),
+      query: mock(() => Promise.resolve({ transactions: dirtyPage })),
+    } as unknown as GQLClient;
+    const sharedCache = {
+      getAccounts: mock(() => Promise.resolve([])),
+      getTags: mock(() => Promise.resolve([])),
+    } as unknown as CopilotDB;
+    const dirtyLive = new LiveDB(dirtyClient, sharedCache);
+    await dirtyLive.getCategoriesCache().read(() => Promise.resolve([]));
+    await dirtyLive.getTagsCache().read(() => Promise.resolve([]));
+    const dirtyTools = new LiveTransactionsTools(dirtyLive);
+
+    const result = await dirtyTools.getTransactions({
+      start_date: '2025-01-01',
+      end_date: '2025-01-31',
+    });
+    expect(result._dropped_invalid_rows).toBe(1);
+
+    // ── Clean page: only valid nodes ────────────────────────────────────────
+    const cleanPage = {
+      edges: [
+        {
+          cursor: 'c1',
+          node: mkNode({ id: 'ok-1', date: '2025-02-15', accountId: 'a1', itemId: 'i1' }),
+        },
+      ],
+      pageInfo: { endCursor: null, hasNextPage: false },
+    };
+    const cleanClient = {
+      mutate: mock(),
+      query: mock(() => Promise.resolve({ transactions: cleanPage })),
+    } as unknown as GQLClient;
+    const cleanLive = new LiveDB(cleanClient, sharedCache);
+    await cleanLive.getCategoriesCache().read(() => Promise.resolve([]));
+    await cleanLive.getTagsCache().read(() => Promise.resolve([]));
+    const cleanTools = new LiveTransactionsTools(cleanLive);
+
+    const cleanResult = await cleanTools.getTransactions({
+      start_date: '2025-02-01',
+      end_date: '2025-02-28',
+    });
+    expect('_dropped_invalid_rows' in cleanResult).toBe(false);
+  });
+});
+
 describe('LiveTransactionsTools — date-less query rejection', () => {
   test('throws when query is set without dates or period', async () => {
     const tools = new LiveTransactionsTools(mkLive());


### PR DESCRIPTION
## Problem

GraphQL READ responses were not runtime-validated (`response-validation.ts` covers mutations only). Since #508, `TransactionNode.accountId`/`itemId` flow from reads into EditTransaction/CreateRecurring mutation variables via the meta index — making the Transactions query the highest-value read surface to validate. A drifted response (null routing id, malformed date) previously flowed silently into rows, the window cache, and the index, guarded only by ad-hoc point checks.

## Fix (warn-and-skip policy)

- **`src/core/graphql/read-validation.ts`**: per-node Zod schema — strict ONLY on write-critical fields (`id`/`accountId`/`itemId` non-empty, `date` `YYYY-MM-DD`, `amount` finite, `name` string); typed-permissive elsewhere. Unknown extra fields and unrecognized `type` enum values NEVER drop a row (enum drift is a separately-ledgered concern). Valid nodes pass through as the original objects.
- **Strip at the single entry point**: `fetchTransactionsPage` is the only place the Transactions operation executes (grep-verified), so rows, window cache, and meta index are protected by construction. Callback-less callers (smoke scripts, preflight) get a DEFAULT deduped warning — drift stays visible on every path.
- **Visibility**: per-call `dropped_invalid_rows` on `getTransactions` (coalesced-fetch attribution documented), session total via `getDroppedInvalidRows()`, verbose-log field gated to >0, and `_dropped_invalid_rows` on `get_transactions_live` responses only when >0 (all three return sites).
- **Ledger**: `Query.transactions:response` upgrades from `unverified` to **`gated`** with oracle `runtime:transactions-read-shape` (registered in `RUNTIME_CHECK_NAMES`, now colocated with the schemas in response-validation.ts, re-exported for compatibility).

Two smoke-script test fixtures needed completing (minimal nodes now fail validation) — fixture-only changes, zero assertion changes (gate-verified).

## External assumptions

No new assumption — this converts the existing `Query.transactions:response` assumption from unverified to **gated** (always-on runtime oracle). Strengthening, not adding.

## Testing

- `bun run check` green: 2225 pass / 20 skip / 0 fail; `sync-manifest` no-op.
- Unit: clean-page identity passthrough; drop-per-strict-field; permissive unknown-fields/new-enum-values; unreadable-id reporting; warning dedupe; default-callback warning; feed protection via real `LiveCopilotDatabase`; tool-surface field presence/absence; ledger hygiene suite.
- **Live smoke ×2 (run, non-mutating):** `2025-10` window — 187 rows, 0 drops; **current month (2026-07-01..2026-07-06) — 32 rows including 16 PENDING, 0 drops** (pending rows were the false-drop risk; the schema is calibrated to production reality).

## Follow-up

Filed: the mutation-side sibling — `create_transaction`'s meta-index feed lacks the empty-routing-id guard the read side now enforces by construction.

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)