### PR TITLE
chore: address audit follow-ups from #600 and #625

### DIFF
--- a/docs/bugs/MINOR.md
+++ b/docs/bugs/MINOR.md
@@ -5,8 +5,10 @@ release plumbing, packaging, and latent defects fixed before anyone hit them.
 
 They are here for two reasons: a class with only minor instances still shows up in the
 [class list](README.md#bug-classes), and a run of minor bugs in one area is often the
-early signal for a major one. `silent-automation-failure` appears four times below and
-has no full entry — that pattern is worth watching.
+early signal for a major one. `silent-failure-masking` appears **seven** times below and
+has no full entry — a class that has never once produced a bug worth a post-mortem, yet
+keeps costing us release and audit incidents, is exactly the pattern this ledger exists to
+make visible.
 
 Promote a row to a full entry if a later instance turns out to be user-visible.
 

--- a/tests/unit/server-protocol.test.ts
+++ b/tests/unit/server-protocol.test.ts
@@ -436,10 +436,9 @@ describe('CopilotMoneyServer.handleCallTool - response format', () => {
 
     // Compact serialization: no newlines, byte-identical to JSON.stringify(result)
     expect(text).not.toContain('\n');
+    // Round-tripping through JSON.parse already proves the payload parses —
+    // a separate parse + toBeDefined() adds no detection power (#601).
     expect(text).toBe(JSON.stringify(JSON.parse(text)));
-    // Parse and verify structure
-    const parsed = JSON.parse(text);
-    expect(parsed).toBeDefined();
   });
 });
 


### PR DESCRIPTION
# Summary

Batches the two open LOW-severity audit follow-ups into one cleanup PR.

Closes #601
Closes #626

## External assumptions

None. Test cleanup and a documentation correction; no code paths and no assumptions about Copilot's API or data change.

## Changes

**#626 — wrong class name and count in `docs/bugs/MINOR.md`.** The intro prose named `silent-automation-failure`, which is not a class in the taxonomy, and said it appeared four times. The rows actually use `silent-failure-masking`, and there are seven.

Worth naming what this is: `doc-reality-drift` — documentation asserting a verifiable property the artifact does not have — appearing *inside the bug corpus itself*, one commit after publishing it. That is not embarrassing so much as confirming: it is the class the corpus lists as invisible to every behavioural gate, because nothing reads Markdown. A taxonomy whose prose disagrees with its own table misleads exactly as much as any other stale doc, and the only thing that caught it was a reviewer counting rows.

I also sharpened the sentence while fixing it, because the corrected number makes a better point than the wrong one did: a class with **seven** minor instances and **zero** full entries is a class that has never once produced a bug worth a post-mortem, yet keeps costing release and audit incidents. That is precisely the pattern a minor ledger exists to surface.

**#601 — redundant assertions in the compact-JSON test.** The line above already round-trips the payload through `JSON.parse`/`JSON.stringify`, which proves it parses. The follow-up `JSON.parse` + `toBeDefined()` executes without adding any detection power — the mild version of the #596 lesson that running a check is not the same as being able to fail.

## Verification

`bun run check` green; the touched test still passes and still fails if the compact-serialization behaviour it guards is broken.