### PR TITLE
chore(build): typecheck scripts/ in the check gate (#531)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lint:fix": "eslint src --fix",
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
-    "typecheck": "tsc --noEmit && tsc -p tsconfig.tests.json",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.tests.json && tsc -p tsconfig.scripts.json",
     "check": "bun run typecheck && bun run lint && bun run format:check && bun run check:version-sync && bun run check:server-json && bun test --bail",
     "snapshot:create": "bun run scripts/snapshot.ts create",
     "snapshot:restore": "bun run scripts/snapshot.ts restore",

--- a/scripts/generate-graphql-operations.ts
+++ b/scripts/generate-graphql-operations.ts
@@ -110,7 +110,7 @@ export function addTypenameToSelectionSets(query: string): string {
     SelectionSet(node, _key, parent) {
       // Skip the operation-level selection set (directly under OperationDefinition).
       // __typename is only meaningful on concrete object type selection sets (fields).
-      if (parent && !Array.isArray(parent) && parent.kind === Kind.OPERATION_DEFINITION) {
+      if (parent && !Array.isArray(parent) && 'kind' in parent && parent.kind === Kind.OPERATION_DEFINITION) {
         return undefined; // no change
       }
       const hasTypename = node.selections.some(

--- a/scripts/graphql-capture/adapt-apollo-log.ts
+++ b/scripts/graphql-capture/adapt-apollo-log.ts
@@ -1,4 +1,4 @@
-import type { RawEntry } from './scrub';
+import type { RawEntry } from './scrub.js';
 
 interface QueryManagerEntry {
   id: string;
@@ -139,7 +139,7 @@ function toRawEntry(
 
 function toRawEntryVerbatim(
   opName: string,
-  kind: 'query' | 'mutation',
+  _kind: 'query' | 'mutation',
   variables: Record<string, unknown>,
   query: string,
   data: unknown,

--- a/scripts/graphql-capture/generate-docs.ts
+++ b/scripts/graphql-capture/generate-docs.ts
@@ -1,6 +1,6 @@
 import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
-import type { RawEntry } from './scrub';
+import type { RawEntry } from './scrub.js';
 
 export interface OperationGroup {
   kind: 'query' | 'mutation';

--- a/scripts/graphql-capture/merge-documents.ts
+++ b/scripts/graphql-capture/merge-documents.ts
@@ -1,5 +1,5 @@
 import { rename } from 'node:fs/promises';
-import type { RawEntry } from './scrub';
+import type { RawEntry } from './scrub.js';
 
 interface DocumentDump {
   documents: Record<string, string>;

--- a/scripts/scheduled-smoke.ts
+++ b/scripts/scheduled-smoke.ts
@@ -13,7 +13,6 @@
  * ~/.claude/copilot-money/smoke-reports/. On pass: silent.
  */
 import { mkdirSync, writeFileSync } from 'fs';
-import { homedir } from 'os';
 import { dirname, join } from 'path';
 import { spawnSync } from 'child_process';
 import {

--- a/scripts/smoke-graphql.ts
+++ b/scripts/smoke-graphql.ts
@@ -49,7 +49,6 @@ import {
   createTransaction,
   deleteTransaction,
   editTransaction,
-  splitTransaction,
 } from '../src/core/graphql/transactions.js';
 import {
   createRecurring,
@@ -731,7 +730,7 @@ async function smokeTransactionsHappyPath(
   });
 
   // isReviewed toggle
-  const originalReviewed = candidate.is_reviewed ?? false;
+  const originalReviewed = candidate.user_reviewed ?? false;
   await step('transactions', 'isReviewed: true → false → restore', async () => {
     await editTransaction(client, {
       id: txnId,
@@ -1252,6 +1251,7 @@ async function smokeTransactionsWrites(
           throw new Error(`deleteTransaction returned ${ok}, expected true`);
         }
         unregisterCleanup(created.id);
+        return;
       }
     );
   } finally {
@@ -1737,7 +1737,7 @@ async function smokeBulkReviewTransactions(
   // Capture original isReviewed state for restoration.
   const original = new Map<string, boolean>();
   for (const t of usable) {
-    original.set(t.transaction_id, t.is_reviewed ?? false);
+    original.set(t.transaction_id, t.user_reviewed ?? false);
   }
 
   await step(
@@ -2031,9 +2031,9 @@ async function smokeErrorInjection(
   // NETWORK
   await step('errors', 'NETWORK via fetch stub', async () => {
     const origFetch = globalThis.fetch;
-    globalThis.fetch = () => {
+    globalThis.fetch = (() => {
       throw new Error('ECONNRESET');
-    };
+    }) as unknown as typeof fetch;
     try {
       const e = await expectThrows(
         () => editTag(client, { id: 'any', input: { name: 'x' } }),
@@ -2542,7 +2542,7 @@ async function smokeMcpToolEndToEnd(
   const usable = allTxns.filter((t) => t.account_id && t.item_id).slice(0, 3);
   if (usable.length >= 3) {
     const original = new Map<string, boolean>();
-    for (const t of usable) original.set(t.transaction_id, t.is_reviewed ?? false);
+    for (const t of usable) original.set(t.transaction_id, t.user_reviewed ?? false);
 
     await step(
       'mcp-e2e',
@@ -2649,9 +2649,8 @@ async function smokeMcpToolEndToEnd(
       'mcp-e2e',
       'tools.setRecurringState (PAUSED → ACTIVE) happy path',
       async () => {
-        const id = (existingRecurring as { recurring_id?: string; id?: string })
-          .recurring_id ??
-          (existingRecurring as { id: string }).id;
+        const rec = existingRecurring as { recurring_id?: string; id: string };
+        const id = rec.recurring_id ?? rec.id;
         await tools.setRecurringState({ recurring_id: id, state: 'PAUSED' });
         await tools.setRecurringState({ recurring_id: id, state: 'ACTIVE' });
       }

--- a/scripts/verify-optimistic-consistency.ts
+++ b/scripts/verify-optimistic-consistency.ts
@@ -447,9 +447,10 @@ async function main(): Promise<void> {
     }
     // Capture the actual current state and uppercase it for the GraphQL enum
     // restore. The decoder yields lowercase ('active'), the API expects upper.
-    // `target.state` is non-undefined here (the .find above filtered on it),
-    // so no fallback is needed.
-    const originalState = target.state.toUpperCase();
+    // The .find matched `state === 'active'`, so `target.state` is 'active'
+    // here; the `?? 'active'` only satisfies the type checker — find's
+    // predicate doesn't narrow the found element's property.
+    const originalState = (target.state ?? 'active').toUpperCase();
     try {
       await tools.setRecurringState({ recurring_id: target.recurring_id, state: 'PAUSED' });
       console.log(`  paused recurring ${target.recurring_id} "${target.name}"`);

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": false
+  },
+  "include": ["scripts/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
# Summary

Closes #531. `scripts/**` was outside every tsconfig (`tsconfig.json` includes only `src/**/*`; `tsconfig.tests.json` covers a curated `tests/` subset), so a `src/` contract change could silently break a `scripts/` caller and only fail at runtime — the class that shipped #530 (the live-smoke gate crashing on `candidates.slice`).

This adds `tsconfig.scripts.json` (modeled on `tsconfig.tests.json`: `rootDir "."`, `noEmit`, `noUncheckedIndexedAccess` relaxed) covering the **whole** `scripts/` tree, and wires it into the `typecheck` npm script so it runs in `bun run check` and CI. Then it fixes the 14 real errors this surfaces — all in dev/smoke scripts, **none in production `src/`**.

**Validation:** `bun run typecheck` (now 3 `tsc -p` invocations) exits 0; `bun run check` green (2262 tests).

## The 14 fixes

- 3× missing `.js` import extension (`graphql-capture/{adapt-apollo-log,generate-docs,merge-documents}.ts`, all `import type` — zero runtime effect)
- 3× unused declaration removed/prefixed (`homedir`, `splitTransaction`, and an unused `_kind` param)
- 1× AST-node narrowing (`'kind' in parent` — `!Array.isArray` doesn't exclude `readonly ASTNode[]` under graphql@17's typings)
- 1× explicit `return;` on a `stepSkippable` fall-through path (`noImplicitReturns`)
- 1× `fetch` stub cast, 1× overlapping-cast consolidation, 1× possibly-undefined `target.state` guard
- **3× `is_reviewed` → `user_reviewed` — a latent bug the gate caught.** The field on `Transaction` is `user_reviewed` (`src/models/transaction.ts:54`); `is_reviewed` doesn't exist, but `TransactionSchema.passthrough()` made the wrong name resolve to `{}` (always truthy) instead of erroring, so `smoke-graphql.ts`'s isReviewed-toggle tests were reading garbage. Corrected all three sites.

## External assumptions

None — build tooling + dev-script fixes; no new assumption about Copilot's API/data.

## Bug fix?

Root cause:       `scripts/**` outside the typecheck path → `src`↔`scripts` contract drift ships silently, failing only at runtime.
Bug class:        Untypechecked `scripts/` drifting from a `src/` contract.
Detector added:   `tsconfig.scripts.json` covering the entire `scripts/` tree, wired into `typecheck` (→ `bun run check` + CI Quality Checks). A reintroduced shape mismatch now fails the build. Verified it flags the #530 mismatch and surfaced the `user_reviewed` latent bug.
Siblings checked: All 14 current `scripts/` type errors fixed; the whole tree is gated (no curated allowlist to drift, unlike the tests config).
Ledger updated:   n/a — not an external-assumption bug.

---

_Note: running `bun run smoke:reads` during validation surfaced one **unrelated, pre-existing** live drift — `securityPrices[0].price` returns `null` while the query types it `price: number`. It does not touch this change's surface and will be tracked separately._