### PR TITLE
chore(ci): add 2-week Dependabot cooldown (30d for majors)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    # Let a release age before proposing it, so upstream regressions surface
+    # in the wider ecosystem first. 2 weeks for minor/patch; a month for
+    # majors (breaking bumps like typescript 6->7 deserve extra soak time).
+    cooldown:
+      default-days: 14
+      semver-major-days: 30
     # Group all minor/patch updates together
     groups:
       production-dependencies:
@@ -50,6 +56,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    # Same 2-week stability cooldown as npm (see above).
+    cooldown:
+      default-days: 14
+      semver-major-days: 30
     # Assignees for workflow PRs
     assignees:
       - "ignaciohermosillacornejo"


### PR DESCRIPTION
# Summary

Makes Dependabot less aggressive for stability: adds a `cooldown` so a newly-published release must age before Dependabot proposes it, letting upstream regressions surface in the wider ecosystem first.

- **14 days** (2 weeks) default cooldown for minor/patch bumps.
- **30 days** for `semver-major` bumps — breaking majors (e.g. the current typescript 6→7 PR #544) deserve extra soak time.
- Applied to both the `npm` and `github-actions` ecosystems. Weekly Monday schedule and grouping unchanged.

Does not affect existing open Dependabot PRs (#543/#544) — cooldown gates future proposals only.

## External assumptions

None — CI/config change only; no assumptions about Copilot API/data.