### PR TITLE
chore(decoder): acknowledge tags._migration_backfill drift (#608)

### DIFF
--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -1910,7 +1910,13 @@ function processTag(fields: Map<string, FirestoreValue>, docId: string): Tag | n
     fields,
     {
       consumed: [...stringFields],
-      ignored: [],
+      ignored: [
+        // Server-side migration marker (#608). Raw-cache inspection
+        // 2026-08-02: boolean, always `true` when present, on 10 of 11
+        // non-tombstone tag docs. Underscore-prefixed bookkeeping flag with
+        // no user-meaningful content — acknowledged, not exposed.
+        '_migration_backfill',
+      ],
     },
     { collection: 'tags', docId }
   );

--- a/tests/core/decoder-coverage.test.ts
+++ b/tests/core/decoder-coverage.test.ts
@@ -1816,6 +1816,47 @@ describe('decoder coverage', () => {
       expect(result.tags[0]?.hex_color).toBe('#0000FF');
     });
 
+    test('tags._migration_backfill is acknowledged but a future unknown field still warns', async () => {
+      // #608: Copilot ships a server-side `_migration_backfill: true` marker
+      // on tag docs. It is on the processor's `ignored` list, so it must not
+      // warn — but the warn system must stay armed for the NEXT drift, so an
+      // unknown sibling field on the same collection must still fire.
+      const dbPath = path.join(FIXTURES_DIR, 'tags-migration-backfill-db');
+      await createTestDatabase(dbPath, [
+        {
+          collection: 'users/user1/tags',
+          id: 'tag-ack',
+          fields: {
+            name: 'Travel',
+            hex_color: '#0000FF',
+            _migration_backfill: true,
+          },
+        },
+        {
+          collection: 'users/user1/tags',
+          id: 'tag-drift',
+          fields: {
+            name: 'Trips',
+            hex_color: '#00FF00',
+            _some_future_field: true,
+          },
+        },
+      ]);
+
+      const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        __resetWarnedKeys();
+        await decodeAllCollections(dbPath);
+        const unreadTagWarns = warnSpy.mock.calls
+          .map((call) => String(call[0] ?? ''))
+          .filter((msg) => msg.includes('collection=tags') && msg.includes('unread field'));
+        expect(unreadTagWarns.some((msg) => msg.includes('field=_migration_backfill'))).toBe(false);
+        expect(unreadTagWarns.some((msg) => msg.includes('field=_some_future_field'))).toBe(true);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     test('decodes balance history via decodeAllCollections', async () => {
       const dbPath = path.join(FIXTURES_DIR, 'balance-hist-db');
       await createDeepTestDatabase(dbPath, [


### PR DESCRIPTION
# Summary

A real-cache scan (2026-08-02, during #607 review) surfaced new Copilot-side drift since the #317 zero-unread-fields baseline: `collection=tags field=_migration_backfill` present in cached tag docs but unread by the tags processor. Raw inspection shows a server-side migration marker; this PR acknowledges it on the tags processor's `ignored` list (read-and-ignore) and re-establishes zero unread fields on tags. Closes #608

## Raw-cache observations (types/shapes only, no user data)

- 18 tag docs in the cache; 7 are empty tombstone docs (no fields)
- 10 of the 11 non-tombstone tag docs carry `_migration_backfill`
- Wire type: boolean; value is always `true` when present (10 of 10)
- Field-name sets observed across tag docs: subsets of `name`, `hex_color`, `color_name`, `_migration_backfill` only — no other new fields

## Decision: read-and-ignore

Underscore-prefixed server-side bookkeeping flag with no user-meaningful content, so it is acknowledged in `warnUnreadFields`' `ignored` list (same pattern #317 used for `transactions.location` / `intelligence_category_scores`) rather than exposed on the `Tag` model. Not user-visible, so no CHANGELOG entry.

## Warn system stays armed

The acknowledgment is field-specific, not collection-wide. New test feeds the tags processor a doc with `_migration_backfill` (suppressed) and a doc with an unknown sibling field (still warns) — a FUTURE new unread field on tags is still caught.

Verified against the real cache: re-running `decodeAllCollections` over the live LevelDB reports zero unread-field warnings for tags.

## Siblings

The verification scan showed this drift is a class, not an instance: the same `_migration_backfill` marker (plus a sibling `_replicated_at`) landed on ~11 other collections, and `user_profile` gained 2 genuinely new fields. Filed as #611 with the full per-collection breakdown; this PR stays scoped to the tags instance from #608.

## External assumptions

- `tags._migration_backfill` is a server-side migration/backfill marker carrying no user-meaningful data (boolean, always `true` when present; on 10 of 11 non-tombstone tag docs). Evidence class: **probe transcript** — read-only raw cache inspection of the local LevelDB on 2026-08-02/03; observations limited to field names, wire types, and presence counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
