### PR TITLE
feat(tools): out-of-window writes via caller-supplied routing ids

### DIFF
--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -380,7 +380,13 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
 
   operation('editTransaction', [
     'update_transaction.transaction_id',
+    'update_transaction.account_id',
+    'update_transaction.item_id',
     'review_transactions.transaction_ids',
+    'review_transactions.rows',
+    'review_transactions.rows[].transaction_id',
+    'review_transactions.rows[].account_id',
+    'review_transactions.rows[].item_id',
   ]),
   gatedInputField('EditTransactionInput.name', ['update_transaction.name']),
   gatedInputField('EditTransactionInput.categoryId', ['update_transaction.category_id']),

--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -409,7 +409,10 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
       'binding, not mere existence — fabricated accountId → "accountId … Not Found"; ' +
       'real-but-wrong pair → "Transaction not found" (server scopes the txn lookup under ' +
       'account/item); correct pair → edit applied. Routing ids therefore cannot be ' +
-      'defaulted or faked; resolveTransactionMeta must supply the true pair.',
+      'defaulted or faked; the true pair must come from resolveTransactionMeta or, on the ' +
+      'out-of-window bypass paths, from the caller (update_transaction account_id/item_id or ' +
+      'review_transactions rows entries, taken from a live read) — a wrong pair fails loudly ' +
+      'either way.',
   },
 
   operation('deleteTransaction', [
@@ -443,6 +446,18 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   gatedInputField('SplitTransactionInput.categoryId', ['split_transaction.splits[].category_id']),
   responseShape('splitTransaction'),
   appliesSurface('splitTransaction'),
+  {
+    surface: 'Mutation.splitTransaction:sum',
+    kind: 'operation',
+    oracle: null,
+    class: 'verified-once',
+    evidence:
+      'Error-leak recon (docs/graphql-capture/hidden-mutations.md, SplitTransactionInput.amount): ' +
+      '"children must sum to parent.amount (server enforces)". Load-bearing for the ' +
+      'out-of-window split bypass, which skips the client-side sum check and leaves the server ' +
+      'as the sole enforcer on that path. Routine live splits with matching sums succeed ' +
+      '(supporting use only — no wrong-sum rejection transcript has been captured).',
+  },
 
   // ----- Tags ---------------------------------------------------------------
   // No top-level args beyond the input object (covered by CreateTagInput.*).

--- a/src/tools/registry/transactions.ts
+++ b/src/tools/registry/transactions.ts
@@ -332,7 +332,10 @@ export const splitTransactionTool = defineTool({
       'least 2 entries. Each split entry requires `amount` and `category_id`; `name` and ' +
       "`date` default to the parent's values if omitted. The sum of all children's `amount` " +
       "fields must equal the parent's `amount` (server-enforced; this tool also validates " +
-      'client-side before dispatching). After success the parent transaction is hidden but ' +
+      'client-side before dispatching). If the parent cannot be resolved locally (outside the ' +
+      'resolution window), the split can still proceed when every split entry carries an ' +
+      'explicit `name` and `date` — the amount-sum check is then deferred to the server. ' +
+      'After success the parent transaction is hidden but ' +
       'not deleted (children reference it via parent_transaction_id) — there is no reversal ' +
       "mutation; to undo a split delete each child and edit the parent's category back. No " +
       'optional per-split fields exist — tags, notes, and reviewed state must be set via ' +
@@ -416,7 +419,9 @@ export const updateTransactionTool = defineTool({
       'pass the type alone, or use REGULAR to keep/set a category. `reviewed` marks a single ' +
       'transaction reviewed (true) or un-reviewed (false), and can be set inline with other edits ' +
       '— use review_transactions instead for bulk/filter-based review. At least one mutable field ' +
-      'must be provided besides transaction_id. Other fields (excluded, internal_transfer, ' +
+      'must be provided besides transaction_id. If the transaction cannot be resolved locally ' +
+      '(outside the resolution window), pass account_id and item_id (from a live read) to write ' +
+      'anyway. Other fields (excluded, internal_transfer, ' +
       'goal_id) are not writable through the GraphQL API and were removed from this tool when the ' +
       'backend was migrated.',
     inputSchema: {
@@ -426,6 +431,20 @@ export const updateTransactionTool = defineTool({
         transaction_id: {
           type: 'string',
           description: 'Transaction ID to update (from get_transactions results)',
+        },
+        account_id: {
+          type: 'string',
+          description:
+            'Optional. Account ID the transaction belongs to (from a live read). Pass together ' +
+            'with item_id to skip local resolution and write to a transaction outside the ' +
+            'resolution window.',
+        },
+        item_id: {
+          type: 'string',
+          description:
+            "Optional. Item ID the account belongs to (Copilot's Firestore item_id, from a live " +
+            'read). Pass together with account_id to skip local resolution and write to a ' +
+            'transaction outside the resolution window.',
         },
         name: {
           type: 'string',
@@ -474,8 +493,12 @@ export const reviewTransactionsTool = defineTool({
   schema: {
     name: 'review_transactions',
     description:
-      'Mark one or more transactions as reviewed (or unreviewed). ' +
-      'Accepts an array of transaction_ids. Writes are issued via GraphQL in parallel with ' +
+      'Bulk mark transactions as reviewed (or unreviewed). Two modes: pass `transaction_ids` ' +
+      '(ids are resolved locally, so this only works for transactions within the resolution ' +
+      'window), OR pass `rows` — an array of {transaction_id, account_id, item_id} taken from a ' +
+      'live read — to review ANY transactions, including out-of-window historical/backlog rows. ' +
+      'Prefer `rows` for large backlog sweeps: it is the true bulk path. One of the two must be ' +
+      'provided; `rows` wins when both are. Writes are issued via GraphQL in parallel with ' +
       'a cap of 5 in flight at a time. On the first GraphQL error, new writes stop, in-flight ' +
       'writes settle, and the error is thrown with a `reviewed_count` reflecting how many ' +
       'succeeded before the failure (partial success is possible).',
@@ -485,14 +508,40 @@ export const reviewTransactionsTool = defineTool({
         transaction_ids: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Transaction IDs to mark as reviewed',
+          description:
+            'Transaction IDs to mark as reviewed. Resolved locally — fails for transactions ' +
+            'outside the resolution window; use `rows` for those.',
+        },
+        rows: {
+          type: 'array',
+          description:
+            'Bypass path: each entry supplies the IDs the GraphQL mutation needs directly ' +
+            '(from a live read), so out-of-window transactions work without local resolution.',
+          items: {
+            type: 'object',
+            additionalProperties: false,
+            properties: {
+              transaction_id: {
+                type: 'string',
+                description: 'Transaction ID to mark',
+              },
+              account_id: {
+                type: 'string',
+                description: 'Account ID the transaction belongs to (from the live row)',
+              },
+              item_id: {
+                type: 'string',
+                description: "Item ID the account belongs to (Copilot's Firestore item_id)",
+              },
+            },
+            required: ['transaction_id', 'account_id', 'item_id'],
+          },
         },
         reviewed: {
           type: 'boolean',
           description: 'Set to true to mark as reviewed, false to unmark. Defaults to true.',
         },
       },
-      required: ['transaction_ids'],
     },
     annotations: {
       readOnlyHint: false,

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3393,8 +3393,17 @@ export class CopilotMoneyTools {
 
     // Normalize both input modes to one entries list; everything below
     // (worker loop, error payloads, result) references only this list.
+    // A caller who passed `rows` chose the bypass mode: an empty/invalid
+    // value gets a rows-shaped error rather than silently falling through
+    // to the transaction_ids path and its misleading message.
     let entries: Array<{ id: string; accountId: string; itemId: string }>;
-    if (Array.isArray(rows) && rows.length > 0) {
+    if (rows !== undefined) {
+      if (!Array.isArray(rows) || rows.length === 0) {
+        throw new Error(
+          'rows must be a non-empty array of {transaction_id, account_id, item_id} when ' +
+            'provided — omit it to use transaction_ids instead'
+        );
+      }
       for (const row of rows) {
         validateDocId(row.transaction_id, 'transaction_id');
         validateDocId(row.account_id, 'account_id');

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -2634,9 +2634,20 @@ export class CopilotMoneyTools {
    * internal_transfer, goal_id) are not writable through the GraphQL
    * EditTransaction mutation and were removed from this tool when the backend
    * was migrated.
+   *
+   * Routing bypass: when the caller supplies BOTH account_id and item_id
+   * (taken from a live read), they are forwarded verbatim and local
+   * resolution is skipped entirely — same defensive "caller-supplied triple"
+   * contract as delete_transaction / split_transaction. This lets writes
+   * reach transactions outside the resolution window; the server still
+   * validates the full (id, accountId, itemId) binding (see the
+   * Mutation.editTransaction:routing ledger entry), so a wrong pair fails
+   * loudly rather than editing a different transaction.
    */
   async updateTransaction(args: {
     transaction_id: string;
+    account_id?: string;
+    item_id?: string;
     name?: string;
     category_id?: string;
     note?: string;
@@ -2656,6 +2667,8 @@ export class CopilotMoneyTools {
     // without going through the MCP dispatch layer).
     const allowedKeys = new Set([
       'transaction_id',
+      'account_id',
+      'item_id',
       'name',
       'category_id',
       'note',
@@ -2669,9 +2682,14 @@ export class CopilotMoneyTools {
       }
     }
 
-    // Require at least one mutable field besides transaction_id.
+    // Require at least one mutable field besides transaction_id. The routing
+    // ids (account_id/item_id) address the write — they are not edits.
     const mutableKeys = Object.keys(args).filter(
-      (k) => k !== 'transaction_id' && (args as Record<string, unknown>)[k] !== undefined
+      (k) =>
+        k !== 'transaction_id' &&
+        k !== 'account_id' &&
+        k !== 'item_id' &&
+        (args as Record<string, unknown>)[k] !== undefined
     );
     if (mutableKeys.length === 0) {
       throw new Error('update_transaction requires at least one field to update');
@@ -2679,18 +2697,39 @@ export class CopilotMoneyTools {
 
     validateDocId(transaction_id, 'transaction_id');
 
-    // Resolve the transaction's accountId/itemId for the GraphQL mutation —
-    // live-first via the meta index / windowed fetch; local cache only in
-    // degraded (no-liveDb) mode. See resolveTransactionMeta().
-    const { meta: metaMap, liveWindowMonths } = await this.resolveTransactionMeta([transaction_id]);
-    const meta = metaMap.get(transaction_id);
-    if (!meta) {
+    // Routing bypass: a caller-supplied account_id + item_id pair (from a
+    // live read) is forwarded verbatim — no local resolution, so writes can
+    // reach transactions outside the resolution window. Half a pair is
+    // always a caller mistake; reject it rather than silently resolving.
+    if ((args.account_id === undefined) !== (args.item_id === undefined)) {
       throw new Error(
-        CopilotMoneyTools.transactionsNotFoundMessage([transaction_id], liveWindowMonths)
+        'update_transaction: account_id and item_id must be passed together (both from a live read) to bypass local resolution'
       );
     }
-    const resolvedAccountId = meta.accountId;
-    const resolvedItemId = meta.itemId;
+    let resolvedAccountId: string;
+    let resolvedItemId: string;
+    if (args.account_id !== undefined && args.item_id !== undefined) {
+      validateDocId(args.account_id, 'account_id');
+      validateDocId(args.item_id, 'item_id');
+      resolvedAccountId = args.account_id;
+      resolvedItemId = args.item_id;
+    } else {
+      // Resolve the transaction's accountId/itemId for the GraphQL mutation —
+      // live-first via the meta index / windowed fetch; local cache only in
+      // degraded (no-liveDb) mode. See resolveTransactionMeta().
+      const { meta: metaMap, liveWindowMonths } = await this.resolveTransactionMeta([
+        transaction_id,
+      ]);
+      const meta = metaMap.get(transaction_id);
+      if (!meta) {
+        throw new Error(
+          CopilotMoneyTools.transactionsNotFoundMessage([transaction_id], liveWindowMonths) +
+            ' Pass account_id and item_id (from a live read) to write anyway.'
+        );
+      }
+      resolvedAccountId = meta.accountId;
+      resolvedItemId = meta.itemId;
+    }
 
     // Per-field validation (runs BEFORE any write for atomicity).
     if ('name' in args && args.name !== undefined) {
@@ -3111,7 +3150,11 @@ export class CopilotMoneyTools {
    * values if omitted by the caller. The sum of all children's `amount`
    * fields must equal the parent's `amount` (server-enforced; we also
    * validate client-side up to a small floating-point epsilon so callers
-   * get a clear local error before a round-trip).
+   * get a clear local error before a round-trip). When the parent cannot
+   * be resolved locally (outside the resolution window) the split still
+   * proceeds if every entry carries an explicit `name` and `date` — no
+   * parent-derived defaults are needed then, and the sum check is deferred
+   * to the server.
    *
    * Contract: all three parent IDs (transaction_id, account_id, item_id)
    * are required and forwarded verbatim. Same defensive stance as
@@ -3200,47 +3243,58 @@ export class CopilotMoneyTools {
     // cache only in degraded (no-liveDb) mode. Routing ids are NOT resolved
     // here: the schema requires the caller-supplied triple. See
     // resolveParentSnapshot().
+    //
+    // An unresolvable parent (outside the resolution window) is only fatal
+    // when a split needs a parent-derived default: with an explicit name and
+    // date on every split, nothing else is read from the snapshot and the
+    // amount-sum check is deferred to the server (which enforces it anyway).
     const { snapshot: parentTxn, liveWindowMonths } =
       await this.resolveParentSnapshot(transaction_id);
-    if (!parentTxn) {
+    if (!parentTxn && splits.some((s) => s.name === undefined || s.date === undefined)) {
       throw new Error(
-        CopilotMoneyTools.transactionsNotFoundMessage([transaction_id], liveWindowMonths)
+        CopilotMoneyTools.transactionsNotFoundMessage([transaction_id], liveWindowMonths) +
+          ' To split anyway, pass an explicit name and date on every split — the amount-sum ' +
+          'check is then deferred to the server.'
       );
     }
 
-    // Client-side sum check. Server also enforces this, but a local error
-    // saves a round-trip and gives the caller more actionable numbers.
-    // 1e-6 epsilon tolerates IEEE-754 drift (0.1 + 0.2 = 0.30000000000000004)
-    // without letting real mismatches through at 2-decimal financial precision.
-    const sum = splits.reduce((acc, s) => acc + s.amount, 0);
-    const parentAmount = parentTxn.amount;
-    const diff = sum - parentAmount;
-    if (Math.abs(diff) > 1e-6) {
-      throw new Error(
-        `Split amounts must sum to parent amount. ` +
-          `Parent=${parentAmount}, sum=${sum}, diff=${diff}`
-      );
+    if (parentTxn) {
+      // Client-side sum check. Server also enforces this, but a local error
+      // saves a round-trip and gives the caller more actionable numbers.
+      // 1e-6 epsilon tolerates IEEE-754 drift (0.1 + 0.2 = 0.30000000000000004)
+      // without letting real mismatches through at 2-decimal financial precision.
+      const sum = splits.reduce((acc, s) => acc + s.amount, 0);
+      const parentAmount = parentTxn.amount;
+      const diff = sum - parentAmount;
+      if (Math.abs(diff) > 1e-6) {
+        throw new Error(
+          `Split amounts must sum to parent amount. ` +
+            `Parent=${parentAmount}, sum=${sum}, diff=${diff}`
+        );
+      }
     }
 
-    // Resolve the default name from the parent. A split without a usable
-    // default can't succeed since the server requires `name: String!` on
-    // every SplitTransactionInput — surface that as a local error rather
-    // than sending an empty string.
-    const parentDefaultName = parentTxn.name;
-    if (splits.some((s) => s.name === undefined) && !parentDefaultName) {
+    // Resolve the default name from the parent (only meaningful when the
+    // parent resolved — otherwise every split carries its own name/date).
+    // A split without a usable default can't succeed since the server
+    // requires `name: String!` on every SplitTransactionInput — surface
+    // that as a local error rather than sending an empty string.
+    const parentDefaultName = parentTxn?.name;
+    if (parentTxn && splits.some((s) => s.name === undefined) && !parentDefaultName) {
       throw new Error(
         `Cannot default split name from parent ${transaction_id}: parent has no usable name. Pass an explicit name on each split.`
       );
     }
 
     // Apply name/date defaults from the parent AFTER validation + sum check.
-    // `parentDefaultName!` is safe here because the guard a few lines above
-    // throws when any split omits `name` and `parentDefaultName` is falsy —
-    // so reaching this line with `s.name === undefined` implies parentDefaultName
-    // is non-empty. TypeScript can't narrow across the `.some` call.
+    // The non-null assertions are safe: with an unresolved parent, the guard
+    // above threw unless every split carries explicit name AND date, so the
+    // fallback arms are unreachable; with a resolved parent, the
+    // `parentDefaultName` guard threw when any split omits `name` and the
+    // default is falsy. TypeScript can't narrow across the `.some` calls.
     const inputs = splits.map((s) => ({
       name: s.name !== undefined ? s.name.trim() : parentDefaultName!,
-      date: s.date !== undefined ? s.date : parentTxn.date,
+      date: s.date !== undefined ? s.date : parentTxn!.date,
       amount: s.amount,
       categoryId: s.category_id,
     }));
@@ -3312,34 +3366,76 @@ export class CopilotMoneyTools {
   /**
    * Mark one or more transactions as reviewed (or unreviewed).
    *
-   * Validates all transaction IDs, sets isReviewed via GraphQL for each; local
-   * cache is refreshed by Copilot's sync process.
+   * Two input modes, normalized to one entries list before dispatch:
+   * - `transaction_ids`: routing ids are resolved locally (live-first meta
+   *   index / windowed fetch; LevelDB in degraded mode) — only works for
+   *   transactions the resolution window can see.
+   * - `rows`: each {transaction_id, account_id, item_id} entry (taken from a
+   *   live read) supplies the mutation's routing ids directly, so
+   *   out-of-window historical/backlog transactions work too. Wins when both
+   *   modes are passed.
+   *
+   * Sets isReviewed via GraphQL for each entry; local cache is refreshed by
+   * Copilot's sync process.
    */
-  async reviewTransactions(args: { transaction_ids: string[]; reviewed?: boolean }): Promise<{
+  async reviewTransactions(args: {
+    transaction_ids?: string[];
+    rows?: Array<{ transaction_id: string; account_id: string; item_id: string }>;
+    reviewed?: boolean;
+  }): Promise<{
     success: boolean;
     reviewed_count: number;
     transaction_ids: string[];
   }> {
     const client = this.getGraphQLClient();
 
-    const { transaction_ids, reviewed = true } = args;
+    const { transaction_ids, rows, reviewed = true } = args;
 
-    if (!Array.isArray(transaction_ids) || transaction_ids.length === 0) {
-      throw new Error('transaction_ids must be a non-empty array');
-    }
+    // Normalize both input modes to one entries list; everything below
+    // (worker loop, error payloads, result) references only this list.
+    let entries: Array<{ id: string; accountId: string; itemId: string }>;
+    if (Array.isArray(rows) && rows.length > 0) {
+      for (const row of rows) {
+        validateDocId(row.transaction_id, 'transaction_id');
+        validateDocId(row.account_id, 'account_id');
+        validateDocId(row.item_id, 'item_id');
+      }
+      entries = rows.map((row) => ({
+        id: row.transaction_id,
+        accountId: row.account_id,
+        itemId: row.item_id,
+      }));
+    } else {
+      if (!Array.isArray(transaction_ids) || transaction_ids.length === 0) {
+        throw new Error(
+          'transaction_ids must be a non-empty array — or pass a rows array of ' +
+            '{transaction_id, account_id, item_id} (from a live read) to bypass local resolution'
+        );
+      }
 
-    for (const id of transaction_ids) {
-      validateDocId(id, 'transaction_id');
-    }
+      for (const id of transaction_ids) {
+        validateDocId(id, 'transaction_id');
+      }
 
-    // Resolve account/item ids for all targets — live-first via the meta
-    // index / windowed fetch; local cache only in degraded (no-liveDb)
-    // mode. See resolveTransactionMeta().
-    const { meta: metaMap, liveWindowMonths } = await this.resolveTransactionMeta(transaction_ids);
-    const missing = transaction_ids.filter((id) => !metaMap.has(id));
-    if (missing.length > 0) {
-      throw new Error(CopilotMoneyTools.transactionsNotFoundMessage(missing, liveWindowMonths));
+      // Resolve account/item ids for all targets — live-first via the meta
+      // index / windowed fetch; local cache only in degraded (no-liveDb)
+      // mode. See resolveTransactionMeta().
+      const { meta: metaMap, liveWindowMonths } =
+        await this.resolveTransactionMeta(transaction_ids);
+      const missing = transaction_ids.filter((id) => !metaMap.has(id));
+      if (missing.length > 0) {
+        throw new Error(
+          CopilotMoneyTools.transactionsNotFoundMessage(missing, liveWindowMonths) +
+            " Pass a 'rows' array of {transaction_id, account_id, item_id} (from a live read) " +
+            'to review out-of-window transactions.'
+        );
+      }
+      entries = transaction_ids.map((id) => {
+        const meta = metaMap.get(id)!;
+        return { id, accountId: meta.accountId, itemId: meta.itemId };
+      });
     }
+    const idList = entries.map((entry) => entry.id);
 
     // Bounded concurrency: never more than CONCURRENCY in flight at once.
     // The user explicitly asked to cap parallel writes at 5 to avoid
@@ -3363,33 +3459,32 @@ export class CopilotMoneyTools {
       while (true) {
         if (firstError) return;
         const idx = cursor++;
-        if (idx >= transaction_ids.length) return;
-        const id = transaction_ids[idx]!;
-        const meta = metaMap.get(id)!;
+        if (idx >= entries.length) return;
+        const entry = entries[idx]!;
         try {
           await editTransaction(client, {
-            id,
-            accountId: meta.accountId,
-            itemId: meta.itemId,
+            id: entry.id,
+            accountId: entry.accountId,
+            itemId: entry.itemId,
             input: { isReviewed: reviewed },
           });
           reviewed_count++;
         } catch (e) {
           // Record the first failure only; other in-flight workers settle.
-          if (!firstError) firstError = { id, error: e };
+          if (!firstError) firstError = { id: entry.id, error: e };
           return;
         }
       }
     };
 
-    const workerCount = Math.min(CONCURRENCY, transaction_ids.length);
+    const workerCount = Math.min(CONCURRENCY, entries.length);
     await Promise.all(Array.from({ length: workerCount }, () => worker()));
 
     if (firstError) {
       const { id, error } = firstError;
       if (error instanceof GraphQLError) {
         throw new Error(
-          `review_transactions failed at id=${id} (${reviewed_count}/${transaction_ids.length} succeeded): ${graphQLErrorToMcpError(error)}`,
+          `review_transactions failed at id=${id} (${reviewed_count}/${entries.length} succeeded): ${graphQLErrorToMcpError(error)}`,
           { cause: error }
         );
       }
@@ -3398,8 +3493,10 @@ export class CopilotMoneyTools {
 
     // Optimistic cache patch — only for ids that successfully completed.
     // A partial-failure throw above would have bypassed this, so here we
-    // patch every id in the batch.
-    for (const id of transaction_ids) {
+    // patch every id in the batch. For rows-mode entries outside the local
+    // cache both patches are no-ops (same eviction-is-a-no-op contract as
+    // delete_transaction).
+    for (const id of idList) {
       this.db.patchCachedTransaction(id, { user_reviewed: reviewed });
       this.liveDb?.patchLiveTransaction(id, { user_reviewed: reviewed });
     }
@@ -3407,7 +3504,7 @@ export class CopilotMoneyTools {
     return {
       success: true,
       reviewed_count,
-      transaction_ids,
+      transaction_ids: idList,
     };
   }
 

--- a/tests/tools/review-transactions-batching.test.ts
+++ b/tests/tools/review-transactions-batching.test.ts
@@ -252,3 +252,125 @@ describe('review_transactions respects 5-parallel concurrency cap', () => {
     ).rejects.toThrow(/review_transactions failed at id=txn-05 \(\d+\/8 succeeded\)/);
   });
 });
+
+describe('review_transactions rows mode (cache bypass)', () => {
+  const echoClient = () =>
+    createMockGraphQLClient({
+      EditTransaction: (vars: any) => ({
+        editTransaction: {
+          transaction: {
+            id: vars.id,
+            name: 'Old Row',
+            categoryId: 'c',
+            userNotes: null,
+            isReviewed: vars.input.isReviewed,
+            type: 'REGULAR',
+            tags: [],
+          },
+        },
+      }),
+    });
+
+  test('rows dispatch with the caller-supplied routing ids, skipping local resolution', async () => {
+    // Empty cache: id-based resolution would reject both rows. The rows
+    // entries carry the routing ids directly (from a live read), so the
+    // writes go out anyway — the out-of-window bulk path.
+    const db = makeMockDb([]);
+    const client = echoClient();
+    const tools = new CopilotMoneyTools(db, client);
+
+    const result = await tools.reviewTransactions({
+      rows: [
+        { transaction_id: 'old-1', account_id: 'acctA', item_id: 'itemA' },
+        { transaction_id: 'old-2', account_id: 'acctB', item_id: 'itemB' },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.reviewed_count).toBe(2);
+    expect(result.transaction_ids).toEqual(['old-1', 'old-2']);
+
+    expect(client._calls).toHaveLength(2);
+    const byId = new Map(client._calls.map((c) => [(c.variables as any).id, c.variables as any]));
+    expect(byId.get('old-1')).toMatchObject({
+      accountId: 'acctA',
+      itemId: 'itemA',
+      input: { isReviewed: true },
+    });
+    expect(byId.get('old-2')).toMatchObject({
+      accountId: 'acctB',
+      itemId: 'itemB',
+      input: { isReviewed: true },
+    });
+  });
+
+  test('large rows batch issues one call per row through the shared worker loop', async () => {
+    const db = makeMockDb([]);
+    const client = echoClient();
+    const tools = new CopilotMoneyTools(db, client);
+
+    const rows = Array.from({ length: 25 }, (_, i) => ({
+      transaction_id: `old-${String(i).padStart(2, '0')}`,
+      account_id: 'acctA',
+      item_id: 'itemA',
+    }));
+    const result = await tools.reviewTransactions({ rows, reviewed: false });
+
+    expect(result.reviewed_count).toBe(25);
+    expect(result.transaction_ids).toEqual(rows.map((r) => r.transaction_id));
+    expect(client._calls).toHaveLength(25);
+    const calledIds = client._calls.map((c) => (c.variables as any).id).sort();
+    expect(calledIds).toEqual(rows.map((r) => r.transaction_id).sort());
+  });
+
+  test('rows win when both modes are passed', async () => {
+    // 'ghost' is unresolvable, which would reject the transaction_ids path —
+    // proving the rows path took precedence.
+    const db = makeMockDb([]);
+    const client = echoClient();
+    const tools = new CopilotMoneyTools(db, client);
+
+    const result = await tools.reviewTransactions({
+      transaction_ids: ['ghost'],
+      rows: [{ transaction_id: 'old-1', account_id: 'acctA', item_id: 'itemA' }],
+    });
+
+    expect(result.transaction_ids).toEqual(['old-1']);
+    expect(client._calls).toHaveLength(1);
+  });
+
+  test('neither transaction_ids nor rows: mode error names both options, no write', async () => {
+    const db = makeMockDb([]);
+    const client = echoClient();
+    const tools = new CopilotMoneyTools(db, client);
+
+    await expect(tools.reviewTransactions({})).rejects.toThrow(
+      /transaction_ids must be a non-empty array.*rows array of \{transaction_id, account_id, item_id\}/
+    );
+    expect(client._calls).toHaveLength(0);
+  });
+
+  test('invalid doc id in a row throws before any write', async () => {
+    const db = makeMockDb([]);
+    const client = echoClient();
+    const tools = new CopilotMoneyTools(db, client);
+
+    await expect(
+      tools.reviewTransactions({
+        rows: [{ transaction_id: 'old-1', account_id: 'bad/acct', item_id: 'itemA' }],
+      })
+    ).rejects.toThrow(/Invalid account_id/);
+    expect(client._calls).toHaveLength(0);
+  });
+
+  test('cache-only path still resolves locally and its not-found error points at rows', async () => {
+    const db = makeMockDb(['txn-1']);
+    const client = echoClient();
+    const tools = new CopilotMoneyTools(db, client);
+
+    await expect(
+      tools.reviewTransactions({ transaction_ids: ['txn-1', 'gone-1'] })
+    ).rejects.toThrow(/Transaction not found: gone-1.*'rows' array/);
+    expect(client._calls).toHaveLength(0);
+  });
+});

--- a/tests/tools/review-transactions-batching.test.ts
+++ b/tests/tools/review-transactions-batching.test.ts
@@ -253,7 +253,7 @@ describe('review_transactions respects 5-parallel concurrency cap', () => {
   });
 });
 
-describe('review_transactions rows mode (cache bypass)', () => {
+describe('review_transactions rows mode (out-of-window bypass)', () => {
   const echoClient = () =>
     createMockGraphQLClient({
       EditTransaction: (vars: any) => ({
@@ -337,6 +337,23 @@ describe('review_transactions rows mode (cache bypass)', () => {
 
     expect(result.transaction_ids).toEqual(['old-1']);
     expect(client._calls).toHaveLength(1);
+  });
+
+  test('explicitly-passed empty rows: rows-shaped error, no fall-through to transaction_ids', async () => {
+    // Passing rows selects the bypass mode; an empty array must not silently
+    // degrade into the transaction_ids path (whose error would misleadingly
+    // talk about transaction_ids).
+    const db = makeMockDb(['txn-1']);
+    const client = echoClient();
+    const tools = new CopilotMoneyTools(db, client);
+
+    await expect(
+      tools.reviewTransactions({ rows: [], transaction_ids: ['txn-1'] })
+    ).rejects.toThrow(/rows must be a non-empty array.*omit it to use transaction_ids/);
+    await expect(tools.reviewTransactions({ rows: [] })).rejects.toThrow(
+      /rows must be a non-empty array/
+    );
+    expect(client._calls).toHaveLength(0);
   });
 
   test('neither transaction_ids nor rows: mode error names both options, no write', async () => {

--- a/tests/tools/write-tools.test.ts
+++ b/tests/tools/write-tools.test.ts
@@ -914,6 +914,30 @@ describe('addTransactionToRecurring', () => {
     (mockDb as any)._allCollectionsLoaded = true;
   });
 
+  test('links a transaction absent from the local cache — ids forwarded verbatim, no lookup', async () => {
+    // Cache-bypass contract for the recurring seed: the caller-supplied
+    // triple is all the mutation needs, so out-of-window transactions work.
+    // Poison the cache accessor to prove no lookup happens.
+    (mockDb as any)._transactions = [];
+    (mockDb as any).getAllTransactions = async () => {
+      throw new Error('local cache must not be consulted');
+    };
+    const client = createMockGraphQLClient({
+      AddTransactionToRecurring: { addTransactionToRecurring: { transaction: linkedTx } },
+    });
+    tools = new CopilotMoneyTools(mockDb, client);
+
+    const result = await tools.addTransactionToRecurring(validArgs);
+    expect(result.success).toBe(true);
+    expect(client._calls).toHaveLength(1);
+    expect(client._calls[0].variables).toEqual({
+      id: 'tx1',
+      accountId: 'acc1',
+      itemId: 'item1',
+      input: { recurringId: 'rec1' },
+    });
+  });
+
   test('dispatches AddTransactionToRecurring with mapped input and returns the linked transaction', async () => {
     const client = createMockGraphQLClient({
       AddTransactionToRecurring: { addTransactionToRecurring: { transaction: linkedTx } },
@@ -1336,14 +1360,59 @@ describe('splitTransaction', () => {
     ).resolves.toMatchObject({ success: true });
   });
 
-  test('rejects when parent transaction is not in the local cache', async () => {
+  test('rejects when the parent is unresolvable and a split needs a parent-derived default', async () => {
     const client = createMockGraphQLClient({});
     tools = new CopilotMoneyTools(mockDb, client);
 
     await expect(
-      tools.splitTransaction({ ...validArgs, transaction_id: 'nonexistent-tx' })
-    ).rejects.toThrow(/Transaction not found/);
+      tools.splitTransaction({
+        ...validArgs,
+        transaction_id: 'nonexistent-tx',
+        splits: [
+          { amount: 400, category_id: 'cat-lodging' },
+          { name: 'Car', date: '2026-04-15', amount: 200, category_id: 'cat-car-rental' },
+        ],
+      })
+    ).rejects.toThrow(/Transaction not found.*explicit name and date on every split/);
     expect(client._calls).toHaveLength(0);
+  });
+
+  test('unresolvable parent + explicit name/date on every split: dispatches, sum check deferred to server', async () => {
+    // Cache-bypass path: the parent is outside the resolution window, but no
+    // parent-derived defaults are needed and the amount-sum validation is the
+    // server's job — the mutation goes out with the caller-supplied triple.
+    // The split amounts deliberately do NOT sum to any locally-known parent.
+    const client = createMockGraphQLClient({
+      SplitTransaction: {
+        splitTransaction: {
+          parentTransaction: { ...parentServer, id: 'nonexistent-tx' },
+          splitTransactions: [childHotel, childCar],
+        },
+      },
+    });
+    tools = new CopilotMoneyTools(mockDb, client);
+
+    const result = await tools.splitTransaction({
+      ...validArgs,
+      transaction_id: 'nonexistent-tx',
+      splits: [
+        { name: 'Hotel', date: '2026-04-15', amount: 123, category_id: 'cat-lodging' },
+        { name: 'Car', date: '2026-04-16', amount: 456, category_id: 'cat-car-rental' },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    expect(client._calls).toHaveLength(1);
+    expect(client._calls[0].op).toBe('SplitTransaction');
+    expect(client._calls[0].variables).toMatchObject({
+      id: 'nonexistent-tx',
+      accountId: 'acc1',
+      itemId: 'item1',
+      input: [
+        { name: 'Hotel', date: '2026-04-15', amount: 123, categoryId: 'cat-lodging' },
+        { name: 'Car', date: '2026-04-16', amount: 456, categoryId: 'cat-car-rental' },
+      ],
+    });
   });
 
   test('rejects invalid transaction_id format before any cache lookup', async () => {

--- a/tests/tools/write-tools.test.ts
+++ b/tests/tools/write-tools.test.ts
@@ -915,7 +915,7 @@ describe('addTransactionToRecurring', () => {
   });
 
   test('links a transaction absent from the local cache — ids forwarded verbatim, no lookup', async () => {
-    // Cache-bypass contract for the recurring seed: the caller-supplied
+    // Out-of-window bypass contract for the recurring seed: the caller-supplied
     // triple is all the mutation needs, so out-of-window transactions work.
     // Poison the cache accessor to prove no lookup happens.
     (mockDb as any)._transactions = [];
@@ -1378,7 +1378,7 @@ describe('splitTransaction', () => {
   });
 
   test('unresolvable parent + explicit name/date on every split: dispatches, sum check deferred to server', async () => {
-    // Cache-bypass path: the parent is outside the resolution window, but no
+    // Out-of-window bypass path: the parent is unresolvable locally, but no
     // parent-derived defaults are needed and the amount-sum validation is the
     // server's job — the mutation goes out with the caller-supplied triple.
     // The split amounts deliberately do NOT sum to any locally-known parent.

--- a/tests/unit/split-transaction-resolution.test.ts
+++ b/tests/unit/split-transaction-resolution.test.ts
@@ -346,7 +346,7 @@ describe('splitTransaction output feeds the meta index', () => {
   });
 });
 
-describe('splitTransaction cache bypass — unresolvable parent, explicit name/date', () => {
+describe('splitTransaction out-of-window bypass — unresolvable parent, explicit name/date', () => {
   test('every split carries name+date: mutation dispatched, sum check deferred to server', async () => {
     // The parent is outside the resolution window (window cache and windowed
     // fetch both come up empty). No parent-derived defaults are needed and

--- a/tests/unit/split-transaction-resolution.test.ts
+++ b/tests/unit/split-transaction-resolution.test.ts
@@ -345,3 +345,81 @@ describe('splitTransaction output feeds the meta index', () => {
     }
   });
 });
+
+describe('splitTransaction cache bypass — unresolvable parent, explicit name/date', () => {
+  test('every split carries name+date: mutation dispatched, sum check deferred to server', async () => {
+    // The parent is outside the resolution window (window cache and windowed
+    // fetch both come up empty). No parent-derived defaults are needed and
+    // the amounts deliberately sum to a value no local snapshot could bless —
+    // the server is the enforcer on this path.
+    const client = createMockGraphQLClient(SPLIT_RESPONSE);
+    const { liveDb, getTransactions } = stubLiveDb({});
+    const tools = new CopilotMoneyTools(makeDb(), client, liveDb);
+
+    const result = await tools.splitTransaction({
+      transaction_id: 'parent-1',
+      account_id: 'acct-P',
+      item_id: 'item-P',
+      splits: [
+        { name: 'Hotel', date: '2025-10-05', amount: 70, category_id: 'catA' },
+        { name: 'Car', date: '2025-10-06', amount: 51, category_id: 'catB' },
+      ],
+    });
+
+    expect(result.success).toBe(true);
+    // Resolution was still attempted (one windowed fetch) before falling
+    // through to the bypass.
+    expect(getTransactions).toHaveBeenCalledTimes(1);
+    expect(client._calls).toHaveLength(1);
+    expect(client._calls[0].op).toBe('SplitTransaction');
+    expect(client._calls[0].variables).toMatchObject({
+      id: 'parent-1',
+      accountId: 'acct-P',
+      itemId: 'item-P',
+      input: [
+        { name: 'Hotel', date: '2025-10-05', amount: 70, categoryId: 'catA' },
+        { name: 'Car', date: '2025-10-06', amount: 51, categoryId: 'catB' },
+      ],
+    });
+  });
+
+  test('a split without name or date: honest window error names the bypass, no mutation', async () => {
+    const client = createMockGraphQLClient({});
+    const { liveDb } = stubLiveDb({});
+    const tools = new CopilotMoneyTools(makeDb(), client, liveDb);
+
+    await expect(
+      tools.splitTransaction({
+        transaction_id: 'parent-1',
+        account_id: 'acct-P',
+        item_id: 'item-P',
+        splits: [
+          { name: 'Hotel', amount: 70, category_id: 'catA' }, // no date
+          { name: 'Car', date: '2025-10-06', amount: 50, category_id: 'catB' },
+        ],
+      })
+    ).rejects.toThrow(/Transaction not found: parent-1.*explicit name and date on every split/);
+    expect(client._calls).toHaveLength(0);
+  });
+
+  test('resolved parent keeps the client-side sum check (bypass does not weaken it)', async () => {
+    const client = createMockGraphQLClient(SPLIT_RESPONSE);
+    const { liveDb } = stubLiveDb({
+      cachedNodes: [node('parent-1', 120, '2025-10-05', 'Cached Parent')],
+    });
+    const tools = new CopilotMoneyTools(makeDb(), client, liveDb);
+
+    await expect(
+      tools.splitTransaction({
+        transaction_id: 'parent-1',
+        account_id: 'acct-P',
+        item_id: 'item-P',
+        splits: [
+          { name: 'Hotel', date: '2025-10-05', amount: 70, category_id: 'catA' },
+          { name: 'Car', date: '2025-10-06', amount: 51, category_id: 'catB' },
+        ],
+      })
+    ).rejects.toThrow(/Split amounts must sum to parent amount/);
+    expect(client._calls).toHaveLength(0);
+  });
+});

--- a/tests/unit/update-transaction.test.ts
+++ b/tests/unit/update-transaction.test.ts
@@ -306,6 +306,86 @@ describe('updateTransaction — validation errors', () => {
   });
 });
 
+describe('updateTransaction — routing bypass (account_id + item_id)', () => {
+  test('cache miss + both ids: dispatches with the caller-supplied routing ids', async () => {
+    // 'txn_out' is nowhere in the local cache — without the bypass this is a
+    // guaranteed "Transaction not found". The caller-supplied pair (from a
+    // live read) routes the mutation directly.
+    const { tools, client } = makeTools({ transactions: [] });
+    const result = await tools.updateTransaction({
+      transaction_id: 'txn_out',
+      account_id: 'acct9',
+      item_id: 'item9',
+      category_id: 'food',
+    });
+    expect(result.success).toBe(true);
+    expect(client._calls).toHaveLength(1);
+    expect(client._calls[0].variables).toEqual({
+      id: 'txn_out',
+      accountId: 'acct9',
+      itemId: 'item9',
+      input: { categoryId: 'food' },
+    });
+  });
+
+  test('caller-supplied ids are forwarded verbatim even when the row is cached', async () => {
+    // Same "no re-resolution of a caller-supplied triple" contract as
+    // delete_transaction: explicit ids win over the cached acct1/item1.
+    const { tools, client } = makeTools();
+    await tools.updateTransaction({
+      transaction_id: 'txn1',
+      account_id: 'acct9',
+      item_id: 'item9',
+      note: 'bypass',
+    });
+    expect(client._calls[0].variables).toMatchObject({
+      id: 'txn1',
+      accountId: 'acct9',
+      itemId: 'item9',
+    });
+  });
+
+  test('cache miss without ids: not-found error points at the bypass', async () => {
+    const { tools, client } = makeTools({ transactions: [] });
+    await expect(
+      tools.updateTransaction({ transaction_id: 'txn_out', category_id: 'food' })
+    ).rejects.toThrow(/Transaction not found.*pass account_id and item_id/i);
+    expect(client._calls).toHaveLength(0);
+  });
+
+  test('half a pair throws, no write', async () => {
+    const { tools, client } = makeTools();
+    await expect(
+      tools.updateTransaction({ transaction_id: 'txn1', account_id: 'acct9', note: 'x' })
+    ).rejects.toThrow(/account_id and item_id must be passed together/i);
+    await expect(
+      tools.updateTransaction({ transaction_id: 'txn1', item_id: 'item9', note: 'x' })
+    ).rejects.toThrow(/account_id and item_id must be passed together/i);
+    expect(client._calls).toHaveLength(0);
+  });
+
+  test('malformed bypass ids throw, no write', async () => {
+    const { tools, client } = makeTools();
+    await expect(
+      tools.updateTransaction({
+        transaction_id: 'txn1',
+        account_id: 'bad/acct',
+        item_id: 'item9',
+        note: 'x',
+      })
+    ).rejects.toThrow(/Invalid account_id/i);
+    expect(client._calls).toHaveLength(0);
+  });
+
+  test('routing ids alone do not count as an edit', async () => {
+    const { tools, client } = makeTools();
+    await expect(
+      tools.updateTransaction({ transaction_id: 'txn1', account_id: 'acct1', item_id: 'item1' })
+    ).rejects.toThrow(/at least one field/i);
+    expect(client._calls).toHaveLength(0);
+  });
+});
+
 describe('updateTransaction — atomicity on validation failure', () => {
   test('valid category_id + invalid tag_id: no GraphQL write', async () => {
     const { tools, client } = makeTools();


### PR DESCRIPTION
# Summary

Write tools fail with `Transaction not found` for transactions the local resolution window cannot see — historical rows beyond the window and freshly-posted rows the local snapshot hasn't picked up yet. This PR lets callers holding routing ids from a live read write anyway, removing the local cache as a write dependency.

- **update_transaction**: optional `account_id` + `item_id` (passed together, doc-id validated) are forwarded verbatim and skip local resolution; the not-found error now points at the bypass. Routing ids are excluded from the mutable-field count.
- **review_transactions**: new optional `rows` mode — an array of `{transaction_id, account_id, item_id}` entries supplying the mutation's routing ids directly — as the out-of-window bulk path. `transaction_ids` stays the locally-resolved path and is no longer schema-required; one of the two must be provided (`rows` wins when both are). Both modes normalize to one entries list feeding the existing bounded-concurrency worker loop (cap unchanged at 5).
- **split_transaction**: an unresolvable parent no longer blocks the split when every entry carries an explicit `name` and `date` — no parent-derived defaults are needed then and the amount-sum check is deferred to the server (which enforces it anyway). Resolved parents keep the client-side sum check.
- **add_transaction_to_recurring**: already takes the full caller-supplied triple with no cache lookup, so the bypass is inherent — regression test added, no code change.
- **conformance ledger**: new routing params registered on the `Mutation.editTransaction` entry.

Tests cover bypass dispatch, half-a-pair and malformed-id errors, rows-mode batching (25 rows → 25 mutations), mode precedence, unchanged cache-only paths, split name/date requirements, and the recurring no-lookup regression. `bun run check` is green.

## External assumptions

None new at the GraphQL surface — no new operations or input fields; the added params only change where the routing ids come from. The one behavioral assumption — that `editTransaction`-family mutations accept caller-supplied `accountId`/`itemId` for rows absent from the local cache and validate the binding server-side (wrong pairs fail loudly) — is **live round-trip** verified: this feature has run for weeks as a local patch doing production writes (single updates, bulk review sweeps of historical rows, splits).