### PR TITLE
docs(readme): add banner noting official MCP beta drops Plaid-connected accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@
 >
 > This project remains useful if you need write tools (categorize transactions, manage budgets, edit recurrings, etc.), fully offline cache-mode reads with zero network requests, or simply want access today without waiting for the official rollout.
 
+> [!WARNING]
+> **The official MCP beta currently does not surface Plaid-connected accounts.** Copilot's team has [confirmed the limitation](https://www.reddit.com/r/copilotmoney/comments/1ueh4lv/) and says they're working on a path forward, but there's no timeline. If most of your institutions connect through Plaid, the official MCP will give you an incomplete picture of your finances. This community server is not affected: it reads the app's full local cache (and, in live mode, the same GraphQL API the app uses), so Plaid-connected accounts are included.
+
 ## Overview
 
 An [MCP](https://modelcontextprotocol.io/) server that gives AI assistants access to your Copilot Money personal finance data. It reads from the locally cached Firestore database (LevelDB + Protocol Buffers) on your Mac. **Reads are 100% local with zero network requests.**


### PR DESCRIPTION
# Summary

Adds a small `[!WARNING]` banner to the README, right below the existing note recommending the official Copilot MCP server, stating that the official MCP beta currently does not surface Plaid-connected accounts (confirmed publicly by the Copilot team, no timeline for a fix, [Reddit thread](https://www.reddit.com/r/copilotmoney/comments/1ueh4lv/) linked as the source). The banner also clarifies that this community server is unaffected since it reads the app's full local cache (and, in live mode, the same GraphQL API the app uses).

README-only change; no code touched.

## External assumptions

None

---
_Generated by [Claude Code](https://claude.ai/code/session_01XgjsXRqcnN1xkFqP2ibjCV)_