### PR TITLE
fix(budgets): anchor live budget windows to current month (#598)

### DIFF
--- a/scripts/smoke/budgets.ts
+++ b/scripts/smoke/budgets.ts
@@ -8,6 +8,7 @@
  *   2. Warm call (within TTL) returns _cache_hit=true with sub-50ms latency
  *   3. refresh_cache --scope budgets invalidates categoriesCache (the alias)
  *      and triggers a refetch on the next get_budgets_live call
+ *   4. months_window=1 anchors to the current month, not future projection rows
  *
  * Exits non-zero on any assertion failure. Output is intended to be pasted
  * into the PR description.
@@ -33,6 +34,19 @@ async function main(): Promise<void> {
   log('cold', { rows: cold.count, total: cold.total_budgeted, hit: cold._cache_hit, ms: coldMs });
   if (cold._cache_hit !== false) throw new Error(`expected cold _cache_hit=false`);
   if (cold.count === 0) throw new Error('expected at least one budget');
+
+  const now = new Date();
+  const currentMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+  const currentWindow = await tools.getBudgets({ months_window: 1 });
+  const offAnchor = currentWindow.budgets
+    .flatMap((budget) => Object.keys(budget.amounts ?? {}))
+    .filter((month) => month !== currentMonth);
+  log('months_window=1', { currentMonth, offAnchor: offAnchor.length });
+  if (offAnchor.length > 0) {
+    throw new Error(
+      `months_window=1 returned non-current budget months: ${[...new Set(offAnchor)].join(', ')}`
+    );
+  }
 
   // 2. Warm
   const t1 = Date.now();

--- a/src/conformance/ledger.ts
+++ b/src/conformance/ledger.ts
@@ -287,13 +287,14 @@ function queryOperation(name: string): LedgerEntry {
  * passed here MUST have a matching QUERY_RESPONSE_SCHEMAS entry — enforced
  * bidirectionally by tests/conformance/ledger.test.ts.
  */
-function gatedQueryResponseShape(name: string): LedgerEntry {
+function gatedQueryResponseShape(name: string, overrides?: Partial<LedgerEntry>): LedgerEntry {
   return {
     surface: `Query.${name}:response`,
     kind: 'response-shape',
     oracle: `runtime:${READ_RESPONSE_SHAPE_RUNTIME_CHECK}`,
     class: 'gated',
     evidence: READ_RESPONSE_SHAPE_GATED,
+    ...overrides,
   };
 }
 
@@ -766,7 +767,13 @@ export const CONFORMANCE_LEDGER: readonly LedgerEntry[] = [
       'surfaced via _dropped_invalid_rows + a deduped stderr warning.',
   },
   queryOperation('categories'),
-  gatedQueryResponseShape('categories'),
+  gatedQueryResponseShape('categories', {
+    evidence:
+      READ_RESPONSE_SHAPE_GATED +
+      '; budget.month ordering/anchoring is guarded by get_budgets_live synthetic tests ' +
+      '(tests/tools/live/budgets.test.ts, issue #598) and the budgets live smoke ' +
+      '(scripts/smoke/budgets.ts).',
+  }),
   queryOperation('tags'),
   gatedQueryResponseShape('tags'),
   queryOperation('recurrings'),

--- a/src/tools/live/budgets.ts
+++ b/src/tools/live/budgets.ts
@@ -43,23 +43,36 @@ export interface GetBudgetsLiveResult {
   _cache_hit: boolean;
 }
 
+function currentMonthKey(now = new Date()): string {
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function monthIndex(month: string): number {
+  const parts = month.split('-');
+  const year = Number(parts[0]);
+  const monthNumber = Number(parts[1]);
+  return year * 12 + monthNumber - 1;
+}
+
 /**
- * Return a trimmed amounts map containing only the most recent N months
- * by lexicographic key order. `YYYY-MM` keys sort chronologically, so this
- * is equivalent to "trailing N months" for normal data. The function does
- * NOT consult the current date; if the input contains future-dated keys
- * (e.g., projected budgets), they win the trailing-N selection. If the
- * input has fewer than N months, returns the input unchanged.
+ * Return a trimmed amounts map containing only the current month plus the
+ * preceding N-1 calendar months. Copilot can return future budget months
+ * (scheduled/rollover projections), so anchoring to the last payload key would
+ * return future amounts for callers asking for the current budget window.
  */
 function trimAmountsToWindow(
   amounts: Record<string, number>,
   windowMonths: number
 ): Record<string, number> {
+  const maxMonth = monthIndex(currentMonthKey());
+  const minMonth = maxMonth - windowMonths + 1;
   const keys = Object.keys(amounts).sort();
-  if (keys.length <= windowMonths) return amounts;
-  const kept = keys.slice(-windowMonths);
   const trimmed: Record<string, number> = {};
-  for (const k of kept) trimmed[k] = amounts[k]!;
+  for (const k of keys) {
+    const idx = monthIndex(k);
+    const amount = amounts[k];
+    if (amount !== undefined && idx >= minMonth && idx <= maxMonth) trimmed[k] = amount;
+  }
   return trimmed;
 }
 
@@ -167,7 +180,7 @@ export function createLiveBudgetsToolSchema(): ToolSchema {
           type: 'integer',
           minimum: 0,
           description:
-            "Number of trailing months to include in each budget's `amounts` map. " +
+            "Number of trailing months, anchored to the current month, to include in each budget's `amounts` map. " +
             'Default: 12. Set to 0 to return the full multi-year history (large response).',
           default: 12,
         },

--- a/tests/tools/live/budgets.test.ts
+++ b/tests/tools/live/budgets.test.ts
@@ -4,6 +4,33 @@ import { CopilotDatabase } from '../../../src/core/database.js';
 import { LiveCopilotDatabase } from '../../../src/core/live-database.js';
 import { LiveBudgetsTools } from '../../../src/tools/live/budgets.js';
 
+async function withMockedDate<T>(dateString: string, run: () => Promise<T>): Promise<T> {
+  const originalDate = Date;
+  const fixedDate = new originalDate(dateString);
+
+  // @ts-expect-error - Mocking global Date in a narrow test scope.
+  globalThis.Date = class extends originalDate {
+    constructor(...args: any[]) {
+      if (args.length === 0) {
+        super(fixedDate.getTime());
+      } else {
+        // @ts-expect-error - Date constructor overloads are preserved at runtime.
+        super(...args);
+      }
+    }
+
+    static now() {
+      return fixedDate.getTime();
+    }
+  };
+
+  try {
+    return await run();
+  } finally {
+    globalThis.Date = originalDate;
+  }
+}
+
 function makeClient(categoriesResponse: unknown[]): GraphQLClient {
   return {
     query: mock(() => Promise.resolve({ categories: categoriesResponse })),
@@ -185,17 +212,19 @@ describe('LiveBudgetsTools.getBudgets', () => {
   });
 
   test('regression C4: default months_window=12 trims amounts to exactly 12 entries', async () => {
-    // 24-month fixture; default trim should return exactly the trailing 12.
-    const client = makeClient([makeRestaurantsCategory(24)]);
-    const live = makeLive(client);
-    await prewarmUserCacheRolloversOff(live);
-    const tools = new LiveBudgetsTools(live);
+    await withMockedDate('2026-05-15T12:00:00Z', async () => {
+      // 24-month fixture; default trim should return exactly the trailing 12.
+      const client = makeClient([makeRestaurantsCategory(24)]);
+      const live = makeLive(client);
+      await prewarmUserCacheRolloversOff(live);
+      const tools = new LiveBudgetsTools(live);
 
-    const result = await tools.getBudgets({});
+      const result = await tools.getBudgets({});
 
-    const restaurants = result.budgets.find((b) => b.category_id === 'cat-restaurants');
-    expect(restaurants?.amounts).toBeDefined();
-    expect(Object.keys(restaurants?.amounts ?? {}).length).toBe(12);
+      const restaurants = result.budgets.find((b) => b.category_id === 'cat-restaurants');
+      expect(restaurants?.amounts).toBeDefined();
+      expect(Object.keys(restaurants?.amounts ?? {}).length).toBe(12);
+    });
   });
 
   test('regression C4: months_window=0 returns all amounts', async () => {
@@ -212,20 +241,65 @@ describe('LiveBudgetsTools.getBudgets', () => {
   });
 
   test('regression C4: explicit months_window trims to that exact count', async () => {
-    // 24-month fixture, custom window of 3 — covers a non-boundary value
-    // (neither the default 12 nor the opt-out sentinel 0).
-    const client = makeClient([makeRestaurantsCategory(24)]);
-    const live = makeLive(client);
-    await prewarmUserCacheRolloversOff(live);
-    const tools = new LiveBudgetsTools(live);
+    await withMockedDate('2026-05-15T12:00:00Z', async () => {
+      // 24-month fixture, custom window of 3 — covers a non-boundary value
+      // (neither the default 12 nor the opt-out sentinel 0).
+      const client = makeClient([makeRestaurantsCategory(24)]);
+      const live = makeLive(client);
+      await prewarmUserCacheRolloversOff(live);
+      const tools = new LiveBudgetsTools(live);
 
-    const result = await tools.getBudgets({ months_window: 3 });
+      const result = await tools.getBudgets({ months_window: 3 });
 
-    const restaurants = result.budgets.find((b) => b.category_id === 'cat-restaurants');
-    const keys = Object.keys(restaurants?.amounts ?? {}).sort();
-    expect(keys.length).toBe(3);
-    // The trailing 3 months ending at 2026-05 are 2026-03, 2026-04, 2026-05.
-    expect(keys).toEqual(['2026-03', '2026-04', '2026-05']);
+      const restaurants = result.budgets.find((b) => b.category_id === 'cat-restaurants');
+      const keys = Object.keys(restaurants?.amounts ?? {}).sort();
+      expect(keys.length).toBe(3);
+      // The trailing 3 months ending at 2026-05 are 2026-03, 2026-04, 2026-05.
+      expect(keys).toEqual(['2026-03', '2026-04', '2026-05']);
+    });
+  });
+
+  test('regression #598: months_window=1 anchors to current month, not future payload tail', async () => {
+    await withMockedDate('2026-05-15T12:00:00Z', async () => {
+      const cat = {
+        ...sampleCategoryWithBudget,
+        budget: {
+          current: {
+            ...sampleCategoryWithBudget.budget.current,
+            amount: 500,
+            month: '2026-05',
+          },
+          histories: [
+            {
+              ...sampleCategoryWithBudget.budget.histories[0],
+              amount: 400,
+              month: '2026-04',
+              id: 'budget-food-2026-04',
+            },
+            {
+              ...sampleCategoryWithBudget.budget.histories[0],
+              amount: 600,
+              month: '2026-06',
+              id: 'budget-food-2026-06',
+            },
+            {
+              ...sampleCategoryWithBudget.budget.histories[0],
+              amount: 700,
+              month: '2026-07',
+              id: 'budget-food-2026-07',
+            },
+          ],
+        },
+      };
+      const client = makeClient([cat]);
+      const live = makeLive(client);
+      await prewarmUserCacheRolloversOff(live);
+      const tools = new LiveBudgetsTools(live);
+
+      const result = await tools.getBudgets({ months_window: 1 });
+
+      expect(result.budgets[0]?.amounts).toEqual({ '2026-05': 500 });
+    });
   });
 
   test('handles category with budget.current present but current.amount=null', async () => {


### PR DESCRIPTION
## Summary

Fix `get_budgets_live` month window selection so that `months_window` is anchored to the current month instead of selecting the last entries from the payload.

This prevents future projected budget months from incorrectly replacing the current budgeting period.

## Changes

- Update live budget window trimming logic to use the current month as the anchor.
- Preserve existing `months_window: 0` behavior for full history output.
- Add regression coverage for payloads containing past, current, and future months.
- Add smoke and conformance coverage for the month anchoring assumption.

## Testing

Verified with:

- `bun test tests/tools/live/budgets.test.ts tests/conformance/ledger.test.ts tests/scripts/read-smoke-coverage.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun test tests/integration/mcpb-bundle.test.ts`
- `bun run check`

Fixes #598

---

## External assumptions

**None new.** This corrects how an already-fetched payload is windowed; it adds no new assumption about Copilot's API or data.

It does make an existing, previously-unstated assumption explicit and wrong-proof: Copilot's `categories` response **can contain future-dated budget months** (scheduled/rollover projections). The old code implicitly assumed it could not. That is now recorded as an evidence note on the existing `Query.categories:response` ledger entry rather than as a new entry, since the response *shape* is unchanged — only our reading of it was wrong. Guarded by `tests/tools/live/budgets.test.ts` and a new assertion in `scripts/smoke/budgets.ts`.

## Bug fix?

```text
Root cause:       trimAmountsToWindow picked the trailing N keys by lexicographic order
                  from the payload and never consulted the clock. Copilot returns
                  future-dated budget months, so those won the trailing-N selection and
                  displaced the current month — "the last 12 keys we were sent" is not
                  "the last 12 months".
Bug class:        Proposing a new one: `data-relative-anchoring` — deriving a "current"
                  reference point from the extent of returned data instead of from an
                  external truth (here, the clock). Safe exactly while the data happens
                  to end where the caller assumes it does.
Detector added:   Instance-level only, honestly. Unit tests pin the anchoring against a
                  mocked clock (which is what makes them deterministic rather than
                  passing by luck of the calendar), and scripts/smoke/budgets.ts gains a
                  4th assertion that months_window=1 returns the current month against
                  the live backend. There is NO class-level gate for "windows anchored to
                  data rather than to now" — see below.
Siblings checked: One other trailing-N site examined: `sortedTxns.slice(-5)` in
                  get_recurring_transactions (src/tools/tools.ts). NOT an instance — it
                  samples the most recent N of what exists rather than claiming a window
                  relative to now, so there is no anchor to get wrong. No other
                  data-anchored windows found in src/.
Ledger updated:   Yes — evidence note added to the Query.categories:response entry
                  (src/conformance/ledger.ts), recording that month ordering/anchoring is
                  now guarded by the budgets tests and live smoke.
```

### Maintainer note

Sections filled in by @ignaciohermosillacornejo a week after the code was ready, so a correct live fix wasn't held up by paperwork the contributor hadn't been asked for when they opened it. The class name above is my proposal, not the contributor's — if `data-relative-anchoring` earns a second instance it should get an entry in [`docs/bugs/`](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/tree/main/docs/bugs); one instance is an accident.

Worth noting the fix's own detector is the interesting gap: the unit tests only became meaningful once the clock was mocked. Before that they'd have passed or failed depending on when in the year CI ran — a test whose correctness is seasonal is a close cousin of a vacuous one.
