### PR TITLE
feat(live): runtime read response-shape (zod-warn) validation infra + gate user/accounts/account/tags (#537)

### DIFF
--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -52,6 +52,7 @@ import {
   RUNTIME_CHECK_NAMES,
 } from '../core/graphql/response-validation.js';
 import { TRANSACTIONS_READ_SHAPE_RUNTIME_CHECK } from '../core/graphql/read-validation.js';
+import { READ_RESPONSE_SHAPE_RUNTIME_CHECK } from '../core/graphql/read-response-validation.js';
 export { RUNTIME_CHECK_NAMES };
 
 /** What kind of external surface the assumption is about. */
@@ -180,6 +181,15 @@ const QUERY_RESPONSE_SHAPE_UNVERIFIED =
   'the Tier-0 read smoke spot-checks load-bearing fields but no runtime schema ' +
   'validation exists — full-shape drift would surface only as downstream undefineds';
 
+/** #537: read response-shape interfaces are mirrored into looseObject Zod
+ * schemas and every live read response is validated warn-mode at runtime, so
+ * drift surfaces as a structured warning + per-surface counter instead of
+ * downstream undefineds. Read analogue of RESPONSE_SHAPE_GATED. */
+const READ_RESPONSE_SHAPE_GATED =
+  'Hand-written TS response interface mirrored into a looseObject Zod schema; every ' +
+  'live read response is validated warn-mode at runtime ' +
+  '(src/core/graphql/read-response-validation.ts, issue #537)';
+
 // ---------------------------------------------------------------------------
 // Entry factories (keep the inventory compact; pass overrides to upgrade an
 // entry's class/oracle/evidence as verification lands)
@@ -285,6 +295,23 @@ function queryResponseShape(name: string): LedgerEntry {
     oracle: null,
     class: 'unverified',
     evidence: QUERY_RESPONSE_SHAPE_UNVERIFIED,
+  };
+}
+
+/**
+ * A read query whose response shape is validated warn-mode at runtime by the
+ * read-side Zod registry (#537). Read analogue of `responseShape` for
+ * mutations. `name` is the root Query field, e.g. 'accounts'. Every name
+ * passed here MUST have a matching QUERY_RESPONSE_SCHEMAS entry — enforced
+ * bidirectionally by tests/conformance/ledger.test.ts.
+ */
+function gatedQueryResponseShape(name: string): LedgerEntry {
+  return {
+    surface: `Query.${name}:response`,
+    kind: 'response-shape',
+    oracle: `runtime:${READ_RESPONSE_SHAPE_RUNTIME_CHECK}`,
+    class: 'gated',
+    evidence: READ_RESPONSE_SHAPE_GATED,
   };
 }
 
@@ -540,13 +567,13 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   // checks (scripts/smoke/read-checks.ts) — a new query cannot ship without
   // both a smoke check and these entries.
   queryOperation('user'),
-  queryResponseShape('user'),
+  gatedQueryResponseShape('user'),
   queryOperation('accounts'),
-  queryResponseShape('accounts'),
+  gatedQueryResponseShape('accounts'),
   // Singular Account: generated document exists but has no hand-written
   // wrapper; the read smoke probes the document directly.
   queryOperation('account'),
-  queryResponseShape('account'),
+  gatedQueryResponseShape('account'),
   queryOperation('transactions'),
   {
     surface: 'Query.transactions:response',
@@ -561,7 +588,7 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   queryOperation('categories'),
   queryResponseShape('categories'),
   queryOperation('tags'),
-  queryResponseShape('tags'),
+  gatedQueryResponseShape('tags'),
   queryOperation('recurrings'),
   queryResponseShape('recurrings'),
   queryOperation('unpaidUpcomingRecurrings'),

--- a/src/core/graphql/client.ts
+++ b/src/core/graphql/client.ts
@@ -17,6 +17,7 @@
 
 import type { FirebaseAuth } from '../auth/firebase-auth.js';
 import { validateMutationResponse } from './response-validation.js';
+import { validateQueryResponse } from './read-response-validation.js';
 
 const ENDPOINT = 'https://app.copilot.money/api/graphql';
 
@@ -299,11 +300,14 @@ export class GraphQLClient {
     for (let attempt = 1; ; attempt++) {
       try {
         const data = await this.requestOnce<TVariables, TResponse>(operationName, query, variables);
-        // Warn-mode response-shape validation (issue #437): logs + counts
-        // drift against the registered Zod schema, never throws, never
-        // alters the payload. Mutations only — live-read queries have their
-        // own response handling.
+        // Warn-mode response-shape validation: logs + counts drift against the
+        // registered Zod schema, never throws, never alters the payload.
+        // Mutations (#437) and reads (#537) have parallel registries. Reads
+        // whose nodes feed writes (Transactions) keep their own drop-based
+        // check and are intentionally absent from the read registry, so
+        // validateQueryResponse skips them silently.
         if (kind === 'mutation') validateMutationResponse(operationName, data);
+        else validateQueryResponse(operationName, data);
         return data;
       } catch (e) {
         if (!(e instanceof GraphQLError)) throw e;

--- a/src/core/graphql/queries/accounts.ts
+++ b/src/core/graphql/queries/accounts.ts
@@ -10,6 +10,7 @@
  * unused; the response shape mirrors AccountFields.
  */
 
+import { z } from 'zod';
 import type { GraphQLClient } from '../client.js';
 import { ACCOUNTS } from '../operations.generated.js';
 
@@ -56,3 +57,39 @@ export async function fetchAccounts(client: GraphQLClient): Promise<AccountNode[
   );
   return data.accounts;
 }
+
+/**
+ * Zod mirror of `AccountNode` (AccountFields fragment) for warn-mode
+ * read-shape validation (#537). Shared by the Accounts (list) and singular
+ * Account queries — the latter has no wrapper, so its schema is assembled in
+ * QUERY_RESPONSE_SCHEMAS from this node schema.
+ */
+export const AccountNodeSchema = z.looseObject({
+  id: z.string(),
+  itemId: z.string(),
+  name: z.string(),
+  balance: z.number(),
+  liveBalance: z.boolean(),
+  type: z.string(),
+  subType: z.string().nullable(),
+  mask: z.string().nullable(),
+  isUserHidden: z.boolean(),
+  isUserClosed: z.boolean(),
+  isManual: z.boolean(),
+  color: z.string().nullable(),
+  limit: z.number().nullable(),
+  institutionId: z.string().nullable(),
+  hasHistoricalUpdates: z.boolean(),
+  hasLiveBalance: z.boolean(),
+  latestBalanceUpdate: z.string().nullable(),
+});
+
+/** Zod mirror of `AccountsResponse` (the list query). */
+export const AccountsResponseSchema = z.looseObject({
+  accounts: z.array(AccountNodeSchema),
+});
+
+/** Zod mirror of the singular `Account` query response (no wrapper exists). */
+export const AccountResponseSchema = z.looseObject({
+  account: AccountNodeSchema,
+});

--- a/src/core/graphql/queries/accounts.ts
+++ b/src/core/graphql/queries/accounts.ts
@@ -35,7 +35,13 @@ export interface AccountNode {
   institutionId: string | null;
   hasHistoricalUpdates: boolean;
   hasLiveBalance: boolean;
-  latestBalanceUpdate: string | null;
+  /**
+   * Numeric epoch timestamp (ms), or null. Drifted from the ISO-string shape
+   * seen in the 2026-04 Chrome capture — the server changed the field's type
+   * string→number since then, caught by the read-shape smoke on 2026-07-16
+   * (#537).
+   */
+  latestBalanceUpdate: number | null;
 }
 
 export interface AccountsResponse {
@@ -81,7 +87,7 @@ export const AccountNodeSchema = z.looseObject({
   institutionId: z.string().nullable(),
   hasHistoricalUpdates: z.boolean(),
   hasLiveBalance: z.boolean(),
-  latestBalanceUpdate: z.string().nullable(),
+  latestBalanceUpdate: z.number().nullable(),
 });
 
 /** Zod mirror of `AccountsResponse` (the list query). */

--- a/src/core/graphql/queries/tags.ts
+++ b/src/core/graphql/queries/tags.ts
@@ -9,6 +9,7 @@
  * exposes only `id`, `name`, `colorName` on each Tag.
  */
 
+import { z } from 'zod';
 import type { GraphQLClient } from '../client.js';
 import { TAGS } from '../operations.generated.js';
 
@@ -26,3 +27,14 @@ export async function fetchTags(client: GraphQLClient): Promise<TagNode[]> {
   const data = await client.query<Record<string, never>, TagsResponse>('Tags', TAGS, {});
   return data.tags;
 }
+
+/** Zod mirror of `TagsResponse` for warn-mode read-shape validation (#537). */
+export const TagsResponseSchema = z.looseObject({
+  tags: z.array(
+    z.looseObject({
+      id: z.string(),
+      name: z.string(),
+      colorName: z.string().nullable(),
+    })
+  ),
+});

--- a/src/core/graphql/queries/user.ts
+++ b/src/core/graphql/queries/user.ts
@@ -14,6 +14,7 @@
  * The User query takes no variables.
  */
 
+import { z } from 'zod';
 import type { GraphQLClient } from '../client.js';
 import { USER } from '../operations.generated.js';
 
@@ -40,3 +41,25 @@ export async function fetchUser(client: GraphQLClient): Promise<UserNode> {
   const data = await client.query<Record<string, never>, UserResponse>('User', USER, {});
   return data.user;
 }
+
+/**
+ * Zod mirror of `UserResponse` for runtime warn-mode read-shape validation
+ * (#537). Only the fields the wrapper projects are gated; the wire response
+ * carries more (onboarding, intercomUserHash, …) which flow through loose.
+ */
+export const UserResponseSchema = z.looseObject({
+  user: z.looseObject({
+    id: z.string(),
+    budgetingConfig: z
+      .looseObject({
+        isEnabled: z.boolean(),
+        rolloversConfig: z
+          .looseObject({
+            isEnabled: z.boolean(),
+            startDate: z.string().nullable(),
+          })
+          .nullable(),
+      })
+      .nullable(),
+  }),
+});

--- a/src/core/graphql/read-response-validation.ts
+++ b/src/core/graphql/read-response-validation.ts
@@ -1,0 +1,124 @@
+/**
+ * Warn-mode Zod validation for GraphQL READ query response payloads
+ * (issue #537).
+ *
+ * The mutation write path already validates response shapes warn-mode
+ * (response-validation.ts, runtime:zod-warn). This module is the same idea
+ * pointed at read queries: the hand-written `*Response` interfaces in
+ * queries/*.ts are only spot-checked on load-bearing fields by the Tier-0
+ * read smoke, so a non-load-bearing field going missing or changing type
+ * degrades output silently. Here every registered read response is validated
+ * against a looseObject Zod mirror; drift is counted and logged, never thrown
+ * or dropped.
+ *
+ * Semantics — strictly WARN-MODE (never throw, never alter the payload):
+ * - Schemas mirror the raw `*Response` shape the client returns (before any
+ *   wrapper post-processing such as the categories flatten), using
+ *   `z.looseObject` so NEW server fields and `__typename` flow through
+ *   without warnings. Drift = a field we READ going missing or changing type.
+ * - Reads whose nodes feed WRITES (Transactions) are intentionally NOT
+ *   registered here — they keep their own drop-based check
+ *   (read-validation.ts). `validateQueryResponse` skips any unregistered
+ *   operation silently: an unregistered read is legitimate `unverified`
+ *   ledger debt, and the ledger + bijection tests provide build-time safety
+ *   without a runtime log-flood.
+ *
+ * This is the `runtime:read-zod-warn` oracle in the conformance ledger: every
+ * `Query.<field>:response` surface it gates must have a schema registered
+ * here — enforced bidirectionally by tests/conformance/ledger.test.ts.
+ */
+
+import type { ZodType } from 'zod';
+import { AccountResponseSchema, AccountsResponseSchema } from './queries/accounts.js';
+import { TagsResponseSchema } from './queries/tags.js';
+import { UserResponseSchema } from './queries/user.js';
+
+/**
+ * Name of this runtime check as registered in the ledger's
+ * RUNTIME_CHECK_NAMES. `runtime:read-zod-warn` oracles point here. Distinct
+ * from the mutation `zod-warn` and the transactions `transactions-read-shape`
+ * checks.
+ */
+export const READ_RESPONSE_SHAPE_RUNTIME_CHECK = 'read-zod-warn' as const;
+
+export interface QueryResponseShapeEntry {
+  /** Conformance ledger surface this schema verifies. */
+  surface: `Query.${string}:response`;
+  schema: ZodType;
+}
+
+function entry(rootField: string, schema: ZodType): QueryResponseShapeEntry {
+  return { surface: `Query.${rootField}:response`, schema };
+}
+
+/**
+ * Registry keyed by GraphQL OPERATION name (the first argument wrappers pass
+ * to `client.query(...)`). Operation names are PascalCase and do NOT always
+ * match the root Query field (Account→account, and in later batches
+ * MonthlySpend→monthlySpending, Networth→networthHistory).
+ *
+ * Every registered surface must have a matching `runtime:read-zod-warn`
+ * ledger entry (and vice-versa) — the ledger test enforces both directions.
+ */
+export const QUERY_RESPONSE_SCHEMAS: Readonly<Record<string, QueryResponseShapeEntry>> = {
+  User: entry('user', UserResponseSchema),
+  Accounts: entry('accounts', AccountsResponseSchema),
+  Account: entry('account', AccountResponseSchema),
+  Tags: entry('tags', TagsResponseSchema),
+};
+
+// ---------------------------------------------------------------------------
+// Warn-mode validation + drift counters (separate from the mutation counters
+// so roundtrip.ts's mutation-drift report stays unpolluted).
+// ---------------------------------------------------------------------------
+
+export type ReadResponseDriftStats = Record<string, number>;
+
+const driftCounts = new Map<string, number>();
+
+// Dedupe key = `${operationName}::${firstIssue.path}::${issue.code}`. One warn
+// per unique key per process — prevents log flood when every call to the same
+// query drifts the same way.
+const warnedKeys = new Set<string>();
+
+/** Snapshot of the per-surface read drift counters (copy, safe to mutate). */
+export function getReadResponseDriftStats(): ReadResponseDriftStats {
+  return Object.fromEntries(driftCounts);
+}
+
+/**
+ * Validate a read query response payload against its registered schema,
+ * warn-mode. Never throws; never alters `data`. Unregistered operations are
+ * skipped silently (see the module doc).
+ */
+export function validateQueryResponse(operationName: string, data: unknown): void {
+  const registered = QUERY_RESPONSE_SCHEMAS[operationName];
+  if (!registered) return;
+
+  const result = registered.schema.safeParse(data);
+  if (result.success) return;
+
+  driftCounts.set(registered.surface, (driftCounts.get(registered.surface) ?? 0) + 1);
+
+  // Warn for EVERY issue, each deduped per (operation, path, code) per process
+  // — the unique drift inventory is logged in full while repeats stay silent.
+  for (const issue of result.error.issues) {
+    const pathStr = issue.path.join('.');
+    const key = `${operationName}::${pathStr}::${issue.code}`;
+    if (warnedKeys.has(key)) continue;
+    warnedKeys.add(key);
+    // console.warn writes to stderr in Node/Bun — safe for the MCP stdio
+    // transport (stdout carries JSON-RPC). Messages describe expected/received
+    // TYPES, not the user's data.
+    console.warn(
+      `[copilot-money-mcp] read response shape drift: operation=${operationName} ` +
+        `surface=${registered.surface} path=${pathStr} code=${issue.code} message="${issue.message}"`
+    );
+  }
+}
+
+// Exposed for tests only: clears the dedupe set and drift counters.
+export function __resetReadResponseDriftState(): void {
+  driftCounts.clear();
+  warnedKeys.clear();
+}

--- a/src/core/graphql/response-validation.ts
+++ b/src/core/graphql/response-validation.ts
@@ -30,6 +30,7 @@
 import { z, type ZodType } from 'zod';
 import { TRANSACTION_TYPES } from './transactions.js';
 import { TRANSACTIONS_READ_SHAPE_RUNTIME_CHECK } from './read-validation.js';
+import { READ_RESPONSE_SHAPE_RUNTIME_CHECK } from './read-response-validation.js';
 
 /**
  * Name of this runtime check as registered in the ledger's
@@ -40,6 +41,7 @@ export const RESPONSE_SHAPE_RUNTIME_CHECK = 'zod-warn' as const;
 export const RUNTIME_CHECK_NAMES: readonly string[] = [
   RESPONSE_SHAPE_RUNTIME_CHECK,
   TRANSACTIONS_READ_SHAPE_RUNTIME_CHECK,
+  READ_RESPONSE_SHAPE_RUNTIME_CHECK,
 ];
 
 // ---------------------------------------------------------------------------

--- a/tests/conformance/ledger.test.ts
+++ b/tests/conformance/ledger.test.ts
@@ -29,6 +29,10 @@ import {
   MUTATION_RESPONSE_SCHEMAS,
   RESPONSE_SHAPE_RUNTIME_CHECK,
 } from '../../src/core/graphql/response-validation.js';
+import {
+  QUERY_RESPONSE_SCHEMAS,
+  READ_RESPONSE_SHAPE_RUNTIME_CHECK,
+} from '../../src/core/graphql/read-response-validation.js';
 
 const SMOKE_DIR = join(import.meta.dir, '..', '..', 'scripts', 'smoke');
 
@@ -150,6 +154,26 @@ describe('conformance ledger', () => {
     expect(registeredSurfaces).toEqual(ledgerSurfaces);
     // Guard against the comparison passing vacuously.
     expect(registeredSurfaces.length).toBeGreaterThanOrEqual(17);
+  });
+
+  test('(b) runtime:read-zod-warn-gated response shapes exactly match the registered read schemas', () => {
+    // Bidirectional, same contract as the mutation registry: a ledger entry
+    // claiming the read-zod-warn oracle without a registered schema is a paper
+    // gate; a registered schema without a ledger entry is untracked
+    // verification. Both directions fail here.
+    const ledgerSurfaces = CONFORMANCE_LEDGER.filter(
+      (entry) =>
+        entry.kind === 'response-shape' &&
+        entry.oracle === `runtime:${READ_RESPONSE_SHAPE_RUNTIME_CHECK}`
+    )
+      .map((entry) => entry.surface)
+      .sort();
+    const registeredSurfaces = Object.values(QUERY_RESPONSE_SCHEMAS)
+      .map((entry) => entry.surface)
+      .sort();
+    expect(registeredSurfaces).toEqual(ledgerSurfaces);
+    // Non-vacuous floor; grows toward 18 as #537's follow-up PRs land.
+    expect(registeredSurfaces.length).toBeGreaterThanOrEqual(4);
   });
 
   test("(c) class 'gated' requires a non-null oracle", () => {

--- a/tests/core/graphql/client.test.ts
+++ b/tests/core/graphql/client.test.ts
@@ -9,6 +9,10 @@ import {
   getResponseDriftStats,
   __resetResponseDriftState,
 } from '../../../src/core/graphql/response-validation.js';
+import {
+  getReadResponseDriftStats,
+  __resetReadResponseDriftState,
+} from '../../../src/core/graphql/read-response-validation.js';
 import type { FirebaseAuth } from '../../../src/core/auth/firebase-auth.js';
 
 let fetchCalls: { url: string; options: RequestInit }[] = [];
@@ -764,19 +768,6 @@ describe('GraphQLClient — warn-mode response-shape validation (#437)', () => {
     expect(getResponseDriftStats()).toEqual({});
   });
 
-  test('query responses are not shape-validated (live reads have their own handling)', async () => {
-    mockFetch({ data: { tags: 'not-even-an-array' } });
-    const client = new GraphQLClient(createMockAuth());
-    const out = await client.query<unknown, { tags: unknown }>(
-      'Tags',
-      'query Tags { tags { id } }',
-      {}
-    );
-    expect(out).toEqual({ tags: 'not-even-an-array' });
-    expect(warnSpy).not.toHaveBeenCalled();
-    expect(getResponseDriftStats()).toEqual({});
-  });
-
   test('validation still runs when a mutation succeeds on a retry attempt', async () => {
     // Attempt 1 provably never reached the server (retryable for mutations);
     // attempt 2 succeeds with a drifted payload — the validator must fire on
@@ -797,5 +788,63 @@ describe('GraphQLClient — warn-mode response-shape validation (#437)', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(String(warnSpy.mock.calls[0][0])).toContain('response shape drift');
     expect(getResponseDriftStats()).toEqual({ 'Mutation.deleteTag:response': 1 });
+  });
+});
+
+describe('GraphQLClient — warn-mode READ response-shape validation (#537)', () => {
+  let warnSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    __resetReadResponseDriftState();
+    warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    restoreFetch();
+  });
+
+  test('a drifted REGISTERED query response warns but resolves with the payload unchanged', async () => {
+    // Tags' registered schema expects { tags: TagNode[] }; a string simulates
+    // server drift on a field we read.
+    mockFetch({ data: { tags: 'not-even-an-array' } });
+    const client = new GraphQLClient(createMockAuth());
+    const out = await client.query<unknown, { tags: unknown }>(
+      'Tags',
+      'query Tags { tags { id } }',
+      {}
+    );
+    expect(out).toEqual({ tags: 'not-even-an-array' }); // payload untouched — warn-mode
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0][0])).toContain('read response shape drift');
+    expect(getReadResponseDriftStats()).toEqual({ 'Query.tags:response': 1 });
+  });
+
+  test('a conforming registered query response produces no warnings and no drift counts', async () => {
+    mockFetch({
+      data: { tags: [{ id: 'tAg111BbB222CcC333Dd', name: 'trip', colorName: 'green' }] },
+    });
+    const client = new GraphQLClient(createMockAuth());
+    const out = await client.query<unknown, { tags: unknown[] }>(
+      'Tags',
+      'query Tags { tags { id } }',
+      {}
+    );
+    expect(out.tags).toHaveLength(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(getReadResponseDriftStats()).toEqual({});
+  });
+
+  test('an UNREGISTERED query is not shape-validated (skips silently)', async () => {
+    mockFetch({ data: { whatever: 'garbage' } });
+    const client = new GraphQLClient(createMockAuth());
+    const out = await client.query<unknown, { whatever: unknown }>(
+      'SomeFutureQuery',
+      'query SomeFutureQuery { whatever }',
+      {}
+    );
+    expect(out).toEqual({ whatever: 'garbage' });
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(getReadResponseDriftStats()).toEqual({});
   });
 });

--- a/tests/core/graphql/queries/accounts.test.ts
+++ b/tests/core/graphql/queries/accounts.test.ts
@@ -25,7 +25,7 @@ describe('fetchAccounts', () => {
             institutionId: 'inst1',
             hasHistoricalUpdates: true,
             hasLiveBalance: true,
-            latestBalanceUpdate: '2026-04-25T00:00:00Z',
+            latestBalanceUpdate: 1_745_539_200_000,
           } as AccountNode,
         ],
       })),

--- a/tests/core/graphql/read-response-validation.test.ts
+++ b/tests/core/graphql/read-response-validation.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for warn-mode READ response-shape validation (issue #537).
+ *
+ * Contract under test (parallels response-validation.test.ts):
+ * - happy path: a response matching the registered schema → zero warnings,
+ *   zero drift counts (covered for ALL registered operations);
+ * - drift (missing/renamed/retyped field we read): one structured warn on
+ *   first occurrence, deduped per (operation, path, code), per-surface counter
+ *   counting EVERY occurrence;
+ * - never throws, never alters the payload;
+ * - new/unknown server fields pass through silently (loose schemas);
+ * - unregistered operations skip silently — no warn, no drift.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import {
+  QUERY_RESPONSE_SCHEMAS,
+  validateQueryResponse,
+  getReadResponseDriftStats,
+  __resetReadResponseDriftState,
+} from '../../../src/core/graphql/read-response-validation.js';
+
+function makeAccount(): Record<string, unknown> {
+  return {
+    __typename: 'Account',
+    id: 'AbC123dEf456GhI789jK',
+    itemId: 'MnO456pQr789StU012vW',
+    name: 'Synthetic Checking',
+    balance: 100,
+    liveBalance: false,
+    type: 'depository',
+    subType: null,
+    mask: null,
+    isUserHidden: false,
+    isUserClosed: false,
+    isManual: false,
+    color: null,
+    limit: null,
+    institutionId: null,
+    hasHistoricalUpdates: false,
+    hasLiveBalance: false,
+    latestBalanceUpdate: null,
+  };
+}
+
+const VALID_RESPONSES: Record<string, unknown> = {
+  User: {
+    user: {
+      __typename: 'User',
+      id: 'uSr111BbB222CcC333Dd',
+      budgetingConfig: {
+        isEnabled: true,
+        rolloversConfig: { isEnabled: false, startDate: null },
+      },
+    },
+  },
+  Accounts: { accounts: [makeAccount()] },
+  Account: { account: makeAccount() },
+  Tags: {
+    tags: [{ __typename: 'Tag', id: 'tAg111BbB222CcC333Dd', name: 'synthetic', colorName: 'blue' }],
+  },
+};
+
+describe('validateQueryResponse', () => {
+  let warnSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    __resetReadResponseDriftState();
+    warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test('every registered operation has a valid fixture that passes silently', () => {
+    const operations = Object.keys(QUERY_RESPONSE_SCHEMAS);
+    expect(operations.sort()).toEqual(Object.keys(VALID_RESPONSES).sort());
+    for (const op of operations) {
+      validateQueryResponse(op, VALID_RESPONSES[op]);
+    }
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(getReadResponseDriftStats()).toEqual({});
+  });
+
+  test('unknown extra fields (new server fields) pass through without warning', () => {
+    const account = makeAccount();
+    account.brandNewServerField = 'whatever';
+    validateQueryResponse('Accounts', { accounts: [account], anotherTopLevelExtra: 42 });
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(getReadResponseDriftStats()).toEqual({});
+  });
+
+  test('a removed/renamed field warns once with a structured message and counts the drift', () => {
+    const account = makeAccount();
+    delete account.balance; // simulate server rename of a field we read
+    validateQueryResponse('Accounts', { accounts: [account] });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0][0] as string;
+    expect(message).toContain('[copilot-money-mcp] read response shape drift:');
+    expect(message).toContain('operation=Accounts');
+    expect(message).toContain('surface=Query.accounts:response');
+    expect(message).toContain('path=accounts.0.balance');
+    expect(message).toContain('code=');
+    expect(getReadResponseDriftStats()).toEqual({ 'Query.accounts:response': 1 });
+  });
+
+  test('a wrong-typed field we read warns (string where number expected)', () => {
+    validateQueryResponse('Accounts', {
+      accounts: [{ ...makeAccount(), balance: 'not-a-number' }],
+    });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(getReadResponseDriftStats()).toEqual({ 'Query.accounts:response': 1 });
+  });
+
+  test('dedupes the warning per (operation, path, code) but counts every drifted response', () => {
+    const drifted = () => {
+      const account = makeAccount();
+      delete account.balance;
+      validateQueryResponse('Accounts', { accounts: [account] });
+    };
+    drifted();
+    drifted();
+    expect(warnSpy).toHaveBeenCalledTimes(1); // deduped
+    expect(getReadResponseDriftStats()).toEqual({ 'Query.accounts:response': 2 }); // counted twice
+  });
+
+  test('unregistered operations skip silently — no warn, no drift', () => {
+    // Transactions is deliberately absent (its own drop-based check owns it);
+    // a totally unknown op must also skip.
+    validateQueryResponse('Transactions', { transactions: 'garbage' });
+    validateQueryResponse('SomeFutureQuery', { anything: 123 });
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(getReadResponseDriftStats()).toEqual({});
+  });
+
+  test('never throws and never alters the payload', () => {
+    const payload = { accounts: 'not-even-an-array' };
+    expect(() => validateQueryResponse('Accounts', payload)).not.toThrow();
+    expect(payload).toEqual({ accounts: 'not-even-an-array' });
+  });
+});

--- a/tests/integration/uid-transition-sweep.test.ts
+++ b/tests/integration/uid-transition-sweep.test.ts
@@ -49,7 +49,7 @@ const account = (id: string, name: string) => ({
   institutionId: 'inst1',
   hasHistoricalUpdates: true,
   hasLiveBalance: true,
-  latestBalanceUpdate: '2026-04-25T00:00:00Z',
+  latestBalanceUpdate: 1_745_539_200_000,
 });
 
 const emptyTransactionsPage = {

--- a/tests/scripts/read-smoke-coverage.test.ts
+++ b/tests/scripts/read-smoke-coverage.test.ts
@@ -22,6 +22,7 @@ import { describe, test, expect } from 'bun:test';
 import * as generated from '../../src/core/graphql/operations.generated.js';
 import { READ_SMOKE_CHECKS } from '../../scripts/smoke/read-checks.js';
 import { CONFORMANCE_LEDGER } from '../../src/conformance/ledger.js';
+import { QUERY_RESPONSE_SCHEMAS } from '../../src/core/graphql/read-response-validation.js';
 
 interface ParsedQuery {
   /** Operation name, e.g. 'Accounts'. */
@@ -108,5 +109,25 @@ describe('read-smoke coverage ratchet', () => {
       stale,
       `Ledger Query.* surfaces without a generated query operation: ${stale.join(', ')}`
     ).toEqual([]);
+  });
+
+  test('(b) every QUERY_RESPONSE_SCHEMAS key is a real generated operation name whose surface matches its root field', () => {
+    // The client dispatches read validation by the registry KEY (the operation
+    // name passed to client.query). A mistyped key would satisfy the ledger
+    // bijection + fixture ratchet yet never fire at runtime — a silent paper
+    // gate. This asserts registration is genuinely activation.
+    const rootFieldByOp = new Map(queries.map((q) => [q.name, q.rootField]));
+    for (const [opName, entry] of Object.entries(QUERY_RESPONSE_SCHEMAS)) {
+      const rootField = rootFieldByOp.get(opName);
+      expect(
+        rootField,
+        `QUERY_RESPONSE_SCHEMAS key '${opName}' is not a generated GraphQL operation name — ` +
+          `client.query('${opName}', …) would never dispatch to it (silent paper gate)`
+      ).toBeDefined();
+      expect(
+        entry.surface,
+        `QUERY_RESPONSE_SCHEMAS['${opName}'].surface must be Query.<rootField>:response for its operation`
+      ).toBe(`Query.${rootField}:response`);
+    }
   });
 });

--- a/tests/tools/live/accounts.test.ts
+++ b/tests/tools/live/accounts.test.ts
@@ -25,7 +25,7 @@ const A = (id: string, opts: Partial<AccountNode> = {}): AccountNode => ({
   institutionId: 'inst1',
   hasHistoricalUpdates: true,
   hasLiveBalance: true,
-  latestBalanceUpdate: '2026-04-25T00:00:00Z',
+  latestBalanceUpdate: 1_745_539_200_000,
   ...opts,
 });
 


### PR DESCRIPTION
# Summary

Adds warn-mode runtime response-shape (Zod) validation for the GraphQL **read** path — the read-side analogue of the existing mutation `runtime:zod-warn` layer — and gates the first four read queries (`user`, `accounts`, `account`, `tags`), flipping them from `unverified` to `runtime:read-zod-warn` in the conformance ledger.

First of 5 domain-grouped PRs for #537 (closing all 18 `unverified` read response shapes). Does **not** close #537 — the remaining 14 queries land in PRs 2–5.

**How it works:** a new `read-response-validation.ts` module holds a registry (`QUERY_RESPONSE_SCHEMAS`, keyed by GraphQL operation name) of `looseObject` mirrors of each query's `*Response` interface. `GraphQLClient.request()` calls `validateQueryResponse` centrally for `kind === 'query'` — so **registration is activation** (no per-wrapper call to forget). Warn-only: drift is counted per-surface and dedup-warned to stderr, never thrown or dropped. Reads whose nodes feed writes (Transactions) keep their own drop-based check and are deliberately excluded.

## External assumptions

No **new** assumptions. This PR **upgrades** four pre-existing read response-shape assumptions (`user`, `accounts`, `account`, `tags`) from `unverified` → `runtime:read-zod-warn`-gated.

Evidence class: **live round-trip** — `bun run smoke:reads` ran (19/19 PASS) and confirms the four mirrored schemas match the production payloads.

Notably, that smoke **immediately caught a real server-side drift on its first run**: `Account.latestBalanceUpdate` is now a numeric epoch on the wire, but the April-2026 Chrome captures (and our interface) had it as an ISO-8601 string — Copilot changed the field's type. Interface + schema corrected to `number | null`; smoke re-run is clean (19/19, zero drift). Details in the Bug fix section below.

## Bug fix?

Root cause:       Copilot's server changed `Account.latestBalanceUpdate` from an ISO-8601 string to a numeric epoch; our hand-written interface/schema still declared `string | null`, so the value was silently mistyped.
Bug class:        read response-shape drift — a field we read changing type on the server with no runtime detector (same class as #419).
Detector added:   this PR's `runtime:read-zod-warn` gate + `bun run smoke:reads` now validate the full Accounts/Account response shape at runtime and on every smoke run — the class-level detector. Also added a ratchet test asserting every `QUERY_RESPONSE_SCHEMAS` key is a real generated operation name whose surface matches its root field, closing a "registered-but-never-dispatched" paper-gate gap.
Siblings checked: the live smoke validated the full shapes of all four gated queries (user/accounts/account/tags) against production — only `latestBalanceUpdate` had drifted. The other 14 read queries stay `unverified` and are gated incrementally by #537 PRs 2–5.
Ledger updated:   `Query.accounts:response` and `Query.account:response` (plus `Query.user:response`, `Query.tags:response`) flipped to `gated` / `runtime:read-zod-warn`; the corrected field type is now enforced by that gate.

## Follow-ups (from the whole-branch review, deferred out of this PR)

- Wire `getReadResponseDriftStats()` into an aggregate report (parallel to how the mutation drift stats feed `roundtrip.ts`) — read drift currently surfaces via stderr only.
- Once all 18 read shapes are gated, fold the near-identical mutation/read warn-count-dedup machinery onto one shared helper (deliberately kept parallel here to keep PRs small).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
