### PR TITLE
fix(leveldb-reader): never let temp DB copies outlive the process (#631)

### DIFF
--- a/docs/bugs/631-temp-copy-deferred-cleanup.md
+++ b/docs/bugs/631-temp-copy-deferred-cleanup.md
@@ -1,0 +1,121 @@
+---
+id: 631
+title: Every LevelDB read left its ~120 MB temp copy on disk — 366 stale directories (~33 GB) filled a user's disk
+class: deferred-cleanup-never-runs
+status: fixed
+detected: user-report  # a user's disk filled; they traced the `copilot-leveldb-*` pile back to this module and filed #631 with the mechanism
+fixed_in: https://github.com/ignaciohermosillacornejo/copilot-money-mcp/pull/632
+issue: https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/631
+date: 2026-08-12
+---
+
+## Symptom
+
+`os.tmpdir()` accumulated one `copilot-leveldb-*` directory per read, forever. Each is a
+full copy of the Copilot LevelDB (~120 MB). On the reporting machine, automation that hit
+the MCP a handful of times a day for several weeks produced **366 directories, ~33 GB**,
+and the disk filled — at which point unrelated work started failing with `ENOSPC` while
+the server itself still appeared healthy.
+
+Nothing in the tool's own output was wrong. The failure surfaced somewhere else entirely
+(a full disk), which is why it went unnoticed for weeks despite being trivially visible in
+`ls "$TMPDIR"`.
+
+## How it was detected
+
+Not by anything this project built. A user ran out of disk space, went looking for what
+was eating it, found the pile of `copilot-leveldb-*` directories, and read the source to
+work out why they were never deleted. The issue arrived with the mechanism already
+diagnosed.
+
+Worth recording plainly: the module had a passing test suite covering exactly this
+lifecycle — refcounting, TTL expiry, the cleanup callback — and none of it could see the
+bug, because all of it ran in a process that never exited during the test.
+
+## Root cause
+
+`releaseTempDatabase` (`src/core/leveldb-reader.ts`) deferred deletion to a timer:
+
+```ts
+if (cached.refCount <= 0) {
+  setTimeout(() => scheduledCleanupCallback(srcPath, scheduledTime), TEMP_DB_CACHE_TTL); // 5 min
+}
+```
+
+The design assumed a long-running host. Neither real host is one: the MCP server is
+normally spawned per request and exits when stdin closes, and the actual decode runs in a
+worker thread (`dist/decode-worker.js`) that is done milliseconds after it posts its
+result. Node drops pending timers on exit, so the 5-minute callback essentially never ran
+— and it was the only thing that deleted anything.
+
+Two aggravating details, both fixed in the same PR:
+
+- The TTL timer was not `unref()`'d, so on the main-thread path it kept the *worker*
+  alive for the full 5 minutes after its work was done — holding the V8 isolate and
+  native LevelDB memory that worker isolation exists to release promptly.
+- `copyDatabaseToTemp` creates the directory with `mkdtempSync` and only records it in
+  `tempDbCache` after the copy loop succeeds. A real mid-copy failure (EACCES/EIO) left a
+  directory that no in-process cleanup path could name. Small, but it is the same class
+  reached from a different direction, and the repo's own test suite was stranding one
+  directory per run through it.
+
+## Why the tests didn't catch it
+
+`tests/unit/signal-timer-coverage.test.ts` and the reader's unit tests exercised the
+cleanup thoroughly — by calling `_runScheduledCleanup` directly, i.e. by doing for the
+code the one thing production never did. They asserted "when the callback runs, the
+directory is deleted", which was true and always had been. The false assumption was not in
+the assertion but in the harness: a same-process test cannot observe that its process
+would have exited before the timer fired.
+
+The property that was actually broken — *no temp copy outlives the process that made it* —
+is not expressible in a same-process test at all. It needs a child process, which is why
+the regression tests spawn one.
+
+## The fix
+
+[PR #632](https://github.com/ignaciohermosillacornejo/copilot-money-mcp/pull/632), in
+three parts:
+
+- **Root cause:** a lazily-registered `process.on('exit')` sweep, plus `once` handlers for
+  SIGINT/SIGTERM/SIGHUP that sweep and re-raise, so deletion is tied to process exit
+  rather than to a timer. The TTL timer stays (it preserves the reuse cache that avoids
+  re-copying ~120 MB) but is now `unref()`'d and is no longer load-bearing.
+- **Reclaim:** a best-effort orphan sweep on startup removes `copilot-leveldb-*`
+  directories untouched for an hour, since the exit sweep does nothing for the users
+  already sitting on tens of GB — and it remains the only reclaim path for genuinely
+  uninterceptable deaths (SIGKILL, `worker.terminate()` on a decode timeout).
+- **Downstream cleanup:** the copy loop now removes its own directory before rethrowing.
+
+## Detector
+
+**None — instance-only regression tests**, and the honest reason is that the class is
+defined by a *deployment* property (does this process outlive its own timers?) that no
+static check in this repo can evaluate. `tests/core/leveldb-reader-temp-cleanup.test.ts`
+asserts the property for this module only: spawn a child, complete a real read, kill it
+normally and by signal, assert an isolated `TMPDIR` is empty afterwards.
+
+**Mutation-verified.** Against `main`'s reader, 4 of the 5 tests fail; the fifth is the
+`COPILOT_MCP_NO_TEMP_SWEEP` opt-out test, which is vacuous against a build that has no
+sweep to disable and was rewritten during review to be non-vacuous against the fixed
+build. The copy-loop test was checked the same way: delete the `cleanupTempDatabase(tempDir)`
+line and it goes red naming the stranded directory.
+
+The cheapest real gate for the class would be a review question rather than code: *does
+anything here schedule cleanup on a timer, and is this process guaranteed to be alive when
+it fires?* Both existing `setTimeout` siblings in `src/` were audited against it
+(`decoder.ts`'s decode timeout, cleared in `settle()` with no resource attached;
+`graphql/client.ts`'s retry backoff) and neither belongs to the class.
+
+## Lesson
+
+A resource whose release is scheduled rather than performed is only as reliable as the
+process's remaining lifetime — and a per-request server plus a fire-and-exit worker have
+approximately none. Tie cleanup to an event the runtime guarantees (`exit`, a `finally`,
+the release call itself), and treat any deferred cleanup as unreliable unless something
+else also guarantees it.
+
+The testing lesson is sharper and more general than the bug: **a lifecycle property that
+only manifests at process death cannot be tested in-process.** The suite here was not thin;
+it was measuring the right thing in a harness where the thing could not go wrong. Spawning
+a child costs a few seconds and was the only way to see it.

--- a/docs/bugs/README.md
+++ b/docs/bugs/README.md
@@ -94,11 +94,12 @@ a class yet.
 | `stale-kill-switch` | A temporary disablement outlives the condition it guarded and silently disables a restored feature. | none |
 | `packaging-environment-mismatch` | The shipped artifact works in dev but fails in the target runtime — missing bundled deps, hardened-runtime constraints, GUI PATH. | `tests/integration/mcpb-bundle.test.ts` (extract-and-boot outside the repo) |
 | `unsettled-promise` | An async operation has a completion path where neither resolve nor reject fires, hanging callers forever. | none |
+| `deferred-cleanup-never-runs` | Releasing a resource is deferred to a timer or callback that only fires if the process outlives it — in a process that routinely exits first. The resource is acquired eagerly and released never, while every same-process test still observes correct bookkeeping. | none — instance-only; the class is a deployment property (does this process outlive its own timers?) that no static check here can evaluate |
 
 ## How we find bugs
 
 Recorded per entry, using a fixed vocabulary so the corpus stays countable. Here is what
-this corpus actually says, across all 43 entries:
+this corpus actually says, across all 44 entries:
 
 | Found by | Count | |
 |---|---|---|
@@ -106,7 +107,7 @@ this corpus actually says, across all 43 entries:
 | `live-probe` — a probe or smoke against the real backend | 7 | ██████ |
 | `audit-sweep` — a deliberate cross-cutting audit | 7 | ██████ |
 | `incidental` — found while working on something else | 6 | █████ |
-| `user-report` | 5 | ████ |
+| `user-report` | 6 | █████ |
 | `adversarial-review` — a reviewer tried to refute a claim or mutation-tested a guard | 2 | █ |
 | `detector-first` — a detector was built, and then found bugs | 1 | ▌ |
 | `code-review` | 1 | ▌ |
@@ -287,3 +288,9 @@ record near-misses.
 | | Bug | Found by | Date |
 |---|---|---|---|
 | #129 | [Decode-worker promise hangs forever if the worker exits without sending a result](129-worker-exit-promise-hang.md) | `code-review` | 2026-03-12 |
+
+**`deferred-cleanup-never-runs`** — 1
+
+| | Bug | Found by | Date |
+|---|---|---|---|
+| #631 | [Every LevelDB read left its ~120 MB temp copy on disk — 366 stale directories (~33 GB) filled a user's disk](631-temp-copy-deferred-cleanup.md) | `user-report` | 2026-08-12 |

--- a/src/core/leveldb-reader.ts
+++ b/src/core/leveldb-reader.ts
@@ -280,8 +280,12 @@ function registerTempDbExitSweep(): void {
 
   // A signal terminates the process WITHOUT emitting 'exit'. Sweep, then
   // re-raise: the listener is registered with `once`, so by the time we
-  // re-raise it has already been removed and the default disposition applies,
-  // preserving the conventional 128+n exit code.
+  // re-raise it has already been removed and the default disposition applies.
+  // That restores the conventional 128+n exit code as long as this is the only
+  // listener for the signal — true for every caller today, since the reader
+  // runs in the decode worker and standalone scripts, never in the server
+  // process that installs its own SIGINT/SIGTERM handlers. A host that does
+  // install its own keeps its handling, not ours; the sweep still runs.
   for (const signal of SWEEP_SIGNALS) {
     process.once(signal, () => {
       cleanupAllTempDatabases();
@@ -316,14 +320,21 @@ let orphanSweepStarted = false;
  *     is one nobody has read from in an hour.
  *
  * Best effort by design: it runs on an unref'd timer with async removal, so it
- * never delays startup, blocks a read, or keeps a short-lived process alive. A
- * per-request process may exit mid-sweep and simply finish the job next run.
- * Set COPILOT_MCP_NO_TEMP_SWEEP=1 to disable.
+ * never delays startup and never blocks a read. The unref'd timer also means a
+ * process that finishes first simply exits without sweeping at all. Once the
+ * pass has started, though, its awaited fs promises do hold the event loop
+ * until it finishes — so the first run after upgrading, with a large backlog to
+ * delete, can briefly delay exit. That is the intended trade-off: the backlog
+ * is the whole reason this exists, and a per-request process interrupted
+ * mid-pass just finishes the job on the next run.
+ *
+ * Set COPILOT_MCP_NO_TEMP_SWEEP=1 to disable (`1` exactly, matching
+ * COPILOT_DISABLE_PERSISTENT_INDEX).
  */
 function startOrphanSweep(): void {
   if (orphanSweepStarted) return;
   orphanSweepStarted = true;
-  if (process.env.COPILOT_MCP_NO_TEMP_SWEEP) return;
+  if (process.env.COPILOT_MCP_NO_TEMP_SWEEP === '1') return;
 
   const timer = setTimeout(() => {
     void runOrphanSweep();
@@ -331,8 +342,8 @@ function startOrphanSweep(): void {
   timer.unref();
 }
 
-/** @internal exported for tests */
-export async function runOrphanSweep(): Promise<number> {
+/** Body of the sweep described by `startOrphanSweep`. Returns dirs removed. */
+async function runOrphanSweep(): Promise<number> {
   const tmpRoot = os.tmpdir();
   let entries: string[];
   try {

--- a/src/core/leveldb-reader.ts
+++ b/src/core/leveldb-reader.ts
@@ -136,6 +136,8 @@ function copyDatabaseToTemp(srcPath: string): string {
   const fingerprint = sourceFingerprint(srcPath);
 
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-leveldb-'));
+  // A copy now exists on disk. Guarantee it cannot outlive this process.
+  registerTempDbExitSweep();
   const files = fs.readdirSync(srcPath);
   for (const file of files) {
     if (!isLevelDBFile(file)) continue;
@@ -174,7 +176,14 @@ function scheduledCleanupCallback(srcPath: string, scheduledTime: number): void 
 
 /**
  * Release a reference to a temporary database copy.
- * When refCount reaches 0, schedule cleanup after TTL.
+ *
+ * When refCount reaches 0 the copy is deliberately KEPT and its cleanup is
+ * scheduled after the TTL, so a subsequent read of the same database reuses it
+ * instead of re-copying (~120 MB). The timer is unref'd: a pending cleanup must
+ * never be the reason a finished server or worker stays alive for the full TTL,
+ * and — since an unref'd timer will usually never fire at all — it must never be
+ * the only thing standing between a temp copy and deletion. That guarantee comes
+ * from `registerTempDbExitSweep`.
  */
 function releaseTempDatabase(srcPath: string): void {
   const cached = tempDbCache.get(srcPath);
@@ -186,7 +195,11 @@ function releaseTempDatabase(srcPath: string): void {
   // Schedule cleanup if no more references
   if (cached.refCount <= 0) {
     const scheduledTime = cached.lastAccess;
-    setTimeout(() => scheduledCleanupCallback(srcPath, scheduledTime), TEMP_DB_CACHE_TTL);
+    const timer = setTimeout(
+      () => scheduledCleanupCallback(srcPath, scheduledTime),
+      TEMP_DB_CACHE_TTL
+    );
+    timer.unref();
   }
 }
 
@@ -201,6 +214,45 @@ function cleanupTempDatabase(tempPath: string): void {
     console.error(
       `[WARN] Failed to clean up temp database at ${tempPath}: ${error instanceof Error ? error.message : String(error)}`
     );
+  }
+}
+
+/** Signals an MCP client may use to stop the server. */
+const SWEEP_SIGNALS = ['SIGINT', 'SIGTERM', 'SIGHUP'] as const;
+
+let exitSweepRegistered = false;
+
+/**
+ * Guarantee that temp copies never outlive the process that created them.
+ *
+ * The TTL timer in `releaseTempDatabase` cannot be relied on to do the actual
+ * deleting: this server usually runs as a short-lived, per-request process, and
+ * decoding runs in a worker thread that exits as soon as it posts its result.
+ * Both are gone long before a 5-minute timer could fire, and pending timers are
+ * simply dropped on exit — so every temp copy was orphaned. In the wild this
+ * accumulated to 366 stale `copilot-leveldb-*` directories (~33 GB) and filled
+ * the disk (issue #631).
+ *
+ * Registered lazily, the first time a copy is actually made, so merely importing
+ * this module never installs process listeners.
+ */
+function registerTempDbExitSweep(): void {
+  if (exitSweepRegistered) return;
+  exitSweepRegistered = true;
+
+  // Normal termination: a worker finishing, stdin closing, an explicit
+  // process.exit(). 'exit' listeners must be synchronous, which rmSync is.
+  process.on('exit', () => cleanupAllTempDatabases());
+
+  // A signal terminates the process WITHOUT emitting 'exit'. Sweep, then
+  // re-raise: the listener is registered with `once`, so by the time we
+  // re-raise it has already been removed and the default disposition applies,
+  // preserving the conventional 128+n exit code.
+  for (const signal of SWEEP_SIGNALS) {
+    process.once(signal, () => {
+      cleanupAllTempDatabases();
+      process.kill(process.pid, signal);
+    });
   }
 }
 

--- a/src/core/leveldb-reader.ts
+++ b/src/core/leveldb-reader.ts
@@ -45,6 +45,9 @@ const tempDbCache = new Map<string, TempDbCacheEntry>();
 // Cleanup interval (5 minutes)
 const TEMP_DB_CACHE_TTL = 5 * 60 * 1000;
 
+/** Prefix every temp copy is created with. */
+const TEMP_DB_PREFIX = 'copilot-leveldb-';
+
 /**
  * Predicate for files that make up a LevelDB database state. Matches the set
  * `copyDatabaseToTemp` actually copies (LOCK is intentionally excluded — we
@@ -87,6 +90,23 @@ function sourceFingerprint(srcPath: string): number {
 }
 
 /**
+ * Mark a temp copy as still in use.
+ *
+ * The orphan sweep decides what to delete from a copy's mtime, which otherwise
+ * only reflects when it was created. Refreshing it on every reuse makes "not
+ * touched in an hour" mean genuinely idle rather than merely old, so a
+ * long-lived process reusing one copy can never have it swept out from under it.
+ */
+function touchTempCopy(tempPath: string): void {
+  try {
+    const now = new Date();
+    fs.utimesSync(tempPath, now, now);
+  } catch {
+    // Best effort only: a failure here costs nothing but sweep precision.
+  }
+}
+
+/**
  * Copy a LevelDB database to a temporary directory.
  * This allows reading while another process has the database locked.
  *
@@ -106,6 +126,7 @@ function copyDatabaseToTemp(srcPath: string): string {
     if (currentFingerprint <= cached.sourceFingerprint) {
       cached.refCount++;
       cached.lastAccess = Date.now();
+      touchTempCopy(cached.tempPath);
       return cached.tempPath;
     }
     // Source has changed since the cached copy was made. If nothing is
@@ -122,6 +143,7 @@ function copyDatabaseToTemp(srcPath: string): string {
     } else {
       cached.refCount++;
       cached.lastAccess = Date.now();
+      touchTempCopy(cached.tempPath);
       return cached.tempPath;
     }
   }
@@ -135,9 +157,11 @@ function copyDatabaseToTemp(srcPath: string): string {
   // to the copy start as possible.
   const fingerprint = sourceFingerprint(srcPath);
 
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'copilot-leveldb-'));
-  // A copy now exists on disk. Guarantee it cannot outlive this process.
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), TEMP_DB_PREFIX));
+  // A copy now exists on disk. Guarantee it cannot outlive this process, and
+  // (once per process) reclaim any copies stranded by an earlier version.
   registerTempDbExitSweep();
+  startOrphanSweep();
   const files = fs.readdirSync(srcPath);
   for (const file of files) {
     if (!isLevelDBFile(file)) continue;
@@ -254,6 +278,78 @@ function registerTempDbExitSweep(): void {
       process.kill(process.pid, signal);
     });
   }
+}
+
+/**
+ * How long a temp copy must sit untouched before the sweep treats it as
+ * abandoned. 12x TEMP_DB_CACHE_TTL: comfortably longer than any read, and
+ * `touchTempCopy` keeps an actively reused copy well under it.
+ */
+const ORPHAN_SWEEP_MIN_AGE_MS = 60 * 60 * 1000;
+
+let orphanSweepStarted = false;
+
+/**
+ * Reclaim temp copies stranded on disk by an earlier version of this module.
+ *
+ * `registerTempDbExitSweep` stops new leaks but cannot help anyone who already
+ * has hundreds of orphans (one reporter had ~33 GB). This removes any
+ * `copilot-leveldb-*` directory that has gone untouched for
+ * ORPHAN_SWEEP_MIN_AGE_MS, including copies left by other processes.
+ *
+ * Deleting another process's copy is safe by construction:
+ *   - copies this process still has cached are skipped explicitly;
+ *   - `copyDatabaseToTemp` guards every reuse with `fs.existsSync` and simply
+ *     re-copies when the directory is gone, so the worst case for another
+ *     process is one extra copy, never a failed read;
+ *   - `touchTempCopy` refreshes mtime on reuse, so a copy old enough to sweep
+ *     is one nobody has read from in an hour.
+ *
+ * Best effort by design: it runs on an unref'd timer with async removal, so it
+ * never delays startup, blocks a read, or keeps a short-lived process alive. A
+ * per-request process may exit mid-sweep and simply finish the job next run.
+ * Set COPILOT_MCP_NO_TEMP_SWEEP=1 to disable.
+ */
+function startOrphanSweep(): void {
+  if (orphanSweepStarted) return;
+  orphanSweepStarted = true;
+  if (process.env.COPILOT_MCP_NO_TEMP_SWEEP) return;
+
+  const timer = setTimeout(() => {
+    void runOrphanSweep();
+  }, 0);
+  timer.unref();
+}
+
+/** @internal exported for tests */
+export async function runOrphanSweep(): Promise<number> {
+  const tmpRoot = os.tmpdir();
+  let entries: string[];
+  try {
+    entries = await fs.promises.readdir(tmpRoot);
+  } catch {
+    return 0;
+  }
+
+  const cutoff = Date.now() - ORPHAN_SWEEP_MIN_AGE_MS;
+  const inUse = new Set([...tempDbCache.values()].map((entry) => entry.tempPath));
+  let removed = 0;
+
+  for (const name of entries) {
+    if (!name.startsWith(TEMP_DB_PREFIX)) continue;
+    const full = path.join(tmpRoot, name);
+    if (inUse.has(full)) continue;
+    try {
+      const stat = await fs.promises.stat(full);
+      if (!stat.isDirectory() || stat.mtimeMs > cutoff) continue;
+      await fs.promises.rm(full, { recursive: true, force: true });
+      removed++;
+    } catch {
+      // Raced with the owning process or another sweeper; nothing to do.
+    }
+  }
+
+  return removed;
 }
 
 /**

--- a/src/core/leveldb-reader.ts
+++ b/src/core/leveldb-reader.ts
@@ -162,15 +162,25 @@ function copyDatabaseToTemp(srcPath: string): string {
   // (once per process) reclaim any copies stranded by an earlier version.
   registerTempDbExitSweep();
   startOrphanSweep();
-  const files = fs.readdirSync(srcPath);
-  for (const file of files) {
-    if (!isLevelDBFile(file)) continue;
-    try {
-      fs.copyFileSync(path.join(srcPath, file), path.join(tempDir, file));
-    } catch (err) {
-      // TOCTOU: compaction may delete .ldb between readdir and copyFile; MANIFEST already dropped it, so omitting is correct, others propagate.
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  try {
+    const files = fs.readdirSync(srcPath);
+    for (const file of files) {
+      if (!isLevelDBFile(file)) continue;
+      try {
+        fs.copyFileSync(path.join(srcPath, file), path.join(tempDir, file));
+      } catch (err) {
+        // TOCTOU: compaction may delete .ldb between readdir and copyFile; MANIFEST already dropped it, so omitting is correct, others propagate.
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
     }
+  } catch (err) {
+    // A real read/copy failure (EACCES, EIO) aborts before the entry reaches
+    // `tempDbCache`, so from here on nothing in the process can name this
+    // directory: the exit sweep and `cleanupAllTempDatabases` both iterate the
+    // cache, and only the orphan sweep would ever reclaim it, an hour later.
+    // This is the last place that still holds the path — delete it here.
+    cleanupTempDatabase(tempDir);
+    throw err;
   }
 
   tempDbCache.set(srcPath, {

--- a/tests/core/leveldb-reader-temp-cleanup.test.ts
+++ b/tests/core/leveldb-reader-temp-cleanup.test.ts
@@ -196,15 +196,25 @@ describe('orphan sweep reclaims copies stranded by earlier versions (issue #631)
     fs.mkdirSync(tmpdir, { recursive: true });
     const stale = makeFakeCopy(tmpdir, 'copilot-leveldb-staleA', 2 * 60 * 60 * 1000);
 
-    const script = path.join(FIXTURES_DIR, 'read-once-no-sweep.ts');
-    writeChildScript(script, false);
+    // Keep the child alive well past the point where the enabled sweep has
+    // demonstrably finished (previous test), otherwise a fast-exiting child
+    // would leave the orphan behind regardless of the env var and this would
+    // pass without proving anything.
+    const script = path.join(FIXTURES_DIR, 'read-and-wait-no-sweep.ts');
+    writeChildScript(script, true);
 
     const child = spawn(process.execPath, [script, dbPath], {
       env: { ...process.env, TMPDIR: tmpdir, COPILOT_MCP_NO_TEMP_SWEEP: '1' },
       stdio: ['ignore', 'pipe', 'inherit'],
     });
+
+    await whenReady(child);
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+    const stillThere = fs.existsSync(stale);
+
+    child.kill('SIGTERM');
     await new Promise<void>((resolve) => child.on('exit', () => resolve()));
 
-    expect(fs.existsSync(stale)).toBe(true);
+    expect(stillThere).toBe(true);
   }, 60000);
 });

--- a/tests/core/leveldb-reader-temp-cleanup.test.ts
+++ b/tests/core/leveldb-reader-temp-cleanup.test.ts
@@ -59,6 +59,26 @@ function whenReady(child: ReturnType<typeof spawn>): Promise<void> {
   });
 }
 
+/** Poll until `predicate` holds, so the async sweep needs no fixed sleep. */
+async function waitUntil(predicate: () => boolean, timeoutMs = 20000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return predicate();
+}
+
+/** Create a directory that looks like a temp copy, aged `ageMs` into the past. */
+function makeFakeCopy(tmpdir: string, name: string, ageMs: number): string {
+  const dir = path.join(tmpdir, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'CURRENT'), 'MANIFEST-000001\n');
+  const stamp = new Date(Date.now() - ageMs);
+  fs.utimesSync(dir, stamp, stamp);
+  return dir;
+}
+
 describe('temp database copies do not outlive the reading process (issue #631)', () => {
   beforeEach(() => {
     fs.mkdirSync(FIXTURES_DIR, { recursive: true });
@@ -116,5 +136,75 @@ describe('temp database copies do not outlive the reading process (issue #631)',
     await new Promise<void>((resolve) => child.on('exit', () => resolve()));
 
     expect(tempCopies(tmpdir)).toEqual([]);
+  }, 60000);
+});
+
+describe('orphan sweep reclaims copies stranded by earlier versions (issue #631)', () => {
+  beforeEach(() => {
+    fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(FIXTURES_DIR, { recursive: true, force: true });
+  });
+
+  test('sweeps idle orphans, keeps recent copies and unrelated directories', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'sweep-db');
+    await createTestDatabase(dbPath, [{ collection: 'test', id: 'doc1', fields: { x: 1 } }]);
+
+    const tmpdir = path.join(FIXTURES_DIR, 'tmp-sweep');
+    fs.mkdirSync(tmpdir, { recursive: true });
+
+    // Two hours idle: what a process killed before the fix leaves behind.
+    const staleA = makeFakeCopy(tmpdir, 'copilot-leveldb-staleA', 2 * 60 * 60 * 1000);
+    const staleB = makeFakeCopy(tmpdir, 'copilot-leveldb-staleB', 2 * 60 * 60 * 1000);
+    // Recently touched: another live process may still be reading it.
+    const recent = makeFakeCopy(tmpdir, 'copilot-leveldb-recent', 0);
+    // Not ours: must never be touched, however old.
+    const foreign = makeFakeCopy(tmpdir, 'some-other-tool-cache', 2 * 60 * 60 * 1000);
+
+    const script = path.join(FIXTURES_DIR, 'read-and-wait-sweep.ts');
+    writeChildScript(script, true);
+
+    const child = spawn(process.execPath, [script, dbPath], {
+      env: { ...process.env, TMPDIR: tmpdir },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+
+    await whenReady(child);
+    const swept = await waitUntil(() => !fs.existsSync(staleA) && !fs.existsSync(staleB));
+
+    const recentSurvived = fs.existsSync(recent);
+    const foreignSurvived = fs.existsSync(foreign);
+
+    child.kill('SIGTERM');
+    await new Promise<void>((resolve) => child.on('exit', () => resolve()));
+
+    expect(swept).toBe(true);
+    expect(recentSurvived).toBe(true);
+    expect(foreignSurvived).toBe(true);
+
+    // And the child's own copy is still cleaned up on exit.
+    expect(tempCopies(tmpdir)).toEqual(['copilot-leveldb-recent']);
+  }, 60000);
+
+  test('sweep is disabled by COPILOT_MCP_NO_TEMP_SWEEP', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'no-sweep-db');
+    await createTestDatabase(dbPath, [{ collection: 'test', id: 'doc1', fields: { x: 1 } }]);
+
+    const tmpdir = path.join(FIXTURES_DIR, 'tmp-no-sweep');
+    fs.mkdirSync(tmpdir, { recursive: true });
+    const stale = makeFakeCopy(tmpdir, 'copilot-leveldb-staleA', 2 * 60 * 60 * 1000);
+
+    const script = path.join(FIXTURES_DIR, 'read-once-no-sweep.ts');
+    writeChildScript(script, false);
+
+    const child = spawn(process.execPath, [script, dbPath], {
+      env: { ...process.env, TMPDIR: tmpdir, COPILOT_MCP_NO_TEMP_SWEEP: '1' },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+    await new Promise<void>((resolve) => child.on('exit', () => resolve()));
+
+    expect(fs.existsSync(stale)).toBe(true);
   }, 60000);
 });

--- a/tests/core/leveldb-reader-temp-cleanup.test.ts
+++ b/tests/core/leveldb-reader-temp-cleanup.test.ts
@@ -18,7 +18,8 @@ import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs';
-import { createTestDatabase } from '../../src/core/leveldb-reader.js';
+import os from 'node:os';
+import { createTestDatabase, iterateDocuments } from '../../src/core/leveldb-reader.js';
 
 const FIXTURES_DIR = path.join(__dirname, '../fixtures/leveldb-temp-cleanup');
 const READER_MODULE = path.resolve(__dirname, '../../src/core/leveldb-reader.ts');
@@ -103,9 +104,7 @@ describe('temp database copies do not outlive the reading process (issue #631)',
       stdio: ['ignore', 'pipe', 'inherit'],
     });
 
-    const code = await new Promise<number>((resolve) =>
-      child.on('exit', (c) => resolve(c ?? 0))
-    );
+    const code = await new Promise<number>((resolve) => child.on('exit', (c) => resolve(c ?? 0)));
 
     // The read must have succeeded — otherwise "no temp copy" is vacuously true.
     expect(code).toBe(0);
@@ -216,5 +215,63 @@ describe('orphan sweep reclaims copies stranded by earlier versions (issue #631)
     await new Promise<void>((resolve) => child.on('exit', () => resolve()));
 
     expect(stillThere).toBe(true);
+  }, 60000);
+});
+
+describe('a failed copy does not strand its temp directory (issue #631)', () => {
+  beforeEach(() => {
+    fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(FIXTURES_DIR, { recursive: true, force: true });
+  });
+
+  /**
+   * `mkdtempSync` creates the directory before the copy loop runs, and the
+   * cache entry is only written after the loop succeeds. A mid-copy failure
+   * therefore used to leave a directory on disk that nothing in the process
+   * could name: both the exit sweep and `cleanupAllTempDatabases` iterate
+   * `tempDbCache`, so only the orphan sweep would reclaim it, an hour later.
+   * Same class as the leak this PR fixes — an uninterceptable copy — reached
+   * by a different path, so it gets its own assertion.
+   *
+   * This one is observable in-process: `os.tmpdir()` re-reads TMPDIR on every
+   * call, so pointing it at an empty directory makes "nothing was left behind"
+   * exact rather than a needle-in-the-haystack search of the real temp dir.
+   */
+  test('a mid-copy failure removes the directory it already created', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'copy-fail-db');
+    await createTestDatabase(dbPath, [{ collection: 'test', id: 'doc1', fields: { x: 1 } }]);
+
+    const tmpdir = path.join(FIXTURES_DIR, 'tmp-copy-fail');
+    fs.mkdirSync(tmpdir, { recursive: true });
+
+    const originalTmpdir = process.env.TMPDIR;
+    const originalCopy = fs.copyFileSync;
+    process.env.TMPDIR = tmpdir;
+    expect(os.tmpdir()).toBe(tmpdir);
+
+    // A real EACCES/EIO mid-copy — not the ENOENT the loop deliberately skips.
+    (fs as { copyFileSync: typeof fs.copyFileSync }).copyFileSync = ((src: fs.PathLike) => {
+      if (typeof src === 'string' && src.startsWith(dbPath + path.sep)) {
+        const err: NodeJS.ErrnoException = new Error('permission denied');
+        err.code = 'EACCES';
+        throw err;
+      }
+      throw new Error(`unexpected copy of ${String(src)}`);
+    }) as typeof fs.copyFileSync;
+
+    try {
+      const gen = iterateDocuments(dbPath);
+      // The failure must still propagate — silently returning a half-copied
+      // database would be a far worse bug than the stranded directory.
+      await expect(gen.next()).rejects.toThrow('permission denied');
+      expect(tempCopies(tmpdir)).toEqual([]);
+    } finally {
+      (fs as { copyFileSync: typeof fs.copyFileSync }).copyFileSync = originalCopy;
+      if (originalTmpdir === undefined) delete process.env.TMPDIR;
+      else process.env.TMPDIR = originalTmpdir;
+    }
   }, 60000);
 });

--- a/tests/core/leveldb-reader-temp-cleanup.test.ts
+++ b/tests/core/leveldb-reader-temp-cleanup.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression tests for temp-copy lifetime (issue #631).
+ *
+ * `copyDatabaseToTemp` copies the LevelDB into `os.tmpdir()` and
+ * `releaseTempDatabase` only SCHEDULES cleanup (TEMP_DB_CACHE_TTL). Because the
+ * server usually runs as a short-lived per-request process — and decoding runs
+ * in a worker thread that exits as soon as it posts its result — that timer
+ * almost never fires, and pending timers are dropped on exit. Every temp copy
+ * was therefore orphaned (366 dirs / ~33 GB observed in the wild).
+ *
+ * These tests assert the property that actually matters and that a same-process
+ * unit test cannot observe: once the reading PROCESS is gone, no temp copy is
+ * left behind. Each child runs with its own TMPDIR so the assertion is exact and
+ * can never collide with a concurrently running server's copies.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import fs from 'node:fs';
+import { createTestDatabase } from '../../src/core/leveldb-reader.js';
+
+const FIXTURES_DIR = path.join(__dirname, '../fixtures/leveldb-temp-cleanup');
+const READER_MODULE = path.resolve(__dirname, '../../src/core/leveldb-reader.ts');
+
+/** Temp copies visible in an isolated TMPDIR. */
+function tempCopies(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir).filter((name) => name.startsWith('copilot-leveldb-'));
+}
+
+/**
+ * Write a child entrypoint that performs one full read of `dbPath`.
+ * When `keepAlive` is set it stays running afterwards so the parent can signal it.
+ */
+function writeChildScript(file: string, keepAlive: boolean): void {
+  fs.writeFileSync(
+    file,
+    [
+      `import { iterateDocuments } from ${JSON.stringify(READER_MODULE)};`,
+      `const dbPath = process.argv[2];`,
+      `for await (const _doc of iterateDocuments(dbPath)) {`,
+      `  // drain`,
+      `}`,
+      `console.log('read-complete');`,
+      keepAlive ? `setInterval(() => {}, 1000);` : ``,
+    ].join('\n')
+  );
+}
+
+/** Resolve once the child prints its ready marker. */
+function whenReady(child: ReturnType<typeof spawn>): Promise<void> {
+  return new Promise((resolve) => {
+    let buf = '';
+    child.stdout?.on('data', (d: Buffer) => {
+      buf += d.toString();
+      if (buf.includes('read-complete')) resolve();
+    });
+  });
+}
+
+describe('temp database copies do not outlive the reading process (issue #631)', () => {
+  beforeEach(() => {
+    fs.mkdirSync(FIXTURES_DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(FIXTURES_DIR, { recursive: true, force: true });
+  });
+
+  test('nothing is left behind when the reading process exits normally', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'exit-db');
+    await createTestDatabase(dbPath, [{ collection: 'test', id: 'doc1', fields: { x: 1 } }]);
+
+    const tmpdir = path.join(FIXTURES_DIR, 'tmp-normal-exit');
+    fs.mkdirSync(tmpdir, { recursive: true });
+
+    const script = path.join(FIXTURES_DIR, 'read-once.ts');
+    writeChildScript(script, false);
+
+    const child = spawn(process.execPath, [script, dbPath], {
+      env: { ...process.env, TMPDIR: tmpdir },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+
+    const code = await new Promise<number>((resolve) =>
+      child.on('exit', (c) => resolve(c ?? 0))
+    );
+
+    // The read must have succeeded — otherwise "no temp copy" is vacuously true.
+    expect(code).toBe(0);
+    expect(tempCopies(tmpdir)).toEqual([]);
+  }, 60000);
+
+  test('nothing is left behind when the reading process is terminated by a signal', async () => {
+    const dbPath = path.join(FIXTURES_DIR, 'signal-db');
+    await createTestDatabase(dbPath, [{ collection: 'test', id: 'doc1', fields: { x: 1 } }]);
+
+    const tmpdir = path.join(FIXTURES_DIR, 'tmp-signal-exit');
+    fs.mkdirSync(tmpdir, { recursive: true });
+
+    const script = path.join(FIXTURES_DIR, 'read-and-wait.ts');
+    writeChildScript(script, true);
+
+    const child = spawn(process.execPath, [script, dbPath], {
+      env: { ...process.env, TMPDIR: tmpdir },
+      stdio: ['ignore', 'pipe', 'inherit'],
+    });
+
+    // Wait until the copy definitely exists, so the assertion is meaningful.
+    await whenReady(child);
+    expect(tempCopies(tmpdir).length).toBe(1);
+
+    // How an MCP client stops the server.
+    child.kill('SIGTERM');
+    await new Promise<void>((resolve) => child.on('exit', () => resolve()));
+
+    expect(tempCopies(tmpdir)).toEqual([]);
+  }, 60000);
+});


### PR DESCRIPTION
Fixes #631.

## The problem

`copyDatabaseToTemp` copies the LevelDB (~120 MB) into `os.tmpdir()` on every read, and `releaseTempDatabase` only *schedules* the cleanup:

```ts
setTimeout(() => scheduledCleanupCallback(srcPath, scheduledTime), TEMP_DB_CACHE_TTL); // 5 min
```

The server usually runs as a **short-lived, per-request process**, and decoding runs in a **worker thread** that exits as soon as it posts its result. Both are gone long before that timer can fire, and pending timers are dropped on exit — so the temp copy is never deleted.

Observed here: **366 orphaned `copilot-leveldb-*` directories ≈ 33 GB**, which filled the disk.

## Part 1 — stop new leaks

The obvious fix — delete immediately when `refCount` hits 0 — works, but it throws away the reuse cache: each subsequent read of the same DB re-copies ~120 MB, and it breaks the contract asserted in `tests/core/leveldb-reader.test.ts` (`cleanupAllTempDatabases` expects the cache to still be populated *after* iteration).

So this PR keeps the cache and its reuse semantics exactly as they are, and instead ties a copy's lifetime to the process:

1. **Sweep `tempDbCache` on `'exit'`** — covers worker exit, stdin close, and explicit `process.exit()`. `rmSync` is synchronous, which `'exit'` requires.
2. **Sweep on `SIGINT`/`SIGTERM`/`SIGHUP`, then re-raise** — a signal terminates the process *without* emitting `'exit'`. The listener is registered with `once`, so by the time we re-raise it has been removed, the default disposition applies, and the conventional `128+n` exit code is preserved.
3. **`unref()` the TTL timer** — a pending cleanup should never keep a finished server or worker alive for the full 5 minutes. (It also means the timer will usually never fire, which is precisely why the exit sweep, not the timer, is what guarantees deletion.)

No behavior change for callers: same reuse, same fingerprint-based invalidation (#345), same TOCTOU handling (#350). Existing tests are untouched.

## Part 2 — reclaim what already leaked

Part 1 stops the bleeding but does nothing for anyone already sitting on hundreds of orphans, so there's now a best-effort background sweep that removes `copilot-leveldb-*` directories untouched for over an hour.

Deleting directories owned by other processes deserves scrutiny, so the safety argument is explicit:

- **Copies this process still has cached are skipped** by path.
- **Deleting another process's idle copy is harmless** — `copyDatabaseToTemp` already guards every reuse with `fs.existsSync` and simply re-copies when the directory is gone. Worst case for another process is one extra copy, never a failed read.
- **`touchTempCopy` refreshes mtime on every reuse**, so "untouched for an hour" means genuinely idle rather than merely old. Without this, a long-lived process reusing one copy for hours could have had it swept mid-use; with it, a sweepable copy is one nobody has read from in an hour (12× `TEMP_DB_CACHE_TTL`).
- **Never blocks anything** — unref'd timer, async `rm`. It can't delay startup or stall a read; a per-request process may exit before the sweep starts, or mid-pass, and simply finishes the job next run.
- **Opt out** with `COPILOT_MCP_NO_TEMP_SWEEP=1`.

## Part 3 — close the class at the source (review follow-up)

@ignaciohermosillacornejo found one more member of the uninterceptable class while reviewing: `copyDatabaseToTemp` runs `mkdtempSync` and only writes to `tempDbCache` *after* the copy loop, so a real mid-copy failure (EACCES/EIO — not the ENOENT the loop deliberately skips) stranded a directory that no in-process cleanup path could name. Pre-existing on `main`, and it's why the suite stranded one small directory per run through the `copy loop propagates non-ENOENT copy errors` test.

The copy loop now removes its own directory before rethrowing, so the sweep is a backstop for that case rather than the only reclaim path. The failure still propagates — silently returning a half-copied database would be a far worse bug than the stranded directory.

## Review nits, all applied

- `runOrphanSweep` was exported as "@internal exported for tests" but nothing imported it. **Unexported** — the child-process tests cover it end to end.
- `COPILOT_MCP_NO_TEMP_SWEEP` now compares **`=== '1'`**, matching `COPILOT_DISABLE_PERSISTENT_INDEX`. Under truthiness, `=0` also disabled the sweep.
- Both **overclaimed doc comments** corrected: the `128+n` preservation is now stated as holding when nothing else listens for the signal (true for every caller today, with the reason recorded), and the sweep's "never keeps the process alive" is now scoped to the unref'd timer — once a pass has started, its awaited fs promises do hold the event loop until it finishes, which the comment now says explicitly, including that the first post-upgrade run against a large backlog can briefly delay exit.
- `bun run fix` applied; `bun run format:check` and `bun run typecheck` are clean.

## Tests

`tests/core/leveldb-reader-temp-cleanup.test.ts` covers the property a same-process unit test structurally cannot observe: **once the reading process is gone, no temp copy remains.** Each child runs with its own `TMPDIR`, so assertions are exact and can't collide with a real server's copies.

- exits normally → no `copilot-leveldb-*` left (asserts exit code 0 first, so "no copy" can't pass vacuously)
- killed with `SIGTERM` → asserts the copy **exists** while running, then that it's gone after exit
- sweep → two 2-hour-old orphans removed, while a recently-touched copy, an unrelated directory, and the child's own in-use copy all survive
- opt-out → child is deliberately kept alive past the point where the enabled sweep demonstrably finishes, so a surviving orphan can only mean the env var was honoured
- **new:** a mid-copy EACCES leaves nothing behind. This one runs in-process by pointing `TMPDIR` at an empty directory — `os.tmpdir()` re-reads the variable on every call — so "nothing was left behind" is an exact assertion rather than a search of the real temp dir.

**Mutation-checked, as requested.** Against `main`'s `leveldb-reader.ts`, **4 of the 5 fail**; the fifth is the opt-out test, which is vacuous against a build with no sweep to disable (inherent to opt-out tests, and it was already rewritten to be non-vacuous against the fixed build). The Part 3 test was checked the same way against this branch: delete the `cleanupTempDatabase(tempDir)` line and it goes red naming the stranded directory.

I verified the mechanisms directly rather than assuming them: that an `unref()`'d timer doesn't hold a worker open, that `process.on('exit')` still fires and can synchronously remove the directory on natural worker exit, that the signal path sweeps, and that the sweep's predicate discriminates correctly across seven cases (2 h and 25 h orphans swept; 59-minute, fresh, in-cache, foreign-prefix, and not-a-directory entries all left alone).

`SIGKILL` and `worker.terminate()` (the decode-timeout path) remain uninterceptable by definition — the orphan sweep is what eventually reclaims those.

## Post-mortem

`docs/bugs/631-temp-copy-deferred-cleanup.md`, filed under a proposed new class **`deferred-cleanup-never-runs`** (added to `docs/bugs/README.md`): *releasing a resource is deferred to a timer or callback that only fires if the process outlives it, in a process that routinely exits first.* Nothing in the existing list fit — it isn't `stale-cache-semantics` or `silent-failure-masking` — and per the README the third instance of a class is the finding, so it seemed better to name it now than to file this under something adjacent.

The `Detector` field says **none — instance-only**, honestly: the class is defined by a deployment property (does this process outlive its own timers?) that no static check in this repo can evaluate, and an invented gate would be worse than the admitted gap. The entry also records *why the existing tests were blind* — they called `_runScheduledCleanup` directly, doing for the code the one thing production never did.

## Two things found while doing this, neither fixed here

1. **`tests/context-budget.test.ts` fails on any machine that has run the scheduled drift check.** `get_connection_status` embeds `readScheduledSmokeStatus()`, which reads `~/.claude/copilot-money/scheduled-smoke.json` — including the full `report` string. Mine is 1330 chars, which pushes the response to 2664 against a 1900 budget. Move that file away and the suite is 68/68. It reproduces identically on `main` (so it is not from this PR), but it's arguably two real findings: a supposedly hermetic test reads real home-directory state, and the #597 budget a user actually experiences can be blown by a file the budget test normally never sees.
2. **One adjacent stranded-artifact sibling**, not of the timer class: `transaction-meta-store.ts`'s cap valve writes `${file}.${pid}.tmp` and renames it — if `writeFileSync` succeeds and `renameSync` throws, the `.tmp` stays. Bounded and tiny (one small file per pid), so I left it alone, but happy to close it if you want the shape gone everywhere.

Full suite on this branch: **2652 pass, 20 skip, 1 fail** — that one failure being (1) above.

## External assumptions

None — this PR touches only local temp-file lifecycle and process-exit handling. It makes no new assumption about Copilot's API, its data shapes, or its on-disk format.

## Bug fix?

```text
Root cause:       temp-copy deletion was deferred to a 5-minute setTimeout that never fires — the MCP server is a short-lived per-request process and the decode worker exits milliseconds after posting its result, and pending timers are dropped on exit
Bug class:        deferred-cleanup-never-runs (new — proposed and defined in docs/bugs/README.md; releasing a resource is deferred to a timer/callback that only fires if the process outlives it, in a process that routinely exits first)
Detector added:   none — instance-only regression tests (tests/core/leveldb-reader-temp-cleanup.test.ts, child-process lifetime assertions, mutation-verified against main). The class is a deployment property no static check here can evaluate; an invented gate would be worse than the admitted gap
Siblings checked: every setTimeout/setInterval in src/ — decoder.ts:3369 (decode timeout, cleared in settle(), no resource attached) and graphql/client.ts:226 (retry backoff, not cleanup). Neither belongs to the class. Also audited every on-disk artifact creator in src/: found one adjacent stranded-artifact case in transaction-meta-store.ts (cap-valve .tmp if rename throws), reported above, not fixed here
Ledger updated:   n/a — not an external-assumption bug
```
