### PR TITLE
fix: surface empty-string routing/id drift on the mutation path (#526)

### DIFF
--- a/src/core/graphql/response-validation.ts
+++ b/src/core/graphql/response-validation.ts
@@ -62,16 +62,20 @@ const TagSchema = z.looseObject({
  * server ever ships a NEW transaction type, responses carrying it will
  * warn until TRANSACTION_TYPES (and its smoke conformance probe) are
  * updated. That first warn is the drift signal working, not a bug.
+ *
+ * Write-critical ids (`id`, `accountId`, `itemId`) are validated with
+ * `.min(1)` to mirror read-validation.ts — empty strings are drift,
+ * symmetric with read-side schema enforcement (#526).
  */
 const CreatedTransactionSchema = z.looseObject({
-  id: z.string(),
+  id: z.string().min(1),
   name: z.string(),
   date: z.string(),
   amount: z.number(),
   categoryId: z.string(),
   type: z.enum(TRANSACTION_TYPES),
-  accountId: z.string(),
-  itemId: z.string(),
+  accountId: z.string().min(1),
+  itemId: z.string().min(1),
   isPending: z.boolean(),
   isReviewed: z.boolean(),
   createdAt: z.number(),

--- a/src/core/live-database.ts
+++ b/src/core/live-database.ts
@@ -524,12 +524,14 @@ export class LiveCopilotDatabase {
   }
 
   /** Single funnel for meta-index writes: in-memory map + persistence
-   *  buffer (#511). Entries with empty routing ids are dropped HERE, not
-   *  just at call sites (#518) — response validation is warn-only, so a
-   *  drifted read or mutation response must never poison the index even
-   *  if a future call site forgets its own guard. */
+   *  buffer (#511). Entries with empty routing ids (accountId, itemId, or id
+   *  itself) are dropped HERE, not just at call sites (#518, #526) — response
+   *  validation is warn-only, so a drifted read or mutation response must
+   *  never poison the index even if a future call site forgets its own guard.
+   *  The !id check completes the funnel invariant and matches the disk format's
+   *  non-empty-id requirement. */
   private feedMeta(id: string, meta: { accountId: string; itemId: string }): void {
-    if (!meta.accountId || !meta.itemId) return;
+    if (!id || !meta.accountId || !meta.itemId) return;
     this.txnMetaIndex.set(id, meta);
     this.metaStore.buffer(id, meta);
   }

--- a/tests/core/graphql/response-validation.test.ts
+++ b/tests/core/graphql/response-validation.test.ts
@@ -247,4 +247,45 @@ describe('validateMutationResponse', () => {
     expect(message).toContain('no registered response schema');
     expect(getResponseDriftStats()).toEqual({});
   });
+
+  describe('empty-string write-critical id drift (#526)', () => {
+    // These three ids are write-critical: accountId/itemId feed the meta
+    // index (routing for EditTransaction/CreateRecurring); id keys it. An
+    // empty string is drift, symmetric with read-validation.ts's .min(1).
+    for (const field of ['id', 'accountId', 'itemId'] as const) {
+      test(`empty ${field} in a createTransaction response warns + counts`, () => {
+        const tx = makeTransaction();
+        tx[field] = '';
+        validateMutationResponse('CreateTransaction', { createTransaction: tx });
+
+        expect(getResponseDriftStats()).toEqual({
+          'Mutation.createTransaction:response': 1,
+        });
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const message = warnSpy.mock.calls[0][0] as string;
+        expect(message).toContain('operation=CreateTransaction');
+        expect(message).toContain(`path=createTransaction.${field}`);
+        expect(message).toContain('code=too_small');
+      });
+    }
+
+    test('empty itemId inside a splitTransaction child warns + counts', () => {
+      const parent = makeTransaction();
+      const child = makeTransaction();
+      child.itemId = '';
+      validateMutationResponse('SplitTransaction', {
+        splitTransaction: { parentTransaction: parent, splitTransactions: [child] },
+      });
+      expect(getResponseDriftStats()).toEqual({
+        'Mutation.splitTransaction:response': 1,
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('non-empty ids still pass clean (no false positives)', () => {
+      validateMutationResponse('CreateTransaction', VALID_RESPONSES.CreateTransaction);
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(getResponseDriftStats()).toEqual({});
+    });
+  });
 });

--- a/tests/core/graphql/response-validation.test.ts
+++ b/tests/core/graphql/response-validation.test.ts
@@ -280,6 +280,28 @@ describe('validateMutationResponse', () => {
         'Mutation.splitTransaction:response': 1,
       });
       expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = warnSpy.mock.calls[0][0] as string;
+      expect(message).toContain('operation=SplitTransaction');
+      expect(message).toContain('path=splitTransaction.splitTransactions.0.itemId');
+      expect(message).toContain('code=too_small');
+    });
+
+    // AddTransactionToRecurring reuses CreatedTransactionSchema, so it inherits
+    // the .min(1) guard; pin it explicitly so the coverage is visible per-op.
+    test('empty accountId in an addTransactionToRecurring response warns + counts', () => {
+      const tx = makeTransaction();
+      tx.accountId = '';
+      validateMutationResponse('AddTransactionToRecurring', {
+        addTransactionToRecurring: { transaction: tx },
+      });
+      expect(getResponseDriftStats()).toEqual({
+        'Mutation.addTransactionToRecurring:response': 1,
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = warnSpy.mock.calls[0][0] as string;
+      expect(message).toContain('operation=AddTransactionToRecurring');
+      expect(message).toContain('path=addTransactionToRecurring.transaction.accountId');
+      expect(message).toContain('code=too_small');
     });
 
     test('non-empty ids still pass clean (no false positives)', () => {

--- a/tests/core/live-database.test.ts
+++ b/tests/core/live-database.test.ts
@@ -10,7 +10,7 @@ import type { CategoryNode } from '../../src/core/graphql/queries/categories.js'
 import type { RecurringNode } from '../../src/core/graphql/queries/recurrings.js';
 import type { UserNode } from '../../src/core/graphql/queries/user.js';
 import { TransactionMetaStore } from '../../src/core/persistence/transaction-meta-store.js';
-import { mkdtempSync, rmSync, mkdirSync, chmodSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, chmodSync, readdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
@@ -1035,6 +1035,8 @@ describe('transaction meta index', () => {
     live.indexTransactionMeta('meta-no-acct', { accountId: '', itemId: 'item-B' });
     live.indexTransactionMeta('meta-no-item', { accountId: 'acct-B', itemId: '' });
     expect(live.lookupTransactionMeta(['meta-no-acct', 'meta-no-item']).size).toBe(0);
+    live.indexTransactionMeta('', { accountId: 'acct-B', itemId: 'item-B' });
+    expect(live.lookupTransactionMeta(['']).size).toBe(0);
   });
 
   test('lookupTransactionMeta returns an empty map for unknown ids', () => {
@@ -1222,6 +1224,29 @@ describe('transaction meta index', () => {
         accountId: 'acct-C',
         itemId: 'item-C',
       });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('empty id is dropped at the funnel and never written to disk (#526)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'live-meta-emptyid-'));
+    try {
+      const store = new TransactionMetaStore({ baseDir: dir, uidProvider: () => 'user-1' });
+      const live = new LiveCopilotDatabase(
+        { mutate: mock(), query: mock() } as unknown as GraphQLClient,
+        {} as CopilotDatabase,
+        { metaStore: store }
+      );
+      // Valid routing ids but a drifted empty id: pre-#526 this buffered
+      // {"i":"", ...} to disk, which loadOnce later rejects with a
+      // misleading skip warning about a line we wrote ourselves.
+      live.indexTransactionMeta('', { accountId: 'acct-A', itemId: 'item-A' });
+
+      expect(live.lookupTransactionMeta(['']).size).toBe(0);
+      // Nothing valid was buffered, so no per-uid index file should exist.
+      const files = readdirSync(dir).filter((f) => f.startsWith('txn-meta-index.'));
+      expect(files).toEqual([]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
# Summary

Closes #526. Empty-string routing-id (and transaction-id) drift on the GraphQL mutation path was dropped safely but **silently** — asymmetric with the read side, which warns + counts. This restores symmetry:

- **`response-validation.ts`** — `CreatedTransactionSchema`'s `id`/`accountId`/`itemId` go from `z.string()` to `z.string().min(1)`, mirroring `read-validation.ts`. Empty-string drift now warns (deduped) and increments the per-surface counter in `getResponseDriftStats()` instead of passing silently. One edit covers the whole class (`createTransaction`, `addTransactionToRecurring`, `splitTransaction` parent + children). Still strictly warn-only — never throws, never drops data.
- **`live-database.ts`** — `feedMeta`'s guard gains the missing `!id` check (`if (!id || !meta.accountId || !meta.itemId) return`), completing the funnel invariant and matching the disk format's non-empty-id requirement (`transaction-meta-store.ts` rejects `rec.i.length === 0`). A drifted `id: ''` can no longer buffer a `{"i":""}` line that next session's loader rejects with a misleading skip warning.

**Validation:** full gate green (`bun run check`, 2261 tests). Live-validated with `bun run smoke:roundtrip` (with the #530 smoke-gate fix applied): 17/17 write round-trips pass, **response-shape drift counters: none** — confirming real live create/split responses carry non-empty routing ids, so `.min(1)` produces no false positives. `bun run smoke` reads: 19/19 pass.

## External assumptions

None — tightens existing warn-mode validation to match the read side; no new assumption about Copilot's API/data.

## Bug fix?

Root cause:       Mutation response schema validated write-critical ids (`id`/`accountId`/`itemId`) with presence-only `z.string()`, which accepts `""`; the downstream `feedMeta` funnel then dropped the empty entry with zero telemetry — asymmetric with the read schema's `.min(1)`.
Bug class:        Write-critical id fields validated by presence, not non-emptiness → silent-drop drift invisible to the drift counters.
Detector added:   `.min(1)` on `id`/`accountId`/`itemId` in `CreatedTransactionSchema` (covers every `CreatedTransactionSchema`-backed response) surfaces drift in `getResponseDriftStats()` + a deduped warn; `!id` in the `feedMeta` guard covers the funnel for all sources. Unit tests assert both the drift-counter/warn and that no empty-id line reaches disk.
Siblings checked: Other id-bearing mutation schemas (tag/category/recurring/account ids, `EditTransaction`'s echoed `transaction.id`) audited — none feed the silent write-resolution meta index; they're returned in tool results (visible). The patch feed's routing ids come from read rows (already `.min(1)`) plus the shared `feedMeta` guard. No additional tightening needed.
Ledger updated:   n/a structurally — `Mutation.createTransaction:response` / `:splitTransaction:response` / `:addTransactionToRecurring:response` already register `CreatedTransactionSchema` under the `runtime:zod-warn` oracle; tightening strengthens the existing detector.