### PR TITLE
Exclude base64 account logos from get_accounts by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`get_accounts` no longer embeds base64 institution logos by default.** Each account's cached `logo` (a base64-encoded PNG) was being returned inline on every call, bloating responses roughly 20-30x for no benefit to an MCP client. Logos are now stripped by default; pass `include_logos: true` to opt back in. Fixes [#589](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/589).
+
 ## [2.2.2] - 2026-06-14
 
 ### Fixed

--- a/docs/tools-by-mode.md
+++ b/docs/tools-by-mode.md
@@ -7,7 +7,7 @@ This server exposes different tools depending on which CLI flags you enable. The
 | Tool | Status | Notes |
 |---|---|---|
 | `get_transactions` | ✅ | Query transactions with filters (date range, category, merchant, amount, account, text search, etc.) |
-| `get_accounts` | ✅ | List accounts with balances; filter by type |
+| `get_accounts` | ✅ | List accounts with balances; filter by type. Logo images are omitted by default (`include_logos: true` to include) |
 | `get_categories` | ✅ | Category hierarchy with spending totals |
 | `get_budgets` | ✅ | Budgets vs. spending |
 | `get_recurring_transactions` | ✅ | Detected subscriptions + recurring charges |

--- a/src/tools/registry/accounts-system.ts
+++ b/src/tools/registry/accounts-system.ts
@@ -57,7 +57,9 @@ export const getAccountsTool = defineTool({
       'total_assets, and total_liabilities. Optionally filter by account type ' +
       '(checking, savings, credit, investment). Checks both account_type ' +
       'and subtype fields for better filtering (e.g., finds checking accounts ' +
-      "even when account_type is 'depository'). By default, hidden accounts are excluded.",
+      "even when account_type is 'depository'). By default, hidden accounts are excluded. " +
+      'Institution logos (base64-encoded images) are omitted by default to keep responses compact; ' +
+      'pass include_logos: true to include them.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -70,6 +72,13 @@ export const getAccountsTool = defineTool({
         include_hidden: {
           type: 'boolean',
           description: 'Include hidden accounts (default: false)',
+          default: false,
+        },
+        include_logos: {
+          type: 'boolean',
+          description:
+            'Include institution logo images (base64-encoded, several KB each). ' +
+            'Omitted by default to keep responses compact (default: false)',
           default: false,
         },
       },

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -973,6 +973,7 @@ export class CopilotMoneyTools {
     options: {
       account_type?: string;
       include_hidden?: boolean;
+      include_logos?: boolean;
     } = {}
   ): Promise<{
     count: number;
@@ -981,7 +982,7 @@ export class CopilotMoneyTools {
     total_liabilities: number;
     accounts: Account[];
   }> {
-    const { account_type, include_hidden = false } = options;
+    const { account_type, include_hidden = false, include_logos = false } = options;
 
     let accounts = await this.db.getAccounts(account_type);
 
@@ -1008,12 +1009,20 @@ export class CopilotMoneyTools {
     }
     const totalBalance = totalAssets - totalLiabilities;
 
+    // `logo` is a base64-encoded PNG (several KB per account) that Firestore
+    // caches alongside every account document. Left in, it dominates the
+    // response (issue: ~20-30x bloat for a handful of accounts) for data an
+    // MCP client has no use for. Strip it by default; include_logos opts back in.
+    const responseAccounts = include_logos
+      ? accounts
+      : accounts.map(({ logo: _logo, logo_content_type: _logoContentType, ...rest }) => rest);
+
     return {
       count: accounts.length,
       total_balance: roundAmount(totalBalance),
       total_assets: roundAmount(totalAssets),
       total_liabilities: roundAmount(totalLiabilities),
-      accounts,
+      accounts: responseAccounts,
     };
   }
 

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -725,6 +725,29 @@ describe('CopilotMoneyTools', () => {
       expect(result.count).toBe(1);
       expect(result.accounts[0].account_type).toBe('checking');
     });
+
+    test('strips logo fields by default', async () => {
+      (db as any)._accounts = [
+        { ...mockAccounts[0], logo: 'iVBORw0KGgoAAAANSU...', logo_content_type: 'image/png' },
+        mockAccounts[1],
+      ];
+      const result = await tools.getAccounts();
+      expect(result.accounts[0]).not.toHaveProperty('logo');
+      expect(result.accounts[0]).not.toHaveProperty('logo_content_type');
+      // Everything else about the account is preserved.
+      expect(result.accounts[0].account_id).toBe('acc1');
+      expect(result.accounts[0].current_balance).toBe(1500.0);
+    });
+
+    test('includes logo fields when include_logos is true', async () => {
+      (db as any)._accounts = [
+        { ...mockAccounts[0], logo: 'iVBORw0KGgoAAAANSU...', logo_content_type: 'image/png' },
+        mockAccounts[1],
+      ];
+      const result = await tools.getAccounts({ include_logos: true });
+      expect(result.accounts[0].logo).toBe('iVBORw0KGgoAAAANSU...');
+      expect(result.accounts[0].logo_content_type).toBe('image/png');
+    });
   });
 
   describe('getAccounts with hidden accounts', () => {


### PR DESCRIPTION
## Summary

Fixes #589 — `get_accounts` was embedding each account's cached `logo` (a base64-encoded PNG, several KB per account) inline on every call, with no way to opt out. For a normal set of linked accounts this dominated the response: in the reporter's case, 15 accounts came back as ~66KB of JSON, of which only ~2-3KB was actual financial data (balances, names, masks, institution names).

For an MCP client this is pure waste — the image bytes aren't usable by a text-based tool caller and can trip response-size limits well before the useful data does.

## Changes

- `CopilotMoneyTools.getAccounts` now strips `logo` / `logo_content_type` from each account by default.
- Added `include_logos` (default `false`) to `get_accounts`'s input schema, mirroring the existing `include_hidden` pattern, for callers that do want the image data.
- Updated the tool description and `docs/tools-by-mode.md` to document the new default.
- Added unit tests covering both the default (stripped) and `include_logos: true` (preserved) behavior.
- Added a CHANGELOG entry.

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes (0 errors; pre-existing unrelated warnings only)
- [x] `bun run format:check` — passes
- [x] `bun run check:version-sync` / `check:server-json` — pass
- [x] `bun test` (full suite via pre-push hook) — 2384 pass, 0 fail
- [x] Manually verified against a real local Copilot Money database: `get_accounts` response dropped from ~66KB to well under the previous size with `logo`/`logo_content_type` absent, and reappeared correctly with `include_logos: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
