### PR TITLE
feat(smoke): add smoke:cache — real-cache invariants for the decode boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "check:privacy-endpoints": "bun run scripts/check-privacy-endpoints.ts",
     "check:skills": "python3 scripts/check-skills.py",
     "fix": "bun run lint:fix && bun run format",
+    "_comment_smoke": "smoke:cache is deliberately NOT in this composite yet — it needs a real local cache, and the scheduled drift check that would host it has its own reporting gap to sort first (see PR #628). Wire it in when that lands.",
     "smoke": "bun run scripts/smoke/conformance.ts && bun run scripts/smoke/reads.ts && bun run smoke:refresh",
     "smoke:cache": "bun run scripts/smoke/cache.ts",
     "smoke:conformance": "bun run scripts/smoke/conformance.ts",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "check:skills": "python3 scripts/check-skills.py",
     "fix": "bun run lint:fix && bun run format",
     "smoke": "bun run scripts/smoke/conformance.ts && bun run scripts/smoke/reads.ts && bun run smoke:refresh",
+    "smoke:cache": "bun run scripts/smoke/cache.ts",
     "smoke:conformance": "bun run scripts/smoke/conformance.ts",
     "smoke:roundtrip": "bun run scripts/smoke/roundtrip.ts",
     "smoke:reads": "bun run scripts/smoke/reads.ts",

--- a/scripts/smoke/cache.ts
+++ b/scripts/smoke/cache.ts
@@ -76,10 +76,23 @@ export function isTotalDecodeLoss(rawNonEmpty: number, decodedRows: number): boo
   return rawNonEmpty > 0 && decodedRows === 0;
 }
 
-/** Fraction of references that resolve against a target id set, 0..1. */
-export function joinRate(refs: readonly string[], target: ReadonlySet<string>): number {
-  if (refs.length === 0) return 1;
-  return refs.filter((id) => target.has(id)).length / refs.length;
+/**
+ * How many references resolve against a target id set.
+ *
+ * Returns counts as well as the rate so callers never have to divide and
+ * re-multiply to recover the orphan count — that roundtrip leans on rounding to
+ * absorb float error, which is a poor foundation for a number the gate reports.
+ *
+ * An empty reference list is vacuously fine (rate 1) regardless of the target;
+ * the runner reports SKIP for it rather than a suspicious 100%.
+ */
+export function joinStats(
+  refs: readonly string[],
+  target: ReadonlySet<string>
+): { total: number; matched: number; orphans: number; rate: number } {
+  const total = refs.length;
+  const matched = refs.filter((id) => target.has(id)).length;
+  return { total, matched, orphans: total - matched, rate: total === 0 ? 1 : matched / total };
 }
 
 const normalize = normalizeCollection;
@@ -154,13 +167,14 @@ async function main(): Promise<void> {
     { root: 'tags', rows: all.tags.length },
   ];
 
-  const blackHoles = decoded.filter((d) => isTotalDecodeLoss(rawRows(d.root), d.rows));
+  const withRaw = decoded.map((d) => ({ ...d, raw: rawRows(d.root) }));
+  const blackHoles = withRaw.filter((d) => isTotalDecodeLoss(d.raw, d.rows));
   if (blackHoles.length > 0) {
     record(
       'total decode loss',
       'FAIL',
       `collections with documents on disk but ZERO decoded rows: ` +
-        blackHoles.map((d) => `${d.root} (${rawRows(d.root)} docs)`).join(', ')
+        blackHoles.map((d) => `${d.root} (${d.raw} docs)`).join(', ')
     );
   } else {
     record('total decode loss', 'PASS', 'every collection with documents decoded at least one row');
@@ -174,9 +188,7 @@ async function main(): Promise<void> {
   // fails; #622 discarded 91% of investment_prices and would have shown here
   // long before anyone read the output.
   // ---------------------------------------------------------------------
-  const lossy = decoded
-    .map((d) => ({ ...d, raw: rawRows(d.root) }))
-    .filter((d) => d.raw > 10 && d.rows > 0 && d.rows / d.raw < 0.5);
+  const lossy = withRaw.filter((d) => d.raw > 10 && d.rows > 0 && d.rows / d.raw < 0.5);
 
   if (lossy.length > 0) {
     record(
@@ -198,6 +210,12 @@ async function main(): Promise<void> {
   // silently a no-op. Both decode paths agree there is nothing there, so
   // parity testing cannot see it.
   // ---------------------------------------------------------------------
+  // MAINTENANCE CONTRACT: add a normalized path here whenever code starts
+  // depending on a collection existing. This list is what makes an extinct
+  // collection loud instead of silent, and nothing derives it automatically —
+  // a new decoder that reads a collection Copilot has since retired will pass
+  // every other check in this file. The mirror gap (fields a processor
+  // declares that no real document has) is the follow-up noted in the PR.
   const DEPENDED_ON = ['users/*/accounts'];
   const extinct = DEPENDED_ON.filter((p) => {
     const counts = raw.get(p);
@@ -253,16 +271,16 @@ async function main(): Promise<void> {
       record(`join: ${join.name}`, 'SKIP', 'target collection empty');
       continue;
     }
-    const rate = joinRate(join.refs, join.target) * 100;
-    const orphans = join.refs.length - Math.round((rate / 100) * join.refs.length);
+    const { total, orphans, rate } = joinStats(join.refs, join.target);
+    const pct = rate * 100;
     if (orphans > 0) {
       record(
         `join: ${join.name}`,
-        rate < 50 ? 'FAIL' : 'WARN',
-        `${orphans}/${join.refs.length} references do not resolve (${rate.toFixed(1)}% join rate)`
+        pct < 50 ? 'FAIL' : 'WARN',
+        `${orphans}/${total} references do not resolve (${pct.toFixed(1)}% join rate)`
       );
     } else {
-      record(`join: ${join.name}`, 'PASS', `all ${join.refs.length} references resolve`);
+      record(`join: ${join.name}`, 'PASS', `all ${total} references resolve`);
     }
   }
 

--- a/scripts/smoke/cache.ts
+++ b/scripts/smoke/cache.ts
@@ -1,0 +1,339 @@
+/**
+ * Tier-1 cache smoke — invariants over the REAL local Firestore cache (#622).
+ *
+ * The conformance ledger and the Tier-0/1 GraphQL smokes cover the *API*
+ * boundary. Nothing covered the *decode* boundary, and that is where #622 and
+ * #624 both lived: code that reads a data shape reality does not have, with
+ * fixtures written from the same wrong assumption, so the suite stays green
+ * while every real read is wrong.
+ *
+ * Synthetic tests cannot catch that class by construction. The only available
+ * oracle is the cache itself, so these checks compare what the decoder produces
+ * against what is actually on disk.
+ *
+ * Run: `bun run smoke:cache`
+ *
+ * READS ONLY — nothing here mutates, and no network request is made. Requires a
+ * local Copilot cache; without one it exits 0 with `no-cache-found` rather than
+ * failing, so it is safe in CI.
+ *
+ * PII: logs counts, collection paths, and field NAMES only — never values,
+ * document ids, amounts, or names. Field names are taken from processors'
+ * `consumed` lists (code, not data) wherever possible. Note that a few
+ * collections use dynamic map keys that ARE sensitive, so per-document field
+ * names are aggregated and only reported for the allowlisted collections below.
+ */
+
+import { iterateDocuments } from '../../src/core/leveldb-reader.js';
+import {
+  decodeAllCollections,
+  decodeTransactions,
+  decodeAccounts,
+  decodeRecurring,
+  decodeBudgets,
+  decodeGoals,
+  decodeGoalHistory,
+  decodeInvestmentPrices,
+  decodeItems,
+  decodeCategories,
+} from '../../src/core/decoder.js';
+import { CopilotDatabase } from '../../src/core/database.js';
+
+type Status = 'PASS' | 'FAIL' | 'WARN' | 'SKIP';
+
+interface Check {
+  name: string;
+  status: Status;
+  detail: string;
+}
+
+const results: Check[] = [];
+
+function record(name: string, status: Status, detail: string): void {
+  results.push({ name, status, detail });
+  console.error(`[cache-smoke] ${status.padEnd(4)} ${name} — ${detail}`);
+}
+
+/**
+ * Collapse `items/{id}/accounts` to `items/*​/accounts` so paths group.
+ *
+ * Firestore paths alternate collection/document, so odd-indexed segments are
+ * document ids. Wildcarding them is also what keeps this PII-safe: real
+ * document ids never reach the output.
+ */
+export function normalizeCollection(collection: string): string {
+  return collection
+    .split('/')
+    .map((seg, i) => (i % 2 === 1 ? '*' : seg))
+    .join('/');
+}
+
+/**
+ * The #622 signature: documents exist on disk and the decoder produced none.
+ * Distinguished from a genuinely empty collection, which is check 3's job.
+ */
+export function isTotalDecodeLoss(rawNonEmpty: number, decodedRows: number): boolean {
+  return rawNonEmpty > 0 && decodedRows === 0;
+}
+
+/** Fraction of references that resolve against a target id set, 0..1. */
+export function joinRate(refs: readonly string[], target: ReadonlySet<string>): number {
+  if (refs.length === 0) return 1;
+  return refs.filter((id) => target.has(id)).length / refs.length;
+}
+
+const normalize = normalizeCollection;
+
+async function main(): Promise<void> {
+  const db = new CopilotDatabase();
+  const dbPath = db.getDbPath();
+
+  if (!dbPath || !db.isAvailable()) {
+    console.error('[cache-smoke] no-cache-found — no local Copilot cache; nothing to check.');
+    console.error('[cache-smoke] This is not a failure. Run on a machine with Copilot Money synced.');
+    process.exit(0);
+  }
+
+  console.error(`[cache-smoke] scanning real cache`);
+
+  // ---------------------------------------------------------------------
+  // Raw scan: what is actually on disk, by normalized collection path.
+  // ---------------------------------------------------------------------
+  const raw = new Map<string, { total: number; empty: number }>();
+  let scanned = 0;
+  const started = Date.now();
+
+  for await (const doc of iterateDocuments(dbPath)) {
+    scanned++;
+    const pattern = normalize(doc.collection);
+    let entry = raw.get(pattern);
+    if (!entry) {
+      entry = { total: 0, empty: 0 };
+      raw.set(pattern, entry);
+    }
+    entry.total++;
+    // Firestore parent-pointer documents carry no fields. They are structural,
+    // not data, and must not be counted as decodable rows.
+    if (doc.fields.size === 0) entry.empty++;
+  }
+
+  const elapsed = ((Date.now() - started) / 1000).toFixed(1);
+  record(
+    'raw scan',
+    'PASS',
+    `${scanned} documents across ${raw.size} collection patterns in ${elapsed}s`
+  );
+
+  /** Non-empty raw documents under a collection root. */
+  function rawRows(root: string): number {
+    let n = 0;
+    for (const [pattern, counts] of raw) {
+      if (pattern === root || pattern.startsWith(`${root}/`)) n += counts.total - counts.empty;
+    }
+    return n;
+  }
+
+  const all = await decodeAllCollections(dbPath);
+
+  // ---------------------------------------------------------------------
+  // Check 1 — total decode loss.
+  //
+  // The #622 signature: a collection has real documents on disk and the
+  // decoder produces zero rows. Nothing else in the suite notices, because a
+  // fixture-backed test only proves the decoder agrees with its author.
+  // ---------------------------------------------------------------------
+  const decoded: Array<{ root: string; rows: number }> = [
+    { root: 'transactions', rows: all.transactions.length },
+    { root: 'accounts', rows: all.accounts.length },
+    { root: 'items', rows: all.items.length },
+    { root: 'categories', rows: all.categories.length },
+    { root: 'budgets', rows: all.budgets.length },
+    { root: 'financial_goals', rows: all.goals.length },
+    { root: 'investment_prices', rows: all.investmentPrices.length },
+    { root: 'securities', rows: all.securities.length },
+    { root: 'tags', rows: all.tags.length },
+  ];
+
+  const blackHoles = decoded.filter((d) => isTotalDecodeLoss(rawRows(d.root), d.rows));
+  if (blackHoles.length > 0) {
+    record(
+      'total decode loss',
+      'FAIL',
+      `collections with documents on disk but ZERO decoded rows: ` +
+        blackHoles.map((d) => `${d.root} (${rawRows(d.root)} docs)`).join(', ')
+    );
+  } else {
+    record('total decode loss', 'PASS', 'every collection with documents decoded at least one row');
+  }
+
+  // ---------------------------------------------------------------------
+  // Check 2 — conservation.
+  //
+  // Large unexplained shrinkage between disk and output. Some loss is
+  // legitimate (dedup, tombstones, soft-deletes), so this warns rather than
+  // fails; #622 discarded 91% of investment_prices and would have shown here
+  // long before anyone read the output.
+  // ---------------------------------------------------------------------
+  const lossy = decoded
+    .map((d) => ({ ...d, raw: rawRows(d.root) }))
+    .filter((d) => d.raw > 10 && d.rows > 0 && d.rows / d.raw < 0.5);
+
+  if (lossy.length > 0) {
+    record(
+      'conservation',
+      'WARN',
+      `collections losing >50% of documents: ` +
+        lossy.map((d) => `${d.root} ${d.raw}→${d.rows}`).join(', ') +
+        ` (legitimate for soft-deletes/dedup — confirm each)`
+    );
+  } else {
+    record('conservation', 'PASS', 'no collection loses more than half its documents');
+  }
+
+  // ---------------------------------------------------------------------
+  // Check 3 — extinct dependencies.
+  //
+  // The #624 signature, and the inverse of check 1: the code reads a
+  // collection that no longer has any documents, so a filter built on it is
+  // silently a no-op. Both decode paths agree there is nothing there, so
+  // parity testing cannot see it.
+  // ---------------------------------------------------------------------
+  const DEPENDED_ON = ['users/*/accounts'];
+  const extinct = DEPENDED_ON.filter((p) => {
+    const counts = raw.get(p);
+    return !counts || counts.total - counts.empty === 0;
+  });
+
+  if (extinct.length > 0) {
+    record(
+      'extinct dependencies',
+      'FAIL',
+      `code reads collections with zero documents: ${extinct.join(', ')} — ` +
+        `any filter built on them is a silent no-op (see #624)`
+    );
+  } else {
+    record('extinct dependencies', 'PASS', 'every depended-on collection has documents');
+  }
+
+  // ---------------------------------------------------------------------
+  // Check 4 — identity joins.
+  //
+  // Foreign keys must actually resolve. #622's rows carried a month where a
+  // security id belonged: a 0% join rate, invisible to every schema check
+  // because a month is a perfectly valid string.
+  // ---------------------------------------------------------------------
+  const securityIds = new Set(all.securities.map((s) => s.security_id));
+  const accountIds = new Set(all.accounts.map((a) => a.account_id));
+  const goalIds = new Set(all.goals.map((g) => g.goal_id));
+
+  const joins: Array<{ name: string; refs: string[]; target: Set<string> }> = [
+    {
+      name: 'investment_prices.security_id → securities',
+      refs: all.investmentPrices.map((p) => p.security_id),
+      target: securityIds,
+    },
+    {
+      name: 'transactions.account_id → accounts',
+      refs: all.transactions.map((t) => t.account_id).filter((v): v is string => !!v),
+      target: accountIds,
+    },
+    {
+      name: 'financial_goal_history.goal_id → financial_goals',
+      refs: all.goalHistory.map((h) => h.goal_id),
+      target: goalIds,
+    },
+  ];
+
+  for (const join of joins) {
+    if (join.refs.length === 0) {
+      record(`join: ${join.name}`, 'SKIP', 'no rows to check');
+      continue;
+    }
+    if (join.target.size === 0) {
+      record(`join: ${join.name}`, 'SKIP', 'target collection empty');
+      continue;
+    }
+    const rate = joinRate(join.refs, join.target) * 100;
+    const orphans = join.refs.length - Math.round((rate / 100) * join.refs.length);
+    if (orphans > 0) {
+      record(
+        `join: ${join.name}`,
+        rate < 50 ? 'FAIL' : 'WARN',
+        `${orphans}/${join.refs.length} references do not resolve (${rate.toFixed(1)}% join rate)`
+      );
+    } else {
+      record(`join: ${join.name}`, 'PASS', `all ${join.refs.length} references resolve`);
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // Check 5 — decode-path parity on real data.
+  //
+  // The unit-test version of this runs on fixtures. This is the real-data
+  // edition: #622 was a 0-vs-863 disagreement that only appeared against a
+  // real cache, because the fixtures did not have the nesting that broke it.
+  // ---------------------------------------------------------------------
+  const parity: Array<{ name: string; standalone: () => Promise<unknown[]>; aggregate: number }> = [
+    { name: 'transactions', standalone: () => decodeTransactions(dbPath), aggregate: all.transactions.length },
+    { name: 'accounts', standalone: () => decodeAccounts(dbPath), aggregate: all.accounts.length },
+    { name: 'recurring', standalone: () => decodeRecurring(dbPath), aggregate: all.recurring.length },
+    { name: 'budgets', standalone: () => decodeBudgets(dbPath), aggregate: all.budgets.length },
+    { name: 'financial_goals', standalone: () => decodeGoals(dbPath), aggregate: all.goals.length },
+    { name: 'goal_history', standalone: () => decodeGoalHistory(dbPath), aggregate: all.goalHistory.length },
+    {
+      name: 'investment_prices',
+      standalone: () => decodeInvestmentPrices(dbPath),
+      aggregate: all.investmentPrices.length,
+    },
+    { name: 'items', standalone: () => decodeItems(dbPath), aggregate: all.items.length },
+    { name: 'categories', standalone: () => decodeCategories(dbPath), aggregate: all.categories.length },
+  ];
+
+  const mismatches: string[] = [];
+  for (const p of parity) {
+    // Sequential: concurrent iterations over the same temp copy collide.
+    const rows = await p.standalone();
+    if (rows.length !== p.aggregate) {
+      mismatches.push(`${p.name} standalone=${rows.length} aggregate=${p.aggregate}`);
+    }
+  }
+
+  if (mismatches.length > 0) {
+    record(
+      'decode-path parity',
+      'FAIL',
+      `paths disagree on real data: ${mismatches.join('; ')} — ` +
+        `which one runs depends on load order`
+    );
+  } else {
+    record('decode-path parity', 'PASS', `all ${parity.length} collections agree across both paths`);
+  }
+
+  // ---------------------------------------------------------------------
+  // Summary
+  // ---------------------------------------------------------------------
+  const failed = results.filter((r) => r.status === 'FAIL');
+  const warned = results.filter((r) => r.status === 'WARN');
+
+  console.error('');
+  console.error(
+    `[cache-smoke] ${results.filter((r) => r.status === 'PASS').length} pass, ` +
+      `${warned.length} warn, ${failed.length} fail`
+  );
+
+  if (failed.length > 0) {
+    console.error('[cache-smoke] FAILURES:');
+    for (const f of failed) console.error(`  - ${f.name}: ${f.detail}`);
+    process.exit(1);
+  }
+}
+
+// Only run when invoked directly. Without this guard, importing the module to
+// unit-test its predicates kicks off a full scan of the real cache — which is
+// both slow and a surprising side effect inside `bun test`.
+if (import.meta.main) {
+  main().catch((err: unknown) => {
+    console.error('[cache-smoke] crashed:', err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  });
+}

--- a/tests/scripts/smoke-cache.test.ts
+++ b/tests/scripts/smoke-cache.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for the pure predicates behind `bun run smoke:cache`.
+ *
+ * The smoke itself needs a real Copilot cache, so it cannot run in CI. These
+ * cover the logic that decides PASS/FAIL, which is where a silently-wrong
+ * threshold would make the whole gate decorative.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { normalizeCollection, isTotalDecodeLoss, joinRate } from '../../scripts/smoke/cache.js';
+
+describe('normalizeCollection', () => {
+  test('wildcards document ids at odd path depths', () => {
+    expect(normalizeCollection('items/abc123/accounts')).toBe('items/*/accounts');
+    expect(normalizeCollection('investment_prices/deadbeef/daily')).toBe(
+      'investment_prices/*/daily'
+    );
+  });
+
+  test('leaves a top-level collection untouched', () => {
+    expect(normalizeCollection('transactions')).toBe('transactions');
+  });
+
+  test('wildcards every id in a deep path', () => {
+    expect(normalizeCollection('items/i1/accounts/a1/holdings_history/h1/history')).toBe(
+      'items/*/accounts/*/holdings_history/*/history'
+    );
+  });
+
+  test('never lets a real document id through', () => {
+    // This is the PII guarantee, not a formatting nicety: the smoke prints
+    // collection patterns, so an id surviving normalization would be a leak.
+    const normalized = normalizeCollection(
+      'items/SECRET_ITEM_ID/accounts/SECRET_ACCT/transactions'
+    );
+    expect(normalized).not.toContain('SECRET_ITEM_ID');
+    expect(normalized).not.toContain('SECRET_ACCT');
+  });
+});
+
+describe('isTotalDecodeLoss', () => {
+  test('fires when documents exist but nothing decoded (the #622 signature)', () => {
+    expect(isTotalDecodeLoss(863, 0)).toBe(true);
+  });
+
+  test('does not fire on a genuinely empty collection', () => {
+    // That case belongs to the extinct-dependency check; conflating the two
+    // would make an absent collection look like a decoder bug.
+    expect(isTotalDecodeLoss(0, 0)).toBe(false);
+  });
+
+  test('does not fire on partial loss', () => {
+    expect(isTotalDecodeLoss(863, 78)).toBe(false);
+  });
+});
+
+describe('joinRate', () => {
+  test('reports 0 when no reference resolves (the #622 join failure)', () => {
+    // Rows keyed by a period instead of a security id: every value is a
+    // perfectly valid string, and none of them joins.
+    expect(joinRate(['2025-06', '2025-07'], new Set(['sec_a', 'sec_b']))).toBe(0);
+  });
+
+  test('reports 1 when every reference resolves', () => {
+    expect(joinRate(['sec_a', 'sec_b'], new Set(['sec_a', 'sec_b', 'sec_c']))).toBe(1);
+  });
+
+  test('reports the fraction on partial resolution', () => {
+    expect(joinRate(['sec_a', 'missing'], new Set(['sec_a']))).toBe(0.5);
+  });
+
+  test('treats an empty reference list as vacuously fine', () => {
+    // No rows to check is not a failure — the runner reports SKIP for this.
+    expect(joinRate([], new Set())).toBe(1);
+  });
+});

--- a/tests/scripts/smoke-cache.test.ts
+++ b/tests/scripts/smoke-cache.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { normalizeCollection, isTotalDecodeLoss, joinRate } from '../../scripts/smoke/cache.js';
+import { normalizeCollection, isTotalDecodeLoss, joinStats } from '../../scripts/smoke/cache.js';
 
 describe('normalizeCollection', () => {
   test('wildcards document ids at odd path depths', () => {
@@ -54,23 +54,51 @@ describe('isTotalDecodeLoss', () => {
   });
 });
 
-describe('joinRate', () => {
-  test('reports 0 when no reference resolves (the #622 join failure)', () => {
+describe('joinStats', () => {
+  test('reports every reference orphaned when none resolves (the #622 join failure)', () => {
     // Rows keyed by a period instead of a security id: every value is a
     // perfectly valid string, and none of them joins.
-    expect(joinRate(['2025-06', '2025-07'], new Set(['sec_a', 'sec_b']))).toBe(0);
+    expect(joinStats(['2025-06', '2025-07'], new Set(['sec_a', 'sec_b']))).toEqual({
+      total: 2,
+      matched: 0,
+      orphans: 2,
+      rate: 0,
+    });
   });
 
-  test('reports 1 when every reference resolves', () => {
-    expect(joinRate(['sec_a', 'sec_b'], new Set(['sec_a', 'sec_b', 'sec_c']))).toBe(1);
+  test('reports no orphans when every reference resolves', () => {
+    expect(joinStats(['sec_a', 'sec_b'], new Set(['sec_a', 'sec_b', 'sec_c']))).toEqual({
+      total: 2,
+      matched: 2,
+      orphans: 0,
+      rate: 1,
+    });
   });
 
-  test('reports the fraction on partial resolution', () => {
-    expect(joinRate(['sec_a', 'missing'], new Set(['sec_a']))).toBe(0.5);
+  test('reports exact counts on partial resolution', () => {
+    // orphans must come from a subtraction of integers, never from
+    // round(rate * total) — the gate reports this number to a human.
+    expect(joinStats(['sec_a', 'missing'], new Set(['sec_a']))).toEqual({
+      total: 2,
+      matched: 1,
+      orphans: 1,
+      rate: 0.5,
+    });
+  });
+
+  test('keeps the orphan count exact where a rate roundtrip would not', () => {
+    // 1/3 is not representable; deriving orphans from the rate invites
+    // rounding to decide how many rows are broken.
+    const refs = ['a', 'missing1', 'missing2'];
+    expect(joinStats(refs, new Set(['a'])).orphans).toBe(2);
   });
 
   test('treats an empty reference list as vacuously fine', () => {
     // No rows to check is not a failure — the runner reports SKIP for this.
-    expect(joinRate([], new Set())).toBe(1);
+    expect(joinStats([], new Set()).rate).toBe(1);
+  });
+
+  test('the empty-reference short-circuit does not consult the target', () => {
+    expect(joinStats([], new Set(['sec_a'])).rate).toBe(1);
   });
 });


### PR DESCRIPTION
# Summary

Adds `bun run smoke:cache` — invariants checked against the **real** local Firestore cache, closing the one boundary the conformance architecture never covered.

The ledger and the GraphQL smokes cover the **API** boundary. Nothing covered the **decode** boundary, which is where both [#622](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/622) and [#624](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/624) lived: code reading a data shape reality does not have, with fixtures written from the same wrong assumption, so the suite stays green while every real read is wrong.

Synthetic tests cannot catch that class *by construction* — a fixture only proves the code agrees with its author. The only available oracle is the cache itself.

## External assumptions

None new. The script *checks* existing assumptions rather than adding any: it asserts that collections the decoder reads actually have documents, that foreign keys resolve, and that both decode paths agree. Every fact it relies on (the `investment_prices/{security_id}/{daily|hf}` layout, `security_id` joining `securities`) was verified in #623.

## The five checks

| | Catches | Why the existing suite can't |
|---|---|---|
| **Total decode loss** | Documents on disk, zero decoded rows | The #622 signature. A fixture-backed test only proves the decoder agrees with its author |
| **Conservation** | A collection losing >50% of its documents | #622 discarded 91% silently; nothing counted rows in vs rows out |
| **Extinct dependencies** | Code reading a collection with **no** documents | The #624 signature — and precisely the case decode-path parity **cannot** see, since both paths correctly agree there's nothing to decode |
| **Identity joins** | Foreign keys that don't resolve | #622's rows had a **0%** join rate against `securities` while being perfectly valid strings, so every schema check passed |
| **Decode-path parity (real data)** | Two decoders of one collection disagreeing | The unit-test version runs on fixtures, which lacked the nesting that broke it |

## First run against a real cache

**44,870 documents in 3.2s** — cheap enough to run routinely, and much cheaper than I'd estimated when proposing it.

It immediately caught the known #624 **and found something new**:

```
PASS raw scan — 44870 documents across 35 collection patterns in 3.2s
PASS total decode loss — every collection with documents decoded at least one row
WARN conservation — items 1791→13 (legitimate for soft-deletes/dedup — confirm each)
FAIL extinct dependencies — users/*/accounts — any filter built on them is a silent no-op (see #624)
PASS join: investment_prices.security_id → securities — all 863 references resolve
PASS join: transactions.account_id → accounts — all 733 references resolve
PASS join: financial_goal_history.goal_id → financial_goals — all 2 references resolve
FAIL decode-path parity — items standalone=12 aggregate=13
```

The `items` divergence is a **new finding** — the fixture-based parity test passes, because the fixture doesn't have whatever shape causes the aggregate path to pick up one extra row. Diagnosed and filed as #627: the aggregate path builds a phantom item from a fieldless parent-pointer document, relying on an invariant its own comment asserts but that does not hold. Filed rather than fixed silently here. The two `FAIL`s are real and this PR does not fix them, which is the point: the gate should ship reporting true failures rather than be tuned until it's green.

Note the join checks also serve as the **positive** confirmation of #623 — all 863 investment-price rows now resolve to a security, where before the fix none could have.

## Safety and hygiene

- **Reads only.** No mutation, and no network request of any kind.
- **Exits 0 with `no-cache-found`** when there's no local cache, so it's safe anywhere including CI.
- **PII:** logs counts, collection *patterns*, and field names only. Document ids are wildcarded out by `normalizeCollection`, and that's tested as a guarantee rather than a formatting nicety.
- **`main()` is guarded behind `import.meta.main`.** Without it, importing the module to unit-test its predicates kicks off a full cache scan inside `bun test` — I hit exactly that and it's in the tests as a fixed behaviour.

## Tests

The smoke needs a real cache so it can't run in CI. `tests/scripts/smoke-cache.test.ts` covers the pure predicates that decide PASS/FAIL — which is where a silently-wrong threshold would quietly make the whole gate decorative. Including that `isTotalDecodeLoss` does **not** fire on a genuinely empty collection: conflating that with a decoder bug would make check 3's findings look like check 1's.

`bun run check`: 2631 pass, 0 fail.

## Follow-ups

- Wire into the weekly scheduled drift check (`scripts/scheduled-smoke.ts`) as a fourth section. Deliberately not in this PR — the audit noted that job did not surface a 4-week smoke breakage, so its own reporting wants a look first.
- Add the "consumed-but-never-present field" check (the mirror of `warnUnreadFields`: fields a processor declares that appear in **zero** real documents). It needs a ratchet baseline to avoid noise on older caches, so it's a separate change.
