### PR TITLE
test: close audit-nit test-symmetry gaps (#556, #549)

### DIFF
--- a/tests/tools/live/aggregated-holdings.test.ts
+++ b/tests/tools/live/aggregated-holdings.test.ts
@@ -107,6 +107,14 @@ describe('LiveAggregatedHoldingsTools.getAggregatedHoldings', () => {
     expect(client.query).toHaveBeenCalledTimes(2);
   });
 
+  test('changing scope (item_id) invalidates the cache and refetches', async () => {
+    const client = makeClient([holding]);
+    const tools = new LiveAggregatedHoldingsTools(makeLive(client));
+    await tools.getAggregatedHoldings({});
+    await tools.getAggregatedHoldings({ item_id: 'item-1' });
+    expect(client.query).toHaveBeenCalledTimes(2);
+  });
+
   test('cache metadata: ISO strings, oldest === newest', async () => {
     const client = makeClient([holding]);
     const tools = new LiveAggregatedHoldingsTools(makeLive(client));

--- a/tests/utils/round.test.ts
+++ b/tests/utils/round.test.ts
@@ -37,5 +37,6 @@ describe('parseAmount', () => {
   test('returns null for non-finite numeric input', () => {
     expect(parseAmount(Number.NaN)).toBeNull();
     expect(parseAmount(Number.POSITIVE_INFINITY)).toBeNull();
+    expect(parseAmount(Number.NEGATIVE_INFINITY)).toBeNull();
   });
 });


### PR DESCRIPTION
# Summary

Batched LOW audit-bot test-symmetry nits (one cleanup PR per repo convention). Test-only; no source changes.

- parseAmount: assert `NEGATIVE_INFINITY` returns null alongside the existing `POSITIVE_INFINITY` case (identical `Number.isFinite` behavior, added for symmetry).
- aggregated-holdings: add an `item_id`-only scope-change cache-invalidation test mirroring the existing `account_id` case (both flow through the same key string).

## External assumptions

None — test-only additions asserting existing behavior; no new assumptions about Copilot API/data.

Closes #556
Closes #549