### PR TITLE
feat(live): gate investment-balance/live-balance/security-prices/high-frequency reads at runtime:read-zod-warn (#537)

### DIFF
--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -604,17 +604,17 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   queryOperation('aggregatedHoldings'),
   gatedQueryResponseShape('aggregatedHoldings'),
   queryOperation('investmentBalance'),
-  queryResponseShape('investmentBalance'),
+  gatedQueryResponseShape('investmentBalance'),
   queryOperation('investmentLiveBalance'),
-  queryResponseShape('investmentLiveBalance'),
+  gatedQueryResponseShape('investmentLiveBalance'),
   queryOperation('investmentAllocation'),
   gatedQueryResponseShape('investmentAllocation'),
   queryOperation('topMovers'),
   gatedQueryResponseShape('topMovers'),
   queryOperation('securityPrices'),
-  queryResponseShape('securityPrices'),
+  gatedQueryResponseShape('securityPrices'),
   queryOperation('securityPricesHighFrequency'),
-  queryResponseShape('securityPricesHighFrequency'),
+  gatedQueryResponseShape('securityPricesHighFrequency'),
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/core/graphql/queries/investment-balance.ts
+++ b/src/core/graphql/queries/investment-balance.ts
@@ -13,6 +13,7 @@
  * applies its own default range.
  */
 
+import { z } from 'zod';
 import type { GraphQLClient } from '../client.js';
 import { INVESTMENT_BALANCE } from '../operations.generated.js';
 import type { TimeFrame } from './_shared.js';
@@ -43,3 +44,16 @@ export async function fetchInvestmentBalance(
   );
   return data.investmentBalance;
 }
+
+/** Zod mirror of `InvestmentBalanceNode` (#537). Shared with the
+ * InvestmentLiveBalance query (identical row shape). */
+export const InvestmentBalanceNodeSchema = z.looseObject({
+  id: z.string(),
+  date: z.string(),
+  balance: z.number(),
+});
+
+/** Zod mirror of `InvestmentBalanceResponse` (timeseries). */
+export const InvestmentBalanceResponseSchema = z.looseObject({
+  investmentBalance: z.array(InvestmentBalanceNodeSchema),
+});

--- a/src/core/graphql/queries/investment-live-balance.ts
+++ b/src/core/graphql/queries/investment-live-balance.ts
@@ -13,9 +13,11 @@
  * type rather than declare a parallel one.
  */
 
+import { z } from 'zod';
 import type { GraphQLClient } from '../client.js';
 import { INVESTMENT_LIVE_BALANCE } from '../operations.generated.js';
 import type { InvestmentBalanceNode } from './investment-balance.js';
+import { InvestmentBalanceNodeSchema } from './investment-balance.js';
 
 export interface InvestmentLiveBalanceResponse {
   investmentLiveBalance: InvestmentBalanceNode;
@@ -31,3 +33,9 @@ export async function fetchInvestmentLiveBalance(
   );
   return data.investmentLiveBalance;
 }
+
+/** Zod mirror of `InvestmentLiveBalanceResponse` — a single "live dot" row,
+ * same shape as InvestmentBalanceNode (#537). */
+export const InvestmentLiveBalanceResponseSchema = z.looseObject({
+  investmentLiveBalance: InvestmentBalanceNodeSchema,
+});

--- a/src/core/graphql/queries/security-prices-high-frequency.ts
+++ b/src/core/graphql/queries/security-prices-high-frequency.ts
@@ -15,6 +15,7 @@
  * but passes it to the resolver as `securityId: $id`.
  */
 
+import { z } from 'zod';
 import type { GraphQLClient } from '../client.js';
 import { SECURITY_PRICES_HIGH_FREQUENCY } from '../operations.generated.js';
 import type { TimeFrame } from './_shared.js';
@@ -54,3 +55,15 @@ export async function fetchSecurityPricesHighFrequency(
   });
   return data.securityPricesHighFrequency;
 }
+
+/** Zod mirror of `SecurityPricesHighFrequencyResponse` (#537). timestamp is an
+ * opaque numeric ordering key. */
+export const SecurityPricesHighFrequencyResponseSchema = z.looseObject({
+  securityPricesHighFrequency: z.array(
+    z.looseObject({
+      id: z.string(),
+      timestamp: z.number(),
+      price: z.number(),
+    })
+  ),
+});

--- a/src/core/graphql/queries/security-prices.ts
+++ b/src/core/graphql/queries/security-prices.ts
@@ -13,6 +13,7 @@
  * the user-facing variable name `id` to match the operation signature.
  */
 
+import { z } from 'zod';
 import type { GraphQLClient } from '../client.js';
 import { SECURITY_PRICES } from '../operations.generated.js';
 import type { TimeFrame } from './_shared.js';
@@ -51,3 +52,15 @@ export async function fetchSecurityPrices(
   );
   return data.securityPrices;
 }
+
+/** Zod mirror of `SecurityPricesResponse` (#537). price is null for a day the
+ * security has no close (live-verified). */
+export const SecurityPricesResponseSchema = z.looseObject({
+  securityPrices: z.array(
+    z.looseObject({
+      id: z.string(),
+      price: z.number().nullable(),
+      date: z.string(),
+    })
+  ),
+});

--- a/src/core/graphql/read-response-validation.ts
+++ b/src/core/graphql/read-response-validation.ts
@@ -34,9 +34,13 @@ import { AggregatedHoldingsResponseSchema } from './queries/aggregated-holdings.
 import { BalanceHistoryResponseSchema } from './queries/balance-history.js';
 import { HoldingsResponseSchema } from './queries/holdings.js';
 import { InvestmentAllocationResponseSchema } from './queries/investment-allocation.js';
+import { InvestmentBalanceResponseSchema } from './queries/investment-balance.js';
+import { InvestmentLiveBalanceResponseSchema } from './queries/investment-live-balance.js';
 import { MonthlySpendResponseSchema } from './queries/monthly-spend.js';
 import { NetworthResponseSchema } from './queries/networth.js';
 import { RecurringsResponseSchema } from './queries/recurrings.js';
+import { SecurityPricesResponseSchema } from './queries/security-prices.js';
+import { SecurityPricesHighFrequencyResponseSchema } from './queries/security-prices-high-frequency.js';
 import { TagsResponseSchema } from './queries/tags.js';
 import { TopMoversResponseSchema } from './queries/top-movers.js';
 import { UpcomingRecurringsResponseSchema } from './queries/upcoming-recurrings.js';
@@ -83,6 +87,13 @@ export const QUERY_RESPONSE_SCHEMAS: Readonly<Record<string, QueryResponseShapeE
   AggregatedHoldings: entry('aggregatedHoldings', AggregatedHoldingsResponseSchema),
   InvestmentAllocation: entry('investmentAllocation', InvestmentAllocationResponseSchema),
   TopMovers: entry('topMovers', TopMoversResponseSchema),
+  InvestmentBalance: entry('investmentBalance', InvestmentBalanceResponseSchema),
+  InvestmentLiveBalance: entry('investmentLiveBalance', InvestmentLiveBalanceResponseSchema),
+  SecurityPrices: entry('securityPrices', SecurityPricesResponseSchema),
+  SecurityPricesHighFrequency: entry(
+    'securityPricesHighFrequency',
+    SecurityPricesHighFrequencyResponseSchema
+  ),
 };
 
 // ---------------------------------------------------------------------------

--- a/tests/core/graphql/read-response-validation.test.ts
+++ b/tests/core/graphql/read-response-validation.test.ts
@@ -164,6 +164,23 @@ const VALID_RESPONSES: Record<string, unknown> = {
       },
     ],
   },
+  InvestmentBalance: {
+    investmentBalance: [{ id: 'iBl111BbB222CcC333Dd', date: '2026-07-01', balance: 5000 }],
+  },
+  InvestmentLiveBalance: {
+    investmentLiveBalance: { id: 'iLb111BbB222CcC333Dd', date: '2026-07-18', balance: 5200 },
+  },
+  SecurityPrices: {
+    securityPrices: [
+      { id: 'sP1111BbB222CcC333Dd', price: 100, date: '2026-07-01' },
+      { id: 'sP2222BbB222CcC333Dd', price: null, date: '2026-06-30' },
+    ],
+  },
+  SecurityPricesHighFrequency: {
+    securityPricesHighFrequency: [
+      { id: 'hF1111BbB222CcC333Dd', timestamp: 1_745_539_200_000, price: 100 },
+    ],
+  },
 };
 
 describe('validateQueryResponse', () => {


### PR DESCRIPTION
# Summary

Gates the final four investment read queries — `investmentBalance`, `investmentLiveBalance`, `securityPrices`, `securityPricesHighFrequency` — from `unverified` to `runtime:read-zod-warn`. `investmentLiveBalance` reuses `InvestmentBalanceNodeSchema` (identical single-row shape).

PR5 of the #537 series. Does **not** close #537: `categories` is the 18th and final read shape, tracked separately in #553 (it needs a `CategoryBudgetMonthly` amount type-fix that touches the budgets write path, so it gets its own PR).

Purely mechanical — no type corrections. A read-only wire-type probe (2026-07-18, logging `typeof` only) confirmed every field matches its declared type: `date: string`, `balance`/`price`/`timestamp: number`, `securityPrices.price: number | null`. Doing the probe up front avoided a fix-cycle.

## External assumptions

No **new** assumptions. Upgrades four pre-existing read response-shape assumptions to `runtime:read-zod-warn`-gated.

Evidence class: **live round-trip** — a `typeof` probe established the wire types, and `bun run smoke:reads` (19/19 PASS, **zero** `read response shape drift`) confirms all four schemas match production, including the `securityPrices.price` null branch.

After this PR, **17 of 18** read response shapes are runtime-gated; `categories` (#553) is the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
