### PR TITLE
fix(release): sync package-lock.json version + gate it in check:version-sync (#563)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-money-mcp",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-money-mcp",
-      "version": "2.2.2",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.2.0",

--- a/scripts/check-version-sync.ts
+++ b/scripts/check-version-sync.ts
@@ -1,13 +1,16 @@
 #!/usr/bin/env bun
 /**
  * Assert that the version in package.json matches the version in server.json
- * (both the top-level `version` and the npm package entry's `version`) and in
- * manifest.json.
+ * (both the top-level `version` and the npm package entry's `version`),
+ * manifest.json, and package-lock.json (its root `version` and the
+ * `packages[""]` self-entry `version`).
  *
  * The MCP registry entry is bound to a specific published npm version, and
  * manifest.json is the version Claude Desktop reads from the .mcpb bundle —
  * drift between any of these would leave a stale pointer or bundle after a
- * release. Run as part of `bun run check`.
+ * release. package-lock.json carries its own self-describing version metadata
+ * that a manual `version` bump can silently miss (issue #563). Run as part of
+ * `bun run check`.
  */
 
 import { readFileSync } from 'fs';
@@ -19,6 +22,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8'));
 const server = JSON.parse(readFileSync(join(__dirname, '../server.json'), 'utf-8'));
 const manifest = JSON.parse(readFileSync(join(__dirname, '../manifest.json'), 'utf-8'));
+const lockfile = JSON.parse(readFileSync(join(__dirname, '../package-lock.json'), 'utf-8'));
 
 const pkgVersion: string = pkg.version;
 const serverVersion: string = server.version;
@@ -27,6 +31,8 @@ const npmPackage = (server.packages ?? []).find(
   (p: { registryType?: string }) => p.registryType === 'npm',
 );
 const npmPackageVersion: string | undefined = npmPackage?.version;
+const lockfileVersion: string = lockfile.version;
+const lockfileSelfVersion: string | undefined = lockfile.packages?.['']?.version;
 
 const mismatches: string[] = [];
 if (serverVersion !== pkgVersion) {
@@ -42,12 +48,24 @@ if (manifestVersion !== pkgVersion) {
     `manifest.json#version (${manifestVersion}) !== package.json#version (${pkgVersion})`,
   );
 }
+if (lockfileVersion !== pkgVersion) {
+  mismatches.push(
+    `package-lock.json#version (${lockfileVersion}) !== package.json#version (${pkgVersion})`,
+  );
+}
+if (lockfileSelfVersion !== pkgVersion) {
+  mismatches.push(
+    `package-lock.json#packages[''].version (${lockfileSelfVersion}) !== package.json#version (${pkgVersion})`,
+  );
+}
 
 if (mismatches.length > 0) {
   console.error('Version sync check failed:');
   for (const m of mismatches) console.error(`  - ${m}`);
   console.error(
-    '\nBump all four version fields (package.json, server.json#version, server.json#packages[npm].version, manifest.json) to the same value before publishing.',
+    '\nBump the version consistently across package.json, server.json (#version + ' +
+      "#packages[npm].version), manifest.json, and package-lock.json (#version + #packages[''].version) " +
+      'to the same value before publishing.',
   );
   process.exit(1);
 }


### PR DESCRIPTION
# Summary

The v2.3.0 bump updated `package.json`/`server.json`/`manifest.json` but missed `package-lock.json`, whose self-describing `version` metadata (root + `packages[""]`) was left at 2.2.2 (audit finding from #562).

- **Instance fix:** bump the lockfile's two root `version` fields to 2.3.0 (transitive deps that coincidentally sit at 2.2.2 — body-parser, napi-macros — untouched).
- **Class fix:** extend `check:version-sync` (part of `bun run check`) to also assert `package-lock.json#version` and `packages[""].version` match `package.json`, so a future manual bump that forgets the lockfile fails the build instead of shipping stale metadata.

Does not affect the published 2.3.0 npm package (npm publish reads `package.json`); this is repo-metadata hygiene + a guard against recurrence.

## External assumptions

None — repo metadata + CI-check change only.

## Bug fix?

Root cause:       the v2.3.0 version bump manually edited package.json/server.json/manifest.json but not package-lock.json, and `check:version-sync` didn't cover the lockfile — so its self-describing version silently went stale.
Bug class:        release version-sync gap — a file carrying the package version that isn't covered by the version-sync gate can ship stale after a manual bump.
Detector added:   `check:version-sync` (run in `bun run check`) now asserts `package-lock.json#version` and `packages[""].version` equal `package.json#version`; a future bump that misses the lockfile fails the build.
Siblings checked: the other version-carrying files (package.json, server.json #version + #packages[npm], manifest.json) were already gated; package-lock.json was the only uncovered one. No other tracked file embeds the package version.
Ledger updated:   n/a — not an external-assumption (Copilot API) bug.

Closes #563