### PR TITLE
chore(persistence): skip warnings are per-uid, matching load warnings

### DIFF
--- a/src/core/persistence/transaction-meta-store.ts
+++ b/src/core/persistence/transaction-meta-store.ts
@@ -49,7 +49,9 @@ export class TransactionMetaStore {
   // still warn even after the first login's file already did.
   private readonly warnedLoadUids = new Set<string>();
   private warnedAppend = false;
-  private warnedSkip = false;
+  // Skip warnings are per-uid for the same reason load warnings are: a
+  // second login's torn file must still warn.
+  private readonly warnedSkipUids = new Set<string>();
   private dirCreated = false;
 
   constructor(opts: TransactionMetaStoreOptions) {
@@ -138,8 +140,8 @@ export class TransactionMetaStore {
           skipped += 1;
         }
       }
-      if (skipped > 0 && !this.warnedSkip) {
-        this.warnedSkip = true;
+      if (skipped > 0 && !this.warnedSkipUids.has(uid)) {
+        this.warnedSkipUids.add(uid);
         console.warn(
           `[copilot-money-mcp] persistent meta index: skipped ${skipped} unparseable line(s) — continuing with the valid remainder.`
         );


### PR DESCRIPTION
Audit-bot LOW from PR #522's review: `warnedSkip` was the last session-wide suppression flag — uid B's torn file wouldn't warn if uid A's already had. Now a per-uid Set, exactly like `warnedLoadUids`.

## External assumptions

None — warning bookkeeping only.

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)