### PR TITLE
feat(tools): out-of-window routing bypass for create_recurring

### DIFF
--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -526,9 +526,27 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
   // No top-level args beyond the input object (covered by CreateRecurringInput.*).
   operation('createRecurring'),
   gatedInputField('CreateRecurringInput.frequency', ['create_recurring.frequency']),
-  gatedInputField('CreateRecurringInput.transaction', ['create_recurring.transaction_id']),
+  gatedInputField('CreateRecurringInput.transaction', [
+    'create_recurring.transaction_id',
+    'create_recurring.account_id',
+    'create_recurring.item_id',
+  ]),
   responseShape('createRecurring'),
   appliesSurface('createRecurring'),
+  {
+    surface: 'Mutation.createRecurring:routing',
+    kind: 'operation',
+    oracle: null,
+    class: 'verified-once',
+    evidence:
+      'Live probe 2026-07-24 (#571): CreateRecurring validates the full (transactionId, ' +
+      'accountId, itemId) binding on the nested transaction ref, mirroring ' +
+      'Mutation.editTransaction:routing — fabricated pair → "Transaction not found"; ' +
+      'real-but-wrong pair (another real account\'s ids) → "Transaction not found"; correct ' +
+      'pair → recurring created. Load-bearing for the create_recurring routing bypass, which ' +
+      'forwards a caller-supplied pair verbatim: a wrong pair fails loudly rather than ' +
+      'seeding the recurring from a different transaction.',
+  },
 
   operation('editRecurring', ['set_recurring_state.recurring_id', 'update_recurring.recurring_id']),
   gatedInputField('EditRecurringInput.name', ['update_recurring.name']),

--- a/src/tools/registry/recurring.ts
+++ b/src/tools/registry/recurring.ts
@@ -137,7 +137,9 @@ export const createRecurringTool = defineTool({
     description:
       'Create a new recurring/subscription item by seeding it from an existing transaction. ' +
       'The recurring inherits its merchant name, account, and initial amount from that transaction; ' +
-      'you only supply the cadence (frequency). Writes directly to Copilot Money via GraphQL.',
+      'you only supply the cadence (frequency). If the seed transaction cannot be resolved ' +
+      'locally (outside the resolution window), pass account_id and item_id (from a live read) ' +
+      'to create the recurring anyway. Writes directly to Copilot Money via GraphQL.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -145,6 +147,20 @@ export const createRecurringTool = defineTool({
           type: 'string',
           description:
             'ID of an existing transaction to seed the recurring from. The recurring inherits its merchant name, account, and initial amount from this transaction.',
+        },
+        account_id: {
+          type: 'string',
+          description:
+            'Optional. Account ID the seed transaction belongs to (from a live read). Pass ' +
+            'together with item_id to skip local resolution and seed from a transaction ' +
+            'outside the resolution window.',
+        },
+        item_id: {
+          type: 'string',
+          description:
+            "Optional. Item ID the account belongs to (Copilot's Firestore item_id, from a " +
+            'live read). Pass together with account_id to skip local resolution and seed from ' +
+            'a transaction outside the resolution window.',
         },
         frequency: {
           type: 'string',

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -3848,8 +3848,21 @@ export class CopilotMoneyTools {
    *
    * Generates a unique recurring_id, writes via GraphQL; local cache is
    * refreshed by Copilot's sync process.
+   *
+   * Routing bypass (#571): when the caller supplies BOTH account_id and
+   * item_id (taken from a live read), the triple is forwarded verbatim and
+   * local resolution is skipped — same contract as update_transaction /
+   * delete_transaction. The server validates the full (id, accountId,
+   * itemId) binding on the nested transaction ref (see the
+   * Mutation.createRecurring:routing ledger entry), so a wrong pair fails
+   * loudly rather than seeding the recurring from a different transaction.
    */
-  async createRecurring(args: { transaction_id: string; frequency: string }): Promise<{
+  async createRecurring(args: {
+    transaction_id: string;
+    account_id?: string;
+    item_id?: string;
+    frequency: string;
+  }): Promise<{
     success: true;
     recurring_id: string;
     name: string;
@@ -3865,16 +3878,34 @@ export class CopilotMoneyTools {
       );
     }
 
-    // Resolve routing ids the same way update_transaction does — live-first
-    // in live mode, local cache only in degraded mode. See
-    // resolveTransactionMeta(). Fixes the class bug where a transaction
-    // older than the local cache window could not be made recurring.
-    const { meta, liveWindowMonths } = await this.resolveTransactionMeta([args.transaction_id]);
-    const txnMeta = meta.get(args.transaction_id);
-    if (!txnMeta) {
+    validateDocId(args.transaction_id, 'transaction_id');
+
+    // Half a pair is always a caller mistake; reject it rather than
+    // silently resolving (same stance as update_transaction).
+    if ((args.account_id === undefined) !== (args.item_id === undefined)) {
       throw new Error(
-        CopilotMoneyTools.transactionsNotFoundMessage([args.transaction_id], liveWindowMonths)
+        'create_recurring: account_id and item_id must be passed together (both from a live read) to bypass local resolution'
       );
+    }
+    let txnMeta: { accountId: string; itemId: string };
+    if (args.account_id !== undefined && args.item_id !== undefined) {
+      validateDocId(args.account_id, 'account_id');
+      validateDocId(args.item_id, 'item_id');
+      txnMeta = { accountId: args.account_id, itemId: args.item_id };
+    } else {
+      // Resolve routing ids the same way update_transaction does — live-first
+      // in live mode, local cache only in degraded mode. See
+      // resolveTransactionMeta(). Fixes the class bug where a transaction
+      // older than the local cache window could not be made recurring.
+      const { meta, liveWindowMonths } = await this.resolveTransactionMeta([args.transaction_id]);
+      const resolved = meta.get(args.transaction_id);
+      if (!resolved) {
+        throw new Error(
+          CopilotMoneyTools.transactionsNotFoundMessage([args.transaction_id], liveWindowMonths) +
+            ' Pass account_id and item_id (from a live read) to create the recurring anyway.'
+        );
+      }
+      txnMeta = resolved;
     }
 
     try {

--- a/tests/tools/write-tools-phase3.test.ts
+++ b/tests/tools/write-tools-phase3.test.ts
@@ -339,6 +339,14 @@ describe('createRecurring', () => {
           frequency: 'MONTHLY',
         })
       ).rejects.toThrow(/Invalid account_id/i);
+      await expect(
+        tools.createRecurring({
+          transaction_id: 'txn-abc',
+          account_id: 'acct9',
+          item_id: 'bad/item',
+          frequency: 'MONTHLY',
+        })
+      ).rejects.toThrow(/Invalid item_id/i);
       expect(client._calls).toHaveLength(0);
     });
 

--- a/tests/tools/write-tools-phase3.test.ts
+++ b/tests/tools/write-tools-phase3.test.ts
@@ -236,4 +236,127 @@ describe('createRecurring', () => {
       expect(result.frequency).toBe(freq);
     }
   });
+
+  describe('routing bypass (account_id + item_id)', () => {
+    const okClient = () =>
+      createMockGraphQLClient({
+        CreateRecurring: {
+          createRecurring: {
+            id: 'rec-out',
+            name: 'Old Sub',
+            state: 'ACTIVE',
+            frequency: 'MONTHLY',
+          },
+        },
+      });
+
+    test('cache miss + both ids: dispatches with the caller-supplied routing ids', async () => {
+      // 'txn-out' is nowhere in the local cache — without the bypass this is
+      // a guaranteed "Transaction not found". The caller-supplied pair (from
+      // a live read) routes the nested transaction ref directly.
+      (mockDb as any)._transactions = [];
+      const client = okClient();
+      tools = new CopilotMoneyTools(mockDb, client);
+
+      const result = await tools.createRecurring({
+        transaction_id: 'txn-out',
+        account_id: 'acct9',
+        item_id: 'item9',
+        frequency: 'MONTHLY',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.recurring_id).toBe('rec-out');
+      expect(client._calls).toHaveLength(1);
+      expect(client._calls[0].variables).toEqual({
+        input: {
+          frequency: 'MONTHLY',
+          transaction: { accountId: 'acct9', itemId: 'item9', transactionId: 'txn-out' },
+        },
+      });
+    });
+
+    test('caller-supplied ids are forwarded verbatim even when the row is cached', async () => {
+      // Same "no re-resolution of a caller-supplied triple" contract as
+      // update_transaction: explicit ids win over the cached acc-1/item-1.
+      const client = okClient();
+      tools = new CopilotMoneyTools(mockDb, client);
+
+      await tools.createRecurring({
+        transaction_id: 'txn-abc',
+        account_id: 'acct9',
+        item_id: 'item9',
+        frequency: 'MONTHLY',
+      });
+
+      expect((client._calls[0].variables as any).input.transaction).toEqual({
+        accountId: 'acct9',
+        itemId: 'item9',
+        transactionId: 'txn-abc',
+      });
+    });
+
+    test('cache miss without ids: not-found error points at the bypass', async () => {
+      const client = createMockGraphQLClient({});
+      tools = new CopilotMoneyTools(mockDb, client);
+
+      await expect(
+        tools.createRecurring({ transaction_id: 'txn-missing', frequency: 'MONTHLY' })
+      ).rejects.toThrow(/Transaction not found.*pass account_id and item_id/i);
+      expect(client._calls).toHaveLength(0);
+    });
+
+    test('half a pair throws, no write', async () => {
+      const client = createMockGraphQLClient({});
+      tools = new CopilotMoneyTools(mockDb, client);
+
+      await expect(
+        tools.createRecurring({
+          transaction_id: 'txn-abc',
+          account_id: 'acct9',
+          frequency: 'MONTHLY',
+        })
+      ).rejects.toThrow(/account_id and item_id must be passed together/i);
+      await expect(
+        tools.createRecurring({
+          transaction_id: 'txn-abc',
+          item_id: 'item9',
+          frequency: 'MONTHLY',
+        })
+      ).rejects.toThrow(/account_id and item_id must be passed together/i);
+      expect(client._calls).toHaveLength(0);
+    });
+
+    test('malformed bypass ids throw, no write', async () => {
+      const client = createMockGraphQLClient({});
+      tools = new CopilotMoneyTools(mockDb, client);
+
+      await expect(
+        tools.createRecurring({
+          transaction_id: 'txn-abc',
+          account_id: 'bad/acct',
+          item_id: 'item9',
+          frequency: 'MONTHLY',
+        })
+      ).rejects.toThrow(/Invalid account_id/i);
+      expect(client._calls).toHaveLength(0);
+    });
+
+    test('malformed transaction_id throws before resolution or write', async () => {
+      // The triple is forwarded verbatim on the bypass path, so all three ids
+      // get the same doc-id shape gate update_transaction applies.
+      const client = createMockGraphQLClient({});
+      tools = new CopilotMoneyTools(mockDb, client);
+
+      await expect(
+        tools.createRecurring({
+          transaction_id: 'bad/txn',
+          account_id: 'acct9',
+          item_id: 'item9',
+          frequency: 'MONTHLY',
+        })
+      ).rejects.toThrow(/Invalid transaction_id/i);
+      expect(client._calls).toHaveLength(0);
+    });
+  });
 });


### PR DESCRIPTION
# Summary

Closes #571

`create_recurring` was the last `resolveTransactionMeta` consumer without a routing bypass, so "make this out-of-window transaction recurring" still failed after #570. It now accepts an optional `account_id` + `item_id` pair (from a live read), forwarded verbatim in the nested `CreateRecurringInput.transaction` ref with local resolution skipped — same contract as `update_transaction`: half a pair rejected, all three ids doc-id-validated, not-found error points at the bypass. TDD (6 new tests watched red first); registry schema + ledger `toolParams` updated; `bun run check` green (2,378 pass), manifest already in sync.

## External assumptions

- `CreateRecurring` validates the full `(transactionId, accountId, itemId)` binding on the nested transaction ref, so a caller-supplied wrong pair fails loudly instead of seeding the recurring from a different transaction — **probe transcript** (attended probe 2026-07-24, synthetic data only: fabricated pair → `Transaction not found`; real-but-wrong pair, i.e. another real account's ids → `Transaction not found`, server scopes the lookup under account/item exactly like the `Mutation.editTransaction:routing` probe; correct-pair control → recurring created; recurring + probe transaction deleted after). Recorded as the new `Mutation.createRecurring:routing` ledger entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)