### PR TITLE
fix(live): dedup drift warns by normalized array-index path (#552)

### DIFF
--- a/src/core/graphql/drift-path.ts
+++ b/src/core/graphql/drift-path.ts
@@ -1,0 +1,10 @@
+/**
+ * Normalize a Zod issue path into a dedupe key segment: array indices (numeric
+ * segments) collapse to `*`, so a single drift on an array field warns once
+ * instead of once per element (issue #552). String keys pass through unchanged.
+ * Shared by both warn-mode response validators (read + mutation) so their dedupe
+ * behavior can't drift apart.
+ */
+export function normalizeDriftPath(path: ReadonlyArray<PropertyKey>): string {
+  return path.map((seg) => (typeof seg === 'number' ? '*' : String(seg))).join('.');
+}

--- a/src/core/graphql/read-response-validation.ts
+++ b/src/core/graphql/read-response-validation.ts
@@ -29,6 +29,7 @@
  */
 
 import type { ZodType } from 'zod';
+import { normalizeDriftPath } from './drift-path.js';
 import { AccountResponseSchema, AccountsResponseSchema } from './queries/accounts.js';
 import { AggregatedHoldingsResponseSchema } from './queries/aggregated-holdings.js';
 import { BalanceHistoryResponseSchema } from './queries/balance-history.js';
@@ -107,9 +108,11 @@ export type ReadResponseDriftStats = Record<string, number>;
 
 const driftCounts = new Map<string, number>();
 
-// Dedupe key = `${operationName}::${firstIssue.path}::${issue.code}`. One warn
-// per unique key per process — prevents log flood when every call to the same
-// query drifts the same way.
+// Dedupe key = `${operationName}::${normalizeDriftPath(issue.path)}::${issue.code}`.
+// Array indices in the path normalize to `*` (#552) so one drift across an
+// array's elements warns once, not once per element. One warn per unique key
+// per process — prevents log flood when every call to the same query drifts
+// the same way.
 const warnedKeys = new Set<string>();
 
 /** Snapshot of the per-surface read drift counters (copy, safe to mutate). */
@@ -135,7 +138,7 @@ export function validateQueryResponse(operationName: string, data: unknown): voi
   // — the unique drift inventory is logged in full while repeats stay silent.
   for (const issue of result.error.issues) {
     const pathStr = issue.path.join('.');
-    const key = `${operationName}::${pathStr}::${issue.code}`;
+    const key = `${operationName}::${normalizeDriftPath(issue.path)}::${issue.code}`;
     if (warnedKeys.has(key)) continue;
     warnedKeys.add(key);
     // console.warn writes to stderr in Node/Bun — safe for the MCP stdio

--- a/src/core/graphql/response-validation.ts
+++ b/src/core/graphql/response-validation.ts
@@ -31,6 +31,7 @@ import { z, type ZodType } from 'zod';
 import { TRANSACTION_TYPES } from './transactions.js';
 import { TRANSACTIONS_READ_SHAPE_RUNTIME_CHECK } from './read-validation.js';
 import { READ_RESPONSE_SHAPE_RUNTIME_CHECK } from './read-response-validation.js';
+import { normalizeDriftPath } from './drift-path.js';
 
 /**
  * Name of this runtime check as registered in the ledger's
@@ -237,9 +238,11 @@ export type ResponseDriftStats = Record<string, number>;
 
 const driftCounts = new Map<string, number>();
 
-// Dedupe key = `${operationName}::${firstIssue.path}::${firstIssue.code}`.
-// One warn per unique key per process — prevents log flood when every call
-// to the same mutation drifts the same way.
+// Dedupe key = `${operationName}::${normalizeDriftPath(issue.path)}::${issue.code}`.
+// Array indices in the path normalize to `*` (#552) so one drift across an
+// array's elements (e.g. every splitTransaction child) warns once, not once
+// per element. One warn per unique key per process — prevents log flood when
+// every call to the same mutation drifts the same way.
 const warnedKeys = new Set<string>();
 
 /** Snapshot of the per-surface drift counters (copy, safe to mutate). */
@@ -280,7 +283,7 @@ export function validateMutationResponse(operationName: string, data: unknown): 
   // silent. The dedupe set bounds total output regardless of call volume.
   for (const issue of result.error.issues) {
     const pathStr = issue.path.join('.');
-    const key = `${operationName}::${pathStr}::${issue.code}`;
+    const key = `${operationName}::${normalizeDriftPath(issue.path)}::${issue.code}`;
     if (warnedKeys.has(key)) continue;
     warnedKeys.add(key);
     // `message` describes expected/received TYPES (and enum option lists over

--- a/tests/core/graphql/drift-path.test.ts
+++ b/tests/core/graphql/drift-path.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Unit tests for `normalizeDriftPath` (issue #552).
+ *
+ * Contract under test: a Zod issue path is collapsed into a dedupe-key
+ * segment where numeric (array-index) segments become `*` and string
+ * segments pass through unchanged, so a single field-type drift across an
+ * array warns ONCE instead of once per element.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { normalizeDriftPath } from '../../../src/core/graphql/drift-path.js';
+
+describe('normalizeDriftPath', () => {
+  test('maps numeric segments to *', () => {
+    expect(normalizeDriftPath([0])).toBe('*');
+    expect(normalizeDriftPath([12])).toBe('*');
+  });
+
+  test('leaves string segments unchanged', () => {
+    expect(normalizeDriftPath(['accounts'])).toBe('accounts');
+    expect(normalizeDriftPath(['createTransaction', 'categoryId'])).toBe(
+      'createTransaction.categoryId'
+    );
+  });
+
+  test('handles a mixed path (object field inside an array element)', () => {
+    expect(normalizeDriftPath(['accounts', 0, 'balance'])).toBe('accounts.*.balance');
+    expect(normalizeDriftPath(['accounts', 1, 'balance'])).toBe('accounts.*.balance');
+    expect(normalizeDriftPath(['accounts', 42, 'balance'])).toBe('accounts.*.balance');
+  });
+
+  test('handles an empty path', () => {
+    expect(normalizeDriftPath([])).toBe('');
+  });
+
+  test('handles nested arrays', () => {
+    expect(normalizeDriftPath(['a', 0, 'b', 1, 'c'])).toBe('a.*.b.*.c');
+  });
+});

--- a/tests/core/graphql/read-response-validation.test.ts
+++ b/tests/core/graphql/read-response-validation.test.ts
@@ -292,6 +292,19 @@ describe('validateQueryResponse', () => {
     expect(getReadResponseDriftStats()).toEqual({ 'Query.accounts:response': 2 }); // counted twice
   });
 
+  test('a same-field drift across multiple array elements dedupes by normalized path (#552)', () => {
+    validateQueryResponse('Accounts', {
+      accounts: [
+        { ...makeAccount(), balance: 'x' },
+        { ...makeAccount(), balance: 'y' },
+        { ...makeAccount(), balance: 'z' },
+      ],
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1); // deduped across all 3 indices
+    expect(getReadResponseDriftStats()).toEqual({ 'Query.accounts:response': 1 });
+  });
+
   test('unregistered operations skip silently — no warn, no drift', () => {
     // Transactions is deliberately absent (its own drop-based check owns it);
     // a totally unknown op must also skip.

--- a/tests/core/graphql/response-validation.test.ts
+++ b/tests/core/graphql/response-validation.test.ts
@@ -210,6 +210,20 @@ describe('validateMutationResponse', () => {
     expect(getResponseDriftStats()).toEqual({ 'Mutation.createTransaction:response': 2 });
   });
 
+  test('a same-field drift across multiple array elements dedupes by normalized path (#552)', () => {
+    const t1 = makeTransaction();
+    delete (t1 as Record<string, unknown>).categoryId;
+    const t2 = makeTransaction();
+    delete (t2 as Record<string, unknown>).categoryId;
+
+    validateMutationResponse('SplitTransaction', {
+      splitTransaction: { parentTransaction: makeTransaction(), splitTransactions: [t1, t2] },
+    });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1); // deduped across both split indices
+    expect(getResponseDriftStats()).toEqual({ 'Mutation.splitTransaction:response': 1 });
+  });
+
   test('drift counters are tracked per surface', () => {
     validateMutationResponse('DeleteTag', { deleteTag: 'yes' }); // not a boolean
     validateMutationResponse('EditBudget', { editCategoryBudget: 1 }); // not a boolean


### PR DESCRIPTION
# Summary

Normalizes array-index path segments in the drift-warn **dedupe key** for both warn-mode Zod validators, so a single field-type drift across an array warns **once** instead of once-per-element. Concretely: gating `categories` once produced **~9,920** stderr lines — one per budget-amount field × every category × current+histories — because each concrete index (`accounts.0.balance`, `accounts.1.balance`, …) was a distinct dedupe key.

- New shared `src/core/graphql/drift-path.ts` → `normalizeDriftPath(path)` maps numeric segments to `*` (`accounts.0.balance` → `accounts.*.balance`).
- Wired into the dedupe key of both `validateQueryResponse` (reads) and `validateMutationResponse` (mutations). The warn **message still shows the concrete path** (a real example index) — only the dedupe key is normalized, so logs stay actionable.

Addresses the dedupe part of #552. The "aggregate read-drift stats into a surfaced report" sub-item is separate (needs a design decision on where to surface it) and is NOT in this PR — #552 stays open for it.

## External assumptions

None — internal stderr logging-dedup behavior only.

## Bug fix?

Root cause:       the drift-warn dedupe key used the concrete Zod issue path including array indices, so one field-type drift across an N-element array emitted N warns (one per index) before the dedupe set saturated.
Bug class:        log-flood from per-array-element dedupe keys in warn-mode Zod validators.
Detector added:   a shared `normalizeDriftPath` used by BOTH GraphQL validators (so their dedup behavior can't drift apart) + two new tests asserting a multi-index array drift warns exactly once and counts the response once. `drift-path.test.ts` unit-tests the normalizer.
Siblings checked: both GraphQL warn-mode validators (read + mutation) normalized via the shared helper. A third warn-mode validator — `schema-warn.ts` (LevelDB decoder) — shares the pattern but keys on only the FIRST issue per doc and is doc-bounded, so it has far lower flood risk; the shared helper is now available to normalize it if a decoder flood is ever observed.
Ledger updated:   n/a — internal logging-hygiene fix, not an external-assumption (Copilot API) bug.