### PR TITLE
chore(conformance): observed wrong-sum rejection evidence + rebase auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,9 +7,7 @@ on:
 jobs:
   auto-merge:
     # Only run when the owner approves
-    if: |
-      github.event.review.state == 'approved' &&
-      github.event.review.user.login == 'ignaciohermosillacornejo'
+    if: github.event.review.state == 'approved' && github.event.review.user.login == 'ignaciohermosillacornejo'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -32,4 +32,4 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           echo "Enabling auto-merge for PR #$PR_NUMBER"
-          gh pr merge "$PR_NUMBER" --auto --squash --delete-branch --repo "${{ github.repository }}"
+          gh pr merge "$PR_NUMBER" --auto --rebase --delete-branch --repo "${{ github.repository }}"

--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -452,11 +452,12 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
     oracle: null,
     class: 'verified-once',
     evidence:
-      'Error-leak recon (docs/graphql-capture/hidden-mutations.md, SplitTransactionInput.amount): ' +
-      '"children must sum to parent.amount (server enforces)". Load-bearing for the ' +
-      'out-of-window split bypass, which skips the client-side sum check and leaves the server ' +
-      'as the sole enforcer on that path. Routine live splits with matching sums succeed ' +
-      '(supporting use only — no wrong-sum rejection transcript has been captured).',
+      'Live probe 2026-07-23 (PR #570 review): wrong-sum split (5 + 4 on a 10 parent) ' +
+      'rejected — "Split amounts (9) must sum to parent amount (10)"; matching-sum control ' +
+      'on the same parent succeeded, so the rejection is sum-caused, not a formation error. ' +
+      'Confirms the error-leak recon (docs/graphql-capture/hidden-mutations.md, ' +
+      'SplitTransactionInput.amount). Load-bearing for the out-of-window split bypass, which ' +
+      'skips the client-side sum check and leaves the server as the sole enforcer on that path.',
   },
 
   // ----- Tags ---------------------------------------------------------------


### PR DESCRIPTION
# Summary

Two small follow-ups from the PR #570 review:

1. **`Mutation.splitTransaction:sum` evidence upgraded** from recon-only to an observed rejection. The out-of-window split bypass (#570) skips the client-side sum check, leaving the server as the sole enforcer on that path — that enforcement is now verified by a live probe instead of a recon-doc comment.
2. **`auto-merge.yml` fixed**: it ran `gh pr merge --auto --squash`, but squash merges are disabled in the repo settings (rebase-only), so the workflow failed on every owner approval. Now `--rebase`.

## External assumptions

- `Mutation.splitTransaction` rejects child amounts that do not sum to the parent amount — **probe transcript** (attended probe 2026-07-23, synthetic data only: wrong-sum split 5 + 4 on a 10 parent → `Split amounts (9) must sum to parent amount (10)`; matching-sum control on the same parent accepted; all probe objects deleted after). This PR records that evidence in the ledger entry added by #570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)