### PR TITLE
fix(smoke): wire FirebaseAuth with the candidates extractor (live-smoke gate was crashing on candidates.slice)

### DIFF
--- a/scripts/smoke-graphql.ts
+++ b/scripts/smoke-graphql.ts
@@ -34,7 +34,7 @@ import * as readline from 'node:readline';
 import { GraphQLClient, GraphQLError } from '../src/core/graphql/client.js';
 import type { GraphQLErrorCode } from '../src/core/graphql/client.js';
 import { FirebaseAuth } from '../src/core/auth/firebase-auth.js';
-import { extractRefreshToken } from '../src/core/auth/browser-token.js';
+import { extractRefreshTokenCandidates } from '../src/core/auth/browser-token.js';
 import { CopilotDatabase } from '../src/core/database.js';
 import { CopilotMoneyTools } from '../src/tools/tools.js';
 
@@ -2912,7 +2912,7 @@ async function main(): Promise<void> {
       `section=${onlySection ?? 'all'}`
   );
 
-  const auth = new FirebaseAuth(() => extractRefreshToken());
+  const auth = new FirebaseAuth(() => extractRefreshTokenCandidates());
   const client = new GraphQLClient(auth);
   const db = new CopilotDatabase();
   const tools = new CopilotMoneyTools(db, client);

--- a/scripts/smoke/_conformance.ts
+++ b/scripts/smoke/_conformance.ts
@@ -16,17 +16,17 @@
  * `Value "<X>" does not exist in "<EnumName>" enum.`
  *
  * Requires an authenticated app.copilot.money browser session — same auth path
- * the production server uses (FirebaseAuth via extractRefreshToken).
+ * the production server uses (FirebaseAuth via extractRefreshTokenCandidates).
  */
 
 import { FirebaseAuth } from '../../src/core/auth/firebase-auth.js';
-import { extractRefreshToken } from '../../src/core/auth/browser-token.js';
+import { extractRefreshTokenCandidates } from '../../src/core/auth/browser-token.js';
 
 const ENDPOINT = 'https://app.copilot.money/api/graphql';
 
 /** Acquire a Firebase id token from the live browser session (once per run). */
 export async function getIdToken(): Promise<string> {
-  const auth = new FirebaseAuth(() => extractRefreshToken());
+  const auth = new FirebaseAuth(() => extractRefreshTokenCandidates());
   return auth.getIdToken();
 }
 

--- a/scripts/smoke/_harness.ts
+++ b/scripts/smoke/_harness.ts
@@ -10,13 +10,13 @@
  *   log('done', { rows: result.length });
  *
  * Requires an authenticated app.copilot.money browser session — same auth
- * path the production server uses (FirebaseAuth via extractRefreshToken).
+ * path the production server uses (FirebaseAuth via extractRefreshTokenCandidates).
  */
 
 import { CopilotDatabase } from '../../src/core/database.js';
 import { GraphQLClient } from '../../src/core/graphql/client.js';
 import { FirebaseAuth } from '../../src/core/auth/firebase-auth.js';
-import { extractRefreshToken } from '../../src/core/auth/browser-token.js';
+import { extractRefreshTokenCandidates } from '../../src/core/auth/browser-token.js';
 import { LiveCopilotDatabase, preflightLiveAuth } from '../../src/core/live-database.js';
 
 export interface SmokeHarnessOptions {
@@ -38,7 +38,7 @@ export async function setupLiveSmoke(opts: SmokeHarnessOptions = {}): Promise<Sm
   if (opts.injectedClient) {
     graphql = opts.injectedClient;
   } else {
-    const auth = new FirebaseAuth(() => extractRefreshToken());
+    const auth = new FirebaseAuth(() => extractRefreshTokenCandidates());
     graphql = new GraphQLClient(auth);
   }
 

--- a/scripts/smoke/reads.ts
+++ b/scripts/smoke/reads.ts
@@ -16,7 +16,7 @@
  */
 
 import { FirebaseAuth } from '../../src/core/auth/firebase-auth.js';
-import { extractRefreshToken } from '../../src/core/auth/browser-token.js';
+import { extractRefreshTokenCandidates } from '../../src/core/auth/browser-token.js';
 import { GraphQLClient } from '../../src/core/graphql/client.js';
 import { READ_SMOKE_CHECKS, type ReadSmokeState } from './read-checks.js';
 
@@ -36,7 +36,7 @@ function log(msg: string, fields?: Record<string, unknown>): void {
 }
 
 async function main(): Promise<void> {
-  const auth = new FirebaseAuth(() => extractRefreshToken());
+  const auth = new FirebaseAuth(() => extractRefreshTokenCandidates());
   try {
     await auth.getIdToken();
   } catch (err: unknown) {

--- a/scripts/smoke/roundtrip.ts
+++ b/scripts/smoke/roundtrip.ts
@@ -20,7 +20,7 @@
  */
 
 import { FirebaseAuth } from '../../src/core/auth/firebase-auth.js';
-import { extractRefreshToken } from '../../src/core/auth/browser-token.js';
+import { extractRefreshTokenCandidates } from '../../src/core/auth/browser-token.js';
 import { GraphQLClient } from '../../src/core/graphql/client.js';
 import { getResponseDriftStats } from '../../src/core/graphql/response-validation.js';
 import {
@@ -85,7 +85,7 @@ async function main(): Promise<void> {
   console.error(formatPlan(checks));
   console.error('');
 
-  const auth = new FirebaseAuth(() => extractRefreshToken());
+  const auth = new FirebaseAuth(() => extractRefreshTokenCandidates());
   try {
     await auth.getIdToken();
   } catch (err: unknown) {

--- a/scripts/verify-optimistic-consistency.ts
+++ b/scripts/verify-optimistic-consistency.ts
@@ -33,7 +33,7 @@ import {
 } from '../src/core/leveldb-reader.js';
 import { GraphQLClient } from '../src/core/graphql/client.js';
 import { FirebaseAuth } from '../src/core/auth/firebase-auth.js';
-import { extractRefreshToken } from '../src/core/auth/browser-token.js';
+import { extractRefreshTokenCandidates } from '../src/core/auth/browser-token.js';
 import { CopilotDatabase } from '../src/core/database.js';
 import { CopilotMoneyTools } from '../src/tools/tools.js';
 
@@ -180,7 +180,7 @@ async function main(): Promise<void> {
   if (skip.size > 0) console.log(`Skipping: ${[...skip].join(', ')}`);
   if (only) console.log(`Only: ${only}`);
 
-  const auth = new FirebaseAuth(() => extractRefreshToken());
+  const auth = new FirebaseAuth(() => extractRefreshTokenCandidates());
   const client = new GraphQLClient(auth);
   const db = new CopilotDatabase(dbPath);
   const tools = new CopilotMoneyTools(db, client);


### PR DESCRIPTION
# Summary

The live-smoke gate (`bun run smoke`, `bun run smoke:roundtrip`) and the two dev harness scripts crashed on `candidates.slice(...)` before any token was consulted, so no user could run the smoke regardless of login. This swaps all six script call sites from the single-result `extractRefreshToken` to `extractRefreshTokenCandidates`, matching production. Verified: `bun run smoke` now passes all read operations + conformance against the live endpoint.

## External assumptions

None — this fixes internal auth wiring in dev/smoke scripts; no new assumption about Copilot's API/data.

## Bug fix?

Root cause:       Smoke/dev scripts constructed `FirebaseAuth` with `() => extractRefreshToken()` (returns a single `{token,browser}`), but `FirebaseAuth.TokenExtractor` is `() => Promise<TokenCandidates>` (`{candidates,checked}`); `getIdToken`'s cold path destructured `candidates` → `undefined` → `candidates.slice` threw.
Bug class:        Untypechecked `scripts/` drifting from a `src/` contract change — the production wiring was migrated to the candidates extractor (#454) but the scripts were never updated, and `tsconfig` includes only `src/**/*` so the mismatch never surfaced at build time.
Detector added:   Deferred to #531 (filed) — the class-level detector is a `scripts/` typecheck gate, which needs its own tsconfig and may surface pre-existing script type errors, so it is scoped as separate work. This PR fixes all six current instances.
Siblings checked: All `new FirebaseAuth(...)` sites audited repo-wide — `src/server.ts` (x2) already correct; the six broken sites (`scripts/smoke/{_conformance,_harness,reads,roundtrip}.ts`, `scripts/smoke-graphql.ts`, `scripts/verify-optimistic-consistency.ts`) all fixed.
Ledger updated:   n/a — not an external-assumption bug.