### PR TITLE
chore: audit-bot LOW nits from #514/#519 reviews

### DIFF
--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3225,7 +3225,7 @@ export class CopilotMoneyTools {
     const parentDefaultName = parentTxn.name;
     if (splits.some((s) => s.name === undefined) && !parentDefaultName) {
       throw new Error(
-        `Cannot default split name from parent ${transaction_id}: parent has no name or original_name. Pass an explicit name on each split.`
+        `Cannot default split name from parent ${transaction_id}: parent has no usable name. Pass an explicit name on each split.`
       );
     }
 

--- a/tests/tools/live/transactions.test.ts
+++ b/tests/tools/live/transactions.test.ts
@@ -133,6 +133,7 @@ async function mkLiveReturning(
         oldest_fetched_at: number;
         newest_fetched_at: number;
         hit: boolean;
+        dropped_invalid_rows: number;
       }>;
     }
   ).getTransactions = async () => ({
@@ -140,6 +141,7 @@ async function mkLiveReturning(
     oldest_fetched_at: fetchedAt,
     newest_fetched_at: fetchedAt,
     hit: false,
+    dropped_invalid_rows: 0,
   });
   // Pre-warm categoriesCache with empty so tests that don't exercise
   // category-dependent paths never call fetchCategories on the mock client.


### PR DESCRIPTION
Batched LOW audit-bot findings, per the standing one-cleanup-PR convention:

- **#515:** the split name-default error exposed internal LevelDB vocabulary (`original_name`) in a user-facing string — now `parent has no usable name`. No test asserted the old wording.
- **#520:** the live transactions test mock omitted `dropped_invalid_rows` from its `getTransactions` cast and return, drifting from the real interface — now type-aligned with `dropped_invalid_rows: 0`.

## External assumptions

None — message wording and test-mock alignment only.

Closes #515
Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)