### PR TITLE
fix(live): flush all live caches on mid-session uid transition (#521)

### DIFF
--- a/docs/graphql-live-reads.md
+++ b/docs/graphql-live-reads.md
@@ -126,7 +126,7 @@ Examples:
 - `refresh_cache({scope: "accounts"})` — flushes only the accounts snapshot.
 - `refresh_cache({scope: "transactions", months: ["2026-04"]})` — flushes one transaction month.
 
-All live caches are identity-scoped by sweep: if a token exchange lands on a different Firebase uid mid-session (re-auth as another account), the server flushes every live cache — the same full flush `refresh_cache` performs — so reads never mix two logins' data. Fetches already in flight across the flush are served to their caller but not re-cached.
+All live caches are identity-scoped by sweep: if a token exchange lands on a different Firebase uid mid-session (re-auth as another account), the server flushes every live cache — the same full flush `refresh_cache` performs — so reads never mix two logins' data. Fetches already in flight across the flush are served to their caller and — except for a ≤ one-request window around the exchange (derived-analytics map caches, and readers that coalesce onto a still-pending pre-flush loader) — not re-cached.
 
 ## Performance note
 

--- a/docs/graphql-live-reads.md
+++ b/docs/graphql-live-reads.md
@@ -126,6 +126,8 @@ Examples:
 - `refresh_cache({scope: "accounts"})` — flushes only the accounts snapshot.
 - `refresh_cache({scope: "transactions", months: ["2026-04"]})` — flushes one transaction month.
 
+All live caches are identity-scoped by sweep: if a token exchange lands on a different Firebase uid mid-session (re-auth as another account), the server flushes every live cache — the same full flush `refresh_cache` performs — so reads never mix two logins' data. Fetches already in flight across the flush are served to their caller but not re-cached.
+
 ## Performance note
 
 GraphQL reads paginate server-side (page size 100 by default). Narrow queries (e.g. one month of one account) typically run in <1s. Broad queries (full year, no account filter) paginate multiple pages — the server has limits on single-response size. When `--verbose` is set, the server logs per-call latency and pagination counts to stderr as `[graphql-read] op=Transactions pages=N latency=Xms rows=Y`. This data informs whether future phases need a richer caching strategy.

--- a/src/core/auth/firebase-auth.ts
+++ b/src/core/auth/firebase-auth.ts
@@ -45,6 +45,7 @@ export class FirebaseAuth {
   private userId: string | null = null;
   private expiresAt: number = 0;
   private extractToken: TokenExtractor;
+  private uidTransitionListener: ((prevUid: string, newUid: string) => void) | null = null;
 
   constructor(extractToken: TokenExtractor) {
     this.extractToken = extractToken;
@@ -86,6 +87,18 @@ export class FirebaseAuth {
     return this.userId;
   }
 
+  /**
+   * Register the single subscriber fired when a token exchange lands on a
+   * DIFFERENT non-null uid than the previous one — a mid-session re-auth as
+   * another account (refresh failure → cold re-extract picking up another
+   * browser login, #521). Fires AFTER the new auth state is fully installed.
+   * Listener exceptions are swallowed: a subscriber must never be able to
+   * break the token exchange.
+   */
+  setUidTransitionListener(listener: (prevUid: string, newUid: string) => void): void {
+    this.uidTransitionListener = listener;
+  }
+
   private async exchangeToken(refreshToken: string): Promise<void> {
     const response = await fetch(TOKEN_ENDPOINT, {
       method: 'POST',
@@ -106,10 +119,21 @@ export class FirebaseAuth {
       user_id: string;
     };
 
+    const prevUid = this.userId;
     this.idToken = data.id_token;
     this.refreshToken = data.refresh_token;
     this.userId = data.user_id;
     this.expiresAt = Date.now() + Number(data.expires_in) * 1000 - EXPIRY_MARGIN_MS;
+
+    // Identity can only change here — userId is assigned nowhere else — so
+    // this is THE chokepoint for the mid-session re-auth sweep (#521).
+    if (prevUid !== null && data.user_id && prevUid !== data.user_id) {
+      try {
+        this.uidTransitionListener?.(prevUid, data.user_id);
+      } catch {
+        // Subscriber failures must not break the exchange.
+      }
+    }
   }
 }
 

--- a/src/core/auth/firebase-auth.ts
+++ b/src/core/auth/firebase-auth.ts
@@ -127,6 +127,8 @@ export class FirebaseAuth {
 
     // Identity can only change here — userId is assigned nowhere else — so
     // this is THE chokepoint for the mid-session re-auth sweep (#521).
+    // `data.user_id &&` is an empty-string drift guard, not type noise: a
+    // drifted "" must not fire the listener with a bogus uid pair.
     if (prevUid !== null && data.user_id && prevUid !== data.user_id) {
       try {
         this.uidTransitionListener?.(prevUid, data.user_id);

--- a/src/core/cache/snapshot-cache.ts
+++ b/src/core/cache/snapshot-cache.ts
@@ -44,6 +44,10 @@ interface Entry<T> {
 
 export class SnapshotCache<T> {
   private entry: Entry<T> | null = null;
+  // Bumped by invalidate(); loaders capture it before fetching so a flush
+  // during the fetch (uid transition, refresh_cache) can't be overwritten
+  // by the stale write-back (#521).
+  private generation = 0;
 
   constructor(
     private readonly opts: SnapshotCacheOptions<T>,
@@ -55,14 +59,15 @@ export class SnapshotCache<T> {
       return { rows: this.entry.rows, fetched_at: this.entry.fetched_at, hit: true };
     }
 
+    const gen = this.generation;
     const result = await this.inflight.run(this.opts.key, async () => {
       const rows = await loader();
       // Cache write happens-before the loader's returned promise resolves,
       // ensuring it precedes the InFlightRegistry's .finally() cleanup.
-      // This also guards against a concurrent invalidate() racing between
-      // awaits — the local `entry` is captured before any external code runs.
+      // Skipped when invalidate() fired mid-flight: callers still receive
+      // the rows, but the next read() refetches fresh (#521).
       const entry: Entry<T> = { rows, fetched_at: Date.now() };
-      this.entry = entry;
+      if (this.generation === gen) this.entry = entry;
       return entry;
     });
 
@@ -87,6 +92,7 @@ export class SnapshotCache<T> {
 
   invalidate(): void {
     this.entry = null;
+    this.generation += 1;
   }
 
   /**

--- a/src/core/cache/transaction-window-cache.ts
+++ b/src/core/cache/transaction-window-cache.ts
@@ -53,6 +53,9 @@ export class TransactionWindowCache<T extends CachedTransaction = CachedTransact
   // Running row count maintained by every mutation. Avoids the previous
   // O(n²) loop where evictLRU recomputed totalRows() on each iteration.
   private _totalRows = 0;
+  // Bumped by every invalidate(); fetchMonth captures it before a network
+  // fetch and skips ingest + meta feed when it moved (#521).
+  private generation = 0;
 
   constructor(
     private readonly opts: TransactionWindowCacheOptions,
@@ -159,7 +162,13 @@ export class TransactionWindowCache<T extends CachedTransaction = CachedTransact
     }
   }
 
+  /** Monotonic invalidation stamp — see the generation field. */
+  generationId(): number {
+    return this.generation;
+  }
+
   invalidate(scope: 'all' | YearMonth[]): void {
+    this.generation += 1;
     if (scope === 'all') {
       this.windows.clear();
       this.lastAccessed.clear();

--- a/src/core/graphql/client.ts
+++ b/src/core/graphql/client.ts
@@ -267,6 +267,13 @@ export class GraphQLClient {
     return this.auth.getUserId();
   }
 
+  /** Register the uid-transition subscriber on the underlying auth — the
+   *  composition root uses this to flush all live caches on a mid-session
+   *  identity change (#521). See FirebaseAuth.setUidTransitionListener. */
+  setUidTransitionListener(listener: (prevUid: string, newUid: string) => void): void {
+    this.auth.setUidTransitionListener(listener);
+  }
+
   async mutate<TVariables, TResponse>(
     operationName: string,
     query: string,

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -229,6 +229,7 @@ export class LiveCopilotDatabase {
     const [monthStart, monthEnd] = getMonthRange(year, m);
     const filter = buildTransactionFilter({ startDate: monthStart, endDate: monthEnd });
     const fetched_at = Date.now();
+    const cacheGen = this.transactionsWindowCache.generationId();
     let pages = 0;
     let droppedInvalid = 0;
     const rawRows = await paginateTransactions(
@@ -246,23 +247,31 @@ export class LiveCopilotDatabase {
       },
       { startDate: monthStart }
     );
-    // Feed the append-only id→(accountId,itemId) index from the raw page
-    // rows — pre-trim, because leaked tail rows are real transactions too
-    // and their routing ids are just as valid. Guard against drifted
-    // responses with null/empty routing ids (see review finding).
-    for (const r of rawRows) {
-      if (r.accountId && r.itemId) {
-        this.feedMeta(r.id, { accountId: r.accountId, itemId: r.itemId });
+    // A flush during the fetch (uid transition / refresh_cache) means these
+    // rows may belong to the previous identity: serve them to this caller,
+    // but let neither the window cache nor the meta index keep them (#521).
+    const flushedMidFetch = this.transactionsWindowCache.generationId() !== cacheGen;
+    if (!flushedMidFetch) {
+      // Feed the append-only id→(accountId,itemId) index from the raw page
+      // rows — pre-trim, because leaked tail rows are real transactions too
+      // and their routing ids are just as valid. Guard against drifted
+      // responses with null/empty routing ids (see review finding).
+      for (const r of rawRows) {
+        if (r.accountId && r.itemId) {
+          this.feedMeta(r.id, { accountId: r.accountId, itemId: r.itemId });
+        }
       }
+      this.metaStore.flush();
     }
-    this.metaStore.flush();
     // Trim leaked tail-page rows that fall outside this month's window.
     // `paginateTransactions` early-exits AFTER appending a page, so the
     // trailing edge of the last page can dip into the previous month.
     // Without this trim, those rows pollute the wrong cache bucket and
     // get double-counted on subsequent full-range queries.
     const rows = rawRows.filter((r) => r.date >= monthStart && r.date <= monthEnd);
-    this.transactionsWindowCache.ingestMonth(month, rows, fetched_at);
+    if (!flushedMidFetch) {
+      this.transactionsWindowCache.ingestMonth(month, rows, fetched_at);
+    }
     return { rows, fetched_at, pages, droppedInvalid };
   }
 

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -250,6 +250,8 @@ export class LiveCopilotDatabase {
     // A flush during the fetch (uid transition / refresh_cache) means these
     // rows may belong to the previous identity: serve them to this caller,
     // but let neither the window cache nor the meta index keep them (#521).
+    // Fail-closed: this may also discard rows fetched under the NEW identity
+    // when the exchange resolved mid-fetch — one redundant refetch, never a mix.
     const flushedMidFetch = this.transactionsWindowCache.generationId() !== cacheGen;
     if (!flushedMidFetch) {
       // Feed the append-only id→(accountId,itemId) index from the raw page

--- a/src/core/persistence/transaction-meta-store.ts
+++ b/src/core/persistence/transaction-meta-store.ts
@@ -48,6 +48,9 @@ export class TransactionMetaStore {
   // Load warnings are per-uid: a corrupt file for a SECOND login must
   // still warn even after the first login's file already did.
   private readonly warnedLoadUids = new Set<string>();
+  // Cap-valve failures warn independently from load failures — two distinct
+  // messages must not share one suppression slot (#522 review, absorbed here).
+  private readonly warnedCapValveUids = new Set<string>();
   private warnedAppend = false;
   // Skip warnings are per-uid for the same reason load warnings are: a
   // second login's torn file must still warn.
@@ -155,8 +158,8 @@ export class TransactionMetaStore {
           writeFileSync(tmp, this.serialize(out));
           renameSync(tmp, file);
         } catch (e) {
-          if (!this.warnedLoadUids.has(uid)) {
-            this.warnedLoadUids.add(uid);
+          if (!this.warnedCapValveUids.has(uid)) {
+            this.warnedCapValveUids.add(uid);
             console.warn(
               `[copilot-money-mcp] persistent meta index cap-valve failed (${(e as Error).message}) — file not compacted. File: ${file}`
             );

--- a/src/server.ts
+++ b/src/server.ts
@@ -109,8 +109,9 @@ export class CopilotMoneyServer {
           console.warn(
             '[copilot-money-mcp] authenticated uid changed mid-session — flushing all live caches'
           );
-          refreshCache.refresh({ scope: 'all' }).catch(() => {
-            // scope:'all' cannot reject today; guard future rejectable awaits.
+          refreshCache.refresh({ scope: 'all' }).catch((e: unknown) => {
+            // scope:'all' cannot reject today; keep future rejections visible.
+            console.warn('[copilot-money-mcp] cache sweep after uid transition failed:', e);
           });
         });
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -109,7 +109,9 @@ export class CopilotMoneyServer {
           console.warn(
             '[copilot-money-mcp] authenticated uid changed mid-session — flushing all live caches'
           );
-          void refreshCache.refresh({ scope: 'all' });
+          refreshCache.refresh({ scope: 'all' }).catch(() => {
+            // scope:'all' cannot reject today; guard future rejectable awaits.
+          });
         });
       }
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -95,6 +95,23 @@ export class CopilotMoneyServer {
         investmentPrices,
         refreshCache: new RefreshCacheTool(liveDb, balanceHistory, investmentPrices),
       };
+
+      // Mid-session re-auth as a DIFFERENT account (#521): without this,
+      // every live cache keeps serving the previous login's data until TTL.
+      // One chokepoint, one sweep: reuse refresh_cache's full flush, which
+      // already enumerates every live cache — caches added there later join
+      // this sweep automatically. Feature-check because injected test
+      // doubles are structural casts without the method (they have no real
+      // auth, so no transitions can occur).
+      const refreshCache = this.live.refreshCache;
+      if (typeof graphqlClient.setUidTransitionListener === 'function') {
+        graphqlClient.setUidTransitionListener(() => {
+          console.warn(
+            '[copilot-money-mcp] authenticated uid changed mid-session — flushing all live caches'
+          );
+          void refreshCache.refresh({ scope: 'all' });
+        });
+      }
     }
 
     this.tools = new CopilotMoneyTools(this.db, graphqlClient, liveDb);

--- a/tests/core/auth/firebase-auth.test.ts
+++ b/tests/core/auth/firebase-auth.test.ts
@@ -279,5 +279,18 @@ describe('FirebaseAuth', () => {
       expect(token).toBe('tok-user-B');
       expect(auth.getUserId()).toBe('user-B');
     });
+
+    test('empty user_id in a drifted exchange response does not fire the listener', async () => {
+      const transitions: [string, string][] = [];
+      auth.setUidTransitionListener((prev, next) => transitions.push([prev, next]));
+      mockFetchSequence([
+        [tokenBody('user-A', '0'), 200],
+        [tokenBody('', '3600'), 200],
+      ]);
+
+      await auth.getIdToken();
+      await auth.getIdToken();
+      expect(transitions).toEqual([]);
+    });
   });
 });

--- a/tests/core/auth/firebase-auth.test.ts
+++ b/tests/core/auth/firebase-auth.test.ts
@@ -226,4 +226,58 @@ describe('FirebaseAuth', () => {
     expect(token2).toBe('refreshed-token');
     expect(fetchCalls).toHaveLength(2);
   });
+
+  describe('uid-transition listener (#521)', () => {
+    const tokenBody = (uid: string, expiresIn: string) => ({
+      id_token: `tok-${uid}`,
+      refresh_token: 'AMf-fake-refresh-token',
+      expires_in: expiresIn,
+      token_type: 'Bearer',
+      user_id: uid,
+    });
+
+    test('fires on a non-null → different-non-null uid change', async () => {
+      const transitions: [string, string][] = [];
+      auth.setUidTransitionListener((prev, next) => transitions.push([prev, next]));
+      // First exchange expires immediately so the second call re-exchanges.
+      mockFetchSequence([
+        [tokenBody('user-A', '0'), 200],
+        [tokenBody('user-B', '3600'), 200],
+      ]);
+
+      await auth.getIdToken();
+      expect(transitions).toEqual([]); // null → user-A is NOT a transition
+      await auth.getIdToken();
+      expect(transitions).toEqual([['user-A', 'user-B']]);
+    });
+
+    test('does not fire on a same-uid refresh', async () => {
+      const transitions: [string, string][] = [];
+      auth.setUidTransitionListener((prev, next) => transitions.push([prev, next]));
+      mockFetchSequence([
+        [tokenBody('user-A', '0'), 200],
+        [tokenBody('user-A', '3600'), 200],
+      ]);
+
+      await auth.getIdToken();
+      await auth.getIdToken();
+      expect(fetchCalls).toHaveLength(2); // a refresh really happened
+      expect(transitions).toEqual([]);
+    });
+
+    test('a throwing listener never breaks the exchange', async () => {
+      auth.setUidTransitionListener(() => {
+        throw new Error('subscriber bug');
+      });
+      mockFetchSequence([
+        [tokenBody('user-A', '0'), 200],
+        [tokenBody('user-B', '3600'), 200],
+      ]);
+
+      await auth.getIdToken();
+      const token = await auth.getIdToken();
+      expect(token).toBe('tok-user-B');
+      expect(auth.getUserId()).toBe('user-B');
+    });
+  });
 });

--- a/tests/core/cache/snapshot-cache.test.ts
+++ b/tests/core/cache/snapshot-cache.test.ts
@@ -136,6 +136,31 @@ describe('SnapshotCache', () => {
     expect(a.rows).toEqual([{ id: '1', name: 'one' }]);
     expect(b.rows).toEqual([{ id: '1', name: 'one' }]);
   });
+
+  test('invalidate during an in-flight load discards the stale write-back (#521)', async () => {
+    const cache = makeCache();
+    let release!: (rows: Row[]) => void;
+    const gate = new Promise<Row[]>((resolve) => {
+      release = resolve;
+    });
+
+    const pending = cache.read(() => gate); // loader in flight
+    cache.invalidate(); // uid-transition flush fires mid-flight
+    release([{ id: 'stale', name: 'previous login' }]);
+    const result = await pending;
+
+    // The caller that initiated the fetch still gets its rows…
+    expect(result.rows.map((r) => r.id)).toEqual(['stale']);
+    // …but nothing was cached: the next read must reload.
+    expect(cache.peek()).toBeUndefined();
+    let reloads = 0;
+    await cache.read(async () => {
+      reloads += 1;
+      return [{ id: 'fresh', name: 'current login' }];
+    });
+    expect(reloads).toBe(1);
+    expect(cache.peek()?.map((r) => r.id)).toEqual(['fresh']);
+  });
 });
 
 describe('SnapshotCache.peek', () => {

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -1311,6 +1311,40 @@ describe('transaction meta index', () => {
     }
   });
 
+  test('flush during an in-flight month fetch discards ingest and meta feed (#521)', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const page = metaPage([metaNode('race-t1', '2025-01-15', 'acct-A', 'item-A')]);
+    let queries = 0;
+    const client = {
+      mutate: mock(),
+      query: mock(async () => {
+        queries += 1;
+        if (queries === 1) await gate; // hold the first fetch in flight
+        return { transactions: page };
+      }),
+    } as unknown as GraphQLClient;
+    const live = new LiveCopilotDatabase(client, {} as CopilotDatabase);
+
+    const pending = live.getTransactions({ from: '2025-01-01', to: '2025-01-31' });
+    // Let getTransactions reach the awaited fetch before flushing.
+    await Bun.sleep(0);
+    live.getTransactionsWindowCache().invalidate('all'); // uid-transition sweep fires
+    release();
+    const result = await pending;
+
+    // The in-flight caller is still served its rows…
+    expect(result.rows.map((r) => r.id)).toEqual(['race-t1']);
+    // …but neither the window cache nor the meta index kept them.
+    expect(live.lookupTransactionMeta(['race-t1']).size).toBe(0);
+    expect(live.getTransactionsWindowCache().hasMonth('2025-01')).toBe(false);
+    // A follow-up read refetches instead of serving the discarded ingest.
+    await live.getTransactions({ from: '2025-01-01', to: '2025-01-31' });
+    expect(queries).toBe(2);
+  });
+
   test('patchLiveTransaction feeds persistence; new instance resolves the routing id without fetching (#511)', () => {
     // Verify that patchLiveTransaction's feedMeta path persists entries so a
     // fresh LiveCopilotDatabase can resolve them without any network call.

--- a/tests/core/persistence/transaction-meta-store.test.ts
+++ b/tests/core/persistence/transaction-meta-store.test.ts
@@ -193,6 +193,50 @@ describe('TransactionMetaStore', () => {
     expect(warns[0]).toContain('skipped 2 unparseable line');
   });
 
+  test('cap-valve and load-failure warnings suppress independently per uid (#521 polish)', () => {
+    mkdirSync(dir, { recursive: true });
+    const line = '{"i":"t1","a":"acct-1","t":"item-1"}\n';
+    writeFileSync(fileFor('userA'), line.repeat(200));
+    writeFileSync(fileFor('userB'), line);
+
+    let current: string | null = 'userA';
+    const s = new TransactionMetaStore({
+      baseDir: dir,
+      uidProvider: () => current,
+      maxBytes: 1024, // force the valve on userA's oversized file
+    });
+
+    const warns: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => warns.push(args.join(' '));
+    try {
+      chmodSync(dir, 0o555); // tmp-file write fails → cap-valve failure path
+      s.loadOnce();
+      expect(warns.some((w) => w.includes('cap-valve failed'))).toBe(true);
+      chmodSync(dir, 0o755);
+
+      // Rotate away and back so userA's file is re-read (loadedForUid moves).
+      current = 'userB';
+      s.loadOnce();
+
+      // Now make userA's file unreadable: the LOAD failure for userA must
+      // still warn — the cap-valve warning above must not have consumed
+      // userA's load-failure suppression slot.
+      chmodSync(fileFor('userA'), 0o000);
+      current = 'userA';
+      s.loadOnce();
+      expect(warns.some((w) => w.includes('unreadable'))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+      chmodSync(dir, 0o755);
+      try {
+        chmodSync(fileFor('userA'), 0o644);
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
   test('uid change between buffer and flush: entries stay with the uid captured at buffer time', () => {
     let current: string | null = 'userA';
     const s = new TransactionMetaStore({ baseDir: dir, uidProvider: () => current });

--- a/tests/integration/uid-transition-sweep.test.ts
+++ b/tests/integration/uid-transition-sweep.test.ts
@@ -10,17 +10,26 @@
  * refetch under the new identity.
  */
 import { test, expect, afterEach, mock } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { CopilotMoneyServer } from '../../src/server.js';
 import { FirebaseAuth } from '../../src/core/auth/firebase-auth.js';
 import { GraphQLClient } from '../../src/core/graphql/client.js';
 import type { TokenResult } from '../../src/core/auth/browser-token.js';
+import { createTestDb } from '../helpers/test-db.js';
 
 const originalFetch = globalThis.fetch;
 const originalDisable = process.env.COPILOT_DISABLE_PERSISTENT_INDEX;
+let tempDbDir: string | undefined;
 afterEach(() => {
   globalThis.fetch = originalFetch;
   if (originalDisable === undefined) delete process.env.COPILOT_DISABLE_PERSISTENT_INDEX;
   else process.env.COPILOT_DISABLE_PERSISTENT_INDEX = originalDisable;
+  if (tempDbDir) {
+    rmSync(tempDbDir, { recursive: true, force: true });
+    tempDbDir = undefined;
+  }
 });
 
 const account = (id: string, name: string) => ({
@@ -92,6 +101,11 @@ test('mid-session uid transition flushes all live caches (#521)', async () => {
     });
   }) as typeof fetch;
 
+  // Provide a synthetic LevelDB so isAvailable() passes on CI (no real DB).
+  // The live tools never touch LevelDB; the DB only needs to satisfy the guard.
+  tempDbDir = mkdtempSync(join(tmpdir(), 'copilot-sweep-'));
+  await createTestDb(tempDbDir, []);
+
   const extractor = mock(() =>
     Promise.resolve({
       candidates: [{ token: 'AMf-r', browser: 'Chrome' }] as TokenResult[],
@@ -99,7 +113,7 @@ test('mid-session uid transition flushes all live caches (#521)', async () => {
     })
   );
   const client = new GraphQLClient(new FirebaseAuth(extractor));
-  const server = new CopilotMoneyServer(undefined, undefined, false, true, client);
+  const server = new CopilotMoneyServer(tempDbDir, undefined, false, true, client);
 
   const warns: string[] = [];
   const origWarn = console.warn;

--- a/tests/integration/uid-transition-sweep.test.ts
+++ b/tests/integration/uid-transition-sweep.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Class-level detector for #521: a mid-session re-auth landing on a DIFFERENT
+ * uid must flush every live cache. Drives the REAL server wiring — real
+ * FirebaseAuth + real GraphQLClient (global fetch mocked) injected into
+ * CopilotMoneyServer with --live-reads — so a regression in the registration
+ * itself (not just the pieces) fails this test.
+ *
+ * Discriminator: after the transition, get_accounts_live would be a
+ * fresh-TTL cache HIT serving the previous login's rows; the sweep forces a
+ * refetch under the new identity.
+ */
+import { test, expect, afterEach, mock } from 'bun:test';
+import { CopilotMoneyServer } from '../../src/server.js';
+import { FirebaseAuth } from '../../src/core/auth/firebase-auth.js';
+import { GraphQLClient } from '../../src/core/graphql/client.js';
+import type { TokenResult } from '../../src/core/auth/browser-token.js';
+
+const originalFetch = globalThis.fetch;
+const originalDisable = process.env.COPILOT_DISABLE_PERSISTENT_INDEX;
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalDisable === undefined) delete process.env.COPILOT_DISABLE_PERSISTENT_INDEX;
+  else process.env.COPILOT_DISABLE_PERSISTENT_INDEX = originalDisable;
+});
+
+const account = (id: string, name: string) => ({
+  id,
+  itemId: 'item1',
+  name,
+  balance: 100,
+  liveBalance: true,
+  type: 'DEPOSITORY',
+  subType: 'checking',
+  mask: '0001',
+  isUserHidden: false,
+  isUserClosed: false,
+  isManual: false,
+  color: null,
+  limit: null,
+  institutionId: 'inst1',
+  hasHistoricalUpdates: true,
+  hasLiveBalance: true,
+  latestBalanceUpdate: '2026-04-25T00:00:00Z',
+});
+
+const emptyTransactionsPage = {
+  transactions: { edges: [], pageInfo: { endCursor: null, hasNextPage: false } },
+};
+
+test('mid-session uid transition flushes all live caches (#521)', async () => {
+  // The suite must never touch the real home directory: this test has a REAL
+  // uid provider, so the persistent meta index must be disabled (#522).
+  process.env.COPILOT_DISABLE_PERSISTENT_INDEX = '1';
+
+  // Exchange #1 lands uid-A with expires_in 0 → every later GraphQL call
+  // re-exchanges. Exchange #2+ lands uid-B (valid 1h).
+  let exchanges = 0;
+  globalThis.fetch = mock(async (url: string | URL | Request, options?: RequestInit) => {
+    const u = String(url);
+    if (u.includes('securetoken.googleapis.com')) {
+      exchanges += 1;
+      const body =
+        exchanges === 1
+          ? {
+              id_token: 'tok-A',
+              refresh_token: 'AMf-r',
+              expires_in: '0',
+              token_type: 'Bearer',
+              user_id: 'user-A',
+            }
+          : {
+              id_token: 'tok-B',
+              refresh_token: 'AMf-r',
+              expires_in: '3600',
+              token_type: 'Bearer',
+              user_id: 'user-B',
+            };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    // GraphQL endpoint: route on operationName from the POST body.
+    const op = (JSON.parse(String(options?.body)) as { operationName: string }).operationName;
+    const data =
+      op === 'Accounts'
+        ? { accounts: [account('acc-1', exchanges === 1 ? 'Account of A' : 'Account of B')] }
+        : emptyTransactionsPage;
+    return new Response(JSON.stringify({ data }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  const extractor = mock(() =>
+    Promise.resolve({
+      candidates: [{ token: 'AMf-r', browser: 'Chrome' }] as TokenResult[],
+      checked: ['Chrome'],
+    })
+  );
+  const client = new GraphQLClient(new FirebaseAuth(extractor));
+  const server = new CopilotMoneyServer(undefined, undefined, false, true, client);
+
+  const warns: string[] = [];
+  const origWarn = console.warn;
+  console.warn = (...args: unknown[]) => warns.push(args.join(' '));
+  try {
+    // 1) Populate the accounts snapshot cache under uid-A.
+    const first = await server.handleCallTool('get_accounts_live', {});
+    expect(JSON.stringify(first)).toContain('Account of A');
+
+    // 2) Any live-tier call re-exchanges (token expired) → uid-B →
+    //    transition fires → all live caches flushed.
+    await server.handleCallTool('get_transactions_live', { period: 'this_month' });
+    expect(exchanges).toBe(2);
+    expect(warns.some((w) => w.includes('flushing all live caches'))).toBe(true);
+
+    // 3) Without the sweep this is a fresh-TTL cache HIT serving uid-A's
+    //    rows. With it, the flush forces a refetch under uid-B.
+    const third = await server.handleCallTool('get_accounts_live', {});
+    expect(JSON.stringify(third)).toContain('Account of B');
+    expect(JSON.stringify(third)).not.toContain('Account of A');
+  } finally {
+    console.warn = origWarn;
+  }
+});


### PR DESCRIPTION
# Summary

A mid-session re-auth that lands on a DIFFERENT account left every in-memory
live cache serving the previous login's data until TTL expiry. #511 closed
this class for the meta index; this PR closes it for all remaining live
caches with one guard at the only chokepoint where identity can change
(the token exchange), reusing refresh_cache's full flush. Closes #521.

## External assumptions

None — process-internal cache lifecycle only (the securetoken `user_id`
field this keys on is the same one #511's per-uid store already relies on).

## Bug fix?

Root cause:       live caches implicitly assume one authenticated identity per process; nothing invalidated them when a token exchange changed the uid
Bug class:        identity-scoped state not invalidated on uid transition (meta-index instance closed by #511; this closes the remaining caches)
Detector added:   end-to-end integration test driving the real auth→client→server wiring: re-auth as a different uid must flush every cache refresh_cache flushes — structurally guaranteed because the transition handler IS refresh_cache's scope-all flush, so future caches added there join the sweep automatically; plus generation-guard tests for the in-flight write-back race
Siblings checked: meta index (#511 per-uid store + lazy clear — untouched, already safe); persistent store files (per-uid on disk); SnapshotCache + TransactionWindowCache in-flight write-backs (generation-guarded here); balance-history/investment-prices in-flight write-backs (accepted residual, below)
Ledger updated:   n/a — not an external-assumption bug

### Known residuals (conscious accepts)

- An in-flight balance-history/investment-prices fetch that resolves after
  the flush can re-cache one entry fetched under the old identity (same
  race the generation guards close for snapshot/window caches). Window:
  one ~350ms request straddling the exchange.
- The InFlightRegistry is not cleared on the sweep, so a read that STARTS
  just after the transition can coalesce onto a still-pending pre-flush
  loader and receive old-identity rows for that one call (not re-cached —
  the generation guard discards the write-back). Same ≤ one-request
  window. If review prefers closing both: an `InFlightRegistry.clear()`
  invoked from the sweep is the natural follow-up shape.
- The rows RETURNED to a caller whose fetch straddled the exchange may
  belong to the old identity (single response, not cached). Unavoidable
  without failing the request.

## Also in this PR

- Store polish absorbed from #522's review: cap-valve compaction-failure
  warnings now suppress independently from load-failure warnings
  (per-uid, two sets, two messages).
- One docs paragraph in docs/graphql-live-reads.md documenting the sweep
  and its residual window.

## Testing

- `bun run check` green: 2254 pass / 0 fail; no tool schema changes.
- e2e (tests/integration/uid-transition-sweep.test.ts): real FirebaseAuth +
  real GraphQLClient (global fetch mocked, URL-routed) injected into
  CopilotMoneyServer — re-auth as a different uid flushes the warm accounts
  cache (without the sweep, step 3 is a fresh-TTL cache hit serving the
  previous login's rows). Persistent meta index disabled via
  COPILOT_DISABLE_PERSISTENT_INDEX so the suite never touches the home dir.
- Race tests: SnapshotCache invalidate-during-in-flight-load discards the
  write-back; fetchMonth crossing a flush serves rows but neither ingests
  nor feeds the meta index; follow-up read refetches.
- Auth unit tests: transition fires only on non-null→different-non-null,
  after state install; listener exceptions never break the exchange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)