### PR TITLE
ci: make Codecov upload best-effort (fail_ci_if_error: false)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,4 +84,8 @@ jobs:
         with:
           files: coverage/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          # Coverage upload is best-effort: a Codecov outage or a missing
+          # CODECOV_TOKEN secret must not fail an otherwise-green build. The
+          # codecov/patch status check still reports coverage on PRs; set back
+          # to true if a hard upload gate is ever wanted.
+          fail_ci_if_error: false


### PR DESCRIPTION
## Summary
One-line CI change: set `fail_ci_if_error: false` on the Codecov upload step.

Today a Codecov outage or a missing `CODECOV_TOKEN` secret fails an otherwise-green build. Coverage feedback on PRs still arrives via the `codecov/patch` status check; the upload step itself shouldn't be a hard gate. A comment in the workflow records the rationale and how to restore the hard gate.

Split out of #588 per review, so the gate loosening gets deliberate review instead of riding along in an unrelated PR.

## External assumptions

None — CI configuration only; no assumptions about Copilot's API or data.

## Test plan
- [x] Pre-push `bun run check` green (2404 pass, 0 fail)
- [ ] CI on this PR runs the upload step and stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
