### PR TITLE
fix(ci): unbreak the Pages build and the fork-PR audit workflow

### DIFF
--- a/.github/workflows/audit-reviews.yml
+++ b/.github/workflows/audit-reviews.yml
@@ -3,9 +3,16 @@ name: Audit PR Reviews
 # Runs after a PR is merged (or via manual dispatch) and asks Claude to identify
 # review suggestions that were NOT applied in the final merged code. Produces
 # at most one follow-up issue per PR, or none if everything was addressed.
+#
+# Trigger is pull_request_target, not pull_request: plain pull_request runs from
+# fork PRs get no repo secrets, so OP_SERVICE_ACCOUNT_TOKEN arrived empty and
+# every fork-PR audit failed at the 1Password step. pull_request_target is safe
+# here because the job is gated on merged == true (or manual dispatch), the
+# workflow definition executes from the base branch, and checkout pulls the base
+# repo's main — no unmerged fork code ever runs with secrets in scope.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
   workflow_dispatch:
     inputs:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,9 @@
+# GitHub Pages (Jekyll) configuration for the docs/ site.
+theme: jekyll-theme-primer
+
+# TEMPLATE.md carries placeholder front matter (e.g. `date: <YYYY-MM-DD the fix
+# landed>`), which Jekyll coerces to a datetime and aborts the whole site build
+# on. The template is meant to be copied, not published — keep it out of the
+# build entirely.
+exclude:
+  - bugs/TEMPLATE.md


### PR DESCRIPTION
# Summary

Two deterministic (not transient) CI failures fixed:

1. **GitHub Pages build**: Jekyll aborts the whole `docs/` site build with `Invalid Date: '"<YYYY-MM-DD the fix landed>"'` because `docs/bugs/TEMPLATE.md` carries placeholder front matter and Jekyll coerces the special `date:` key into a datetime. Added `docs/_config.yml` that excludes the template from the build (it's meant to be copied, not published) and pins `theme: jekyll-theme-primer`, the default the build already uses.
2. **Audit PR Reviews workflow**: `pull_request`-triggered runs from fork PRs receive no repo secrets, so `OP_SERVICE_ACCOUNT_TOKEN` arrived empty and the 1Password step failed for every fork contribution (runs for #636 and #603), while same-repo PRs (#635, #633) passed. Switched the trigger to `pull_request_target: types: [closed]`, which provides secrets. This is safe here: the job is gated on `merged == true` (or manual dispatch), the workflow definition executes from the base branch, and checkout pulls the base repo's `main` — no unmerged fork code ever runs with secrets in scope.

## External assumptions

None

## Bug fix?

Root cause: two CI-config defects — (1) Jekyll coerces the special `date:` front-matter key, so the template's placeholder aborts the whole Pages build; (2) `pull_request`-triggered workflow runs from fork PRs receive no repo secrets, so the audit's 1Password step fails deterministically for every fork contribution.
Bug class: CI configuration validated only on the happy path — non-publishable content flowing into a production build, and workflows assuming secrets are available regardless of the PR's origin repo.
Detector added: none beyond the gates themselves — both defects are config-only with no unit-testable surface here; the Pages build and the audit run now exercise the fixed configuration on every merge, and the audit failing loudly (rather than skipping) remains the signal if secrets go missing again.
Siblings checked: all other `docs/*` front matter carries valid ISO dates (only `bugs/TEMPLATE.md` had a placeholder); other secret-using workflows audited — `claude-review.yml` already guards fork PRs out explicitly (`head.repo.full_name == github.repository`), and `test.yml`'s Codecov upload passes on fork PRs in practice (#636, #603 merged green). No other workflow shares the defect.
Ledger updated: n/a — not an external-assumption bug (no Copilot API surface involved).