### PR TITLE
feat(live): persistent per-uid routing-id index for cross-session write resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,9 @@ COPILOT_CACHE_TTL_MINUTES=0 copilot-money-mcp
 COPILOT_WRITE_RESOLVE_WINDOW_MONTHS=30 copilot-money-mcp --write
 
 # Write-resolution routing ids (opaque transaction/account/item ids only —
-# never amounts or names) persist to ~/.claude/copilot-money/ keyed by the
-# logged-in account, so cross-session writes skip the live window fetch.
+# never amounts or names) persist whenever live reads are enabled (including
+# --write mode), keyed by the logged-in account, so cross-session writes
+# skip the live window fetch.
 # Disable entirely:
 COPILOT_DISABLE_PERSISTENT_INDEX=1 copilot-money-mcp --write
 ```

--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ COPILOT_CACHE_TTL_MINUTES=0 copilot-money-mcp
 # window fetch when the in-memory index (fed by live reads) misses.
 # Default window: 13 months. Raise it to edit older transactions:
 COPILOT_WRITE_RESOLVE_WINDOW_MONTHS=30 copilot-money-mcp --write
+
+# Write-resolution routing ids (opaque transaction/account/item ids only —
+# never amounts or names) persist to ~/.claude/copilot-money/ keyed by the
+# logged-in account, so cross-session writes skip the live window fetch.
+# Disable entirely:
+COPILOT_DISABLE_PERSISTENT_INDEX=1 copilot-money-mcp --write
 ```
 
 You can also refresh manually using the `refresh_database` tool.

--- a/src/core/graphql/client.ts
+++ b/src/core/graphql/client.ts
@@ -261,6 +261,12 @@ export class GraphQLClient {
     this.jitterMs = opts.jitterMs ?? DEFAULT_JITTER_MS;
   }
 
+  /** Firebase uid of the authenticated session, or null before the first
+   *  token exchange. Used to identity-scope local persistence (#511). */
+  getUserId(): string | null {
+    return this.auth.getUserId();
+  }
+
   async mutate<TVariables, TResponse>(
     operationName: string,
     query: string,

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -540,6 +540,12 @@ export class LiveCopilotDatabase {
     const curUid = this.metaStore.currentUid();
     if (prevUid !== null && curUid !== null && prevUid !== curUid) {
       this.txnMetaIndex.clear();
+      // Replay entries buffered under the NEW uid (fed after the switch but
+      // not yet — or not successfully — flushed) so the clear can't drop
+      // fresh data the disk doesn't hold.
+      for (const [id, m] of this.metaStore.pendingFor(curUid)) {
+        this.txnMetaIndex.set(id, m);
+      }
     }
     // Opportunistic hydration from disk (#511): in-memory entries win (they
     // are newest); loadOnce is idempotent/cheap after the first real load.

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -19,8 +19,11 @@
  * See docs/superpowers/plans/2026-04-25-graphql-live-tiered-cache.md.
  */
 
+import { homedir } from 'os';
+import { join } from 'path';
 import type { GraphQLClient } from './graphql/client.js';
 import type { CopilotDatabase } from './database.js';
+import { TransactionMetaStore } from './persistence/transaction-meta-store.js';
 import {
   buildTransactionFilter,
   buildTransactionSort,
@@ -47,6 +50,10 @@ import { ONE_HOUR_MS, SIX_HOURS_MS, ONE_DAY_MS, ONE_WEEK_MS } from '../utils/dur
 
 export interface LiveDatabaseOptions {
   verbose?: boolean;
+  /** Injectable persistence store for the routing-id index (#511). Defaults
+   *  to a uid-scoped JSONL store in ~/.claude/copilot-money/. Pass an
+   *  explicit instance in tests to avoid touching the real home directory. */
+  metaStore?: TransactionMetaStore;
 }
 
 const DEFAULT_MAX_TX_ROWS = 20_000;
@@ -100,6 +107,10 @@ export class LiveCopilotDatabase {
    * bytes/entry; a full history is a few MB).
    */
   private readonly txnMetaIndex = new Map<string, { accountId: string; itemId: string }>();
+  /** Persistent backing store for txnMetaIndex (#511). Defaults to a
+   *  uid-scoped JSONL file under ~/.claude/copilot-money/. Inert when
+   *  COPILOT_DISABLE_PERSISTENT_INDEX=1 or uid is unavailable. */
+  private readonly metaStore: TransactionMetaStore;
 
   /** Session-total Transactions nodes dropped by read-shape validation (#512). */
   private droppedInvalidRows = 0;
@@ -114,6 +125,18 @@ export class LiveCopilotDatabase {
     opts: LiveDatabaseOptions = {}
   ) {
     this.verbose = opts.verbose ?? false;
+    this.metaStore =
+      opts.metaStore ??
+      new TransactionMetaStore({
+        baseDir: join(homedir(), '.claude', 'copilot-money'),
+        uidProvider: () => {
+          try {
+            return this.graphql.getUserId();
+          } catch {
+            return null;
+          }
+        },
+      });
 
     this.inflight = new InFlightRegistry();
     this.fetchLimit = pLimit(4);
@@ -229,9 +252,10 @@ export class LiveCopilotDatabase {
     // responses with null/empty routing ids (see review finding).
     for (const r of rawRows) {
       if (r.accountId && r.itemId) {
-        this.txnMetaIndex.set(r.id, { accountId: r.accountId, itemId: r.itemId });
+        this.feedMeta(r.id, { accountId: r.accountId, itemId: r.itemId });
       }
     }
+    this.metaStore.flush();
     // Trim leaked tail-page rows that fall outside this month's window.
     // `paginateTransactions` early-exits AFTER appending a page, so the
     // trailing edge of the last page can dip into the previous month.
@@ -488,16 +512,31 @@ export class LiveCopilotDatabase {
     return this.transactionsWindowCache;
   }
 
+  /** Single funnel for meta-index writes: in-memory map + persistence
+   *  buffer (#511). Entries here already passed #512 validation (all feeds
+   *  are downstream of the fetch strip) or came from mutation responses
+   *  guarded at their call sites. */
+  private feedMeta(id: string, meta: { accountId: string; itemId: string }): void {
+    this.txnMetaIndex.set(id, meta);
+    this.metaStore.buffer(id, meta);
+  }
+
   /** Feed the meta index for a transaction learned outside a month fetch
    *  (e.g. the create_transaction response). */
   indexTransactionMeta(id: string, meta: { accountId: string; itemId: string }): void {
-    this.txnMetaIndex.set(id, meta);
+    this.feedMeta(id, meta);
+    this.metaStore.flush();
   }
 
   /** Resolve routing ids for the given transaction ids from the in-memory
    *  index. Returns only the ids present; callers treat absence as
    *  "not seen by any live fetch this session". */
   lookupTransactionMeta(ids: string[]): Map<string, { accountId: string; itemId: string }> {
+    // Opportunistic hydration from disk (#511): in-memory entries win (they
+    // are newest); loadOnce is idempotent/cheap after the first real load.
+    for (const [id, m] of this.metaStore.loadOnce()) {
+      if (!this.txnMetaIndex.has(id)) this.txnMetaIndex.set(id, m);
+    }
     const out = new Map<string, { accountId: string; itemId: string }>();
     for (const id of ids) {
       const m = this.txnMetaIndex.get(id);
@@ -555,7 +594,8 @@ export class LiveCopilotDatabase {
     // camelCase keys), and the ids are server-immutable regardless.
     // Guard against drifted responses with null/empty routing ids (review finding).
     if (merged.accountId && merged.itemId) {
-      this.txnMetaIndex.set(id, { accountId: merged.accountId, itemId: merged.itemId });
+      this.feedMeta(id, { accountId: merged.accountId, itemId: merged.itemId });
+      this.metaStore.flush();
     }
     this.transactionsWindowCache.upsert(merged);
   }

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -532,6 +532,15 @@ export class LiveCopilotDatabase {
    *  index. Returns only the ids present; callers treat absence as
    *  "not seen by any live fetch this session". */
   lookupTransactionMeta(ids: string[]): Map<string, { accountId: string; itemId: string }> {
+    // Identity guard (#511): on a non-null → different-non-null uid transition
+    // (re-auth as another account), drop the previous login's in-memory routing
+    // entries before hydrating the new login's history — the memory tier must
+    // honor the same isolation the per-uid files do.
+    const prevUid = this.metaStore.loadedUid();
+    const curUid = this.metaStore.currentUid();
+    if (prevUid !== null && curUid !== null && prevUid !== curUid) {
+      this.txnMetaIndex.clear();
+    }
     // Opportunistic hydration from disk (#511): in-memory entries win (they
     // are newest); loadOnce is idempotent/cheap after the first real load.
     for (const [id, m] of this.metaStore.loadOnce()) {

--- a/src/core/persistence/transaction-meta-store.ts
+++ b/src/core/persistence/transaction-meta-store.ts
@@ -47,6 +47,7 @@ export class TransactionMetaStore {
   private pending = new Map<string, { meta: Meta; uid: string | null }>();
   private warnedLoad = false;
   private warnedAppend = false;
+  private warnedSkip = false;
 
   constructor(opts: TransactionMetaStoreOptions) {
     this.baseDir = opts.baseDir;
@@ -62,10 +63,29 @@ export class TransactionMetaStore {
     return join(this.baseDir, `txn-meta-index.${uid}.jsonl`);
   }
 
+  /** Never-throw wrapper around uidProvider: returns null on any exception. */
+  private safeUid(): string | null {
+    try {
+      return this.uidProvider();
+    } catch {
+      return null;
+    }
+  }
+
+  /** The uid for which the disk index was last loaded (null = not yet loaded). */
+  loadedUid(): string | null {
+    return this.loadedForUid;
+  }
+
+  /** The current uid as seen by the provider right now (null = not authenticated). */
+  currentUid(): string | null {
+    return this.safeUid();
+  }
+
   loadOnce(): Map<string, Meta> {
     const out = new Map<string, Meta>();
     if (this.disabled()) return out;
-    const uid = this.uidProvider();
+    const uid = this.safeUid();
     if (!uid || this.loadedForUid === uid) return out;
     // Latch before the try: a transient load error should not retry — warn once and degrade for the session.
     this.loadedForUid = uid;
@@ -73,6 +93,7 @@ export class TransactionMetaStore {
     try {
       if (!existsSync(file)) return out;
       const raw = readFileSync(file, 'utf8');
+      let skipped = 0;
       for (const line of raw.split('\n')) {
         if (!line.trim()) continue;
         try {
@@ -86,17 +107,26 @@ export class TransactionMetaStore {
             rec.t.length > 0
           ) {
             out.set(rec.i, { accountId: rec.a, itemId: rec.t });
+          } else {
+            skipped += 1;
           }
         } catch {
           // torn/corrupt line (crash mid-append) — skip; valid prefix wins.
+          skipped += 1;
         }
+      }
+      if (skipped > 0 && !this.warnedSkip) {
+        this.warnedSkip = true;
+        console.warn(
+          `[copilot-money-mcp] persistent meta index: skipped ${skipped} unparseable line(s) — continuing with the valid remainder.`
+        );
       }
       for (const id of out.keys()) this.persisted.add(id);
       // Size valve: duplicates across many sessions can bloat the file far
       // past its logical content; rewrite deduped once, atomically.
       if (statSync(file).size > this.maxBytes) {
         try {
-          const tmp = `${file}.tmp`;
+          const tmp = `${file}.${process.pid}.tmp`;
           writeFileSync(tmp, this.serialize(out));
           renameSync(tmp, file);
         } catch (e) {
@@ -125,12 +155,12 @@ export class TransactionMetaStore {
     if (this.persisted.has(id)) return;
     // Stamp the uid at buffer time so a mid-session re-auth cannot redirect
     // this entry to a different user's file at flush.
-    this.pending.set(id, { meta, uid: this.uidProvider() });
+    this.pending.set(id, { meta, uid: this.safeUid() });
   }
 
   flush(): void {
     if (this.disabled() || this.pending.size === 0) return;
-    const flushUid = this.uidProvider();
+    const flushUid = this.safeUid();
 
     // Group entries by effective uid: use the uid captured at buffer time when
     // available; null-stamped (pre-auth) entries adopt the current flush-time

--- a/src/core/persistence/transaction-meta-store.ts
+++ b/src/core/persistence/transaction-meta-store.ts
@@ -1,0 +1,137 @@
+/**
+ * Persistent per-uid transaction meta index (#511).
+ *
+ * The id → (accountId, itemId) mapping is immutable server-side (ledger:
+ * Mutation.editTransaction:routing), so persistence is append-only JSONL —
+ * never invalidated, no TTL. Identity scoping is load-bearing: the file is
+ * keyed by the AUTHENTICATED SESSION's Firebase uid, so an index written
+ * under one login can never be consulted under another (the desktop app's
+ * cache and the browser session token may belong to different accounts).
+ *
+ * Failure philosophy: persistence must never fail the caller. Load errors,
+ * torn lines, corrupt files, and append failures degrade to in-memory
+ * behavior with a single warning.
+ *
+ * Privacy: opaque ids only — no amounts, names, dates, or merchants.
+ * Opt-out: COPILOT_DISABLE_PERSISTENT_INDEX=1.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+type Meta = { accountId: string; itemId: string };
+
+export interface TransactionMetaStoreOptions {
+  baseDir: string;
+  uidProvider: () => string | null;
+  maxBytes?: number;
+}
+
+const DEFAULT_MAX_BYTES = 32 * 1024 * 1024;
+
+export class TransactionMetaStore {
+  private readonly baseDir: string;
+  private readonly uidProvider: () => string | null;
+  private readonly maxBytes: number;
+  private loadedForUid: string | null = null;
+  /** ids known to be on disk already (loaded or flushed this session). */
+  private readonly persisted = new Set<string>();
+  private pending = new Map<string, Meta>();
+  private warnedLoad = false;
+  private warnedAppend = false;
+
+  constructor(opts: TransactionMetaStoreOptions) {
+    this.baseDir = opts.baseDir;
+    this.uidProvider = opts.uidProvider;
+    this.maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+  }
+
+  private disabled(): boolean {
+    return process.env.COPILOT_DISABLE_PERSISTENT_INDEX === '1';
+  }
+
+  private fileFor(uid: string): string {
+    return join(this.baseDir, `txn-meta-index.${uid}.jsonl`);
+  }
+
+  loadOnce(): Map<string, Meta> {
+    const out = new Map<string, Meta>();
+    if (this.disabled()) return out;
+    const uid = this.uidProvider();
+    if (!uid || this.loadedForUid === uid) return out;
+    this.loadedForUid = uid;
+    const file = this.fileFor(uid);
+    try {
+      if (!existsSync(file)) return out;
+      const raw = readFileSync(file, 'utf8');
+      for (const line of raw.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          const rec = JSON.parse(line) as { i?: unknown; a?: unknown; t?: unknown };
+          if (
+            typeof rec.i === 'string' && rec.i.length > 0 &&
+            typeof rec.a === 'string' && rec.a.length > 0 &&
+            typeof rec.t === 'string' && rec.t.length > 0
+          ) {
+            out.set(rec.i, { accountId: rec.a, itemId: rec.t });
+          }
+        } catch {
+          // torn/corrupt line (crash mid-append) — skip; valid prefix wins.
+        }
+      }
+      for (const id of out.keys()) this.persisted.add(id);
+      // Size valve: duplicates across many sessions can bloat the file far
+      // past its logical content; rewrite deduped once, atomically.
+      if (statSync(file).size > this.maxBytes) {
+        const tmp = `${file}.tmp`;
+        writeFileSync(tmp, this.serialize(out));
+        renameSync(tmp, file);
+      }
+    } catch (e) {
+      if (!this.warnedLoad) {
+        this.warnedLoad = true;
+        console.warn(
+          `[copilot-money-mcp] persistent meta index unreadable (${(e as Error).message}) — continuing in-memory. File: ${file}`
+        );
+      }
+      return new Map();
+    }
+    return out;
+  }
+
+  buffer(id: string, meta: Meta): void {
+    if (this.disabled()) return;
+    if (this.persisted.has(id)) return;
+    this.pending.set(id, meta);
+  }
+
+  flush(): void {
+    if (this.disabled() || this.pending.size === 0) return;
+    const uid = this.uidProvider();
+    if (!uid) return; // keep buffering until authenticated
+    const batch = this.pending;
+    this.pending = new Map();
+    try {
+      mkdirSync(this.baseDir, { recursive: true });
+      appendFileSync(this.fileFor(uid), this.serialize(batch));
+      for (const id of batch.keys()) this.persisted.add(id);
+    } catch (e) {
+      if (!this.warnedAppend) {
+        this.warnedAppend = true;
+        console.warn(
+          `[copilot-money-mcp] persistent meta index append failed (${(e as Error).message}) — continuing in-memory.`
+        );
+      }
+      // Do not re-buffer: repeated failures would grow memory; the entries
+      // stay served by the in-memory index for this session regardless.
+    }
+  }
+
+  private serialize(entries: Map<string, Meta>): string {
+    let s = '';
+    for (const [i, m] of entries) {
+      s += `${JSON.stringify({ i, a: m.accountId, t: m.itemId })}\n`;
+    }
+    return s;
+  }
+}

--- a/src/core/persistence/transaction-meta-store.ts
+++ b/src/core/persistence/transaction-meta-store.ts
@@ -45,7 +45,9 @@ export class TransactionMetaStore {
   /** ids known to be on disk already (loaded or flushed this session). */
   private readonly persisted = new Set<string>();
   private pending = new Map<string, { meta: Meta; uid: string | null }>();
-  private warnedLoad = false;
+  // Load warnings are per-uid: a corrupt file for a SECOND login must
+  // still warn even after the first login's file already did.
+  private readonly warnedLoadUids = new Set<string>();
   private warnedAppend = false;
   private warnedSkip = false;
   private dirCreated = false;
@@ -151,8 +153,8 @@ export class TransactionMetaStore {
           writeFileSync(tmp, this.serialize(out));
           renameSync(tmp, file);
         } catch (e) {
-          if (!this.warnedLoad) {
-            this.warnedLoad = true;
+          if (!this.warnedLoadUids.has(uid)) {
+            this.warnedLoadUids.add(uid);
             console.warn(
               `[copilot-money-mcp] persistent meta index cap-valve failed (${(e as Error).message}) — file not compacted. File: ${file}`
             );
@@ -160,8 +162,8 @@ export class TransactionMetaStore {
         }
       }
     } catch (e) {
-      if (!this.warnedLoad) {
-        this.warnedLoad = true;
+      if (!this.warnedLoadUids.has(uid)) {
+        this.warnedLoadUids.add(uid);
         console.warn(
           `[copilot-money-mcp] persistent meta index unreadable (${(e as Error).message}) — continuing in-memory. File: ${file}`
         );

--- a/src/core/persistence/transaction-meta-store.ts
+++ b/src/core/persistence/transaction-meta-store.ts
@@ -16,7 +16,15 @@
  * Opt-out: COPILOT_DISABLE_PERSISTENT_INDEX=1.
  */
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'fs';
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
 import { join } from 'path';
 
 type Meta = { accountId: string; itemId: string };
@@ -36,7 +44,7 @@ export class TransactionMetaStore {
   private loadedForUid: string | null = null;
   /** ids known to be on disk already (loaded or flushed this session). */
   private readonly persisted = new Set<string>();
-  private pending = new Map<string, Meta>();
+  private pending = new Map<string, { meta: Meta; uid: string | null }>();
   private warnedLoad = false;
   private warnedAppend = false;
 
@@ -59,6 +67,7 @@ export class TransactionMetaStore {
     if (this.disabled()) return out;
     const uid = this.uidProvider();
     if (!uid || this.loadedForUid === uid) return out;
+    // Latch before the try: a transient load error should not retry — warn once and degrade for the session.
     this.loadedForUid = uid;
     const file = this.fileFor(uid);
     try {
@@ -69,9 +78,12 @@ export class TransactionMetaStore {
         try {
           const rec = JSON.parse(line) as { i?: unknown; a?: unknown; t?: unknown };
           if (
-            typeof rec.i === 'string' && rec.i.length > 0 &&
-            typeof rec.a === 'string' && rec.a.length > 0 &&
-            typeof rec.t === 'string' && rec.t.length > 0
+            typeof rec.i === 'string' &&
+            rec.i.length > 0 &&
+            typeof rec.a === 'string' &&
+            rec.a.length > 0 &&
+            typeof rec.t === 'string' &&
+            rec.t.length > 0
           ) {
             out.set(rec.i, { accountId: rec.a, itemId: rec.t });
           }
@@ -83,9 +95,18 @@ export class TransactionMetaStore {
       // Size valve: duplicates across many sessions can bloat the file far
       // past its logical content; rewrite deduped once, atomically.
       if (statSync(file).size > this.maxBytes) {
-        const tmp = `${file}.tmp`;
-        writeFileSync(tmp, this.serialize(out));
-        renameSync(tmp, file);
+        try {
+          const tmp = `${file}.tmp`;
+          writeFileSync(tmp, this.serialize(out));
+          renameSync(tmp, file);
+        } catch (e) {
+          if (!this.warnedLoad) {
+            this.warnedLoad = true;
+            console.warn(
+              `[copilot-money-mcp] persistent meta index cap-valve failed (${(e as Error).message}) — file not compacted. File: ${file}`
+            );
+          }
+        }
       }
     } catch (e) {
       if (!this.warnedLoad) {
@@ -102,19 +123,38 @@ export class TransactionMetaStore {
   buffer(id: string, meta: Meta): void {
     if (this.disabled()) return;
     if (this.persisted.has(id)) return;
-    this.pending.set(id, meta);
+    // Stamp the uid at buffer time so a mid-session re-auth cannot redirect
+    // this entry to a different user's file at flush.
+    this.pending.set(id, { meta, uid: this.uidProvider() });
   }
 
   flush(): void {
     if (this.disabled() || this.pending.size === 0) return;
-    const uid = this.uidProvider();
-    if (!uid) return; // keep buffering until authenticated
-    const batch = this.pending;
-    this.pending = new Map();
+    const flushUid = this.uidProvider();
+
+    // Group entries by effective uid: use the uid captured at buffer time when
+    // available; null-stamped (pre-auth) entries adopt the current flush-time
+    // uid. Entries still unresolvable (both stamps null) stay pending.
+    const groups = new Map<string, Map<string, Meta>>();
+    const stillPending = new Map<string, { meta: Meta; uid: string | null }>();
+    for (const [id, entry] of this.pending) {
+      const effectiveUid = entry.uid ?? flushUid;
+      if (!effectiveUid) {
+        stillPending.set(id, entry);
+        continue;
+      }
+      let group = groups.get(effectiveUid);
+      if (!group) {
+        group = new Map();
+        groups.set(effectiveUid, group);
+      }
+      group.set(id, entry.meta);
+    }
+    this.pending = stillPending;
+
+    if (groups.size === 0) return;
     try {
       mkdirSync(this.baseDir, { recursive: true });
-      appendFileSync(this.fileFor(uid), this.serialize(batch));
-      for (const id of batch.keys()) this.persisted.add(id);
     } catch (e) {
       if (!this.warnedAppend) {
         this.warnedAppend = true;
@@ -122,8 +162,23 @@ export class TransactionMetaStore {
           `[copilot-money-mcp] persistent meta index append failed (${(e as Error).message}) — continuing in-memory.`
         );
       }
-      // Do not re-buffer: repeated failures would grow memory; the entries
-      // stay served by the in-memory index for this session regardless.
+      return;
+    }
+
+    for (const [uidKey, batch] of groups) {
+      try {
+        appendFileSync(this.fileFor(uidKey), this.serialize(batch));
+        for (const id of batch.keys()) this.persisted.add(id);
+      } catch (e) {
+        if (!this.warnedAppend) {
+          this.warnedAppend = true;
+          console.warn(
+            `[copilot-money-mcp] persistent meta index append failed (${(e as Error).message}) — continuing in-memory.`
+          );
+        }
+        // Do not re-buffer: repeated failures would grow memory; the entries
+        // stay served by the in-memory index for this session regardless.
+      }
     }
   }
 

--- a/src/core/persistence/transaction-meta-store.ts
+++ b/src/core/persistence/transaction-meta-store.ts
@@ -48,6 +48,7 @@ export class TransactionMetaStore {
   private warnedLoad = false;
   private warnedAppend = false;
   private warnedSkip = false;
+  private dirCreated = false;
 
   constructor(opts: TransactionMetaStoreOptions) {
     this.baseDir = opts.baseDir;
@@ -60,7 +61,9 @@ export class TransactionMetaStore {
   }
 
   private fileFor(uid: string): string {
-    return join(this.baseDir, `txn-meta-index.${uid}.jsonl`);
+    // Firebase uids are alphanumeric; this guards a future non-Firebase uid source.
+    const safe = uid.replace(/[^a-zA-Z0-9_-]/g, '_');
+    return join(this.baseDir, `txn-meta-index.${safe}.jsonl`);
   }
 
   /** Never-throw wrapper around uidProvider: returns null on any exception. */
@@ -82,6 +85,24 @@ export class TransactionMetaStore {
     return this.safeUid();
   }
 
+  /**
+   * Entries currently buffered under the given uid (or stamped null —
+   * pre-auth entries that will adopt it). For post-transition replay.
+   */
+  pendingFor(uid: string): Map<string, Meta> {
+    const out = new Map<string, Meta>();
+    for (const [id, e] of this.pending) {
+      if (e.uid === uid || e.uid === null) out.set(id, e.meta);
+    }
+    return out;
+  }
+
+  /**
+   * Load the on-disk index for the current uid into a fresh Map and return it.
+   * Repeat calls for the same uid return an EMPTY map — the disk is read once
+   * per uid; the in-memory index (txnMetaIndex in live-database) owns all
+   * entries thereafter.
+   */
   loadOnce(): Map<string, Meta> {
     const out = new Map<string, Meta>();
     if (this.disabled()) return out;
@@ -183,16 +204,28 @@ export class TransactionMetaStore {
     this.pending = stillPending;
 
     if (groups.size === 0) return;
-    try {
-      mkdirSync(this.baseDir, { recursive: true });
-    } catch (e) {
-      if (!this.warnedAppend) {
-        this.warnedAppend = true;
-        console.warn(
-          `[copilot-money-mcp] persistent meta index append failed (${(e as Error).message}) — continuing in-memory.`
-        );
+
+    if (!this.dirCreated) {
+      try {
+        mkdirSync(this.baseDir, { recursive: true });
+        this.dirCreated = true;
+      } catch (e) {
+        // Re-stamp: entries are not yet on disk; a uid-transition replay needs
+        // them. Bounded: same batch re-cycles until persisted or session ends —
+        // no growth because buffer() skips already-persisted ids.
+        for (const [uidKey, batch] of groups) {
+          for (const [id, meta] of batch) {
+            this.pending.set(id, { meta, uid: uidKey });
+          }
+        }
+        if (!this.warnedAppend) {
+          this.warnedAppend = true;
+          console.warn(
+            `[copilot-money-mcp] persistent meta index append failed (${(e as Error).message}) — continuing in-memory.`
+          );
+        }
+        return;
       }
-      return;
     }
 
     for (const [uidKey, batch] of groups) {
@@ -200,14 +233,18 @@ export class TransactionMetaStore {
         appendFileSync(this.fileFor(uidKey), this.serialize(batch));
         for (const id of batch.keys()) this.persisted.add(id);
       } catch (e) {
+        // Re-stamp: entries are not yet on disk; a uid-transition replay needs
+        // them. Bounded: same batch re-cycles until persisted or session ends —
+        // no growth because buffer() skips already-persisted ids.
+        for (const [id, meta] of batch) {
+          this.pending.set(id, { meta, uid: uidKey });
+        }
         if (!this.warnedAppend) {
           this.warnedAppend = true;
           console.warn(
             `[copilot-money-mcp] persistent meta index append failed (${(e as Error).message}) — continuing in-memory.`
           );
         }
-        // Do not re-buffer: repeated failures would grow memory; the entries
-        // stay served by the in-memory index for this session regardless.
       }
     }
   }

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -9,6 +9,10 @@ import type { Tag } from '../../src/models/index.js';
 import type { CategoryNode } from '../../src/core/graphql/queries/categories.js';
 import type { RecurringNode } from '../../src/core/graphql/queries/recurrings.js';
 import type { UserNode } from '../../src/core/graphql/queries/user.js';
+import { TransactionMetaStore } from '../../src/core/persistence/transaction-meta-store.js';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 function mkClient(): GraphQLClient {
   return { mutate: mock(), query: mock() } as unknown as GraphQLClient;
@@ -1158,5 +1162,55 @@ describe('transaction meta index', () => {
       itemId: 'item-B',
     });
     expect(live.lookupTransactionNodes(['future-ish']).has('future-ish')).toBe(true);
+  });
+
+  test('persistent store round-trip: fetched ids resolve in a NEW LiveCopilotDatabase with zero fetches (#511)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'live-meta-'));
+    try {
+      const store1 = new TransactionMetaStore({ baseDir: dir, uidProvider: () => 'user-1' });
+      const page = metaPage([metaNode('persist-t1', '2025-01-15', 'acct-P', 'item-P')]);
+      const client1 = {
+        mutate: mock(),
+        query: mock(() => Promise.resolve({ transactions: page })),
+      } as unknown as GraphQLClient;
+      const live1 = new LiveCopilotDatabase(client1, {} as CopilotDatabase, { metaStore: store1 });
+      await live1.getTransactions({ from: '2025-01-01', to: '2025-01-31' });
+
+      // Fresh instance, fresh store on the same dir/uid — no fetches issued.
+      const store2 = new TransactionMetaStore({ baseDir: dir, uidProvider: () => 'user-1' });
+      const client2 = { mutate: mock(), query: mock() } as unknown as GraphQLClient;
+      const live2 = new LiveCopilotDatabase(client2, {} as CopilotDatabase, { metaStore: store2 });
+      const found = live2.lookupTransactionMeta(['persist-t1']);
+      expect(found.get('persist-t1')).toEqual({ accountId: 'acct-P', itemId: 'item-P' });
+      expect((client2.query as ReturnType<typeof mock>).mock.calls).toHaveLength(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('indexTransactionMeta feeds persistence too (#511)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'live-meta-'));
+    try {
+      const store1 = new TransactionMetaStore({ baseDir: dir, uidProvider: () => 'user-1' });
+      const live1 = new LiveCopilotDatabase(
+        { mutate: mock(), query: mock() } as unknown as GraphQLClient,
+        {} as CopilotDatabase,
+        { metaStore: store1 }
+      );
+      live1.indexTransactionMeta('created-t1', { accountId: 'acct-C', itemId: 'item-C' });
+
+      const store2 = new TransactionMetaStore({ baseDir: dir, uidProvider: () => 'user-1' });
+      const live2 = new LiveCopilotDatabase(
+        { mutate: mock(), query: mock() } as unknown as GraphQLClient,
+        {} as CopilotDatabase,
+        { metaStore: store2 }
+      );
+      expect(live2.lookupTransactionMeta(['created-t1']).get('created-t1')).toEqual({
+        accountId: 'acct-C',
+        itemId: 'item-C',
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -1213,4 +1213,34 @@ describe('transaction meta index', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  test('uid transition: previous login entries are cleared from in-memory index before new login hydrates (#511)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'live-meta-uid-'));
+    try {
+      let currentUid: string | null = 'userA';
+      const store = new TransactionMetaStore({
+        baseDir: dir,
+        uidProvider: () => currentUid,
+      });
+      const live = new LiveCopilotDatabase(
+        { mutate: mock(), query: mock() } as unknown as GraphQLClient,
+        {} as CopilotDatabase,
+        { metaStore: store }
+      );
+
+      // Feed an entry as userA; indexTransactionMeta buffers + flushes to disk.
+      live.indexTransactionMeta('txA', { accountId: 'acct-A', itemId: 'item-A' });
+      // Trigger a lookup to latch loadOnce under userA.
+      const beforeSwitch = live.lookupTransactionMeta(['txA']);
+      expect(beforeSwitch.get('txA')).toEqual({ accountId: 'acct-A', itemId: 'item-A' });
+
+      // Re-auth as a different account — userA's entries must not leak.
+      currentUid = 'userB';
+
+      const afterSwitch = live.lookupTransactionMeta(['txA']);
+      expect(afterSwitch.has('txA')).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -10,7 +10,7 @@ import type { CategoryNode } from '../../src/core/graphql/queries/categories.js'
 import type { RecurringNode } from '../../src/core/graphql/queries/recurrings.js';
 import type { UserNode } from '../../src/core/graphql/queries/user.js';
 import { TransactionMetaStore } from '../../src/core/persistence/transaction-meta-store.js';
-import { mkdtempSync, rmSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, chmodSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -1241,6 +1241,118 @@ describe('transaction meta index', () => {
       expect(afterSwitch.has('txA')).toBe(false);
     } finally {
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('uid-transition clear does not drop entries fed under the new uid when flush failed (#511)', () => {
+    // Uses an unwritable baseDir so every flush attempt fails silently. The
+    // re-stamp fix ensures those buffered entries survive the transition clear
+    // via pendingFor replay, satisfying the invariant: "an entry fed under the
+    // current uid is resolvable until persisted or superseded."
+    const tmpBase = mkdtempSync(join(tmpdir(), 'live-meta-ro-'));
+    const roDir = join(tmpBase, 'store');
+    mkdirSync(roDir);
+    chmodSync(roDir, 0o555);
+    try {
+      let currentUid: string | null = 'userA';
+      const store = new TransactionMetaStore({
+        baseDir: roDir,
+        uidProvider: () => currentUid,
+      });
+      const live = new LiveCopilotDatabase(
+        { mutate: mock(), query: mock() } as unknown as GraphQLClient,
+        {} as CopilotDatabase,
+        { metaStore: store }
+      );
+
+      const origWarn = console.warn;
+      console.warn = () => {};
+      try {
+        // Feed under A; flush fails silently (unwritable dir) — entry re-stamped to pending.
+        live.indexTransactionMeta('txA', { accountId: 'acct-A', itemId: 'item-A' });
+        // Latch loadedUid = userA via a lookup.
+        expect(live.lookupTransactionMeta(['txA']).get('txA')).toEqual({
+          accountId: 'acct-A',
+          itemId: 'item-A',
+        });
+
+        // Switch to B.
+        currentUid = 'userB';
+
+        // Feed under B; flush fails silently — entry re-stamped to pending under userB.
+        live.indexTransactionMeta('bEntry', { accountId: 'acct-B', itemId: 'item-B' });
+
+        // Transition guard fires: clear + replay pending under userB.
+        const found = live.lookupTransactionMeta(['bEntry']);
+        expect(found.get('bEntry')).toEqual({ accountId: 'acct-B', itemId: 'item-B' });
+        // userA's entry must be gone.
+        expect(live.lookupTransactionMeta(['txA']).has('txA')).toBe(false);
+      } finally {
+        console.warn = origWarn;
+      }
+    } finally {
+      try {
+        chmodSync(roDir, 0o755);
+      } catch {}
+      rmSync(tmpBase, { recursive: true, force: true });
+    }
+  });
+
+  test('patchLiveTransaction feeds persistence; new instance resolves the routing id without fetching (#511)', () => {
+    // Verify that patchLiveTransaction's feedMeta path persists entries so a
+    // fresh LiveCopilotDatabase can resolve them without any network call.
+    const tmpDir = mkdtempSync(join(tmpdir(), 'live-meta-patch-'));
+    try {
+      const store1 = new TransactionMetaStore({ baseDir: tmpDir, uidProvider: () => 'user-1' });
+      const live1 = new LiveCopilotDatabase(
+        { mutate: mock(), query: mock() } as unknown as GraphQLClient,
+        {} as CopilotDatabase,
+        { metaStore: store1 }
+      );
+
+      // Seed the window cache directly (bypassing getTransactions so the meta
+      // index is not pre-populated — patchLiveTransaction is the entry point).
+      const wc = live1.getTransactionsWindowCache();
+      wc.ingestMonth(
+        '2025-03',
+        [
+          {
+            id: 'patch-t1',
+            date: '2025-03-10',
+            accountId: 'acct-P',
+            itemId: 'item-P',
+            categoryId: null,
+            recurringId: null,
+            parentId: null,
+            isReviewed: false,
+            isPending: false,
+            amount: 50,
+            name: 'Before Patch',
+            type: 'REGULAR' as const,
+            userNotes: null,
+            tipAmount: null,
+            suggestedCategoryIds: [],
+            isoCurrencyCode: 'USD',
+            createdAt: 0,
+            tags: [],
+            goal: null,
+          },
+        ],
+        Date.now()
+      );
+
+      // patchLiveTransaction feeds the meta index for this not-yet-persisted id.
+      live1.patchLiveTransaction('patch-t1', { name: 'After Patch' } as Record<string, unknown>);
+
+      // Fresh instance + fresh store on the same dir must resolve without fetching.
+      const store2 = new TransactionMetaStore({ baseDir: tmpDir, uidProvider: () => 'user-1' });
+      const client2 = { mutate: mock(), query: mock() } as unknown as GraphQLClient;
+      const live2 = new LiveCopilotDatabase(client2, {} as CopilotDatabase, { metaStore: store2 });
+      const found = live2.lookupTransactionMeta(['patch-t1']);
+      expect(found.get('patch-t1')).toEqual({ accountId: 'acct-P', itemId: 'item-P' });
+      expect((client2.query as ReturnType<typeof mock>).mock.calls).toHaveLength(0);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
     }
   });
 });

--- a/tests/core/persistence/transaction-meta-store.test.ts
+++ b/tests/core/persistence/transaction-meta-store.test.ts
@@ -79,16 +79,29 @@ describe('TransactionMetaStore', () => {
       '{"i":"t1","a":"acct-1","t":"item-1"}\n{"i":"t2","a":"acc' // torn
     );
     const s = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') });
-    const m = s.loadOnce();
-    expect(m.get('t1')).toEqual(META);
-    expect(m.has('t2')).toBe(false);
+    const origWarn = console.warn;
+    console.warn = () => {};
+    let m: ReturnType<typeof s.loadOnce>;
+    try {
+      m = s.loadOnce();
+    } finally {
+      console.warn = origWarn;
+    }
+    expect(m!.get('t1')).toEqual(META);
+    expect(m!.has('t2')).toBe(false);
   });
 
   test('corrupt file: warn + start fresh, no crash', () => {
     mkdirSync(dir, { recursive: true });
     writeFileSync(fileFor('userA'), 'not json at all\x00\x01');
     const s = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') });
-    expect(() => s.loadOnce()).not.toThrow();
+    const origWarn = console.warn;
+    console.warn = () => {};
+    try {
+      expect(() => s.loadOnce()).not.toThrow();
+    } finally {
+      console.warn = origWarn;
+    }
   });
 
   test('dedupe on load: duplicate ids hydrate once, last wins', () => {
@@ -154,6 +167,30 @@ describe('TransactionMetaStore', () => {
     expect(m.size).toBe(1);
     const rewritten = readFileSync(fileFor('userA'), 'utf8').trim().split('\n');
     expect(rewritten).toHaveLength(1);
+  });
+
+  test('skipped lines emit a warn-once warning, valid entries still load', () => {
+    mkdirSync(dir, { recursive: true });
+    // One valid line, two invalid: a torn line and a JSON object missing required fields.
+    writeFileSync(
+      fileFor('userA'),
+      '{"i":"t1","a":"acct-1","t":"item-1"}\n{"i":"bad"\n{"bad":true}\n'
+    );
+    const s = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') });
+    const warns: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => warns.push(args.join(' '));
+    let m: Map<string, { accountId: string; itemId: string }>;
+    try {
+      m = s.loadOnce();
+    } finally {
+      console.warn = origWarn;
+    }
+    // Valid entry survives.
+    expect(m!.get('t1')).toEqual(META);
+    // Exactly one warning, mentioning the skip count.
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toContain('skipped 2 unparseable line');
   });
 
   test('uid change between buffer and flush: entries stay with the uid captured at buffer time', () => {

--- a/tests/core/persistence/transaction-meta-store.test.ts
+++ b/tests/core/persistence/transaction-meta-store.test.ts
@@ -4,7 +4,15 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync } from 'fs';
+import {
+  mkdtempSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  chmodSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { TransactionMetaStore } from '../../../src/core/persistence/transaction-meta-store.js';
@@ -146,5 +154,22 @@ describe('TransactionMetaStore', () => {
     expect(m.size).toBe(1);
     const rewritten = readFileSync(fileFor('userA'), 'utf8').trim().split('\n');
     expect(rewritten).toHaveLength(1);
+  });
+
+  test('uid change between buffer and flush: entries stay with the uid captured at buffer time', () => {
+    let current: string | null = 'userA';
+    const s = new TransactionMetaStore({ baseDir: dir, uidProvider: () => current });
+    s.loadOnce();
+    s.buffer('tA', META); // buffered under userA
+    current = 'userB'; // re-auth as a different account
+    s.buffer('tB', { accountId: 'acct-2', itemId: 'item-2' }); // buffered under userB
+    s.flush();
+
+    const a = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') }).loadOnce();
+    const b = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userB') }).loadOnce();
+    expect(a.get('tA')).toEqual(META);
+    expect(a.has('tB')).toBe(false);
+    expect(b.get('tB')).toEqual({ accountId: 'acct-2', itemId: 'item-2' });
+    expect(b.has('tA')).toBe(false);
   });
 });

--- a/tests/core/persistence/transaction-meta-store.test.ts
+++ b/tests/core/persistence/transaction-meta-store.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Persistent per-uid transaction meta index (#511). Append-only JSONL,
+ * identity-scoped, crash-tolerant, never fails the caller.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, mkdirSync, chmodSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { TransactionMetaStore } from '../../../src/core/persistence/transaction-meta-store.js';
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'meta-store-'));
+  delete process.env.COPILOT_DISABLE_PERSISTENT_INDEX;
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  delete process.env.COPILOT_DISABLE_PERSISTENT_INDEX;
+});
+
+const uid = (u: string | null) => () => u;
+const META = { accountId: 'acct-1', itemId: 'item-1' };
+
+function fileFor(u: string): string {
+  return join(dir, `txn-meta-index.${u}.jsonl`);
+}
+
+describe('TransactionMetaStore', () => {
+  test('round-trip: buffered+flushed entries hydrate in a fresh instance', () => {
+    const a = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') });
+    a.loadOnce();
+    a.buffer('t1', META);
+    a.buffer('t2', { accountId: 'acct-2', itemId: 'item-2' });
+    a.flush();
+
+    const b = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') });
+    const hydrated = b.loadOnce();
+    expect(hydrated.get('t1')).toEqual(META);
+    expect(hydrated.get('t2')).toEqual({ accountId: 'acct-2', itemId: 'item-2' });
+  });
+
+  test('identity isolation: uid A entries invisible to uid B', () => {
+    const a = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') });
+    a.loadOnce();
+    a.buffer('t1', META);
+    a.flush();
+
+    const b = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userB') });
+    expect(b.loadOnce().size).toBe(0);
+  });
+
+  test('no uid: fully inert (no file created, no load, buffered entries flush later)', () => {
+    let current: string | null = null;
+    const s = new TransactionMetaStore({ baseDir: dir, uidProvider: () => current });
+    expect(s.loadOnce().size).toBe(0);
+    s.buffer('t1', META);
+    s.flush();
+    expect(existsSync(fileFor('userA'))).toBe(false);
+
+    current = 'userA';
+    s.flush(); // uid now known — buffered entry lands
+    const b = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') });
+    expect(b.loadOnce().get('t1')).toEqual(META);
+  });
+
+  test('torn last line: valid prefix loads, no crash', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      fileFor('userA'),
+      '{"i":"t1","a":"acct-1","t":"item-1"}\n{"i":"t2","a":"acc' // torn
+    );
+    const s = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') });
+    const m = s.loadOnce();
+    expect(m.get('t1')).toEqual(META);
+    expect(m.has('t2')).toBe(false);
+  });
+
+  test('corrupt file: warn + start fresh, no crash', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(fileFor('userA'), 'not json at all\x00\x01');
+    const s = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') });
+    expect(() => s.loadOnce()).not.toThrow();
+  });
+
+  test('dedupe on load: duplicate ids hydrate once, last wins', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      fileFor('userA'),
+      '{"i":"t1","a":"old","t":"old"}\n{"i":"t1","a":"acct-1","t":"item-1"}\n'
+    );
+    const m = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') }).loadOnce();
+    expect(m.size).toBe(1);
+    expect(m.get('t1')).toEqual(META);
+  });
+
+  test('flush skips entries already persisted (no duplicate lines across sessions)', () => {
+    const a = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') });
+    a.loadOnce();
+    a.buffer('t1', META);
+    a.flush();
+
+    const b = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') });
+    b.loadOnce();
+    b.buffer('t1', META); // already persisted — must not append again
+    b.buffer('t3', { accountId: 'acct-3', itemId: 'item-3' });
+    b.flush();
+
+    const lines = readFileSync(fileFor('userA'), 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(2); // t1 once, t3 once
+  });
+
+  test('append failure never throws (unwritable dir)', () => {
+    const roDir = join(dir, 'ro');
+    mkdirSync(roDir);
+    const s = new TransactionMetaStore({ baseDir: roDir, uidProvider: uid('userA') });
+    s.loadOnce();
+    s.buffer('t1', META);
+    chmodSync(roDir, 0o555);
+    try {
+      expect(() => s.flush()).not.toThrow();
+    } finally {
+      chmodSync(roDir, 0o755);
+    }
+  });
+
+  test('opt-out env var: no file, no load', () => {
+    process.env.COPILOT_DISABLE_PERSISTENT_INDEX = '1';
+    const s = new TransactionMetaStore({ baseDir: dir, uidProvider: uid('userA') });
+    s.loadOnce();
+    s.buffer('t1', META);
+    s.flush();
+    expect(existsSync(fileFor('userA'))).toBe(false);
+  });
+
+  test('cap valve: oversized file is rewritten deduped on load', () => {
+    mkdirSync(dir, { recursive: true });
+    const dupLine = '{"i":"t1","a":"acct-1","t":"item-1"}\n';
+    writeFileSync(fileFor('userA'), dupLine.repeat(200));
+    const s = new TransactionMetaStore({
+      baseDir: dir,
+      uidProvider: uid('userA'),
+      maxBytes: 1024, // force the valve
+    });
+    const m = s.loadOnce();
+    expect(m.size).toBe(1);
+    const rewritten = readFileSync(fileFor('userA'), 'utf8').trim().split('\n');
+    expect(rewritten).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Problem

The in-memory meta index (#508) resolves any transaction read THIS session, but a fresh MCP process pays the windowed live fetch (~25 rows/request; ~30s+ for a cold 13-month window) for ids from previous sessions, and >window ids fail. The `id → (accountId, itemId)` mapping is immutable server-side (ledger: `Mutation.editTransaction:routing`), so persistence is append-only, never-stale, and needs no invalidation.

## Fix

- **`TransactionMetaStore`** (`src/core/persistence/`): identity-scoped append-only JSONL at `~/.claude/copilot-money/txn-meta-index.<uid>.jsonl`. Entries are stamped with the uid AT BUFFER TIME and appends are grouped per uid, so a mid-session re-auth can never write one login's entries into another's file; the memory tier honors the same isolation (index cleared on a non-null→different-non-null uid transition before hydrating). Torn last lines are skipped with a warning; corrupt files degrade to fresh; a 32 MiB load-time valve rewrites deduped atomically (pid-scoped tmp); persistence failures never throw to callers (warn-once).
- **Wiring**: all meta-index writes funnel through one private `feedMeta`; `lookupTransactionMeta` hydrates lazily on first authenticated lookup (in-memory entries win); flush per ingest batch. Store injectable for tests — the full suite provably never touches the real home directory (mock clients yield a null uid; the store is inert without one).
- **Privacy:** opaque ids only — never amounts, names, dates, or merchants; local file on the disk that already holds the full LevelDB cache; created whenever live reads are enabled; opt-out documented: `COPILOT_DISABLE_PERSISTENT_INDEX=1`.
- Ordering: lands after #512, so only shape-validated rows are ever persisted.

## Performance (measured in review)

Realistic hydration 15ms one-time per process (5 MiB / 49k ids); absolute valve-ceiling case 187ms — against a ~350ms/request GraphQL baseline and replacing a ~30s cold window fetch. Cold-start hydration verified real: `preflightLiveAuth` completes the token exchange before any tool call, so the uid exists at first lookup.

## External assumptions

None new — but note the linkage explicitly for the next boundary audit: the store's presence-based dedupe (a persisted id is never value-updated) DEPENDS on the ledgered routing-immutability entry (`Mutation.editTransaction:routing`, verified-once). If that entry is ever downgraded, dedupe needs value comparison.

## Testing

- `bun run check` green: 2241 pass / 0 fail; `sync-manifest` no-op.
- Store suite (12): round-trip, identity isolation, uid-change-between-buffer-and-flush, no-uid inert + deferred flush, torn line, corrupt file, dedupe/last-wins, flush-skips-persisted, append-failure never throws, opt-out, cap valve.
- Wiring: persistence round-trip across fresh `LiveCopilotDatabase` instances with zero GraphQL calls; `indexTransactionMeta` path; uid-transition memory clear.
- **Live smoke (run, non-mutating, temp dir):** `[1] session1 read 67 rows; store file=1, lines=187`; `[2] session2 cross-instance resolution: 1ms, match=true -> PASS`.

## Follow-up

Filed: the all-caches uid-transition sweep — the window/snapshot caches retain the previous login's full nodes across mid-session re-auth (pre-existing class; #511 closed it for the meta index).

Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)