### PR TITLE
fix(write): guard create_transaction meta feed against empty routing ids (#518)

### DIFF
--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -513,10 +513,12 @@ export class LiveCopilotDatabase {
   }
 
   /** Single funnel for meta-index writes: in-memory map + persistence
-   *  buffer (#511). Entries here already passed #512 validation (all feeds
-   *  are downstream of the fetch strip) or came from mutation responses
-   *  guarded at their call sites. */
+   *  buffer (#511). Entries with empty routing ids are dropped HERE, not
+   *  just at call sites (#518) — response validation is warn-only, so a
+   *  drifted read or mutation response must never poison the index even
+   *  if a future call site forgets its own guard. */
   private feedMeta(id: string, meta: { accountId: string; itemId: string }): void {
+    if (!meta.accountId || !meta.itemId) return;
     this.txnMetaIndex.set(id, meta);
     this.metaStore.buffer(id, meta);
   }

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2923,8 +2923,12 @@ export class CopilotMoneyTools {
       };
 
       // Feed the live meta index so an immediate follow-up write on the new
-      // transaction resolves without a network fetch.
-      this.liveDb?.indexTransactionMeta(tx.id, { accountId: tx.accountId, itemId: tx.itemId });
+      // transaction resolves without a network fetch. Same empty-id guard as
+      // the other mutation feeds (#518) — response validation is warn-only,
+      // so a drifted response must not reach the index.
+      if (tx.accountId && tx.itemId) {
+        this.liveDb?.indexTransactionMeta(tx.id, { accountId: tx.accountId, itemId: tx.itemId });
+      }
 
       return {
         success: true,

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -1024,6 +1024,19 @@ describe('transaction meta index', () => {
     });
   });
 
+  test('indexTransactionMeta ignores empty routing ids at the funnel (#518)', () => {
+    // Mutation responses are Zod-validated warn-only (never stripped), so a
+    // drifted response can hand empty routing ids to any feed. The funnel
+    // must drop them even when a call site forgets its own guard.
+    const live = new LiveCopilotDatabase(
+      { mutate: mock(), query: mock() } as unknown as GraphQLClient,
+      {} as CopilotDatabase
+    );
+    live.indexTransactionMeta('meta-no-acct', { accountId: '', itemId: 'item-B' });
+    live.indexTransactionMeta('meta-no-item', { accountId: 'acct-B', itemId: '' });
+    expect(live.lookupTransactionMeta(['meta-no-acct', 'meta-no-item']).size).toBe(0);
+  });
+
   test('lookupTransactionMeta returns an empty map for unknown ids', () => {
     const live = new LiveCopilotDatabase(
       { mutate: mock(), query: mock() } as unknown as GraphQLClient,

--- a/tests/tools/write-tools.test.ts
+++ b/tests/tools/write-tools.test.ts
@@ -7,7 +7,7 @@
  * into set_budget.
  */
 
-import { describe, test, expect, beforeEach } from 'bun:test';
+import { describe, test, expect, beforeEach, mock } from 'bun:test';
 import { CopilotMoneyTools } from '../../src/tools/tools.js';
 import { CopilotDatabase } from '../../src/core/database.js';
 import { createMockGraphQLClient } from '../helpers/mock-graphql.js';
@@ -15,6 +15,7 @@ import type {
   CreatedTransaction,
   CreateTransactionResponse,
 } from '../../src/core/graphql/transactions.js';
+import type { LiveCopilotDatabase } from '../../src/core/live-database.js';
 
 describe('updateCategory', () => {
   let tools: CopilotMoneyTools;
@@ -621,6 +622,54 @@ describe('createTransaction', () => {
       tools.createTransaction({ ...validArgs, tag_ids: ['tag1', 'ghost_tag'] })
     ).rejects.toThrow(/Tag not found.*ghost_tag/i);
     expect(client._calls).toHaveLength(0);
+  });
+
+  test('response routing ids feed the live meta index', async () => {
+    const client = createMockGraphQLClient({ CreateTransaction: { createTransaction: createdTx } });
+    const indexTransactionMeta = mock();
+    tools = new CopilotMoneyTools(mockDb, client, {
+      indexTransactionMeta,
+    } as unknown as LiveCopilotDatabase);
+
+    await tools.createTransaction(validArgs);
+
+    expect(indexTransactionMeta).toHaveBeenCalledTimes(1);
+    expect(indexTransactionMeta).toHaveBeenCalledWith('new-tx-1', {
+      accountId: 'acc1',
+      itemId: 'item1',
+    });
+  });
+
+  test('drifted response with empty routing ids is not fed to the index (#518)', async () => {
+    // Mutation responses are validated WARN-ONLY (response-validation.ts never
+    // strips), so a drifted CreateTransaction response reaches this feed
+    // as-is. Same guard as the split_transaction feed.
+    const client = createMockGraphQLClient({
+      CreateTransaction: { createTransaction: { ...createdTx, accountId: '' } },
+    });
+    const indexTransactionMeta = mock();
+    tools = new CopilotMoneyTools(mockDb, client, {
+      indexTransactionMeta,
+    } as unknown as LiveCopilotDatabase);
+
+    await tools.createTransaction(validArgs);
+
+    expect(indexTransactionMeta).not.toHaveBeenCalled();
+  });
+
+  test('drifted response with empty itemId is not fed to the index (#518)', async () => {
+    // Symmetric case: the guard must check both routing ids.
+    const client = createMockGraphQLClient({
+      CreateTransaction: { createTransaction: { ...createdTx, itemId: '' } },
+    });
+    const indexTransactionMeta = mock();
+    tools = new CopilotMoneyTools(mockDb, client, {
+      indexTransactionMeta,
+    } as unknown as LiveCopilotDatabase);
+
+    await tools.createTransaction(validArgs);
+
+    expect(indexTransactionMeta).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
# Summary

The create_transaction meta-index feed wrote mutation-response routing ids
unguarded — unlike the split-output and fetchMonth feeds. A drifted
CreateTransaction response (mutation validation is warn-only, never strips)
could poison the meta index. Closes #518.

Two layers: the class fix is an empty-id guard inside the `feedMeta` funnel
(every current and future feed passes through it); the instance fix is the
same call-site guard the split feed already has, at the create feed.

## External assumptions

None

## Bug fix?

Root cause:       create feed passed response accountId/itemId to indexTransactionMeta without the empty-id guard; response validation is warn-only so drifted values flow through
Bug class:        mutation-response-driven meta-index feeds unguarded against empty routing ids (read-side twin closed by #512)
Detector added:   empty-id guard inside the feedMeta funnel + funnel-level test — every current and future feed passes through it, so an unguarded call site can no longer poison the index
Siblings checked: split_transaction feed (guarded, tools.ts), fetchMonth feed (guarded, live-database.ts), patchLiveTransaction (guarded, live-database.ts), add_transaction_to_recurring (does not feed the index; ids are caller args validated non-empty by validateDocId)
Ledger updated:   n/a — not an external-assumption bug (no new claim about Copilot's API; response shapes already ledgered warn-only)

Known blind spot, declared: an empty-string drift on the mutation path is
now dropped *safely* but *silently* — mutation response schemas use plain
`z.string()` so `''` passes Zod without a warning (unlike `undefined`/`null`),
asymmetric with the read side's `.min(1)` warn+count. Filed as #526 (class-wide,
pre-dates this PR).

## Testing

- `bun run check` green: 2247 pass / 0 fail; no tool schema changes (no sync-manifest churn).
- Funnel-level test: indexTransactionMeta drops empty accountId and empty itemId.
- Tool-level tests (stubbed liveDb, pinning the call site independently of the funnel): valid routing ids are fed exactly once with the right triple; drifted `accountId: ''` and `itemId: ''` responses are never fed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)