### PR TITLE
chore(check-skills): address follow-up nits from #577

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ bun run fix          # Run lint:fix + format
 
 > `bun run check` does NOT run `check:skills` (the `skills/` linter). Run
 > `bun run check:skills` separately when touching anything under `skills/`.
+> It shells out to `scripts/dump-tool-names.ts` under bun to get the real tool
+> list, so it needs `bun` on PATH and a completed `bun install`.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,12 @@ bun run sync-manifest  # Verify manifest.json matches code
 bun run check:skills   # Lint skills/ (NOT part of `check` — run separately for skills work)
 ```
 
+`check:skills` resolves the tool names skills reference by running
+`scripts/dump-tool-names.ts` under bun, so it needs `bun` on PATH and a
+completed `bun install` — it is no longer a standalone python3 script. When
+either is missing it reports a linter fault and validates nothing, rather than
+reporting every skill reference as an unknown tool.
+
 #### Writes-enabled bundle (local-only)
 
 `bun run pack:mcpb:write` produces `copilot-money-mcp-write.mcpb`, a variant

--- a/scripts/dump-tool-names.ts
+++ b/scripts/dump-tool-names.ts
@@ -15,16 +15,13 @@
  * source the server's dispatch is built from, so it covers read, write, and
  * live tools alike — `manifest.json` covers only the 14 cache-mode reads and
  * would miss every write tool the skills lean on.
+ *
+ * This prints whatever the registry holds, including an empty array. Refusing
+ * the degenerate answer is the caller's job: check-skills.py raises on an empty
+ * list, and that is the path under test.
  */
 import { ALL_TOOL_DEFS } from '../src/tools/registry/index.js';
 
 const names = ALL_TOOL_DEFS.map((def) => def.name).sort();
-
-if (names.length === 0) {
-  // Unreachable in practice; a registry that imports cleanly but enumerates
-  // nothing is exactly the degenerate answer the caller must not trust.
-  console.error('dump-tool-names: ALL_TOOL_DEFS is empty');
-  process.exit(1);
-}
 
 console.log(JSON.stringify(names));

--- a/tests/scripts/check-skills.test.ts
+++ b/tests/scripts/check-skills.test.ts
@@ -29,11 +29,15 @@ import { ALL_TOOL_DEFS } from '../../src/tools/registry/index.js';
 const SCRIPT = fileURLToPath(new URL('../../scripts/check-skills.py', import.meta.url));
 const REAL_REPO = fileURLToPath(new URL('../..', import.meta.url));
 
+// Resolved once, so a test can strip PATH without also losing the interpreter.
+const PYTHON = Bun.which('python3') ?? 'python3';
+
 async function runLinter(
-  repoRoot: string
+  repoRoot: string,
+  envOverrides: Record<string, string> = {}
 ): Promise<{ code: number; stderr: string; stdout: string }> {
-  const proc = Bun.spawn(['python3', SCRIPT], {
-    env: { ...process.env, CHECK_SKILLS_REPO_ROOT: repoRoot },
+  const proc = Bun.spawn([PYTHON, SCRIPT], {
+    env: { ...process.env, CHECK_SKILLS_REPO_ROOT: repoRoot, ...envOverrides },
     stdout: 'pipe',
     stderr: 'pipe',
   });
@@ -117,6 +121,27 @@ describe('tool-lookup gate (class-level detector)', () => {
       });
     });
   }
+
+  // The one lookup failure the table above cannot express: it is about the
+  // environment, not the dump script's output, so the dump here is a good one.
+  test('fails as a linter fault when bun is not on PATH', async () => {
+    const root = await makeRepo({ dumpBody: WORKING_DUMP });
+    const emptyDir = await mkdtemp(join(tmpdir(), 'check-skills-nobun-'));
+    try {
+      // PATH points at an empty directory so shutil.which('bun') finds nothing.
+      // python3 is spawned by absolute path, so stripping PATH cannot break the
+      // run itself — the linter reaches the lookup and fails there.
+      const { code, stderr } = await runLinter(root, { PATH: emptyDir });
+      expect(code).toBe(1);
+      expect(stderr).toContain('linter self-check');
+      expect(stderr).toContain('bun is not on PATH');
+      expect(stderr).toContain('Skill references were NOT validated');
+      expect(stderr).not.toContain('references unknown MCP tool');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(emptyDir, { recursive: true, force: true });
+    }
+  });
 
   test('reports the failure cleanly rather than as a traceback', async () => {
     await withRepo({ dumpBody: `console.log('not json at all');` }, ({ stderr }) => {

--- a/tests/scripts/check-skills.test.ts
+++ b/tests/scripts/check-skills.test.ts
@@ -75,12 +75,12 @@ async function makeRepo(opts: { dumpBody?: string; skill?: string }): Promise<st
 const WORKING_DUMP = `console.log(JSON.stringify(['get_transactions', 'update_transaction']));`;
 
 async function withRepo(
-  opts: { dumpBody?: string; skill?: string },
+  opts: { dumpBody?: string; skill?: string; env?: Record<string, string> },
   assertions: (result: { code: number; stderr: string; stdout: string }) => void
 ): Promise<void> {
   const root = await makeRepo(opts);
   try {
-    assertions(await runLinter(root));
+    assertions(await runLinter(root, opts.env));
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -125,20 +125,19 @@ describe('tool-lookup gate (class-level detector)', () => {
   // The one lookup failure the table above cannot express: it is about the
   // environment, not the dump script's output, so the dump here is a good one.
   test('fails as a linter fault when bun is not on PATH', async () => {
-    const root = await makeRepo({ dumpBody: WORKING_DUMP });
     const emptyDir = await mkdtemp(join(tmpdir(), 'check-skills-nobun-'));
     try {
       // PATH points at an empty directory so shutil.which('bun') finds nothing.
       // python3 is spawned by absolute path, so stripping PATH cannot break the
       // run itself — the linter reaches the lookup and fails there.
-      const { code, stderr } = await runLinter(root, { PATH: emptyDir });
-      expect(code).toBe(1);
-      expect(stderr).toContain('linter self-check');
-      expect(stderr).toContain('bun is not on PATH');
-      expect(stderr).toContain('Skill references were NOT validated');
-      expect(stderr).not.toContain('references unknown MCP tool');
+      await withRepo({ dumpBody: WORKING_DUMP, env: { PATH: emptyDir } }, ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('linter self-check');
+        expect(stderr).toContain('bun is not on PATH');
+        expect(stderr).toContain('Skill references were NOT validated');
+        expect(stderr).not.toContain('references unknown MCP tool');
+      });
     } finally {
-      await rm(root, { recursive: true, force: true });
       await rm(emptyDir, { recursive: true, force: true });
     }
   });


### PR DESCRIPTION
# Summary

Three leftovers from the #577 review. All were flagged as optional there and
none change what the linter accepts or rejects.

## External assumptions

None — this PR touches repo tooling and contributor docs only. No new
assumptions about Copilot's API, data, enum values, or response shapes.

## What changed

**`scripts/dump-tool-names.ts`** — drop the unreachable empty-registry guard.
Its own comment called it unreachable, and `check-skills.py` already raises on
an empty list; that is the layer with a test behind it. The header now states
that refusing the degenerate answer is deliberately the caller's job, so the
split reads as a decision rather than an omission.

**`tests/scripts/check-skills.test.ts`** — cover the one lookup failure that
had no case: `bun` missing from PATH. It is an environment fault rather than a
bad dump payload, so it needs a `PATH` override instead of a row in the
existing table. `python3` is now resolved once up front via `Bun.which`, so
stripping `PATH` for that test cannot cost us the interpreter as well.

**`CONTRIBUTING.md`, `CLAUDE.md`** — document the dependency profile.
`check:skills` shells out to `scripts/dump-tool-names.ts` under bun, so it
needs `bun` on PATH and a completed `bun install`. Both files described it as a
standalone python3 script, which was true before #577 and is not now. This
matters for #578: the proposal there justifies a CI step partly on the check
being "fast, hermetic, python3-only", so whoever implements it needs to know
the step must come after `bun install`.

## Verification

- `bun run check` — exit 0, 2382 pass / 0 fail
- `bun run check:skills` — exit 0, `OK: 6 skills validated`
- New test is a detector, not decoration: removing the `shutil.which("bun")`
  guard from `check-skills.py` fails `fails as a linter fault when bun is not
  on PATH` and only that test (10 pass / 1 fail).

## Not addressed here

#578 stays open. This corrects the stale premise in its description but does
not add the CI step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
