### PR TITLE
feat(smoke): report read response-shape drift counters after the read smoke (#552)

### DIFF
--- a/scripts/smoke/reads.ts
+++ b/scripts/smoke/reads.ts
@@ -18,6 +18,7 @@
 import { FirebaseAuth } from '../../src/core/auth/firebase-auth.js';
 import { extractRefreshTokenCandidates } from '../../src/core/auth/browser-token.js';
 import { GraphQLClient } from '../../src/core/graphql/client.js';
+import { getReadResponseDriftStats } from '../../src/core/graphql/read-response-validation.js';
 import { READ_SMOKE_CHECKS, type ReadSmokeState } from './read-checks.js';
 
 interface ReadSmokeResult {
@@ -76,6 +77,21 @@ async function main(): Promise<void> {
   for (const r of results) {
     const suffix = r.status === 'SKIP' && r.detail ? `  (${r.detail})` : '';
     console.error(`  ${r.operation.padEnd(width)}  ${r.status}${suffix}`);
+  }
+
+  // Read response-shape drift counters accumulated over this run (runtime
+  // read-zod-warn, warn-mode — informational, never a failure by itself).
+  // Parallel to the roundtrip smoke's mutation-drift report (#552): read
+  // drift previously only hit stderr as it happened; this aggregates it.
+  const drift = getReadResponseDriftStats();
+  const driftEntries = Object.entries(drift);
+  if (driftEntries.length > 0) {
+    console.error('\n[smoke] Read response-shape drift counters (read-zod-warn, warn-mode):');
+    for (const [surface, count] of driftEntries) {
+      console.error(`  ${surface}: ${String(count)}`);
+    }
+  } else {
+    console.error('\n[smoke] Read response-shape drift counters (read-zod-warn): none');
   }
 
   const failed = results.filter((r) => r.status === 'FAIL');


### PR DESCRIPTION
# Summary

Completes the second sub-item of #552: surface the accumulated read response-shape drift counters at the end of the Tier-1 read smoke — the read-side parallel to how the round-trip smoke already reports mutation-response drift (`getResponseDriftStats()`).

Read drift previously only hit stderr *as it happened* (now deduped by #565); this aggregates the per-surface counts into the smoke's summary. Warn-mode/informational — never fails the run by itself (drift on a load-bearing field still fails via the existing read-back assertions). Prints `... none` when clean (the common case), or one `surface: count` line per drifted response shape.

Verified live: `bun run smoke:reads` prints `[smoke] Read response-shape drift counters (read-zod-warn): none` and passes 19/19.

With this, both halves of #552 (dedupe normalization in #565 + this stats report) are done.

## External assumptions

None — smoke-script output only; reads an existing in-process counter.

Closes #552