### PR TITLE
fix: make privacy comment stripping syntax-aware

### DIFF
--- a/scripts/check-privacy-endpoints.ts
+++ b/scripts/check-privacy-endpoints.ts
@@ -45,6 +45,7 @@
 import { readFileSync, readdirSync, statSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import ts from 'typescript';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // CHECK_PRIVACY_ENDPOINTS_ROOT lets tests point the checker at a synthetic
@@ -76,9 +77,43 @@ function sourceFiles(dir: string): string[] {
   return out;
 }
 
-/** Strip // and block comments so @see links don't read as live destinations. */
+/**
+ * Strip actual TypeScript comments so @see links do not read as destinations.
+ * Parser-owned ranges keep comment-like text in strings, templates, and regexes.
+ */
 function stripComments(src: string): string {
-  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const sourceFile = ts.createSourceFile(
+    'privacy-endpoints.ts',
+    src,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+  const comments = new Map<string, ts.CommentRange>();
+  const collect = (ranges: readonly ts.CommentRange[] | undefined): void => {
+    for (const range of ranges ?? []) comments.set(`${range.pos}:${range.end}`, range);
+  };
+
+  const nodes: ts.Node[] = [sourceFile];
+  while (nodes.length > 0) {
+    const node = nodes.pop();
+    if (node === undefined) continue;
+    collect(ts.getLeadingCommentRanges(src, node.getFullStart()));
+    collect(ts.getTrailingCommentRanges(src, node.getEnd()));
+    for (const child of node.getChildren(sourceFile)) nodes.push(child);
+  }
+
+  const out: string[] = [];
+  let cursor = 0;
+  const ranges = [...comments.values()].sort((a, b) => a.pos - b.pos || a.end - b.end);
+  for (const range of ranges) {
+    if (range.pos < cursor) continue;
+    out.push(src.slice(cursor, range.pos));
+    out.push(src.slice(range.pos, range.end).replace(/[^\r\n]/g, ' '));
+    cursor = range.end;
+  }
+  out.push(src.slice(cursor));
+  return out.join('');
 }
 
 // Matches http:// as well as https://. Nothing in src/ uses plain http today,

--- a/tests/scripts/check-privacy-endpoints.test.ts
+++ b/tests/scripts/check-privacy-endpoints.test.ts
@@ -157,6 +157,85 @@ describe('comments are not destinations', () => {
       ({ code }) => expect(code).toBe(0)
     );
   });
+
+  test('comment delimiters in separate literals do not hide traffic between them', async () => {
+    const literalPairs = [
+      [`const include = 'src/*';`, `const generated = '*/output';`],
+      [`const include = "src/*";`, `const generated = "*/output";`],
+      ['const include = `src/*`;', 'const generated = `*/output`;'],
+      [`const include = 'it\\'s /*';`, `const generated = '*/output';`],
+      [`const include = /[/*]/;`, `const generated = /[*/]/;`],
+    ];
+
+    for (const [include, generated] of literalPairs) {
+      await withTree(
+        {
+          'client.ts': [
+            include,
+            `fetch('https://telemetry.example.net/collect');`,
+            generated,
+            `fetch('https://api.example.com/graphql');`,
+          ].join('\n'),
+        },
+        'We contact https://api.example.com.',
+        ({ code, stderr }) => {
+          expect(code).toBe(1);
+          expect(stderr).toContain('telemetry.example.net');
+          expect(stderr).not.toContain('api.example.com');
+        }
+      );
+    }
+  });
+
+  test('real comments inside template expressions are still ignored', async () => {
+    await withTree(
+      {
+        'client.ts': [
+          `const value = 'shown';`,
+          'const rendered = `${value /* https://block-comment.example.net */}`; // https://line-comment.example.net',
+          `fetch('https://api.example.com/graphql');`,
+        ].join('\n'),
+      },
+      'We contact https://api.example.com.',
+      ({ code, stderr }) => {
+        expect(code).toBe(0);
+        expect(stderr).not.toContain('comment.example.net');
+      }
+    );
+  });
+
+  test('a regex containing quotes does not preserve a following block comment', async () => {
+    await withTree(
+      {
+        'client.ts': [
+          `const quote = /["']/;`,
+          `/* https://comment-only.example.net */`,
+          `fetch('https://api.example.com/graphql');`,
+        ].join('\n'),
+      },
+      'We contact https://api.example.com.',
+      ({ code, stderr }) => {
+        expect(code).toBe(0);
+        expect(stderr).not.toContain('comment-only.example.net');
+      }
+    );
+  });
+
+  test('a regex containing // does not hide traffic later on the line', async () => {
+    await withTree(
+      {
+        'client.ts': [
+          `const slash = /[//]/; fetch('https://telemetry.example.net/collect');`,
+          `fetch('https://api.example.com/graphql');`,
+        ].join('\n'),
+      },
+      'We contact https://api.example.com.',
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('telemetry.example.net');
+      }
+    );
+  });
 });
 
 describe('cleartext endpoints are caught', () => {


### PR DESCRIPTION
# Summary

- Replace whole-file regex comment stripping with TypeScript parser-owned comment ranges, preserving delimiter text inside strings, templates, and regex literals.
- Add synthetic-tree coverage for cross-literal delimiters and the template/regex siblings that a hand-written quote state can misclassify.

Closes #614

## External assumptions

None

## Bug fix?

Root cause: A whole-file block-comment regex treated delimiter-like characters inside literals as comment syntax.
Bug class: Source scanners inferring TypeScript comment boundaries without parser context.
Detector added: End-to-end synthetic-tree cases cover cross-literal delimiters across quote styles, escapes, templates, and regexes, plus actual comments inside template expressions and regex parser boundaries.
Siblings checked: Real block and line comments, single/double/template literals, escaped quotes, template expressions, regex quote/slash/block-delimiter forms, and the real repository endpoint scan.
Ledger updated: n/a — not an external-assumption bug.

## Testing

- `bun test tests/scripts/check-privacy-endpoints.test.ts` (14 passed)
- `bun run check` (2,598 passed; 20 integration tests requiring a real local database skipped)
- Mutation check: restoring the old regex makes the new cross-literal regression fail.
