### PR TITLE
fix: two real-cache findings from smoke:cache

### DIFF
--- a/scripts/smoke/cache.ts
+++ b/scripts/smoke/cache.ts
@@ -215,8 +215,14 @@ async function main(): Promise<void> {
   // collection loud instead of silent, and nothing derives it automatically —
   // a new decoder that reads a collection Copilot has since retired will pass
   // every other check in this file. The mirror gap (fields a processor
-  // declares that no real document has) is the follow-up noted in the PR.
-  const DEPENDED_ON = ['users/*/accounts'];
+  // declares that no real document has) is a separate follow-up.
+  //
+  // `users/*/accounts` was the founding entry and has been removed: #624
+  // resolved by moving the two things that read it — the hidden-account filter
+  // and the account name map — onto the account documents, where Copilot now
+  // puts those customizations. The collection is still decoded, so the data is
+  // there if it ever comes back, but no behaviour depends on it.
+  const DEPENDED_ON: string[] = [];
   const extinct = DEPENDED_ON.filter((p) => {
     const counts = raw.get(p);
     return !counts || counts.total - counts.empty === 0;

--- a/scripts/smoke/cache.ts
+++ b/scripts/smoke/cache.ts
@@ -77,6 +77,28 @@ export function isTotalDecodeLoss(rawNonEmpty: number, decodedRows: number): boo
 }
 
 /**
+ * Which of the collections a caller depends on have no real documents.
+ *
+ * "Real" excludes Firestore's fieldless parent pointers, which exist for any
+ * path with subcollections and say nothing about whether the collection itself
+ * holds data — counting them would make an extinct collection look alive.
+ *
+ * Extracted and tested separately because `DEPENDED_ON` is currently empty
+ * (#624 removed its only entry), so the check cannot exercise itself against
+ * the real cache. Without this the gate would be documentation-only until
+ * someone adds a new entry, and a bug in it would surface only then.
+ */
+export function findExtinctDependencies(
+  dependedOn: readonly string[],
+  raw: ReadonlyMap<string, { total: number; empty: number }>
+): string[] {
+  return dependedOn.filter((pattern) => {
+    const counts = raw.get(pattern);
+    return !counts || counts.total - counts.empty === 0;
+  });
+}
+
+/**
  * How many references resolve against a target id set.
  *
  * Returns counts as well as the rate so callers never have to divide and
@@ -223,10 +245,7 @@ async function main(): Promise<void> {
   // puts those customizations. The collection is still decoded, so the data is
   // there if it ever comes back, but no behaviour depends on it.
   const DEPENDED_ON: string[] = [];
-  const extinct = DEPENDED_ON.filter((p) => {
-    const counts = raw.get(p);
-    return !counts || counts.total - counts.empty === 0;
-  });
+  const extinct = findExtinctDependencies(DEPENDED_ON, raw);
 
   if (extinct.length > 0) {
     record(

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -1329,12 +1329,20 @@ export class CopilotDatabase {
   }
 
   /**
-   * Build a map of account ID to user-defined account name.
+   * Build a map of account ID to the name a user would recognize.
    *
-   * This map can be used to look up user-friendly account names.
+   * Sourced from the account documents themselves, preferring a user-set
+   * `nickname` over the institution-supplied `name`.
+   *
+   * This previously read the `users/{uid}/accounts` customization collection,
+   * which Copilot no longer populates — so the map came back EMPTY on every
+   * real cache and its one consumer (`get_balance_history`'s `account_name`)
+   * silently returned `undefined` for every row. Same root cause as the hidden
+   * filter in #624: those customizations moved onto the account records.
+   *
    * The map is cached after the first call.
    *
-   * @returns Map from account_id to user-defined account name
+   * @returns Map from account_id to display name
    */
   async getAccountNameMap(): Promise<Map<string, string>> {
     // Return cached map if available
@@ -1342,12 +1350,13 @@ export class CopilotDatabase {
       return this._accountNameMap;
     }
 
-    const userAccounts = await this.loadUserAccounts();
+    const accounts = await this.loadAccounts();
     const nameMap = new Map<string, string>();
 
-    for (const userAccount of userAccounts) {
-      if (userAccount.name) {
-        nameMap.set(userAccount.account_id, userAccount.name);
+    for (const account of accounts) {
+      const displayName = account.nickname ?? account.name;
+      if (displayName) {
+        nameMap.set(account.account_id, displayName);
       }
     }
 

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -2879,9 +2879,18 @@ export async function decodeAllCollections(dbPath: string): Promise<AllCollectio
     } else if (collectionMatches(collection, 'investment_splits')) {
       const split = processInvestmentSplit(fields, documentId);
       if (split) rawInvestmentSplits.push(split);
-    } else if (collectionMatches(collection, 'items') || /^items\/[^/]+$/.test(collection)) {
-      // Match both top-level items and items/{item_id} parent-pointer docs.
-      // Parent-pointer docs (items/{item_id}) have empty fields and processItem returns null.
+    } else if (collectionMatches(collection, 'items')) {
+      // Only the real `items` collection. A previous version also matched
+      // `items/{item_id}` — Firestore's fieldless parent-pointer entries —
+      // on the stated assumption that "parent-pointer docs have empty fields
+      // and processItem returns null". That assumption was wrong in both
+      // halves: processItem always returns at least `{ item_id }`, so every
+      // such entry became a phantom row carrying nothing else (#627).
+      //
+      // A real cache holds hundreds of those pointers against a dozen real
+      // items, and none of them has a single field, so the clause could only
+      // ever manufacture rows. Dedup by item_id hid the scale, collapsing them
+      // to the handful whose ids matched no real item.
       const item = processItem(fields, documentId);
       if (item) rawItems.push(item);
     } else if (collectionMatches(collection, 'tags')) {

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -2508,6 +2508,13 @@ function processAmazonIntegration(
   fields: Map<string, FirestoreValue>,
   docId: string
 ): AmazonIntegration | null {
+  // Fieldless documents are Firestore parent pointers, not integrations.
+  // Without this the function seeds `{ amazon_id: docId }` and would emit a
+  // stub for every pointer its dispatch clause matches — the #627 shape.
+  if (fields.size === 0) {
+    return null;
+  }
+
   const data: Record<string, unknown> = { amazon_id: docId };
 
   // Extract any fields generically

--- a/src/core/decoder.ts
+++ b/src/core/decoder.ts
@@ -1588,6 +1588,16 @@ function processInvestmentPrice(
  * Internal helper to process an item document.
  */
 function processItem(fields: Map<string, FirestoreValue>, docId: string): Item | null {
+  // A document with no fields is a Firestore parent pointer, not an item.
+  // Without this guard the function below always returns at least
+  // `{ item_id: docId }`, so any caller that routes a parent pointer here gets
+  // a phantom row (#627). Guarding at the processor rather than only at the
+  // call site makes the invariant hold for every caller, present and future —
+  // `processUserProfile` already does the same.
+  if (fields.size === 0) {
+    return null;
+  }
+
   const itemId = getString(fields, 'item_id') ?? docId;
 
   const itemData: Record<string, unknown> = {

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -1215,15 +1215,17 @@ export class CopilotMoneyTools {
 
     let accounts = await this.db.getAccounts(account_type);
 
-    // Filter hidden/deleted accounts if needed (same pattern as getNetWorth)
     if (!include_hidden) {
-      // Filter out accounts marked as user_deleted (merged or removed accounts)
-      accounts = accounts.filter((acc) => acc.user_deleted !== true);
-
-      // Also filter by hidden flag from user account customizations
-      const userAccounts = await this.db.getUserAccounts();
-      const hiddenIds = new Set(userAccounts.filter((ua) => ua.hidden).map((ua) => ua.account_id));
-      accounts = accounts.filter((acc) => !hiddenIds.has(acc.account_id));
+      // Both flags live on the account document itself:
+      //   user_deleted — merged or removed accounts
+      //   user_hidden  — hidden by the user in the Copilot app
+      //
+      // This previously read `user_hidden` from a `users/{uid}/accounts`
+      // customization collection, which no longer has any documents — Copilot
+      // moved these flags onto the account records. So the hidden filter was a
+      // silent no-op: the collection was always empty, and the flag that IS
+      // present was decoded into the model and then never read (#624).
+      accounts = accounts.filter((acc) => acc.user_deleted !== true && acc.user_hidden !== true);
     }
 
     // Calculate totals by asset/liability classification

--- a/tests/core/database.test.ts
+++ b/tests/core/database.test.ts
@@ -671,6 +671,57 @@ describe('CopilotDatabase', () => {
     });
   });
 
+  describe('getAccountNameMap (#624)', () => {
+    beforeEach(() => {
+      // The account documents themselves are the source of truth. The
+      // customization collection this map used to read is deliberately left
+      // EMPTY, the way every real cache has it.
+      (db as any)._accounts = [
+        { account_id: 'acc_plain', current_balance: 100, name: 'Bank Checking' },
+        {
+          account_id: 'acc_renamed',
+          current_balance: 200,
+          name: 'BANK PERSONAL CHECKING 1234',
+          nickname: 'Everyday',
+        },
+        { account_id: 'acc_nameless', current_balance: 300 },
+      ];
+      (db as any)._userAccounts = [];
+      (db as any)._accountNameMap = null;
+      (db as any)._allCollectionsLoaded = true;
+    });
+
+    test('is populated from account documents, not the extinct customization collection', async () => {
+      const map = await db.getAccountNameMap();
+
+      // Before the fix this map was always empty on a real cache, so
+      // get_balance_history reported account_name: undefined for every row.
+      expect(map.size).toBe(2);
+      expect(map.get('acc_plain')).toBe('Bank Checking');
+    });
+
+    test('prefers a user-set nickname over the institution name', async () => {
+      const map = await db.getAccountNameMap();
+      expect(map.get('acc_renamed')).toBe('Everyday');
+    });
+
+    test('omits accounts with no name at all rather than mapping undefined', async () => {
+      const map = await db.getAccountNameMap();
+      expect(map.has('acc_nameless')).toBe(false);
+    });
+
+    test('ignores the users/{uid}/accounts collection entirely', async () => {
+      // Populating the dead collection must not change the answer; if it does,
+      // the path that made this a silent no-op has been reintroduced.
+      (db as any)._userAccounts = [{ account_id: 'acc_plain', name: 'Ghost Name' }];
+      (db as any)._accountNameMap = null;
+
+      const map = await db.getAccountNameMap();
+
+      expect(map.get('acc_plain')).toBe('Bank Checking');
+    });
+  });
+
   describe('getSecurityMap', () => {
     const mockSecurities: Security[] = [
       {

--- a/tests/core/parent-pointer-documents.test.ts
+++ b/tests/core/parent-pointer-documents.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Fieldless documents must never become rows (#627).
+ *
+ * Firestore materializes an empty "parent pointer" document at any path that
+ * has subcollections. A real cache holds thousands of them — roughly 150 per
+ * real item — and they carry no data at all: they exist only so the path
+ * resolves.
+ *
+ * A processor that builds a row from one manufactures a record that does not
+ * exist. `processItem` did exactly that: it fell back to `item_id: docId` and
+ * so always returned at least a stub, while a comment at the call site asserted
+ * the opposite ("parent-pointer docs have empty fields and processItem returns
+ * null"). The code trusted its own documentation.
+ *
+ * These pin the invariant at the processor, so it holds for every caller rather
+ * than only the one call site that was fixed.
+ */
+
+import { describe, test, expect, afterAll } from 'bun:test';
+import path from 'node:path';
+import fs from 'node:fs';
+import os from 'node:os';
+import { decodeItems, decodeAllCollections } from '../../src/core/decoder.js';
+import { createTestDatabase } from '../../src/core/leveldb-reader.js';
+
+const FIXTURES_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'parent-pointer-'));
+
+afterAll(() => {
+  fs.rmSync(FIXTURES_DIR, { recursive: true, force: true });
+});
+
+const REAL_ITEM = 'itm_5pQw8ZnRvL3MxK7cHt2J';
+const POINTER_ONLY = 'itm_9wKe4RnTpB2XvL7mQd3F';
+
+describe('fieldless documents never become rows (#627)', () => {
+  test('a fieldless items document is not decoded as an item', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'items-pointer');
+    await createTestDatabase(dbPath, [
+      { collection: 'items', id: REAL_ITEM, fields: { institution_name: 'Synthetic Bank' } },
+      { collection: 'items', id: POINTER_ONLY, fields: {} },
+    ]);
+
+    const items = await decodeItems(dbPath);
+
+    expect(items.map((i) => i.item_id)).toEqual([REAL_ITEM]);
+  });
+
+  test('the aggregate path agrees — no phantom row from the fieldless document', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'items-pointer-aggregate');
+    await createTestDatabase(dbPath, [
+      { collection: 'items', id: REAL_ITEM, fields: { institution_name: 'Synthetic Bank' } },
+      { collection: 'items', id: POINTER_ONLY, fields: {} },
+    ]);
+
+    const all = await decodeAllCollections(dbPath);
+
+    expect(all.items.map((i) => i.item_id)).toEqual([REAL_ITEM]);
+  });
+
+  test('a phantom would otherwise carry an id and nothing else', async () => {
+    // Documents what the bug actually looked like, so the assertions above
+    // cannot be mistaken for a count check. The phantom was not malformed —
+    // it was a structurally valid Item whose every field but the id was absent,
+    // which is why no schema validation objected.
+    const dbPath = path.join(FIXTURES_DIR, 'items-pointer-shape');
+    await createTestDatabase(dbPath, [{ collection: 'items', id: POINTER_ONLY, fields: {} }]);
+
+    const items = await decodeItems(dbPath);
+
+    expect(items).toEqual([]);
+  });
+});

--- a/tests/core/parent-pointer-documents.test.ts
+++ b/tests/core/parent-pointer-documents.test.ts
@@ -70,3 +70,41 @@ describe('fieldless documents never become rows (#627)', () => {
     expect(items).toEqual([]);
   });
 });
+
+describe('every parent-pointer dispatch clause guards its processor (#627)', () => {
+  // The class-level ratchet. Three dispatch clauses in decodeAllCollections
+  // deliberately match Firestore's parent-pointer paths with a
+  // `/^name\/[^/]+$/` regex. Each is only safe because the processor it calls
+  // returns null for a fieldless document — an invariant that lived nowhere
+  // enforceable, which is how `items` shipped without it.
+  //
+  // This pins the pairing: add a parent-pointer clause, and the processor it
+  // dispatches to must carry the guard.
+  test('each processor reachable from a parent-pointer clause checks fields.size === 0', () => {
+    const src = fs.readFileSync(path.join(import.meta.dir, '../../src/core/decoder.ts'), 'utf8');
+
+    const clause = /\/\^(\w+)\\\/\[\^\/\]\+\$\/\.test\(collection\)\)\s*\{([\s\S]{0,400}?)\n\s*\}/g;
+    const checked: string[] = [];
+    const unguarded: string[] = [];
+
+    let m: RegExpExecArray | null;
+    while ((m = clause.exec(src)) !== null) {
+      const body = m[2] ?? '';
+      const call = /\b(process\w+)\(/.exec(body);
+      if (!call) continue;
+      const processor = call[1]!;
+      checked.push(processor);
+
+      // Pull the processor's own body and look for the guard.
+      const declIdx = src.indexOf(`function ${processor}(`);
+      expect(declIdx).toBeGreaterThan(-1);
+      const decl = src.slice(declIdx, declIdx + 900);
+      if (!/fields\.size === 0/.test(decl)) unguarded.push(processor);
+    }
+
+    // Vacuity guard: if the clause pattern stops matching (a refactor, a
+    // rename), this test would silently pass while checking nothing.
+    expect(checked.length).toBeGreaterThanOrEqual(2);
+    expect(unguarded).toEqual([]);
+  });
+});

--- a/tests/core/parent-pointer-documents.test.ts
+++ b/tests/core/parent-pointer-documents.test.ts
@@ -83,15 +83,27 @@ describe('every parent-pointer dispatch clause guards its processor (#627)', () 
   test('each processor reachable from a parent-pointer clause checks fields.size === 0', () => {
     const src = fs.readFileSync(path.join(import.meta.dir, '../../src/core/decoder.ts'), 'utf8');
 
-    const clause = /\/\^(\w+)\\\/\[\^\/\]\+\$\/\.test\(collection\)\)\s*\{([\s\S]{0,400}?)\n\s*\}/g;
+    // `[-\w]+` not `\w+`: a hyphenated collection name would otherwise not
+    // match the clause at all, and an unmatched clause is an unchecked one.
+    const clause =
+      /\/\^([-\w]+)\\\/\[\^\/\]\+\$\/\.test\(collection\)\)\s*\{([\s\S]{0,400}?)\n\s*\}/g;
     const checked: string[] = [];
     const unguarded: string[] = [];
+    const unresolved: string[] = [];
 
     let m: RegExpExecArray | null;
     while ((m = clause.exec(src)) !== null) {
+      const collectionName = m[1] ?? '?';
       const body = m[2] ?? '';
       const call = /\b(process\w+)\(/.exec(body);
-      if (!call) continue;
+      if (!call) {
+        // A clause whose processor we could not identify is NOT a pass. The
+        // body window is capped, so a long comment or nested logic before the
+        // call would land here — and skipping silently is exactly the failure
+        // this ratchet exists to prevent, one level up.
+        unresolved.push(collectionName);
+        continue;
+      }
       const processor = call[1]!;
       checked.push(processor);
 
@@ -105,6 +117,7 @@ describe('every parent-pointer dispatch clause guards its processor (#627)', () 
     // Vacuity guard: if the clause pattern stops matching (a refactor, a
     // rename), this test would silently pass while checking nothing.
     expect(checked.length).toBeGreaterThanOrEqual(2);
+    expect(unresolved).toEqual([]);
     expect(unguarded).toEqual([]);
   });
 });

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -43,6 +43,10 @@ export interface TestAccount {
   available_balance?: number;
   iso_currency_code?: string;
   item_id?: string;
+  /** User customizations now live on the account document itself (#624). */
+  nickname?: string;
+  user_hidden?: boolean;
+  user_deleted?: boolean;
 }
 
 export interface TestRecurring {
@@ -330,6 +334,9 @@ export async function createAccountDb(dbPath: string, accounts: TestAccount[]): 
       official_name: a.official_name,
       mask: a.mask,
       account_type: a.account_type,
+      nickname: a.nickname,
+      user_hidden: a.user_hidden,
+      user_deleted: a.user_deleted,
       subtype: a.subtype,
       institution_name: a.institution_name,
       institution_id: a.institution_id,
@@ -551,6 +558,9 @@ export async function createCombinedDb(
           official_name: a.official_name,
           mask: a.mask,
           account_type: a.account_type,
+          nickname: a.nickname,
+          user_hidden: a.user_hidden,
+          user_deleted: a.user_deleted,
           subtype: a.subtype,
           institution_name: a.institution_name,
           institution_id: a.institution_id,

--- a/tests/scripts/smoke-cache.test.ts
+++ b/tests/scripts/smoke-cache.test.ts
@@ -7,7 +7,12 @@
  */
 
 import { describe, test, expect } from 'bun:test';
-import { normalizeCollection, isTotalDecodeLoss, joinStats } from '../../scripts/smoke/cache.js';
+import {
+  normalizeCollection,
+  isTotalDecodeLoss,
+  joinStats,
+  findExtinctDependencies,
+} from '../../scripts/smoke/cache.js';
 
 describe('normalizeCollection', () => {
   test('wildcards document ids at odd path depths', () => {
@@ -100,5 +105,43 @@ describe('joinStats', () => {
 
   test('the empty-reference short-circuit does not consult the target', () => {
     expect(joinStats([], new Set(['sec_a'])).rate).toBe(1);
+  });
+});
+
+describe('findExtinctDependencies', () => {
+  // DEPENDED_ON is empty right now (#624 removed its only entry), so the check
+  // cannot exercise itself against a real cache. These keep it honest anyway —
+  // otherwise a gate nobody can currently trip is indistinguishable from a
+  // gate that is broken.
+  const raw = new Map([
+    ['transactions', { total: 100, empty: 0 }],
+    // A collection consisting ENTIRELY of Firestore parent pointers: documents
+    // exist, but none carries a field. This is what an extinct collection with
+    // surviving subcollections looks like, and it must read as extinct.
+    ['users/*/accounts', { total: 438, empty: 438 }],
+    ['items', { total: 20, empty: 8 }],
+  ]);
+
+  test('flags a collection whose documents are all parent pointers', () => {
+    expect(findExtinctDependencies(['users/*/accounts'], raw)).toEqual(['users/*/accounts']);
+  });
+
+  test('flags a collection absent from the cache entirely', () => {
+    expect(findExtinctDependencies(['never/*/existed'], raw)).toEqual(['never/*/existed']);
+  });
+
+  test('does not flag a collection with real documents', () => {
+    expect(findExtinctDependencies(['transactions'], raw)).toEqual([]);
+  });
+
+  test('does not flag a collection that merely has SOME parent pointers', () => {
+    // items has 8 empty of 20 — normal, not extinct. Counting raw totals
+    // instead of non-empty ones would miss the real case; counting any empty
+    // document as fatal would flag every healthy collection.
+    expect(findExtinctDependencies(['items'], raw)).toEqual([]);
+  });
+
+  test('returns nothing for an empty dependency list', () => {
+    expect(findExtinctDependencies([], raw)).toEqual([]);
   });
 });

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -140,6 +140,10 @@ const mockTransactionsWithFilters: Transaction[] = [
   },
 ];
 
+// Hidden-ness lives on the account document itself (#624). It used to be
+// modelled here via a `users/{uid}/accounts` customization collection, which
+// Copilot no longer populates — so the fixture described a world in which the
+// filter worked while real caches got no filtering at all.
 const mockAccountsWithHidden: Account[] = [
   {
     account_id: 'acc_visible',
@@ -152,14 +156,7 @@ const mockAccountsWithHidden: Account[] = [
     current_balance: 5000.0,
     name: 'Hidden Account',
     account_type: 'investment',
-  },
-];
-
-// UserAccountCustomization for hidden accounts
-const mockUserAccounts = [
-  {
-    account_id: 'acc_hidden',
-    hidden: true,
+    user_hidden: true,
   },
 ];
 
@@ -857,9 +854,10 @@ describe('CopilotMoneyTools', () => {
 
   describe('getAccounts with hidden accounts', () => {
     beforeEach(() => {
-      // Override with mock data that includes hidden accounts
+      // Deliberately seed the customization collection EMPTY, the way a real
+      // cache has it since Copilot moved these flags onto the account records.
       (db as any)._accounts = [...mockAccountsWithHidden];
-      (db as any)._userAccounts = [...mockUserAccounts];
+      (db as any)._userAccounts = [];
     });
 
     test('excludes hidden accounts by default', async () => {
@@ -873,6 +871,35 @@ describe('CopilotMoneyTools', () => {
       const result = await tools.getAccounts({ include_hidden: true });
       expect(result.count).toBe(2);
       expect(result.total_balance).toBe(6000.0);
+    });
+
+    test('does not rely on the users/{uid}/accounts customization collection (#624)', async () => {
+      // The whole bug: the filter consulted a collection that is always empty,
+      // so it silently did nothing. Populating that collection must not change
+      // the answer — if it does, the dead path has been reintroduced.
+      (db as any)._userAccounts = [{ account_id: 'acc_visible', hidden: true }];
+
+      const result = await tools.getAccounts();
+
+      expect(result.count).toBe(1);
+      expect(result.accounts[0].account_id).toBe('acc_visible');
+    });
+
+    test('excludes user_deleted accounts alongside user_hidden ones', async () => {
+      (db as any)._accounts = [
+        ...mockAccountsWithHidden,
+        {
+          account_id: 'acc_deleted',
+          current_balance: 250.0,
+          name: 'Merged Account',
+          account_type: 'checking',
+          user_deleted: true,
+        },
+      ];
+
+      const result = await tools.getAccounts();
+
+      expect(result.accounts.map((a) => a.account_id)).toEqual(['acc_visible']);
     });
   });
 


### PR DESCRIPTION
# Summary

Fixes both bugs `bun run smoke:cache` reported on its first run. The gate that found them now passes against a real cache: **7 pass, 1 warn, 0 fail**.

Closes #624
Closes #627

## External assumptions

Two, both **live round-trip** verified against a real cache (structural metadata only):

1. **Firestore's `items/{item_id}` parent-pointer entries never carry fields.** A real cache holds ~1,800 of them against 12 real items, and not one has a single field — so a clause matching them could only ever manufacture rows.
2. **Account customizations now live on the account document.** `user_hidden` and `nickname` are present there; the `users/{uid}/accounts` collection that used to hold them has **zero** documents. Since one cache cannot prove absence in general, the decoder for that collection is deliberately **kept** — only the behaviour that depended on it moved.

## Bug fix?

```text
Root cause:       Code depending on a shape reality no longer has. #627: an assumption
                  written into a comment ("parent-pointer docs return null") that was
                  false in both halves. #624: reading a collection Copilot stopped
                  populating, while the replacement flag sat decoded and unread on the
                  account document.
Bug class:        #627 path-divergence; #624 fixture-reality-drift.
                  See docs/bugs/README.md.
Detector added:   Both are now covered by `bun run smoke:cache` (shipped in #628), which
                  is what found them. #627 by decode-path parity on real data, #624 by
                  the extinct-dependency check. Neither is expressible as a fixture test
                  — see "Why there is no fixture test for #627" below.
Siblings checked: YES, and the audit paid off — see below. #627: all other decoders
                  audited for parent-pointer clauses; `items` was the only one.
                  #624: found TWO more instances of the same root cause.
Ledger updated:   n/a — the ledger covers the GraphQL boundary; these are decode-side.
```

## #627 — phantom `items` row

The aggregate path matched `items/{item_id}` on the stated assumption that *"parent-pointer docs have empty fields and processItem returns null."* Both halves were wrong: `processItem` always returns at least `{ item_id }`, so every such entry became a row carrying nothing else — no institution, no connection state.

Dedup by `item_id` hid the scale, collapsing ~1,800 pointers down to the one whose id matched no real item. So it presented as a harmless off-by-one rather than a flood, which is presumably why it survived.

Anything enumerating items — `get_connection_status` most visibly — showed a nameless extra connection.

## #624 — hidden accounts, plus two siblings the audit found

`include_hidden=false` filtered against `users/{uid}/accounts`, which no longer has documents, while `user_hidden` on the account record was decoded and never read. The filter was a silent no-op.

Checking siblings of that root cause — the ritual's most useful line — found the same mistake twice more, both in `getAccountNameMap`, which read only the same extinct collection:

- **`get_balance_history` reported `account_name: undefined` for every row**, because the map was always empty.
- **User-set account nicknames were never applied anywhere.** They live on the account document now; nothing read them.

The map is now built from the account documents, preferring `nickname` over the institution-supplied `name`.

Measured on a real cache, this is the larger of the two problems: the name map went from **0 entries to 18**, and **10 of those accounts have a nickname that differs from the institution name** — so wherever a name was shown, ten of them were either missing or showing the bank's internal string instead of what the user called the account. That is a re-run of historical bug #70, arriving by a different route.

## Fixtures moved too, because they were the root cause on the #624 side

The old fixture seeded hidden-ness via the customization collection — describing a world in which the filter worked, while every real cache got no filtering at all. Now:

- hidden-ness is seeded via `user_hidden` **on the account**, matching reality;
- the customization collection is seeded **empty**, the way real caches have it;
- a test asserts that **populating that dead collection does not change the answer**, so reintroducing the dead path fails loudly rather than silently passing.

## Why there is no fixture test for #627

I tried to write one and could not, which is worth recording rather than papering over.

Real parent pointers parse to a **two-segment collection** (`items/{id}`). The fixture writer emits utf8 string keys, and the string-key parser only recognizes 2- and 4-segment document paths — a 3-segment path is re-parsed as something else entirely. The shape is **inexpressible in a fixture today**.

That is the same structural limitation behind #622's defect 3 (binary vs utf8 keys), and it is why this PR leans on the real-cache gate for #627 rather than pretending a synthetic test covers it. The fixture-substrate work is the real fix for that whole family.

## Verification

`bun run check`: **2639 pass, 0 fail**.

`bun run smoke:cache` against a real cache, before → after:

```
FAIL extinct dependencies — users/*/accounts        →  PASS
FAIL decode-path parity — items 12 vs 13            →  PASS (all 9 collections agree)
                                                       7 pass, 1 warn, 0 fail
```

**Mutation-verified**, per #596 — reverting each fix turns specific tests red:

- `user_hidden` check removed → 3 tests red, including the one asserting the dead collection is not consulted
- name map reverted to the extinct collection → 3 tests red

`users/*/accounts` also leaves the smoke's `DEPENDED_ON` list, since no behaviour depends on it now.
