### PR TITLE
chore(deps): drop protobufjs, unused since the parser was hand-rolled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,13 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.2.0",
         "classic-level": "^3.0.0",
-        "protobufjs": "^8.7.1",
         "zod": "^4.3.5"
       },
       "bin": {
         "copilot-money-mcp": "dist/cli.js"
       },
       "devDependencies": {
-        "@anthropic-ai/mcpb": "*",
+        "@anthropic-ai/mcpb": "latest",
         "@eslint/js": "^10.0.1",
         "@types/bun": "^1.3.14",
         "@types/node": "^26.1.1",
@@ -629,6 +628,7 @@
       "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.64.0",
         "@typescript-eslint/types": "8.64.0",
@@ -850,6 +850,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1335,6 +1336,7 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -1569,6 +1571,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1978,6 +1981,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.5.tgz",
       "integrity": "sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2276,12 +2280,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/long": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0"
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2576,6 +2574,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2629,18 +2628,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/protobufjs": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
-      "integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-addr": {
@@ -3041,6 +3028,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3195,6 +3183,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.2.0",
     "classic-level": "^3.0.0",
-    "protobufjs": "^8.7.1",
     "zod": "^4.3.5"
   },
   "devDependencies": {


### PR DESCRIPTION
# Summary

`protobufjs` is declared as a production dependency and imported nowhere.

## External assumptions

None — this PR removes an unused dependency. No new assumptions about
Copilot's API, data, enum values, or response shapes.

## History

| When | What |
|---|---|
| 2026-01-11 | `175e4ee` creates the first `package.json` with `protobufjs` in `dependencies`, alongside the initial Zod models. The decoder did not exist yet. |
| 2026-01-14 | `af0c4d6` (#73) adds `src/core/protobuf-parser.ts`, a hand-rolled Firestore wire-format parser. |

That second commit is the moment the dependency became dead. It has been
carried for roughly six months since.

This is not inference from a current-tree grep. A pickaxe search over every
commit on every branch finds the literal string `protobufjs` in **no `.ts` or
`.js` file at any point in the repo's history** — it was added speculatively
and never once imported:

```bash
git rev-list --all | while read c; do
  git grep -l "protobufjs" $c -- '*.ts' '*.js' 2>/dev/null
done | sort -u   # -> empty
```

## Why it is worth removing rather than ignoring

It is a `dependencies` entry, not `devDependencies`, so it shipped in the
`.mcpb` bundle and in the published npm package, and it counted against the
production license gate. It also generated recurring dependabot churn — an
8.6.x bump earlier, and 8.6.6 → 8.7.1 in #568 merged about an hour before this
PR.

Removing it drops **2 packages** from the production tree: `protobufjs`
(BSD-3-Clause) and one Apache-2.0 transitive. The license summary goes from
`MIT 93 / ISC 7 / BSD-3 4 / BSD-2 1 / Apache-2.0 1` to
`MIT 93 / ISC 7 / BSD-3 3 / BSD-2 1`.

## Verification

Run with the dependency actually removed and `node_modules` reinstalled:

- `bun run check` — 2382 pass / 0 fail
- `bun run check:skills` — `OK: 6 skills validated`
- `bun run build` — all three entry points build
- `bun run pack:mcpb` — bundle packs (this one matters, it runs `npm install --omit=dev`)
- CI license gate, run locally — passes

`package-lock.json` regenerated with `npm install --package-lock-only`, since
it is tracked and consumed by `scripts/pack-mcpb.ts` and the CI license job.

## Not addressed here

Two adjacent observations from the same sweep, left out to keep this diff to
one line. Happy to file either as an issue:

1. **`ajv` / `ajv-formats` are undeclared runtime requires.** The built
   bundles `require("ajv/dist/runtime/...")` and
   `require("ajv-formats/dist/formats")`, but neither is in our
   `dependencies` — they resolve only transitively through
   `@modelcontextprotocol/sdk`. If the SDK ever drops or restructures that
   dep, the published package breaks at runtime and nothing in our manifest
   would have warned us.
2. **`@anthropic-ai/mcpb` is pinned to `"latest"`.** Everything else is
   ranged or pinned, and CI pins `license-checker@25.0.1` with an explicit
   supply-chain-determinism comment. This is the one unpinned specifier, and
   it sits on the packaging/release path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
