### PR TITLE
chore(release): 2.3.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "copilot-money-mcp",
   "display_name": "Copilot Money MCP Server",
   "description": "Query your personal finances with AI using local Copilot Money data. 14 read-only tools for transactions, investments, budgets, goals, and more.",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "icon": "icon.png",
   "author": {
     "name": "Ignacio Hermosilla",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "copilot-money-mcp",
   "mcpName": "io.github.ignaciohermosillacornejo/copilot-money-mcp",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "MCP server for Copilot Money — query personal finances locally (14 cache-mode read tools), opt into GraphQL-backed live reads with --live-reads (21 read tools: 8 cache + 13 live), and manage data via Copilot's GraphQL API (17 write tools, opt-in with --write)",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "source": "github"
   },
   "websiteUrl": "https://github.com/ignaciohermosillacornejo/copilot-money-mcp#readme",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "copilot-money-mcp",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
# Summary

Release **v2.3.0** (from 2.2.2). Bumps the version across `package.json`, `server.json` (top-level + npm package), and `manifest.json` (in sync). Merging this to `main` triggers `auto-release`: builds the `.mcpb`, cuts the GitHub release, and publishes to npm.

## Highlights since v2.2.2 (93 commits)

- **Runtime read-shape validation (#537):** all 18 GraphQL read response shapes now validated warn-mode (`runtime:read-zod-warn`) via `read-response-validation.ts` — closing the largest `unverified` bucket in the conformance ledger. On its first live runs it caught **4 real server type-drifts** (Copilot returns timestamps/amounts as numbers; interfaces mislabeled them `string`): `latestBalanceUpdate`, `networth`/`monthly` amounts, `Security.lastUpdate`, and `CategoryBudgetMonthly` amounts — all corrected.
- **Investment tools epic (#536):** 4 new live read tools — `get_investment_allocation_live`, `get_top_movers_live`, `get_aggregated_holdings_live`, `get_investment_balance_live`.
- **CI/stability:** 2-week Dependabot cooldown (30d for majors).

No breaking changes to the tool surface → minor bump.

## External assumptions

None — version bump + release metadata only; no new assumptions about Copilot API/data.