### PR TITLE
docs(schemas): compress largest tool descriptions (#597 T3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Largest tool descriptions compressed** ([#597](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/597)). The nine largest tool schemas (plus `create_recurring`, which shared a duplicated frequency blurb) were rewritten for density: redundant restatements, list scaffolding, and facts duplicated between a tool description and its parameter descriptions were collapsed, with every behavioral constraint and footgun warning preserved. Aggregate schema size across all registered tools dropped ~7% (~4.9K chars); the dieted schemas individually shrank 6-34%. Schema budgets in the context-budget ratchet moved down accordingly.
 - **Tool responses are now compact JSON** ([#597](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/597)). The server previously pretty-printed every tool response (`JSON.stringify(result, null, 2)`), a measured 10-20% pure-whitespace tax on every response an MCP client loads into context. Responses are now serialized compact (`JSON.stringify(result)`). No semantic change — the JSON content is identical, only inter-token whitespace is gone.
 
 ### Fixed

--- a/src/tools/live/investment-prices.ts
+++ b/src/tools/live/investment-prices.ts
@@ -310,20 +310,17 @@ export function createLiveInvestmentPricesToolSchema(): ToolSchema {
   return {
     name: 'get_investment_prices_live',
     description:
-      'Get price history for a single security (live, GraphQL-backed). One MCP tool routes ' +
-      'to two underlying queries based on time_frame: ONE_DAY and ONE_WEEK return intraday ' +
-      'timestamps (5-minute cache TTL); ONE_MONTH / THREE_MONTHS / YTD / ONE_YEAR / ALL return ' +
-      'daily closes (1-hour cache TTL). The output `granularity` field tells callers which ' +
-      'row field to use (`date` for daily, `timestamp` for intraday). ' +
-      'IMPORTANT — server-side ownership gate: this query is restricted to securities you ' +
-      'currently hold. For any security_id not in your linked-account positions, the tool ' +
-      'returns a clean error ("not currently in your linked accounts"). Use `get_holdings_live` ' +
-      'to enumerate valid security_ids. Long-range responses are paginated via `max_rows` ' +
-      '(default 500, max 5000) and `offset` (counts from the most-recent row); the response ' +
-      'reports `total_rows` and `truncated` so callers can detect when older data was elided. ' +
-      'Daily series omit days the security had no price (the server returns null for those); ' +
-      '`count`/`total_rows` therefore count priced days, not calendar days. ' +
-      'Available when --live-reads is on.',
+      'Get price history for a single security (live, GraphQL-backed). time_frame picks the ' +
+      'query: ONE_DAY and ONE_WEEK return intraday timestamps (5-minute cache TTL); ' +
+      'ONE_MONTH / THREE_MONTHS / YTD / ONE_YEAR / ALL return daily closes (1-hour TTL). The ' +
+      'output `granularity` field says which row field to use (`date` daily, `timestamp` ' +
+      'intraday). Server-side ownership gate: only securities you currently hold work — any ' +
+      'other security_id returns a clean "not currently in your linked accounts" error; ' +
+      'enumerate valid ids via get_holdings_live. Long ranges paginate via `max_rows` and ' +
+      '`offset`; the response reports `total_rows` and `truncated` when older data was ' +
+      'elided. Daily series omit days with no price (the server returns null for those), so ' +
+      '`count`/`total_rows` count priced days, not calendar days. Available when ' +
+      '--live-reads is on.',
     inputSchema: {
       type: 'object' as const,
       properties: {
@@ -334,23 +331,20 @@ export function createLiveInvestmentPricesToolSchema(): ToolSchema {
         time_frame: {
           type: 'string',
           enum: ALL_TIME_FRAMES,
-          description:
-            'Date range. Default: ONE_MONTH. ONE_DAY and ONE_WEEK return intraday timestamps; ' +
-            'larger ranges return daily closes.',
+          description: 'Date range. Default: ONE_MONTH.',
         },
         max_rows: {
           type: 'integer',
           description:
-            'Cap response to the most recent N rows (default 500, max 5000). Helps avoid the ' +
-            'MCP single-tool-result token limit on long-range queries. If hit, response ' +
-            'includes `truncated: true`.',
+            'Cap response to the most recent N rows (default 500, max 5000); avoids the MCP ' +
+            'tool-result token limit on long ranges. If hit, response includes `truncated: true`.',
           default: DEFAULT_MAX_ROWS,
         },
         offset: {
           type: 'integer',
           description:
-            'Number of rows to skip from the most-recent end. Default 0. Set to `max_rows` to ' +
-            'fetch the next-most-recent batch (counts backwards through history).',
+            'Rows to skip from the most-recent end (default 0). Set to `max_rows` for the ' +
+            'next-most-recent batch (counts backwards through history).',
           default: 0,
         },
       },

--- a/src/tools/live/transactions.ts
+++ b/src/tools/live/transactions.ts
@@ -412,7 +412,7 @@ export function createLiveTransactionsToolSchema(): ToolSchema {
   return {
     name: 'get_transactions_live',
     description:
-      "Read and filter a user's transactions live from Copilot's GraphQL API — the right tool for questions like 'how much did I spend on <category>' or 'list my <merchant> transactions', and for any spending lookup by category, merchant, date, or amount. Filter by `category` (a category ID from get_categories_live), `merchant`/`query`, date range (`period` or `start_date`/`end_date`), `min_amount`/`max_amount`, `account_id`, `tag`, or `pending`, then sum the returned `amount` values to total spending for a category or period. Requires the --live-reads flag and network connectivity. Unlike get_transactions, the following filters are NOT supported and must not be included: city, lat, lon, radius_km, region, country, transaction_type=foreign, transaction_type=duplicates, exclude_split_parents=false, and exclude_deleted=false — any of these returns an error telling you to retry without the parameter. Single-transaction lookup requires transaction_id + account_id + item_id AND a date range (start_date, end_date, or period) — pass the transaction's date from the prior list result; the server has no single-row-by-id filter so unbounded lookups paginate the whole account. If the backend is unreachable, this tool returns an isError result; it does NOT fall back to the local cache.",
+      "Read and filter transactions live from Copilot's GraphQL API — the right tool for any spending lookup by category, merchant, date, or amount; sum the returned `amount` values to total spending. Filters: `category` (a category ID from get_categories_live), `merchant`/`query`, date range (`period` or `start_date`/`end_date`), `min_amount`/`max_amount`, `account_id`, `tag`, `pending`. Requires --live-reads and network connectivity. NOT supported (each returns an error telling you to retry without it): city, lat, lon, radius_km, region, country, transaction_type foreign/duplicates, exclude_split_parents=false, exclude_deleted=false. Single-transaction lookup requires transaction_id + account_id + item_id AND a date range — the server has no single-row-by-id filter, so pass the transaction's date from the prior list result; unbounded lookups would paginate the whole account. If the backend is unreachable this returns an isError result; it does NOT fall back to the local cache.",
     inputSchema: {
       type: 'object',
       properties: {
@@ -439,8 +439,7 @@ export function createLiveTransactionsToolSchema(): ToolSchema {
         account_id: { type: 'string', description: 'Filter by account ID' },
         item_id: {
           type: 'string',
-          description:
-            'Item ID paired with account_id. Required only when using transaction_id to fetch a single transaction.',
+          description: 'Item ID paired with account_id; required only for transaction_id lookups.',
         },
         min_amount: {
           type: 'number',
@@ -463,25 +462,25 @@ export function createLiveTransactionsToolSchema(): ToolSchema {
         exclude_transfers: {
           type: 'boolean',
           description:
-            'Exclude internal transfers between accounts (default: true). When true, filter types=[REGULAR, INCOME].',
+            'Exclude internal transfers between accounts (default: true; filters types to REGULAR/INCOME).',
           default: true,
         },
         exclude_deleted: {
           type: 'boolean',
           description:
-            'Must be true or omitted — the GraphQL server already excludes deleted transactions. Passing false returns an error.',
+            'Must be true or omitted — the server already excludes deleted transactions; false errors.',
           default: true,
         },
         exclude_excluded: {
           type: 'boolean',
           description:
-            'Exclude transactions in user-excluded categories (default: true). Cross-referenced against Category.isExcluded from the local cache.',
+            'Exclude transactions in user-excluded categories (default: true; checked against Category.isExcluded from the local cache).',
           default: true,
         },
         exclude_split_parents: {
           type: 'boolean',
           description:
-            'Must be true or omitted — the server omits split parents from the transactions query. Passing false returns an error.',
+            'Must be true or omitted — the server already omits split parents; false errors.',
           default: true,
         },
         pending: {
@@ -491,18 +490,17 @@ export function createLiveTransactionsToolSchema(): ToolSchema {
         transaction_id: {
           type: 'string',
           description:
-            'Get one transaction by ID — REQUIRES account_id and item_id alongside (all three come from a previous get_transactions_live result).',
+            'Get one transaction by ID — REQUIRES account_id, item_id, and a date range alongside (all from a previous result).',
         },
         query: {
           type: 'string',
           description:
-            'Free-text merchant search (server-side matchString). Equivalent to passing merchant.',
+            'Free-text merchant search (server-side matchString); equivalent to merchant.',
         },
         transaction_type: {
           type: 'string',
           enum: [...LIVE_TRANSACTION_TYPES],
-          description:
-            'Filter by special type. Note: foreign and duplicates are NOT supported in live mode.',
+          description: 'Filter by special type (foreign/duplicates are cache-only).',
         },
         tag: {
           type: 'string',

--- a/src/tools/registry/recurring.ts
+++ b/src/tools/registry/recurring.ts
@@ -5,6 +5,11 @@
 import { defineTool, type ToolMethodArgs } from './types.js';
 import { RECURRING_FREQUENCIES, RECURRING_STATE_VALUES } from '../../core/graphql/recurrings.js';
 
+/** Shared cadence explanation for the `frequency` enum (create + update). */
+const FREQUENCY_DESCRIPTION =
+  'How often the recurring repeats. BIWEEKLY = every 2 weeks, BIMONTHLY = every 2 months, ' +
+  'QUADMONTHLY = every 4 months, SEMIANNUALLY = every 6 months; the rest are literal.';
+
 export const getRecurringTransactionsTool = defineTool({
   schema: {
     name: 'get_recurring_transactions',
@@ -165,11 +170,7 @@ export const createRecurringTool = defineTool({
         frequency: {
           type: 'string',
           enum: [...RECURRING_FREQUENCIES],
-          description:
-            'How often the recurring repeats. Maps to the Copilot frequency options: ' +
-            'WEEKLY (every week), BIWEEKLY (every 2 weeks), MONTHLY (every month), ' +
-            'BIMONTHLY (every 2 months), QUARTERLY (every 3 months), QUADMONTHLY (every 4 months), ' +
-            'SEMIANNUALLY (every 6 months), ANNUALLY (every year).',
+          description: FREQUENCY_DESCRIPTION,
         },
       },
       required: ['transaction_id', 'frequency'],
@@ -189,10 +190,8 @@ export const updateRecurringTool = defineTool({
   schema: {
     name: 'update_recurring',
     description:
-      'Update an existing recurring transaction. Pass recurring_id plus any combination of ' +
-      'name, category_id, frequency, state, or rule (name_contains, min_amount, max_amount, days). ' +
-      'At least one mutable field must be provided besides recurring_id. ' +
-      'Writes directly to Copilot Money via GraphQL.',
+      'Update an existing recurring transaction. Pass recurring_id plus at least one of ' +
+      'name, category_id, frequency, state, or rule. Writes directly to Copilot Money via GraphQL.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -207,23 +206,18 @@ export const updateRecurringTool = defineTool({
         category_id: {
           type: 'string',
           description:
-            'New category ID to assign (from get_categories results). Changes the default category for future matched transactions.',
+            'New category ID (from get_categories results). Becomes the default category for future matched transactions.',
         },
         frequency: {
           type: 'string',
           enum: [...RECURRING_FREQUENCIES],
-          description:
-            'How often the recurring repeats. Maps to the Copilot frequency options: ' +
-            'WEEKLY (every week), BIWEEKLY (every 2 weeks), MONTHLY (every month), ' +
-            'BIMONTHLY (every 2 months), QUARTERLY (every 3 months), QUADMONTHLY (every 4 months), ' +
-            'SEMIANNUALLY (every 6 months), ANNUALLY (every year).',
+          description: FREQUENCY_DESCRIPTION,
         },
         state: {
           type: 'string',
           enum: [...RECURRING_STATE_VALUES],
           description:
-            'State of the recurring. Use set_recurring_state instead if you only want to ' +
-            'change state — this tool is for broader edits.',
+            'New state. If state is the only change, set_recurring_state is the more specific tool.',
         },
         rule: {
           type: 'object',

--- a/src/tools/registry/transactions.ts
+++ b/src/tools/registry/transactions.ts
@@ -167,14 +167,10 @@ export const createTransactionTool = defineTool({
   schema: {
     name: 'create_transaction',
     description:
-      'Create a brand-new manual transaction on an existing account. Seven ' +
-      'fields are required: account_id, item_id (from get_accounts), name, date ' +
-      '(YYYY-MM-DD), amount (positive = expense, negative = income; Copilot sign ' +
-      'convention), category_id (from get_categories), and type. type is one of ' +
-      'REGULAR, INCOME, or INTERNAL_TRANSFER. Three optional metadata fields may ' +
-      'also be supplied: tag_ids (from get_tags), note (free-text), and ' +
-      'recurring_id (link to an existing recurring series, from ' +
-      'get_recurring_transactions). Returns the newly-created transaction.',
+      'Create a brand-new manual transaction on an existing account. Requires ' +
+      'account_id, item_id, name, date, amount, category_id, and type; optional ' +
+      'tag_ids, note, and recurring_id. Formats, sign convention, and ID sources ' +
+      'are documented per parameter. Returns the newly-created transaction.',
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -326,20 +322,17 @@ export const splitTransactionTool = defineTool({
   schema: {
     name: 'split_transaction',
     description:
-      'Split one parent transaction into multiple child transactions (e.g., split a single ' +
-      "'Hotel + Car + Meals' charge into three category-specific children). All three parent " +
-      'IDs are required (transaction_id, account_id, item_id) plus a `splits` array with at ' +
-      'least 2 entries. Each split entry requires `amount` and `category_id`; `name` and ' +
-      "`date` default to the parent's values if omitted. The sum of all children's `amount` " +
-      "fields must equal the parent's `amount` (server-enforced; this tool also validates " +
-      'client-side before dispatching). If the parent cannot be resolved locally (outside the ' +
-      'resolution window), the split can still proceed when every split entry carries an ' +
-      'explicit `name` and `date` — the amount-sum check is then deferred to the server. ' +
-      'After success the parent transaction is hidden but ' +
-      'not deleted (children reference it via parent_transaction_id) — there is no reversal ' +
-      "mutation; to undo a split delete each child and edit the parent's category back. No " +
-      'optional per-split fields exist — tags, notes, and reviewed state must be set via ' +
-      'update_transaction on each child after split.',
+      'Split one parent transaction into 2+ child transactions (e.g. a ' +
+      "'Hotel + Car + Meals' charge into three per-category children). Requires the parent " +
+      'transaction_id, account_id, and item_id plus `splits` (min 2 entries; ' +
+      "each needs `amount` and `category_id`; `name`/`date` default to the parent's). Child " +
+      "amounts must sum to the parent's amount — validated client-side and server-enforced. " +
+      'If the parent cannot be resolved locally (outside the resolution window), the split ' +
+      'still proceeds when every entry carries explicit `name` and `date`; the sum check ' +
+      'then defers to the server. On success the parent is hidden but not deleted (children ' +
+      'reference it via parent_transaction_id); there is no reversal mutation — undo means ' +
+      "deleting each child and editing the parent's category back. Splits accept no per-split " +
+      'tags/notes/reviewed — set those via update_transaction on each child afterwards.',
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -359,8 +352,7 @@ export const splitTransactionTool = defineTool({
         splits: {
           type: 'array',
           minItems: 2,
-          description:
-            'Children to create. Must have at least 2 entries; child amounts must sum to the parent amount.',
+          description: 'Children to create.',
           items: {
             type: 'object',
             additionalProperties: false,
@@ -376,7 +368,7 @@ export const splitTransactionTool = defineTool({
               amount: {
                 type: 'number',
                 description:
-                  'Child amount. Positive = expense, negative = income (Copilot sign convention). All child amounts must sum to the parent amount.',
+                  'Child amount. Positive = expense, negative = income (Copilot sign convention).',
               },
               category_id: {
                 type: 'string',
@@ -409,27 +401,16 @@ export const updateTransactionTool = defineTool({
   schema: {
     name: 'update_transaction',
     description:
-      "Update a single transaction's name, category, note, tags, type, reviewed-state, date, or " +
-      'amount. Pass transaction_id plus any combination of name, category_id, note, tag_ids, type, ' +
-      'reviewed, date, or amount ' +
-      '— only specified fields are changed. Pass note="" to clear the note. Pass tag_ids=[] to ' +
-      'clear all tags. `type` sets the high-level classification (REGULAR, INCOME, or ' +
-      'INTERNAL_TRANSFER) — use INTERNAL_TRANSFER to exclude internal/transfer mechanics from ' +
-      "spending. Setting type to INCOME or INTERNAL_TRANSFER clears the transaction's category " +
-      '(Copilot does this server-side), so category_id cannot be combined with those two types — ' +
-      'pass the type alone, or use REGULAR to keep/set a category. `reviewed` marks a single ' +
-      'transaction reviewed (true) or un-reviewed (false), and can be set inline with other edits ' +
-      '— use review_transactions instead for bulk/filter-based review. To edit MANY transactions, ' +
-      'use update_transactions (plural) — it takes an array of these same edits in one call ' +
-      'instead of one call per row. At least one mutable field ' +
-      'must be provided besides transaction_id. If the transaction cannot be resolved locally ' +
-      '(outside the resolution window), pass account_id and item_id (from a live read) to write ' +
-      "anyway. `date` corrects the transaction's date (YYYY-MM-DD); on a synced bank transaction " +
-      'it may be reverted by the next institution sync. `amount` corrects the signed transaction ' +
-      'amount (income is negative); on a synced bank transaction it may be reverted by the next ' +
-      'institution sync. Other fields (excluded, internal_transfer, ' +
-      'goal_id) are not writable through the GraphQL API and were removed from this tool when the ' +
-      'backend was migrated.',
+      'Update a single transaction. Pass transaction_id plus at least one of name, ' +
+      'category_id, note, tag_ids, type, reviewed, date, or amount — only the fields you ' +
+      'pass change. note="" clears the note; tag_ids=[] clears all tags. category_id cannot ' +
+      'be combined with type INCOME or INTERNAL_TRANSFER (those clear the category ' +
+      'server-side) — pass the type alone, or REGULAR to keep/set a category. If the ' +
+      'transaction cannot be resolved locally (outside the resolution window), also pass ' +
+      'account_id and item_id from a live read. To edit MANY transactions use ' +
+      'update_transactions (an array of these same edits in one call); for bulk review-only ' +
+      'changes use review_transactions. excluded, internal_transfer, and goal_id are not ' +
+      "writable through Copilot's GraphQL API.",
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -441,16 +422,14 @@ export const updateTransactionTool = defineTool({
         account_id: {
           type: 'string',
           description:
-            'Optional. Account ID the transaction belongs to (from a live read). Pass together ' +
-            'with item_id to skip local resolution and write to a transaction outside the ' +
-            'resolution window.',
+            'Optional. Pass with item_id (both from a live read) to skip local resolution and ' +
+            'write to a transaction outside the resolution window.',
         },
         item_id: {
           type: 'string',
           description:
             "Optional. Item ID the account belongs to (Copilot's Firestore item_id, from a live " +
-            'read). Pass together with account_id to skip local resolution and write to a ' +
-            'transaction outside the resolution window.',
+            'read). Pass with account_id.',
         },
         name: {
           type: 'string',
@@ -473,28 +452,24 @@ export const updateTransactionTool = defineTool({
           type: 'string',
           enum: ['REGULAR', 'INCOME', 'INTERNAL_TRANSFER'],
           description:
-            'High-level classification. INTERNAL_TRANSFER excludes the transaction from spending. ' +
-            'INCOME/INTERNAL_TRANSFER clear the category server-side — do not pass category_id with them.',
+            'High-level classification. INTERNAL_TRANSFER excludes the transaction from spending.',
         },
         reviewed: {
           type: 'boolean',
-          description:
-            'Mark this transaction reviewed (true) or un-reviewed (false). For bulk/filter-based ' +
-            'review across many transactions, use review_transactions instead.',
+          description: 'Mark this transaction reviewed (true) or un-reviewed (false).',
         },
         date: {
           type: 'string',
           description:
-            'New transaction date in YYYY-MM-DD (corrects the settled/posted date). NOTE: for a ' +
-            'synced (non-manual) bank transaction this may be reverted on the next institution ' +
-            'sync; manual-account transactions persist.',
+            'New settled/posted date, YYYY-MM-DD. On a synced (non-manual) bank transaction ' +
+            'the next institution sync may revert it; manual-account transactions persist.',
         },
         amount: {
           type: 'number',
           description:
-            "New transaction amount as a signed number, using Copilot's stored sign " +
-            '(income is negative). NOTE: for a synced (non-manual) bank transaction this may ' +
-            'be reverted on the next institution sync; manual-account transactions persist.',
+            "New signed amount, using Copilot's stored sign (income is negative). On a synced " +
+            '(non-manual) bank transaction the next institution sync may revert it; ' +
+            'manual-account transactions persist.',
         },
       },
       required: ['transaction_id'],
@@ -522,14 +497,14 @@ const BULK_EDIT_ITEM_PROPERTIES = {
   account_id: {
     type: 'string',
     description:
-      'Optional. Account ID the transaction belongs to (from a live read). Pass together with ' +
-      'item_id to skip local resolution and edit a transaction outside the resolution window.',
+      'Optional. Pass with item_id (both from a live read) to skip local resolution and edit ' +
+      'a transaction outside the resolution window.',
   },
   item_id: {
     type: 'string',
     description:
-      "Optional. Item ID the account belongs to (Copilot's Firestore item_id, from a live read). " +
-      'Pass together with account_id.',
+      "Optional. Item ID the account belongs to (Copilot's Firestore item_id, from a live " +
+      'read). Pass with account_id.',
   },
   name: { type: 'string', description: 'New display name. Must not be empty.' },
   category_id: {
@@ -546,21 +521,20 @@ const BULK_EDIT_ITEM_PROPERTIES = {
     type: 'string',
     enum: ['REGULAR', 'INCOME', 'INTERNAL_TRANSFER'],
     description:
-      'High-level classification. INCOME/INTERNAL_TRANSFER clear the category server-side — ' +
-      'do not pass category_id with them.',
+      'High-level classification. INCOME/INTERNAL_TRANSFER clear the category server-side.',
   },
   reviewed: { type: 'boolean', description: 'Mark this transaction reviewed/un-reviewed.' },
   date: {
     type: 'string',
     description:
-      'New transaction date in YYYY-MM-DD. May be reverted by the next institution sync on a ' +
-      'synced (non-manual) transaction.',
+      'New date, YYYY-MM-DD. May be reverted by the next institution sync on a synced ' +
+      '(non-manual) transaction.',
   },
   amount: {
     type: 'number',
     description:
-      "New signed amount, using Copilot's stored sign (income is negative). May be reverted by " +
-      'the next institution sync on a synced (non-manual) transaction.',
+      "New signed amount, Copilot's stored sign (income is negative). May be reverted by the " +
+      'next institution sync on a synced (non-manual) transaction.',
   },
 } as const;
 
@@ -569,30 +543,17 @@ export const updateTransactionsTool = defineTool({
     name: 'update_transactions',
     description:
       'Apply many DIFFERENT transaction edits in ONE call — the per-row bulk form of ' +
-      'update_transaction. Use this when the target rows need DIFFERENT values from each ' +
-      'other, or when the edit touches name, note, date or amount (Copilot cannot bulk-edit ' +
-      'those four at all). If every target gets the IDENTICAL change and it only touches ' +
-      'category/type/reviewed, or adds/removes a tag, prefer bulk_edit_transactions — that is ' +
-      "ONE request instead of N. WARNING on tags: an entry's tag_ids REPLACES that row's " +
-      'whole tag list, so using it to add a trip tag silently drops any tags the row already ' +
-      'had; to add or remove a tag across many rows while keeping their existing tags, use ' +
-      'bulk_edit_transactions with add_tag_ids / remove_tag_ids. ' +
-      'Each entry in `edits` takes the same fields as update_transaction ' +
-      '(transaction_id plus any of name, category_id, note, tag_ids, type, reviewed, date, ' +
-      'amount), and each is validated identically — including the rule that category_id cannot ' +
-      'be combined with type INCOME or INTERNAL_TRANSFER. Entries are independent: different ' +
-      'transactions may change different fields. Two entries for the SAME transaction_id are ' +
-      'rejected — combine them into one entry. Max 200 edits per call; split larger jobs. ' +
-      'ALL validation and ID resolution happen before the first write, so a malformed entry ' +
-      'anywhere in the batch fails the call without writing anything. Writes then go out via ' +
-      'GraphQL with a cap of 5 in flight. `continue_on_error` (default false) controls write ' +
-      'failures only: false stops the batch at the first failure and throws with a count of what ' +
-      'succeeded; true attempts every edit and returns the failures in `failures[]`. With ' +
-      'continue_on_error the response`s `updated_count` and `results[]` reflect exactly what ' +
-      'was written, so retry `failures[]` rather than the whole batch; in the default mode the ' +
-      'call throws instead, and since every edit is an absolute assignment it is safe to ' +
-      're-run the whole batch. For marking many transactions reviewed and nothing else, ' +
-      'review_transactions is cheaper.',
+      'update_transaction. Use it when rows need different values, or the edit touches name, ' +
+      'note, date, or amount (Copilot cannot bulk-edit those four); for one IDENTICAL change ' +
+      'to category/type/reviewed or a tag add/remove, prefer bulk_edit_transactions (ONE ' +
+      "request instead of N). WARNING: an entry's tag_ids REPLACES that row's whole tag " +
+      'list, silently dropping existing tags — to add/remove a tag while keeping the rest, ' +
+      'use bulk_edit_transactions add_tag_ids/remove_tag_ids. Entries are independent and ' +
+      "take update_transaction's fields and validation, including: no category_id with type " +
+      'INCOME/INTERNAL_TRANSFER. ALL validation and ID resolution run before the first ' +
+      'write — a malformed entry anywhere fails the call with nothing written; writes then ' +
+      'go via GraphQL, max 5 in flight. Every edit is an absolute assignment, so re-running ' +
+      'a failed batch is safe. For review-only bulk changes, review_transactions is cheaper.',
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -605,8 +566,9 @@ export const updateTransactionsTool = defineTool({
           minItems: 1,
           maxItems: 200,
           description:
-            'The edits to apply, one entry per transaction. Non-empty, max 200, no duplicate ' +
-            'transaction_ids.',
+            'The edits to apply, one entry per transaction. Non-empty, max 200 per call ' +
+            '(split larger jobs), no duplicate transaction_ids (combine same-row edits into ' +
+            'one entry).',
           items: {
             type: 'object',
             additionalProperties: false,
@@ -617,9 +579,11 @@ export const updateTransactionsTool = defineTool({
         continue_on_error: {
           type: 'boolean',
           description:
-            'When true, attempt every edit and report per-entry write failures in `failures[]` ' +
-            'instead of stopping at the first one. Defaults to false. Does not affect validation ' +
-            'errors, which always fail the whole call before any write.',
+            'Controls write failures only (validation errors always fail the whole call ' +
+            'before any write). false (default): stop at the first failed write and throw ' +
+            'with a count of what succeeded. true: attempt every edit; failures land in ' +
+            '`failures[]` while `updated_count`/`results[]` reflect exactly what was ' +
+            'written — retry `failures[]`, not the whole batch.',
         },
       },
       required: ['edits'],
@@ -639,15 +603,13 @@ export const reviewTransactionsTool = defineTool({
   schema: {
     name: 'review_transactions',
     description:
-      'Bulk mark transactions as reviewed (or unreviewed). Two modes: pass `transaction_ids` ' +
-      '(ids are resolved locally, so this only works for transactions within the resolution ' +
-      'window), OR pass `rows` — an array of {transaction_id, account_id, item_id} taken from a ' +
-      'live read — to review ANY transactions, including out-of-window historical/backlog rows. ' +
-      'Prefer `rows` for large backlog sweeps: it is the true bulk path. One of the two must be ' +
-      'provided; `rows` wins when both are. The whole set is applied in ONE GraphQL request, so ' +
-      'reviewing 200 transactions costs one round trip. If the server rejects or silently skips ' +
-      'any row the call throws, naming the affected ids; `reviewed_count` reflects what actually ' +
-      'landed.',
+      'Bulk mark transactions as reviewed (or unreviewed). Pass `transaction_ids` (resolved ' +
+      'locally — works only within the resolution window) OR `rows` — an array of ' +
+      '{transaction_id, account_id, item_id} from a live read that works for ANY ' +
+      'transactions, including out-of-window backlog; prefer `rows` for large sweeps. One of ' +
+      'the two is required; `rows` wins when both are given. The whole set is applied in ONE ' +
+      'GraphQL request. If the server rejects or silently skips any row the call throws, ' +
+      'naming the affected ids; `reviewed_count` reflects what actually landed.',
     inputSchema: {
       type: 'object',
       // Matches every other write tool (and bulk_edit_transactions); this was
@@ -658,14 +620,14 @@ export const reviewTransactionsTool = defineTool({
           type: 'array',
           items: { type: 'string' },
           description:
-            'Transaction IDs to mark as reviewed. Resolved locally — fails for transactions ' +
-            'outside the resolution window; use `rows` for those.',
+            'Transaction IDs to mark. Resolved locally — fails outside the resolution window; ' +
+            'use `rows` for those.',
         },
         rows: {
           type: 'array',
           description:
             'Bypass path: each entry supplies the IDs the GraphQL mutation needs directly ' +
-            '(from a live read), so out-of-window transactions work without local resolution.',
+            '(from a live read), so no local resolution.',
           items: {
             type: 'object',
             additionalProperties: false,
@@ -676,7 +638,7 @@ export const reviewTransactionsTool = defineTool({
               },
               account_id: {
                 type: 'string',
-                description: 'Account ID the transaction belongs to (from the live row)',
+                description: 'Account ID from the live row',
               },
               item_id: {
                 type: 'string',
@@ -709,14 +671,14 @@ const BULK_TARGET_PROPERTIES = {
     type: 'array',
     items: { type: 'string' },
     description:
-      'Transaction IDs to edit. Resolved locally — fails for transactions outside the ' +
-      'resolution window; use `rows` for those.',
+      'Transaction IDs to edit. Resolved locally — fails outside the resolution window; ' +
+      'use `rows` for those.',
   },
   rows: {
     type: 'array',
     description:
       'Bypass path: each entry supplies the IDs the GraphQL mutation needs directly (from a ' +
-      'live read), so out-of-window transactions work without local resolution.',
+      'live read), so no local resolution.',
     items: {
       type: 'object',
       additionalProperties: false,
@@ -724,7 +686,7 @@ const BULK_TARGET_PROPERTIES = {
         transaction_id: { type: 'string', description: 'Transaction ID to edit' },
         account_id: {
           type: 'string',
-          description: 'Account ID the transaction belongs to (from the live row)',
+          description: 'Account ID from the live row',
         },
         item_id: {
           type: 'string',
@@ -741,21 +703,16 @@ export const bulkEditTransactionsTool = defineTool({
     name: 'bulk_edit_transactions',
     description:
       "Apply the SAME edit to MANY transactions in ONE request — Copilot's native bulk-edit " +
-      'endpoint, the one its own multi-select UI uses. Use this when every target gets the ' +
-      'identical change: recategorizing a merchant across months, tagging a trip, marking a ' +
-      'batch reviewed. Targets come from `transaction_ids` (resolved locally) or `rows` ' +
-      '(from a live read, works for out-of-window transactions); `rows` wins when both are ' +
-      'given. At least one of category_id, type, reviewed, add_tag_ids, remove_tag_ids must ' +
-      'be provided. If rows need DIFFERENT values from each other, or the edit touches ' +
-      'name/note/date/amount, use update_transactions instead. ' +
-      'IMPORTANT LIMITS: (1) One edit for the whole set — to give different ' +
-      'transactions different values, make separate calls. (2) Copilot supports ONLY these ' +
-      'five fields in bulk; `name`, `date`, `amount` and `note` are NOT bulk-editable, use ' +
-      'update_transaction for those. (3) Tags are add/remove, not replace — there is no bulk ' +
-      '"set the tag list" operation; use update_transaction`s tag_ids to replace. ' +
-      'type INCOME or INTERNAL_TRANSFER clears the category server-side, so it cannot be ' +
-      'combined with category_id. Max 500 targets per call. All ids are validated before the ' +
-      'write because Copilot does NOT validate them server-side. If any row is rejected or ' +
+      'endpoint (the one its multi-select UI uses) — e.g. recategorizing a merchant, tagging ' +
+      'a trip, marking a batch reviewed. Targets: `transaction_ids` (resolved locally) or ' +
+      '`rows` (from a live read; works out-of-window); `rows` wins if both are given. ' +
+      'Requires at least one of category_id, type, reviewed, add_tag_ids, remove_tag_ids — ' +
+      'Copilot bulk-edits ONLY these five fields. For different values per target, or ' +
+      'name/note/date/amount edits, use update_transactions instead. Tags are add/remove ' +
+      "only, never replace (to set a row's whole tag list use update_transaction tag_ids). " +
+      'type INCOME/INTERNAL_TRANSFER clears the category server-side — cannot be combined ' +
+      'with category_id. Max 500 targets per call. All ids are validated before the write ' +
+      'because Copilot does NOT validate them server-side; if any row is rejected or ' +
       'silently skipped the call throws and names it.',
     inputSchema: {
       type: 'object',
@@ -764,16 +721,12 @@ export const bulkEditTransactionsTool = defineTool({
         ...BULK_TARGET_PROPERTIES,
         category_id: {
           type: 'string',
-          description:
-            'Category ID to assign to every target (from get_categories results). Cannot be ' +
-            'combined with type INCOME or INTERNAL_TRANSFER.',
+          description: 'Category ID to assign to every target (from get_categories results).',
         },
         type: {
           type: 'string',
           enum: ['REGULAR', 'INCOME', 'INTERNAL_TRANSFER'],
-          description:
-            'Classification to apply to every target. INCOME/INTERNAL_TRANSFER clear the ' +
-            'category server-side.',
+          description: 'Classification to apply to every target.',
         },
         reviewed: {
           type: 'boolean',

--- a/tests/context-budget.test.ts
+++ b/tests/context-budget.test.ts
@@ -74,7 +74,7 @@ const SCHEMA_BUDGETS: Record<string, number> = {
   get_balance_history: 1_395,
   get_goal_history: 1_040,
   // Live (--live-reads) tools
-  get_transactions_live: 4_400,
+  get_transactions_live: 3_890,
   get_accounts_live: 570,
   get_categories_live: 1_555,
   get_tags_live: 530,
@@ -85,21 +85,21 @@ const SCHEMA_BUDGETS: Record<string, number> = {
   get_monthly_spend_live: 1_235,
   get_holdings_live: 1_210,
   get_balance_history_live: 1_800,
-  get_investment_prices_live: 2_255,
+  get_investment_prices_live: 1_835,
   get_investment_allocation_live: 810,
   get_top_movers_live: 1_175,
   get_aggregated_holdings_live: 1_285,
   get_investment_balance_live: 1_110,
   refresh_cache: 1_335,
   // Write (--write) tools
-  create_transaction: 2_270,
+  create_transaction: 1_980,
   delete_transaction: 1_205,
   add_transaction_to_recurring: 1_305,
-  split_transaction: 2_675,
-  update_transaction: 4_265,
-  update_transactions: 4_760,
-  review_transactions: 2_035,
-  bulk_edit_transactions: 3_550,
+  split_transaction: 2_300,
+  update_transaction: 2_815,
+  update_transactions: 3_735,
+  review_transactions: 1_760,
+  bulk_edit_transactions: 2_910,
   create_tag: 900,
   delete_tag: 435,
   create_category: 1_340,
@@ -109,12 +109,12 @@ const SCHEMA_BUDGETS: Record<string, number> = {
   set_recurring_state: 795,
   delete_recurring: 520,
   update_tag: 845,
-  create_recurring: 1_965,
-  update_recurring: 2_320,
+  create_recurring: 1_845,
+  update_recurring: 2_020,
 };
 
 /** Aggregate schema budget across ALL registered tools (measured +~10%). */
-const SCHEMA_TOTAL_BUDGET = 76_000;
+const SCHEMA_TOTAL_BUDGET = 71_000;
 
 // ---------------------------------------------------------------------------
 // Synthetic fixture. Deterministic content, opaque Firestore-shaped IDs


### PR DESCRIPTION
# Summary

Tier-3 of the context diet (#597): the base tool schemas load into every MCP session, so this PR compresses the largest tool descriptions. Pure compression, not a content cut — every behavioral constraint, required-arg relationship, enum meaning, footgun warning, and cross-tool reference survives; what went was redundant restatements, numbered-list scaffolding, and facts duplicated between a tool description and its own parameter descriptions (each fact now lives once, in the more specific place). Part of #597.

## External assumptions

None — this PR only rewords our own tool descriptions; no new claims about Copilot's API or data.

## Per-tool schema size (chars, `JSON.stringify(def.schema).length`)

| Tool | Before | After | Δ |
|---|---:|---:|---:|
| update_transactions | 4324 | 3394 | -21.5% |
| get_transactions_live | 3999 | 3536 | -11.6% |
| update_transaction | 3876 | 2559 | -34.0% |
| bulk_edit_transactions | 3226 | 2642 | -18.1% |
| split_transaction | 2428 | 2091 | -13.9% |
| update_recurring | 2106 | 1833 | -13.0% |
| create_transaction | 2061 | 1796 | -12.9% |
| get_investment_prices_live | 2050 | 1668 | -18.6% |
| review_transactions | 1847 | 1599 | -13.4% |
| create_recurring (bonus) | 1785 | 1673 | -6.3% |
| **TOTAL (all 51 registered schemas)** | **69328** | **64417** | **-7.1%** |

Schema chars include the fixed JSON scaffolding (property names, types, enums), which caps the achievable percentage — the description-text cuts themselves are considerably deeper (e.g. update_transaction's description went from ~1.7K to ~0.6K chars by moving per-field facts into the field descriptions that already restated them).

`create_recurring` was not on the target list but shared a verbatim-duplicated frequency-enum blurb with `update_recurring`; both now use one `FREQUENCY_DESCRIPTION` constant that keeps only the non-obvious cadences (BIWEEKLY/BIMONTHLY/QUADMONTHLY/SEMIANNUALLY) spelled out.

## Deliberately kept despite length

- bulk_edit's silent-skip + no-server-side-referential-validation warnings, the five-bulk-editable-fields limit, and tags-are-add/remove-never-replace.
- update_transactions' tag_ids-REPLACES-the-tag-list warning and the routing guidance between update_transaction / update_transactions / bulk_edit_transactions / review_transactions.
- The category_id × type INCOME/INTERNAL_TRANSFER server-side category-clearing rule (in every tool that accepts `type`).
- get_transactions_live's single-lookup triple (transaction_id + account_id + item_id) + date-bounds requirement, and its full unsupported-filter list.
- The institution-sync-may-revert caveat on date/amount edits, the split-transaction no-reversal/undo procedure, and the investment-prices ownership gate + priced-days-not-calendar-days counting note.

## Excluded

Cache-mode `get_transactions` is untouched (its description is being rewritten in #593); measured 3764 chars before and after.

## Mechanics

- `bun run sync-manifest` ran clean (manifest embeds only cache-mode read tools; no changes needed).
- `SCHEMA_BUDGETS` entries for the dieted tools + `SCHEMA_TOTAL_BUDGET` (76,000 → 71,000) re-derived downward at measured +~10% per the ratchet convention. RESPONSE_BUDGETS untouched.
- `bun run check` fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
