### PR TITLE
fix(live): tolerate nullable securityPrices price; drop null-price days (#534)

### DIFF
--- a/scripts/smoke/read-checks.ts
+++ b/scripts/smoke/read-checks.ts
@@ -96,6 +96,12 @@ function assertNumber(value: unknown, label: string): void {
   }
 }
 
+function assertNumberOrNull(value: unknown, label: string): void {
+  if (value !== null && (typeof value !== 'number' || !Number.isFinite(value))) {
+    throw new Error(`${label}: expected a finite number or null, got ${JSON.stringify(value)}`);
+  }
+}
+
 /**
  * All Tier-0 read smoke checks, in dependency order (id producers before
  * id consumers).
@@ -355,8 +361,13 @@ export const READ_SMOKE_CHECKS: readonly ReadSmokeCheck[] = [
       if (!first) {
         throw new Error('securityPrices: expected at least one price point over ONE_MONTH');
       }
-      assertNumber(first.price, 'securityPrices[0].price');
-      log('security-prices', { rows: rows.length });
+      // price is null for un-priceable days (e.g. the earliest in the window);
+      // tolerate null but assert number-or-null so a type drift still fails (#534).
+      rows.forEach((r, i) => assertNumberOrNull(r.price, `securityPrices[${i}].price`));
+      log('security-prices', {
+        rows: rows.length,
+        null_prices: rows.filter((r) => r.price === null).length,
+      });
       return undefined;
     },
   },

--- a/src/core/graphql/queries/security-prices.ts
+++ b/src/core/graphql/queries/security-prices.ts
@@ -19,7 +19,14 @@ import type { TimeFrame } from './_shared.js';
 
 export interface SecurityPricePointNode {
   id: string;
-  price: number;
+  /**
+   * Daily close for the security. NULL for a day the security has no price
+   * (e.g. the earliest day in the requested window). Live-verified via
+   * `bun run smoke:reads` on 2026-07-12. Downstream (get_investment_prices_live)
+   * drops null points; this wrapper passes them through so the read-shape gate
+   * can observe them.
+   */
+  price: number | null;
   /** ISO YYYY-MM-DD; one row per market day in the requested range. */
   date: string;
 }

--- a/src/tools/live/investment-prices.ts
+++ b/src/tools/live/investment-prices.ts
@@ -321,6 +321,8 @@ export function createLiveInvestmentPricesToolSchema(): ToolSchema {
       'to enumerate valid security_ids. Long-range responses are paginated via `max_rows` ' +
       '(default 500, max 5000) and `offset` (counts from the most-recent row); the response ' +
       'reports `total_rows` and `truncated` so callers can detect when older data was elided. ' +
+      'Daily series omit days the security had no price (the server returns null for those); ' +
+      '`count`/`total_rows` therefore count priced days, not calendar days. ' +
       'Available when --live-reads is on.',
     inputSchema: {
       type: 'object' as const,

--- a/src/tools/live/investment-prices.ts
+++ b/src/tools/live/investment-prices.ts
@@ -265,7 +265,12 @@ export class LiveInvestmentPricesTools {
         entry = { rows, fetched_at: Date.now() };
         this.dailyCache.set(key, entry);
       }
-      const sorted = entry.rows.slice().sort((a, b) => a.date.localeCompare(b.date));
+      // Drop null-price days (server returns null for un-priceable days, e.g.
+      // the earliest in a window; #534). The output series is priced days only.
+      const priced = entry.rows.filter(
+        (r): r is SecurityPricePointNode & { price: number } => r.price !== null
+      );
+      const sorted = priced.slice().sort((a, b) => a.date.localeCompare(b.date));
       const page = paginate(sorted, { max_rows: args.max_rows, offset: args.offset });
       totalRows = page.total_rows;
       truncated = page.truncated;

--- a/tests/core/graphql/queries/security-prices.test.ts
+++ b/tests/core/graphql/queries/security-prices.test.ts
@@ -53,4 +53,25 @@ describe('fetchSecurityPrices', () => {
       timeFrame: undefined,
     });
   });
+
+  test('passes a null-price point through unchanged (#534)', async () => {
+    const client = {
+      query: mock(() =>
+        Promise.resolve({
+          securityPrices: [
+            { id: 'sec-A', price: null, date: '2026-01-01' },
+            { id: 'sec-A', price: 101, date: '2026-01-02' },
+          ],
+        })
+      ),
+    } as unknown as GraphQLClient;
+
+    const { fetchSecurityPrices } =
+      await import('../../../../src/core/graphql/queries/security-prices.js');
+    const rows = await fetchSecurityPrices(client, { id: 'sec-A', timeFrame: 'ONE_MONTH' });
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.price).toBeNull();
+    expect(rows[1]?.price).toBe(101);
+  });
 });

--- a/tests/tools/live/investment-prices.test.ts
+++ b/tests/tools/live/investment-prices.test.ts
@@ -90,6 +90,26 @@ describe('LiveInvestmentPricesTools.getInvestmentPrices — happy daily path', (
     const queryMock = client.query as ReturnType<typeof mock>;
     expect(queryMock.mock.calls[0]?.[0]).toBe('SecurityPrices');
   });
+
+  test('daily: null-price points are dropped from the series (#534)', async () => {
+    const client = makeClient({
+      daily: [
+        { id: SECURITY_ID, price: null, date: '2026-01-01' }, // un-priceable gap day
+        { id: SECURITY_ID, price: 101, date: '2026-01-02' },
+        { id: SECURITY_ID, price: 102, date: '2026-01-03' },
+      ],
+    });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+    });
+    expect(result.granularity).toBe('daily');
+    expect(result.count).toBe(2);
+    expect(result.total_rows).toBe(2);
+    expect(result.prices.every((p) => p.price !== null)).toBe(true);
+    expect(result.prices.map((p) => p.date)).toEqual(['2026-01-02', '2026-01-03']);
+  });
 });
 
 describe('LiveInvestmentPricesTools.getInvestmentPrices — happy intraday path', () => {

--- a/tests/tools/live/investment-prices.test.ts
+++ b/tests/tools/live/investment-prices.test.ts
@@ -110,6 +110,24 @@ describe('LiveInvestmentPricesTools.getInvestmentPrices — happy daily path', (
     expect(result.prices.every((p) => p.price !== null)).toBe(true);
     expect(result.prices.map((p) => p.date)).toEqual(['2026-01-02', '2026-01-03']);
   });
+
+  test('daily: an all-null series yields an empty priced series (#534)', async () => {
+    const client = makeClient({
+      daily: [
+        { id: SECURITY_ID, price: null, date: '2026-01-01' },
+        { id: SECURITY_ID, price: null, date: '2026-01-02' },
+      ],
+    });
+    const tools = new LiveInvestmentPricesTools(makeLive(client));
+    const result = await tools.getInvestmentPrices({
+      security_id: SECURITY_ID,
+      time_frame: 'ONE_MONTH',
+    });
+    expect(result.granularity).toBe('daily');
+    expect(result.count).toBe(0);
+    expect(result.total_rows).toBe(0);
+    expect(result.prices).toEqual([]);
+  });
 });
 
 describe('LiveInvestmentPricesTools.getInvestmentPrices — happy intraday path', () => {


### PR DESCRIPTION
# Summary

Closes #534. The daily `securityPrices` query returns `price: null` for un-priceable days (observed at the earliest point in a window), but the wire type declared `price: number` — the live read-smoke gate flagged it (`securityPrices[0].price: expected a finite number, got null`).

- `security-prices.ts`: `SecurityPricePointNode.price` → `number | null` (with a doc comment citing the live evidence). `fetchSecurityPrices` stays a thin pass-through so the read-gate can still observe nulls.
- `investment-prices.ts` (daily branch): drop null-price points before sort/paginate via a type guard, so `get_investment_prices_live` emits a priced-days-only series and `GetInvestmentPricesLiveEntry.price` stays `number`. `count`/`total_rows` reflect priced days. Intraday/HF branch untouched.
- `read-checks.ts`: new `assertNumberOrNull`, applied per row for `SecurityPrices` — tolerates null but still fails on other type drift; logs a `null_prices` count.

**Validation:** `bun run check` green (2264 tests). `bun run smoke:reads` now **PASS** on `SecurityPrices` (`null_prices: 1` logged), 19/19 read ops green — the exact drift is fixed against live data.

## External assumptions

`securityPrices[].price` is nullable — evidence class: **live round-trip** (`bun run smoke:reads`, 2026-07-12). No `unverified` ledger entry needed.

## Bug fix?

Root cause:       The `securityPrices` daily query response typed `price` as non-null `number`, but the server returns `null` for un-priceable days.
Bug class:        Query response fields typed stricter than the server guarantees.
Detector added:   The read-shape smoke gate now asserts `number | null` per `securityPrices[].price` (and caught this instance); unit tests pin the drop + pass-through behavior.
Siblings checked: `SecurityPricesHighFrequency.price` — NOT changed (no evidence it returns null; widening its type would be an unverified assumption). Left as an evidence-scoped monitored sibling — the read smoke would flag it if it ever drifts.
Ledger updated:   n/a — live-verified and gated by `smoke:reads`; the generic `Query.securityPrices:response` shape entry stays `unverified` (we verified one field's nullability, not the whole shape).