### PR TITLE
fix(check-skills): scan all of src/tools/ and gate on parser health

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ scripts/*
 !scripts/check-version-sync.ts
 !scripts/check-server-json.ts
 !scripts/check-skills.py
+!scripts/dump-tool-names.ts
 !scripts/scheduled-smoke.ts
 !scripts/install-scheduled-smoke.sh
 !scripts/uninstall-scheduled-smoke.sh

--- a/scripts/check-skills.py
+++ b/scripts/check-skills.py
@@ -4,16 +4,18 @@
 Checks:
 1. Frontmatter — every skills/<name>/SKILL.md has YAML frontmatter with
    `name:` matching <name> and `description:` non-empty.
-2. MCP tool references resolve against the tool definitions under src/tools/.
+2. MCP tool references resolve against the server's own tool registry.
 3. Profile path is canonical (~/.claude/copilot-money/user-profile.md),
    except for the literal template reference skills/user-profile.template.md.
 
-Before check 2 runs, the parser is validated against manifest.json: every
-tool the manifest declares must be visible to the parser. Without that gate,
-a parser that silently stops seeing tool definitions — because they moved,
-or because the literal format changed — reports every skill reference as an
-unknown tool. That reads as dozens of skill bugs when it is really one
-linter bug.
+Check 2 gets its tool list from `scripts/dump-tool-names.ts`, which imports
+`ALL_TOOL_DEFS` — the same registry the server builds dispatch from. This
+script used to scrape `name: '...'` literals out of TypeScript instead, which
+failed open: when the schemas moved to `src/tools/registry/`, the parse
+collapsed to one incidental literal and every skill reference was reported as
+an unknown tool. That reads as dozens of skill bugs when it is really one
+linter bug. Asking the registry directly removes the failure mode rather than
+guarding it — a move that breaks the import fails typecheck loudly.
 
 Exit 1 on any failure with a clear per-check message.
 """
@@ -23,6 +25,8 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -32,8 +36,7 @@ REPO_ROOT = Path(
     or Path(__file__).resolve().parent.parent
 ).resolve()
 SKILLS_DIR = REPO_ROOT / "skills"
-TOOLS_DIR = REPO_ROOT / "src" / "tools"
-MANIFEST_FILE = REPO_ROOT / "manifest.json"
+DUMP_SCRIPT = REPO_ROOT / "scripts" / "dump-tool-names.ts"
 
 # Prefixes that look like MCP tool names in our skills (kept narrow to
 # avoid matching English words that happen to share a prefix).
@@ -58,71 +61,66 @@ ALLOWED_PROFILE_PATHS = (
 )
 
 
-def parse_tool_names(tools_src: str) -> set[str]:
-    """Extract tool names from a TypeScript tools source string.
+class ToolLookupError(Exception):
+    """The tool registry could not be enumerated.
 
-    Tool names appear as `name: 'tool_name'` or `name: "tool_name"` in
-    TypeScript object literals. We extract them by string match.
+    Always a fault in this linter or its environment, never in the skills —
+    callers must report it as such and validate nothing.
     """
-    return set(re.findall(r"""name:\s*['"]([a-z_][a-z0-9_]*)['"]""", tools_src))
 
 
 def collect_all_tool_names() -> set[str]:
-    """Collect tool names from every TypeScript file under src/tools/.
+    """Ask the registry for every dispatchable tool name.
 
-    Scanned recursively rather than from a hardcoded list of files, so
-    tool definitions can be reorganised (tools.ts -> registry/, live/,
-    or anything future) without silently blinding this linter.
+    Runs `scripts/dump-tool-names.ts` under bun and reads back a JSON array.
+    Every failure mode is raised as ToolLookupError so the caller reports one
+    linter fault instead of blaming every skill reference — the whole point of
+    the bug this replaced.
     """
-    names: set[str] = set()
-    if not TOOLS_DIR.is_dir():
-        return names
-    for ts_file in sorted(TOOLS_DIR.rglob("*.ts")):
-        names |= parse_tool_names(ts_file.read_text())
-    return names
+    bun = shutil.which("bun")
+    if bun is None:
+        raise ToolLookupError(
+            "bun is not on PATH, so the tool registry cannot be enumerated"
+        )
+    if not DUMP_SCRIPT.exists():
+        raise ToolLookupError(f"{DUMP_SCRIPT} is missing")
 
+    try:
+        proc = subprocess.run(
+            [bun, "run", str(DUMP_SCRIPT)],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        raise ToolLookupError(f"{DUMP_SCRIPT.name} timed out after 120s") from None
 
-def manifest_tool_names() -> set[str]:
-    """Tool names declared in manifest.json (kept current by sync-manifest).
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout).strip().splitlines()
+        tail = detail[-1] if detail else "no output"
+        raise ToolLookupError(
+            f"{DUMP_SCRIPT.name} exited {proc.returncode}: {tail}"
+        )
 
-    This is the read-only bundle's surface, not every tool — but it is
-    derived independently of this script, so it is a sound tripwire for
-    "the parser stopped working".
-    """
-    if not MANIFEST_FILE.exists():
-        return set()
-    manifest = json.loads(MANIFEST_FILE.read_text())
-    return {
-        tool["name"]
-        for tool in manifest.get("tools", [])
-        if isinstance(tool, dict) and "name" in tool
-    }
+    try:
+        names = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise ToolLookupError(
+            f"{DUMP_SCRIPT.name} did not print valid JSON ({exc})"
+        ) from None
 
+    if not isinstance(names, list) or not all(isinstance(n, str) for n in names):
+        raise ToolLookupError(
+            f"{DUMP_SCRIPT.name} printed {type(names).__name__}, expected a JSON "
+            "array of strings"
+        )
+    if not names:
+        # A registry that enumerates nothing is the degenerate answer that let
+        # the original bug through. Refuse it rather than validating against it.
+        raise ToolLookupError(f"{DUMP_SCRIPT.name} returned an empty tool list")
 
-def check_parser_health(known_tools: set[str]) -> list[str]:
-    """Fail loudly when the parser cannot see the tools we know exist.
-
-    manifest.json enumerates shipped tools independently of this script, so
-    anything it declares must also be visible to `collect_all_tool_names`.
-    A shortfall means the parser is broken, not that the skills are wrong.
-    """
-    declared = manifest_tool_names()
-    if not declared:
-        return [
-            f"linter self-check: no tools declared in {MANIFEST_FILE.name} — "
-            "cannot validate that the tool parser still works"
-        ]
-    missing = sorted(declared - known_tools)
-    if missing:
-        return [
-            "linter self-check: the tool parser found "
-            f"{len(known_tools)} name(s) under {TOOLS_DIR.relative_to(REPO_ROOT)}/ "
-            f"but cannot see {len(missing)} tool(s) that {MANIFEST_FILE.name} "
-            f"declares (e.g. {', '.join(missing[:3])}). Tool definitions have "
-            "likely moved or changed shape — fix parse_tool_names/"
-            "collect_all_tool_names. Skill references were NOT validated."
-        ]
-    return []
+    return set(names)
 
 
 def check_frontmatter(skill_dir: Path) -> list[str]:
@@ -193,17 +191,15 @@ def check_profile_path(skill_dir: Path) -> list[str]:
 
 
 def main() -> int:
-    if not TOOLS_DIR.is_dir():
-        print(f"ERROR: tools directory not found at {TOOLS_DIR}", file=sys.stderr)
-        return 1
-    known_tools = collect_all_tool_names()
-
-    # Gate the whole run: if the parser is blind, every downstream tool-ref
-    # error is a false positive, so report the parser and stop.
-    parser_errors = check_parser_health(known_tools)
-    if parser_errors:
-        for err in parser_errors:
-            print(f"FAIL: {err}", file=sys.stderr)
+    # Gate the whole run: without a trustworthy tool list every downstream
+    # tool-ref error is a false positive, so report the linter and stop.
+    try:
+        known_tools = collect_all_tool_names()
+    except ToolLookupError as exc:
+        print(
+            f"FAIL: linter self-check: {exc}. Skill references were NOT validated.",
+            file=sys.stderr,
+        )
         return 1
 
     all_errors: list[str] = []

--- a/scripts/check-skills.py
+++ b/scripts/check-skills.py
@@ -4,23 +4,36 @@
 Checks:
 1. Frontmatter — every skills/<name>/SKILL.md has YAML frontmatter with
    `name:` matching <name> and `description:` non-empty.
-2. MCP tool references resolve against src/tools/tools.ts.
+2. MCP tool references resolve against the tool definitions under src/tools/.
 3. Profile path is canonical (~/.claude/copilot-money/user-profile.md),
    except for the literal template reference skills/user-profile.template.md.
+
+Before check 2 runs, the parser is validated against manifest.json: every
+tool the manifest declares must be visible to the parser. Without that gate,
+a parser that silently stops seeing tool definitions — because they moved,
+or because the literal format changed — reports every skill reference as an
+unknown tool. That reads as dozens of skill bugs when it is really one
+linter bug.
 
 Exit 1 on any failure with a clear per-check message.
 """
 
 from __future__ import annotations
 
+import json
+import os
 import re
 import sys
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parent.parent
+# Overridable so tests can point the linter at a synthetic repo tree.
+REPO_ROOT = Path(
+    os.environ.get("CHECK_SKILLS_REPO_ROOT")
+    or Path(__file__).resolve().parent.parent
+).resolve()
 SKILLS_DIR = REPO_ROOT / "skills"
-TOOLS_FILE = REPO_ROOT / "src" / "tools" / "tools.ts"
 TOOLS_DIR = REPO_ROOT / "src" / "tools"
+MANIFEST_FILE = REPO_ROOT / "manifest.json"
 
 # Prefixes that look like MCP tool names in our skills (kept narrow to
 # avoid matching English words that happen to share a prefix).
@@ -55,15 +68,61 @@ def parse_tool_names(tools_src: str) -> set[str]:
 
 
 def collect_all_tool_names() -> set[str]:
-    """Collect tool names from tools.ts and all src/tools/live/*.ts files."""
-    if not TOOLS_FILE.exists():
-        return set()
-    names = parse_tool_names(TOOLS_FILE.read_text())
-    live_dir = TOOLS_DIR / "live"
-    if live_dir.is_dir():
-        for ts_file in live_dir.glob("*.ts"):
-            names |= parse_tool_names(ts_file.read_text())
+    """Collect tool names from every TypeScript file under src/tools/.
+
+    Scanned recursively rather than from a hardcoded list of files, so
+    tool definitions can be reorganised (tools.ts -> registry/, live/,
+    or anything future) without silently blinding this linter.
+    """
+    names: set[str] = set()
+    if not TOOLS_DIR.is_dir():
+        return names
+    for ts_file in sorted(TOOLS_DIR.rglob("*.ts")):
+        names |= parse_tool_names(ts_file.read_text())
     return names
+
+
+def manifest_tool_names() -> set[str]:
+    """Tool names declared in manifest.json (kept current by sync-manifest).
+
+    This is the read-only bundle's surface, not every tool — but it is
+    derived independently of this script, so it is a sound tripwire for
+    "the parser stopped working".
+    """
+    if not MANIFEST_FILE.exists():
+        return set()
+    manifest = json.loads(MANIFEST_FILE.read_text())
+    return {
+        tool["name"]
+        for tool in manifest.get("tools", [])
+        if isinstance(tool, dict) and "name" in tool
+    }
+
+
+def check_parser_health(known_tools: set[str]) -> list[str]:
+    """Fail loudly when the parser cannot see the tools we know exist.
+
+    manifest.json enumerates shipped tools independently of this script, so
+    anything it declares must also be visible to `collect_all_tool_names`.
+    A shortfall means the parser is broken, not that the skills are wrong.
+    """
+    declared = manifest_tool_names()
+    if not declared:
+        return [
+            f"linter self-check: no tools declared in {MANIFEST_FILE.name} — "
+            "cannot validate that the tool parser still works"
+        ]
+    missing = sorted(declared - known_tools)
+    if missing:
+        return [
+            "linter self-check: the tool parser found "
+            f"{len(known_tools)} name(s) under {TOOLS_DIR.relative_to(REPO_ROOT)}/ "
+            f"but cannot see {len(missing)} tool(s) that {MANIFEST_FILE.name} "
+            f"declares (e.g. {', '.join(missing[:3])}). Tool definitions have "
+            "likely moved or changed shape — fix parse_tool_names/"
+            "collect_all_tool_names. Skill references were NOT validated."
+        ]
+    return []
 
 
 def check_frontmatter(skill_dir: Path) -> list[str]:
@@ -134,17 +193,17 @@ def check_profile_path(skill_dir: Path) -> list[str]:
 
 
 def main() -> int:
-    if not TOOLS_FILE.exists():
-        print(
-            f"ERROR: tools.ts not found at {TOOLS_FILE}", file=sys.stderr
-        )
+    if not TOOLS_DIR.is_dir():
+        print(f"ERROR: tools directory not found at {TOOLS_DIR}", file=sys.stderr)
         return 1
     known_tools = collect_all_tool_names()
-    if not known_tools:
-        print(
-            "ERROR: parsed 0 tool names from tools.ts — check the regex",
-            file=sys.stderr,
-        )
+
+    # Gate the whole run: if the parser is blind, every downstream tool-ref
+    # error is a false positive, so report the parser and stop.
+    parser_errors = check_parser_health(known_tools)
+    if parser_errors:
+        for err in parser_errors:
+            print(f"FAIL: {err}", file=sys.stderr)
         return 1
 
     all_errors: list[str] = []

--- a/scripts/dump-tool-names.ts
+++ b/scripts/dump-tool-names.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env bun
+/**
+ * Print every dispatchable MCP tool name as a JSON array, sorted.
+ *
+ * Exists so `scripts/check-skills.py` can resolve skill tool references against
+ * the registry itself instead of text-scraping TypeScript. Scraping is what
+ * broke: the linter matched `name: '...'` literals in a hardcoded path, the
+ * schemas moved to `src/tools/registry/`, and the parse silently collapsed to a
+ * single incidental literal — so every skill reference became a false
+ * "unknown MCP tool".
+ *
+ * Importing `ALL_TOOL_DEFS` gives this the same immunity `sync-manifest.ts`
+ * has: a move that breaks the import fails typecheck loudly rather than
+ * degrading into a wrong-but-plausible answer. `ALL_TOOL_DEFS` is the same
+ * source the server's dispatch is built from, so it covers read, write, and
+ * live tools alike — `manifest.json` covers only the 14 cache-mode reads and
+ * would miss every write tool the skills lean on.
+ */
+import { ALL_TOOL_DEFS } from '../src/tools/registry/index.js';
+
+const names = ALL_TOOL_DEFS.map((def) => def.name).sort();
+
+if (names.length === 0) {
+  // Unreachable in practice; a registry that imports cleanly but enumerates
+  // nothing is exactly the degenerate answer the caller must not trust.
+  console.error('dump-tool-names: ALL_TOOL_DEFS is empty');
+  process.exit(1);
+}
+
+console.log(JSON.stringify(names));

--- a/tests/scripts/check-skills.test.ts
+++ b/tests/scripts/check-skills.test.ts
@@ -2,22 +2,29 @@
  * Behavioural tests for scripts/check-skills.py — the `bun run check:skills`
  * linter that validates skills/*\/SKILL.md against the real tool definitions.
  *
- * Regression context: the linter collected tool names from a hardcoded
- * src/tools/tools.ts. When the tool schemas moved to src/tools/registry/*.ts
- * the parser went blind, and because an empty-ish result was treated as a
- * valid answer it reported every tool reference in every skill as unknown —
- * 38 false failures that read as skill bugs rather than one linter bug.
+ * Regression context: the linter collected tool names by scraping `name: '...'`
+ * literals out of a hardcoded src/tools/tools.ts. When the schemas moved to
+ * src/tools/registry/*.ts the parse collapsed to one incidental literal, and
+ * because a near-empty result was treated as a valid answer the linter reported
+ * every tool reference in every skill as unknown — 38 false failures that read
+ * as skill bugs rather than one linter bug.
  *
- * The class-level gate is `check_parser_health`: manifest.json independently
- * declares the shipped tools, so anything it names must be visible to the
- * parser. These tests drive the script against synthetic repo trees via the
- * CHECK_SKILLS_REPO_ROOT override.
+ * The fix removes the failure mode instead of guarding it: tool names now come
+ * from scripts/dump-tool-names.ts, which imports the same ALL_TOOL_DEFS the
+ * server dispatches from. So the tests below cover the two things that still
+ * matter — every way the lookup can fail must be reported as a linter fault and
+ * validate nothing, and the lookup must cover write and live tools, not just
+ * the 14 cache-mode reads manifest.json knows about.
+ *
+ * Synthetic repo trees are driven through the CHECK_SKILLS_REPO_ROOT override.
  */
 import { describe, expect, test } from 'bun:test';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import { ALL_TOOL_DEFS } from '../../src/tools/registry/index.js';
 
 const SCRIPT = fileURLToPath(new URL('../../scripts/check-skills.py', import.meta.url));
 const REAL_REPO = fileURLToPath(new URL('../..', import.meta.url));
@@ -46,129 +53,136 @@ Call \`get_transactions\` and then \`update_transaction\`.
 `;
 
 /**
- * Build a minimal repo tree. `toolsPath` is where the tool definitions get
- * written, relative to the repo root — varying it simulates the schemas
- * living in (or moving out of) src/tools/.
+ * Build a minimal repo tree. `dumpBody` is the entire body of the synthetic
+ * scripts/dump-tool-names.ts — varying it simulates the tool lookup succeeding,
+ * failing, or answering degenerately, without needing the real registry.
  */
-async function makeRepo(opts: {
-  toolsPath: string;
-  manifestTools: string[];
-  definedTools: string[];
-  skill?: string;
-}): Promise<string> {
+async function makeRepo(opts: { dumpBody?: string; skill?: string }): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'check-skills-'));
-  const toolsFile = join(root, opts.toolsPath);
-  await mkdir(join(toolsFile, '..'), { recursive: true });
-  await writeFile(
-    toolsFile,
-    opts.definedTools.map((n) => `  { name: '${n}', description: 'x' },`).join('\n')
-  );
-  // src/tools/ must exist even when the definitions were moved away, so the
-  // run reaches the parser-health gate rather than the missing-dir guard.
-  await mkdir(join(root, 'src', 'tools'), { recursive: true });
-  await writeFile(
-    join(root, 'manifest.json'),
-    JSON.stringify({ tools: opts.manifestTools.map((n) => ({ name: n, description: 'x' })) })
-  );
+  if (opts.dumpBody !== undefined) {
+    await mkdir(join(root, 'scripts'), { recursive: true });
+    await writeFile(join(root, 'scripts', 'dump-tool-names.ts'), opts.dumpBody);
+  }
   await mkdir(join(root, 'skills', 'demo'), { recursive: true });
   await writeFile(join(root, 'skills', 'demo', 'SKILL.md'), opts.skill ?? SKILL_BODY);
   return root;
 }
 
-describe('parser health gate (class-level detector)', () => {
-  test('fails loudly when tool definitions move out of src/tools/', async () => {
-    const root = await makeRepo({
-      toolsPath: 'src/elsewhere/tools.ts',
-      manifestTools: ['get_transactions', 'update_transaction'],
-      definedTools: ['get_transactions', 'update_transaction'],
-    });
-    try {
-      const { code, stderr } = await runLinter(root);
-      expect(code).toBe(1);
-      expect(stderr).toContain('linter self-check');
-      // The whole point: it must NOT blame the skills.
-      expect(stderr).not.toContain('references unknown MCP tool');
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
+const WORKING_DUMP = `console.log(JSON.stringify(['get_transactions', 'update_transaction']));`;
 
-  test('a near-empty parse does not slip through as a valid answer', async () => {
-    // The historical failure shape: tools.ts still parses to one incidental
-    // `name:` literal, so an emptiness-only guard passes and the run proceeds.
-    const root = await makeRepo({
-      toolsPath: 'src/tools/tools.ts',
-      manifestTools: ['get_transactions', 'update_transaction'],
-      definedTools: ['name'],
-    });
-    try {
-      const { code, stderr } = await runLinter(root);
-      expect(code).toBe(1);
-      expect(stderr).toContain('linter self-check');
-      expect(stderr).not.toContain('references unknown MCP tool');
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
+async function withRepo(
+  opts: { dumpBody?: string; skill?: string },
+  assertions: (result: { code: number; stderr: string; stdout: string }) => void
+): Promise<void> {
+  const root = await makeRepo(opts);
+  try {
+    assertions(await runLinter(root));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
 
-  test('names the missing tools so the failure is actionable', async () => {
-    const root = await makeRepo({
-      toolsPath: 'src/tools/tools.ts',
-      manifestTools: ['get_transactions'],
-      definedTools: ['name'],
+describe('tool-lookup gate (class-level detector)', () => {
+  // Each case is a different way the lookup can go wrong. The invariant is the
+  // same every time: report the linter, validate nothing, blame no skill.
+  const cases: Array<{ name: string; dumpBody?: string }> = [
+    { name: 'the dump script is missing entirely', dumpBody: undefined },
+    {
+      name: 'the dump script exits non-zero',
+      dumpBody: `console.error('registry blew up'); process.exit(1);`,
+    },
+    {
+      name: 'the dump script prints something that is not JSON',
+      dumpBody: `console.log('not json at all');`,
+    },
+    {
+      name: 'the dump script prints JSON of the wrong shape',
+      dumpBody: `console.log(JSON.stringify({ tools: ['get_transactions'] }));`,
+    },
+    {
+      // The historical shape: a lookup that "works" but answers with nothing.
+      name: 'the dump script returns an empty list',
+      dumpBody: `console.log(JSON.stringify([]));`,
+    },
+  ];
+
+  for (const { name, dumpBody } of cases) {
+    test(`fails as a linter fault when ${name}`, async () => {
+      await withRepo({ dumpBody }, ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('linter self-check');
+        expect(stderr).toContain('Skill references were NOT validated');
+        // The whole point: it must NOT blame the skills.
+        expect(stderr).not.toContain('references unknown MCP tool');
+      });
     });
-    try {
-      const { stderr } = await runLinter(root);
-      expect(stderr).toContain('get_transactions');
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+  }
+
+  test('reports the failure cleanly rather than as a traceback', async () => {
+    await withRepo({ dumpBody: `console.log('not json at all');` }, ({ stderr }) => {
+      expect(stderr).toContain('FAIL:');
+      expect(stderr).not.toContain('Traceback (most recent call last)');
+    });
   });
 });
 
-describe('tool discovery', () => {
-  test('finds definitions in nested subdirectories of src/tools/', async () => {
-    const root = await makeRepo({
-      toolsPath: 'src/tools/registry/transactions.ts',
-      manifestTools: ['get_transactions', 'update_transaction'],
-      definedTools: ['get_transactions', 'update_transaction'],
-    });
-    try {
-      const { code, stdout } = await runLinter(root);
+describe('skill validation', () => {
+  test('passes when every referenced tool is in the registry', async () => {
+    await withRepo({ dumpBody: WORKING_DUMP }, ({ code, stdout }) => {
       expect(code).toBe(0);
       expect(stdout).toContain('1 skills validated');
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    });
   });
 
   test('still rejects a skill referencing a genuinely nonexistent tool', async () => {
-    const root = await makeRepo({
-      toolsPath: 'src/tools/registry/transactions.ts',
-      manifestTools: ['get_transactions'],
-      definedTools: ['get_transactions'],
-      skill: `---
+    await withRepo(
+      {
+        dumpBody: WORKING_DUMP,
+        skill: `---
 name: demo
 description: A demo skill.
 ---
 
 Call \`get_transactions\` and then \`delete_everything\`.
 `,
+      },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('references unknown MCP tool `delete_everything`');
+      }
+    );
+  });
+});
+
+describe('registry coverage', () => {
+  // manifest.json declares only the 14 cache-mode reads, so a manifest-based
+  // lookup silently omitted all 17 write tools — including the 9 the skills
+  // lean on hardest. Assert the lookup spans every family the registry has.
+  test('the dump covers read, write and live tools', async () => {
+    const proc = Bun.spawn(['bun', 'run', 'scripts/dump-tool-names.ts'], {
+      cwd: REAL_REPO,
+      stdout: 'pipe',
+      stderr: 'pipe',
     });
-    try {
-      const { code, stderr } = await runLinter(root);
-      expect(code).toBe(1);
-      expect(stderr).toContain('references unknown MCP tool `delete_everything`');
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    const stdout = await new Response(proc.stdout).text();
+    expect(await proc.exited).toBe(0);
+
+    const names: string[] = JSON.parse(stdout);
+    const registry = ALL_TOOL_DEFS.map((def) => def.name);
+
+    expect(names.sort()).toEqual([...registry].sort());
+    expect(names).toContain('get_transactions'); // cache read
+    expect(names).toContain('update_transaction'); // write
+    expect(names).toContain('get_transactions_live'); // live
   });
 });
 
 describe('the real repository', () => {
   test('check:skills passes against the checked-in skills and tools', async () => {
     const { code, stdout, stderr } = await runLinter(REAL_REPO);
-    expect(stderr).toBe('');
+    // Not toBe('') — an unrelated python deprecation warning on stderr should
+    // not turn this red.
+    expect(stderr).not.toContain('FAIL');
     expect(code).toBe(0);
     expect(stdout).toContain('skills validated');
   });

--- a/tests/scripts/check-skills.test.ts
+++ b/tests/scripts/check-skills.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Behavioural tests for scripts/check-skills.py — the `bun run check:skills`
+ * linter that validates skills/*\/SKILL.md against the real tool definitions.
+ *
+ * Regression context: the linter collected tool names from a hardcoded
+ * src/tools/tools.ts. When the tool schemas moved to src/tools/registry/*.ts
+ * the parser went blind, and because an empty-ish result was treated as a
+ * valid answer it reported every tool reference in every skill as unknown —
+ * 38 false failures that read as skill bugs rather than one linter bug.
+ *
+ * The class-level gate is `check_parser_health`: manifest.json independently
+ * declares the shipped tools, so anything it names must be visible to the
+ * parser. These tests drive the script against synthetic repo trees via the
+ * CHECK_SKILLS_REPO_ROOT override.
+ */
+import { describe, expect, test } from 'bun:test';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = fileURLToPath(new URL('../../scripts/check-skills.py', import.meta.url));
+const REAL_REPO = fileURLToPath(new URL('../..', import.meta.url));
+
+async function runLinter(
+  repoRoot: string
+): Promise<{ code: number; stderr: string; stdout: string }> {
+  const proc = Bun.spawn(['python3', SCRIPT], {
+    env: { ...process.env, CHECK_SKILLS_REPO_ROOT: repoRoot },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  return { code: await proc.exited, stderr, stdout };
+}
+
+const SKILL_BODY = `---
+name: demo
+description: A demo skill.
+---
+
+Call \`get_transactions\` and then \`update_transaction\`.
+`;
+
+/**
+ * Build a minimal repo tree. `toolsPath` is where the tool definitions get
+ * written, relative to the repo root — varying it simulates the schemas
+ * living in (or moving out of) src/tools/.
+ */
+async function makeRepo(opts: {
+  toolsPath: string;
+  manifestTools: string[];
+  definedTools: string[];
+  skill?: string;
+}): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'check-skills-'));
+  const toolsFile = join(root, opts.toolsPath);
+  await mkdir(join(toolsFile, '..'), { recursive: true });
+  await writeFile(
+    toolsFile,
+    opts.definedTools.map((n) => `  { name: '${n}', description: 'x' },`).join('\n')
+  );
+  // src/tools/ must exist even when the definitions were moved away, so the
+  // run reaches the parser-health gate rather than the missing-dir guard.
+  await mkdir(join(root, 'src', 'tools'), { recursive: true });
+  await writeFile(
+    join(root, 'manifest.json'),
+    JSON.stringify({ tools: opts.manifestTools.map((n) => ({ name: n, description: 'x' })) })
+  );
+  await mkdir(join(root, 'skills', 'demo'), { recursive: true });
+  await writeFile(join(root, 'skills', 'demo', 'SKILL.md'), opts.skill ?? SKILL_BODY);
+  return root;
+}
+
+describe('parser health gate (class-level detector)', () => {
+  test('fails loudly when tool definitions move out of src/tools/', async () => {
+    const root = await makeRepo({
+      toolsPath: 'src/elsewhere/tools.ts',
+      manifestTools: ['get_transactions', 'update_transaction'],
+      definedTools: ['get_transactions', 'update_transaction'],
+    });
+    try {
+      const { code, stderr } = await runLinter(root);
+      expect(code).toBe(1);
+      expect(stderr).toContain('linter self-check');
+      // The whole point: it must NOT blame the skills.
+      expect(stderr).not.toContain('references unknown MCP tool');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('a near-empty parse does not slip through as a valid answer', async () => {
+    // The historical failure shape: tools.ts still parses to one incidental
+    // `name:` literal, so an emptiness-only guard passes and the run proceeds.
+    const root = await makeRepo({
+      toolsPath: 'src/tools/tools.ts',
+      manifestTools: ['get_transactions', 'update_transaction'],
+      definedTools: ['name'],
+    });
+    try {
+      const { code, stderr } = await runLinter(root);
+      expect(code).toBe(1);
+      expect(stderr).toContain('linter self-check');
+      expect(stderr).not.toContain('references unknown MCP tool');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('names the missing tools so the failure is actionable', async () => {
+    const root = await makeRepo({
+      toolsPath: 'src/tools/tools.ts',
+      manifestTools: ['get_transactions'],
+      definedTools: ['name'],
+    });
+    try {
+      const { stderr } = await runLinter(root);
+      expect(stderr).toContain('get_transactions');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('tool discovery', () => {
+  test('finds definitions in nested subdirectories of src/tools/', async () => {
+    const root = await makeRepo({
+      toolsPath: 'src/tools/registry/transactions.ts',
+      manifestTools: ['get_transactions', 'update_transaction'],
+      definedTools: ['get_transactions', 'update_transaction'],
+    });
+    try {
+      const { code, stdout } = await runLinter(root);
+      expect(code).toBe(0);
+      expect(stdout).toContain('1 skills validated');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('still rejects a skill referencing a genuinely nonexistent tool', async () => {
+    const root = await makeRepo({
+      toolsPath: 'src/tools/registry/transactions.ts',
+      manifestTools: ['get_transactions'],
+      definedTools: ['get_transactions'],
+      skill: `---
+name: demo
+description: A demo skill.
+---
+
+Call \`get_transactions\` and then \`delete_everything\`.
+`,
+    });
+    try {
+      const { code, stderr } = await runLinter(root);
+      expect(code).toBe(1);
+      expect(stderr).toContain('references unknown MCP tool `delete_everything`');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the real repository', () => {
+  test('check:skills passes against the checked-in skills and tools', async () => {
+    const { code, stdout, stderr } = await runLinter(REAL_REPO);
+    expect(stderr).toBe('');
+    expect(code).toBe(0);
+    expect(stdout).toContain('skills validated');
+  });
+});


### PR DESCRIPTION
# Summary

`bun run check:skills` has failed on a clean `main` since the tool-registry
refactor: it reports all 38 tool references across the 6 skills as unknown
tools, every one a false positive. The linter scraped tool names from a
hardcoded `src/tools/tools.ts`, which no longer contains any.

## External assumptions

None — this PR touches only repo tooling. No new assumptions about Copilot's
API, data, enum values, or response shapes.

## Bug fix?

Root cause:       `collect_all_tool_names()` scraped a hardcoded `src/tools/tools.ts`; the schemas moved to `src/tools/registry/*.ts` in 8230a63, so the parse returned one incidental `name: 'name'` literal and the emptiness-only guard let the run continue against a phantom tool list.
Bug class:        Tooling that reconstructs a fact the codebase already knows — here, by text-scraping TypeScript for tool names — and then treats a degenerate reconstruction as a valid answer, failing open and blaming its inputs instead of reporting itself.
Detector added:   `tests/scripts/check-skills.test.ts` drives the script against synthetic repo trees covering every way the tool lookup can fail (missing, non-zero exit, invalid JSON, wrong shape, empty list); each must report a linter fault and validate no skill. A separate test asserts the lookup equals the registry exactly and spans read, write, and live tools — the coverage gap a `manifest.json`-based tripwire would have left.
Siblings checked: `scripts/sync-manifest.ts` — immune, it imports `createToolSchemas` from source so a move fails typecheck loudly rather than silently. `scripts/smoke-graphql.ts` — mentions `tools.ts` only in a comment. No other script locates tool definitions by text-scraping a path.
Ledger updated:   n/a — not an external-assumption bug.

## What changed

**`scripts/dump-tool-names.ts`** (new)
- Imports `ALL_TOOL_DEFS` — the same registry the server builds dispatch from —
  and prints the 48 tool names as a JSON array.

**`scripts/check-skills.py`**
- Resolve skill tool references against that dump instead of scraping
  TypeScript. `parse_tool_names`, the recursive collector, `manifest_tool_names`
  and `check_parser_health` are deleted: asking the registry removes the failure
  mode rather than guarding it, and gives the linter the same immunity
  `sync-manifest.ts` has — a move that breaks the import fails typecheck loudly.
- Every lookup failure raises `ToolLookupError` and is reported as
  `FAIL: linter self-check: … Skill references were NOT validated.`, naming the
  real cause (bun missing, dump missing, non-zero exit, invalid JSON, wrong
  shape, empty list) rather than a guessed one.
- Keep the `CHECK_SKILLS_REPO_ROOT` override so tests can point the linter at a
  synthetic tree.

**`tests/scripts/check-skills.test.ts`** (new, follows `check-pr-sections.test.ts`)
- Each way the lookup can fail reports a linter fault and blames no skill.
- Failures are clean `FAIL:` output, never a traceback.
- The dump equals the registry exactly, and covers read, write and live tools.
- A genuinely nonexistent tool reference is still rejected.
- The real repository validates clean.

## Verification

- `bun run check` — exit 0, 2381 pass / 20 skip / 0 fail across 135 files
  (2377 before, minus the 6 tests this replaces, plus 10 new)
- `bun run check:skills` — exit 0, `OK: 6 skills validated`
- Mutation-tested rather than asserted — restoring the pre-fix script fails 8 of
  10; making the lookup fail open fails 5 of 10; accepting an empty registry
  fails 1 of 10.

## Note, not addressed here

No CI workflow invokes `check:skills` by name (#578). Merging this does put it
in CI indirectly — the `the real repository` test runs under `bun test`, which
the `tests` job executes on `ubuntu-latest` with python3 preinstalled — but that
is coverage by side effect: it surfaces as a test failure rather than a named
check, and it depends on python3 staying in the runner image. #578 is still
worth doing as an explicit step.
