### PR TITLE
fix(scheduled-smoke-status): make the status path one knob and bound report on read

### DIFF
--- a/docs/bugs/638-unbounded-trusted-payload-in-budgeted-response.md
+++ b/docs/bugs/638-unbounded-trusted-payload-in-budgeted-response.md
@@ -1,0 +1,130 @@
+---
+id: 638
+title: A context-budget assertion counted bytes it did not own, and the field that could blow the budget was the one it could not see
+class: unbounded-trusted-payload
+status: fixed
+detected: incidental  # surfaced while working #631; `bun run check` failed on a dev machine and passed in CI
+fixed_in: not yet
+issue: https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/638
+date: 2026-08-12
+---
+
+## Symptom
+
+Two behaviours from one cause.
+
+**Developer-visible.** `bun run check` failed on any machine that had a
+`~/.claude/copilot-money/scheduled-smoke.json`, and passed everywhere else:
+
+```
+(fail) context-budget ratchet (#597) > response-size budgets (cache-mode read tools, synthetic DB)
+       > get_connection_status response stays within budget
+Expected: <= 1900
+Received: 2664
+```
+
+Moving that one file aside made the same suite 68/68. Nothing else in the file is
+environment-dependent — the DB is synthetic, as intended.
+
+**Silent, and the more expensive of the two.** `get_connection_status` embedded
+`scheduled_smoke.report` verbatim, and the schema accepted any string. With the repo's own
+writer that field is a path (~80 chars, `null` on pass), so upstream-only machines stayed
+well inside 1900 and nothing ever looked wrong. Any other writer to that path could inflate
+a budgeted response without tripping a gate, because the budget test could not see the
+field at all — see below.
+
+## How it was detected
+
+Incidentally, and by a gate firing for the *wrong* reason. While working #631 the local
+`bun run check` went red on the budget assertion. The proximate cause was a stale
+oversized status file left on the machine by earlier debugging, not by
+`scripts/scheduled-smoke.ts` — so the honest reading is that a machine-specific artifact
+made a latent design gap briefly visible. CI never saw it and never could: the file does
+not exist there, so the populated branch had never been exercised in the project's history.
+
+Worth recording against this corpus's `ci-gate: 0` tally: this is not a point for CI. The
+gate fired locally, on a condition CI is structurally blind to, and the finding was the
+gate's *own* non-hermeticity.
+
+## Root cause
+
+One asymmetry and one missing bound, both in `src/utils/scheduled-smoke-status.ts`.
+
+**1. The env override was writer-only.** `scripts/scheduled-smoke.ts:63` read
+`COPILOT_MCP_SMOKE_STATUS_PATH`; the reader did not. `getConnectionStatus`
+(`src/tools/tools.ts:1345`) calls `readScheduledSmokeStatus()` with no argument, so it
+resolved `defaultScheduledSmokeStatusPath()` → `join(homedir(), …)`. The reader took an
+optional `path`, but the tool never passed one and no env seam existed on the read side, so
+a test had no way to point it at a fixture. That is why nothing did, and why an assertion
+about byte counts ended up counting whatever a developer's home directory contained.
+
+**2. `report` was unbounded inside a budgeted response.** `ScheduledSmokeStatusSchema`
+declared `report: z.string()`, while the doc comment said "dated report file". The intent
+was a path; the type permitted a novel. The contract lived in prose, and prose is not
+enforced.
+
+The second defect was undetectable while the first existed — the only test that measures
+this response could not construct a populated status. Hermeticity was the load-bearing fix.
+
+## Why the tests didn't catch it
+
+- **The context-budget ratchet (`tests/context-budget.test.ts`) had no seam.** It ran the
+  real tool, which read a real home-directory path. In CI that file never exists, so the
+  budget was only ever measured against `scheduled_smoke: null` — the cheapest possible
+  branch. The ratchet held not because the response was bounded but because every writer it
+  had met was polite.
+- **`tests/tools/scheduled-smoke-status.test.ts` covered the reader in isolation** and
+  asserted `report` round-trips, which it did. It never asked how large `report` may be,
+  because nothing in the schema suggested a limit.
+- **`tests/scripts/scheduled-smoke-e2e.test.ts` sets `COPILOT_MCP_SMOKE_STATUS_PATH`** and
+  passes — reinforcing the impression that the variable was a shared seam, when it was
+  honoured on one side only.
+
+## The fix
+
+- **Root cause:** `defaultScheduledSmokeStatusPath()` now honours
+  `COPILOT_MCP_SMOKE_STATUS_PATH`, so reader and writer resolve identically from one
+  variable. `scripts/scheduled-smoke.ts` drops its own `??` and calls the shared helper, so
+  there is a single knob rather than two that happen to agree.
+- **Downstream:** `report` is truncated on read at `SCHEDULED_SMOKE_REPORT_MAX_CHARS`
+  (256) with an ellipsis marker, and the doc comment now states plainly that the intended
+  payload is a path.
+
+Truncating rather than `z.string().max()` is deliberate. A schema max turns an oversized
+file into a parse failure, which drops the whole status and degrades
+`get_connection_status` on exactly the machines whose state is most worth reporting — a
+worse failure mode than the overage it prevents.
+
+## Detector
+
+**Partial, and mutation-verified in both directions.**
+
+- `tests/context-budget.test.ts` now pins `COPILOT_MCP_SMOKE_STATUS_PATH` to a temp path
+  for the whole suite, so every budget in the file measures only bytes the test owns.
+  Verified by reintroducing the oversized `$HOME` file: upstream goes red at 4537 chars
+  against the 1900 budget, patched stays green.
+- A new case exercises the populated branch against a *maximal legitimate* status — worst
+  case summary, and a `report` deliberately written past the ceiling — so the budget is
+  enforced against the true upper bound instead of `null`. Verified by deleting the
+  truncation: the case goes red (382 > 256), and green again when restored. It also asserts
+  `scheduled_smoke` is non-null first, so a broken seam cannot make it pass vacuously.
+
+Honest limit: this is class-level for *this* surface only. Nothing here enumerates other
+budgeted responses that embed externally-written files and checks them all — today
+`scheduled_smoke` is the only one, so the general detector would have exactly one member
+and would be a regression test wearing a costume. If a second such surface appears, that is
+the moment to build the sweep, and this entry is the argument for doing it then.
+
+## Lesson
+
+A budget test has to own every byte it counts; if any input comes from outside the test,
+the number is a coincidence. The cheap general habit is that any assertion about *size*
+should be paired with a case that constructs the largest legitimate input, because the
+default path is almost always the small one — the null branch here passed for the entire
+life of the test while the populated branch was never measured once.
+
+The rhyme with [#631](631-temp-copy-deferred-cleanup.md) is worth naming: there, cleanup
+was correct for every process that lived long enough to run it. Here, a budget was correct
+for every writer polite enough to stay small. Both are the same mistake at different
+layers — a guarantee that depends on the good behaviour of something the code does not
+control, and which therefore is not a guarantee.

--- a/docs/bugs/638-unbounded-trusted-payload-in-budgeted-response.md
+++ b/docs/bugs/638-unbounded-trusted-payload-in-budgeted-response.md
@@ -4,7 +4,7 @@ title: A context-budget assertion counted bytes it did not own, and the field th
 class: unbounded-trusted-payload
 status: fixed
 detected: incidental  # surfaced while working #631; `bun run check` failed on a dev machine and passed in CI
-fixed_in: not yet
+fixed_in: https://github.com/ignaciohermosillacornejo/copilot-money-mcp/pull/639
 issue: https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/638
 date: 2026-08-12
 ---

--- a/docs/bugs/README.md
+++ b/docs/bugs/README.md
@@ -95,18 +95,19 @@ a class yet.
 | `packaging-environment-mismatch` | The shipped artifact works in dev but fails in the target runtime — missing bundled deps, hardened-runtime constraints, GUI PATH. | `tests/integration/mcpb-bundle.test.ts` (extract-and-boot outside the repo) |
 | `unsettled-promise` | An async operation has a completion path where neither resolve nor reject fires, hanging callers forever. | none |
 | `deferred-cleanup-never-runs` | Releasing a resource is deferred to a timer or callback that only fires if the process outlives it — in a process that routinely exits first. The resource is acquired eagerly and released never, while every same-process test still observes correct bookkeeping. | none — instance-only; the class is a deployment property (does this process outlive its own timers?) that no static check here can evaluate |
+| `unbounded-trusted-payload` | A budgeted or validated surface embeds a value whose size or shape is guaranteed only by convention, because the only writer it has met is well-behaved. The guarantee holds until something else writes the file. | partial — `tests/context-budget.test.ts` measures the populated branch against a maximal legitimate input, for this surface only; no sweep across budgeted responses that embed external files |
 
 ## How we find bugs
 
 Recorded per entry, using a fixed vocabulary so the corpus stays countable. Here is what
-this corpus actually says, across all 44 entries:
+this corpus actually says, across all 45 entries:
 
 | Found by | Count | |
 |---|---|---|
 | `dogfooding` — used the tool, noticed the answer disagreed with the Copilot app | 14 | ████████████ |
 | `live-probe` — a probe or smoke against the real backend | 7 | ██████ |
 | `audit-sweep` — a deliberate cross-cutting audit | 7 | ██████ |
-| `incidental` — found while working on something else | 6 | █████ |
+| `incidental` — found while working on something else | 7 | ██████ |
 | `user-report` | 6 | █████ |
 | `adversarial-review` — a reviewer tried to refute a claim or mutation-tested a guard | 2 | █ |
 | `detector-first` — a detector was built, and then found bugs | 1 | ▌ |
@@ -294,3 +295,7 @@ record near-misses.
 | | Bug | Found by | Date |
 |---|---|---|---|
 | #631 | [Every LevelDB read left its ~120 MB temp copy on disk — 366 stale directories (~33 GB) filled a user's disk](631-temp-copy-deferred-cleanup.md) | `user-report` | 2026-08-12 |
+**`unbounded-trusted-payload`** — 1
+
+- [#638 — a context-budget assertion counted bytes it did not own](638-unbounded-trusted-payload-in-budgeted-response.md)
+

--- a/scripts/scheduled-smoke.ts
+++ b/scripts/scheduled-smoke.ts
@@ -60,7 +60,9 @@ function notify(title: string, message: string): void {
  * tests can execute the full flow in-process, where coverage is visible). */
 export function runScheduledSmoke(): number {
   const repoDir = process.env.COPILOT_MCP_REPO ?? join(import.meta.dir, '..');
-  const statusPath = process.env.COPILOT_MCP_SMOKE_STATUS_PATH ?? defaultScheduledSmokeStatusPath();
+  // The override now lives in defaultScheduledSmokeStatusPath(), so reader and
+  // writer resolve the same path from the same variable (#638).
+  const statusPath = defaultScheduledSmokeStatusPath();
   const reportsDir = join(dirname(statusPath), 'smoke-reports');
   mkdirSync(dirname(statusPath), { recursive: true });
 

--- a/src/utils/scheduled-smoke-status.ts
+++ b/src/utils/scheduled-smoke-status.ts
@@ -4,6 +4,12 @@
  * here so get_connection_status can surface drift-check staleness/failures
  * inside a dev session. Missing or unreadable status is `null` — the tool
  * must never fail because the scheduled job isn't installed.
+ *
+ * Reader and writer resolve the path identically through
+ * `defaultScheduledSmokeStatusPath()`, so `COPILOT_MCP_SMOKE_STATUS_PATH` is
+ * one knob rather than a writer-only override (#638). Without that symmetry a
+ * test had no seam to point the reader at a fixture, which is why the
+ * context-budget ratchet was reading real `$HOME` state.
  */
 import { readFileSync } from 'fs';
 import { homedir } from 'os';
@@ -13,22 +19,49 @@ import { z } from 'zod';
 export const SCHEDULED_SMOKE_RESULTS = ['pass', 'fail', 'auth-missing'] as const;
 export type ScheduledSmokeResult = (typeof SCHEDULED_SMOKE_RESULTS)[number];
 
+/**
+ * Ceiling for `report` as surfaced by the reader. Comfortably above the ~80
+ * chars a real report path occupies, small enough that a pathological writer
+ * cannot push `get_connection_status` off its context budget.
+ */
+export const SCHEDULED_SMOKE_REPORT_MAX_CHARS = 256;
+
+/** Bound `report` on read; the ellipsis marks that truncation occurred. */
+function truncateReport(value: string | null): string | null {
+  if (value === null || value.length <= SCHEDULED_SMOKE_REPORT_MAX_CHARS) return value;
+  return `${value.slice(0, SCHEDULED_SMOKE_REPORT_MAX_CHARS - 1)}…`;
+}
+
 const ScheduledSmokeStatusSchema = z.object({
   last_run: z.string(),
   result: z.enum(SCHEDULED_SMOKE_RESULTS),
   summary: z.string(),
-  /** Dated report file for failures; null for pass/auth-missing. */
+  /**
+   * Path to a dated report file for failures; null for pass/auth-missing.
+   *
+   * The intended payload is a *path*, not report contents. That intent is only
+   * a convention, because this reader does not control who writes the file, so
+   * the value is truncated on read to keep `get_connection_status` inside its
+   * context budget regardless of the writer (#638).
+   *
+   * Truncating rather than rejecting is deliberate: a `z.string().max()` would
+   * turn an oversized file into a parse failure, degrading the tool on exactly
+   * the machines whose status is most worth reporting.
+   */
   report: z
     .string()
     .nullable()
     .optional()
-    .transform((v) => v ?? null),
+    .transform((v) => truncateReport(v ?? null)),
 });
 
 export type ScheduledSmokeStatus = z.infer<typeof ScheduledSmokeStatusSchema>;
 
 export function defaultScheduledSmokeStatusPath(): string {
-  return join(homedir(), '.claude', 'copilot-money', 'scheduled-smoke.json');
+  return (
+    process.env.COPILOT_MCP_SMOKE_STATUS_PATH ??
+    join(homedir(), '.claude', 'copilot-money', 'scheduled-smoke.json')
+  );
 }
 
 export function readScheduledSmokeStatus(

--- a/tests/context-budget.test.ts
+++ b/tests/context-budget.test.ts
@@ -21,11 +21,14 @@
  */
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { ALL_TOOL_DEFS, type ToolContext } from '../src/tools/registry/index.js';
 import { CopilotDatabase } from '../src/core/database.js';
 import { CopilotMoneyTools } from '../src/tools/tools.js';
 import { createCombinedDb, cleanupTestDb } from './helpers/test-db.js';
+import { SCHEDULED_SMOKE_REPORT_MAX_CHARS } from '../src/utils/scheduled-smoke-status.js';
 
 const DB_PATH = path.join(__dirname, 'fixtures/context-budget-db');
 
@@ -400,7 +403,32 @@ const EXTRA_ARGS: Record<string, Record<string, unknown>> = {
 
 let ctx: ToolContext;
 
+/**
+ * Scheduled-smoke status seam (#638).
+ *
+ * `get_connection_status` embeds the scheduled drift-check status, which is
+ * read from a well-known path under `$HOME`. Before this seam existed the
+ * budget below measured whatever the developer's machine happened to contain:
+ * loose in CI, where the file never exists, and able to fail spuriously in dev.
+ * A test that asserts a byte count has to own every byte it is counting.
+ */
+let smokeStatusDir: string | null = null;
+let previousSmokeStatusPath: string | undefined;
+
+function writeSmokeStatus(contents: unknown): string {
+  smokeStatusDir ??= mkdtempSync(path.join(tmpdir(), 'ctx-budget-smoke-'));
+  const file = path.join(smokeStatusDir, 'scheduled-smoke.json');
+  writeFileSync(file, JSON.stringify(contents));
+  return file;
+}
+
 beforeAll(async () => {
+  previousSmokeStatusPath = process.env.COPILOT_MCP_SMOKE_STATUS_PATH;
+  // Point the reader at a path that does not exist, so the generic budget loop
+  // below measures the `scheduled_smoke: null` envelope deterministically.
+  smokeStatusDir = mkdtempSync(path.join(tmpdir(), 'ctx-budget-smoke-'));
+  process.env.COPILOT_MCP_SMOKE_STATUS_PATH = path.join(smokeStatusDir, 'absent.json');
+
   cleanupTestDb(DB_PATH);
   await seedFixture();
   const db = new CopilotDatabase(DB_PATH);
@@ -409,6 +437,10 @@ beforeAll(async () => {
 
 afterAll(() => {
   cleanupTestDb(DB_PATH);
+  if (previousSmokeStatusPath === undefined) delete process.env.COPILOT_MCP_SMOKE_STATUS_PATH;
+  else process.env.COPILOT_MCP_SMOKE_STATUS_PATH = previousSmokeStatusPath;
+  if (smokeStatusDir) rmSync(smokeStatusDir, { recursive: true, force: true });
+  smokeStatusDir = null;
 });
 
 /** Serialize exactly like `src/server.ts` does for tool responses. */
@@ -472,6 +504,47 @@ describe('context-budget ratchet (#597)', () => {
         expect(size).toBeLessThanOrEqual(RESPONSE_BUDGETS[def.name] ?? 0);
       });
     }
+
+    /**
+     * The loop above only ever measures `scheduled_smoke: null`, because CI has
+     * no status file — so before #638 the populated branch of
+     * `get_connection_status` had never been inside a budget at all. This pins
+     * it against a maximal *legitimate* status: worst-case summary, and a
+     * `report` at the truncation ceiling, which is the largest value the reader
+     * can now emit no matter what wrote the file.
+     */
+    test('get_connection_status stays within budget with a maximal populated smoke status', async () => {
+      const file = writeSmokeStatus({
+        last_run: '2026-12-31T23:59:59.999Z',
+        result: 'fail',
+        // Worst-case one-line summary the writer can produce.
+        summary: `${'surface failed: '.repeat(8)}see report`,
+        // Deliberately over the ceiling: asserts the budget holds against the
+        // truncated value, not against a conveniently short path.
+        report: `/Users/${'x'.repeat(64)}/.claude/copilot-money/smoke-reports/${'9'.repeat(SCHEDULED_SMOKE_REPORT_MAX_CHARS)}-smoke-failure.txt`,
+      });
+      const previous = process.env.COPILOT_MCP_SMOKE_STATUS_PATH;
+      process.env.COPILOT_MCP_SMOKE_STATUS_PATH = file;
+      try {
+        const result = (await runTool('get_connection_status')) as {
+          scheduled_smoke: { report: string } | null;
+        };
+        // Guard against a vacuous pass: if the seam broke and this read null,
+        // the size assertion below would trivially hold.
+        expect(result.scheduled_smoke).not.toBeNull();
+        expect(result.scheduled_smoke?.report.length).toBeLessThanOrEqual(
+          SCHEDULED_SMOKE_REPORT_MAX_CHARS
+        );
+        const size = serializedSize(result);
+        if (process.env.CONTEXT_BUDGET_PRINT) {
+          console.log(`[response] get_connection_status (populated): ${size} chars`);
+        }
+        expect(size).toBeLessThanOrEqual(RESPONSE_BUDGETS.get_connection_status ?? 0);
+      } finally {
+        if (previous === undefined) delete process.env.COPILOT_MCP_SMOKE_STATUS_PATH;
+        else process.env.COPILOT_MCP_SMOKE_STATUS_PATH = previous;
+      }
+    });
   });
 
   describe('schema-size budgets (all registered tools)', () => {

--- a/tests/tools/scheduled-smoke-status.test.ts
+++ b/tests/tools/scheduled-smoke-status.test.ts
@@ -8,7 +8,11 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { readScheduledSmokeStatus } from '../../src/utils/scheduled-smoke-status.js';
+import {
+  SCHEDULED_SMOKE_REPORT_MAX_CHARS,
+  defaultScheduledSmokeStatusPath,
+  readScheduledSmokeStatus,
+} from '../../src/utils/scheduled-smoke-status.js';
 
 let dir: string | null = null;
 afterEach(() => {
@@ -84,5 +88,70 @@ describe('readScheduledSmokeStatus', () => {
       JSON.stringify({ last_run: '2026-06-11T10:00:00Z', result: 'unknown', summary: 'x' })
     );
     expect(readScheduledSmokeStatus(file)).toBeNull();
+  });
+});
+
+describe('report bounding (#638)', () => {
+  test('leaves a realistic report path untouched', () => {
+    const report = '/Users/x/.claude/copilot-money/smoke-reports/2026-06-11-smoke-failure.txt';
+    const file = statusFile(
+      JSON.stringify({ last_run: '2026-06-11T10:00:00Z', result: 'fail', summary: 's', report })
+    );
+    expect(readScheduledSmokeStatus(file)?.report).toBe(report);
+  });
+
+  test('truncates an oversized report rather than rejecting the status', () => {
+    const file = statusFile(
+      JSON.stringify({
+        last_run: '2026-06-11T10:00:00Z',
+        result: 'fail',
+        summary: 's',
+        report: 'x'.repeat(SCHEDULED_SMOKE_REPORT_MAX_CHARS * 4),
+      })
+    );
+    const status = readScheduledSmokeStatus(file);
+    // Rejecting would drop the whole status, degrading get_connection_status on
+    // exactly the machines whose state is most worth reporting.
+    expect(status).not.toBeNull();
+    expect(status?.report?.length).toBe(SCHEDULED_SMOKE_REPORT_MAX_CHARS);
+    expect(status?.report?.endsWith('…')).toBe(true);
+  });
+
+  test('keeps a report of exactly the ceiling intact', () => {
+    const report = 'x'.repeat(SCHEDULED_SMOKE_REPORT_MAX_CHARS);
+    const file = statusFile(
+      JSON.stringify({ last_run: '2026-06-11T10:00:00Z', result: 'fail', summary: 's', report })
+    );
+    expect(readScheduledSmokeStatus(file)?.report).toBe(report);
+  });
+});
+
+describe('status path resolution (#638)', () => {
+  const VAR = 'COPILOT_MCP_SMOKE_STATUS_PATH';
+
+  test('reader and writer resolve the same override', () => {
+    const previous = process.env[VAR];
+    process.env[VAR] = '/tmp/some-explicit-smoke-status.json';
+    try {
+      // The writer in scripts/scheduled-smoke.ts calls this same function, so
+      // agreement here is agreement on both sides — the asymmetry that left the
+      // context-budget ratchet reading real $HOME state.
+      expect(defaultScheduledSmokeStatusPath()).toBe('/tmp/some-explicit-smoke-status.json');
+    } finally {
+      if (previous === undefined) delete process.env[VAR];
+      else process.env[VAR] = previous;
+    }
+  });
+
+  test('falls back to the home-directory path when unset', () => {
+    const previous = process.env[VAR];
+    delete process.env[VAR];
+    try {
+      expect(defaultScheduledSmokeStatusPath()).toContain(
+        join('.claude', 'copilot-money', 'scheduled-smoke.json')
+      );
+    } finally {
+      if (previous !== undefined) process.env[VAR] = previous;
+    }
   });
 });


### PR DESCRIPTION
# Summary

Makes the context-budget ratchet hermetic and bounds `scheduled_smoke.report` on read. Closes #638.

The budget test asserted a byte count that included bytes it did not own: `get_connection_status` reads the drift-check status from a `$HOME` path, and the reader had no seam to point at a fixture because `COPILOT_MCP_SMOKE_STATUS_PATH` was honoured by the writer only. `bun run check` therefore failed on any machine with a status file and passed everywhere else, while CI only ever measured `scheduled_smoke: null`.

That blind spot hid the second defect: `report` was `z.string()` with the intent stated only in prose, so any writer to that path could inflate a budgeted response without tripping a gate.

## External assumptions

None

## Bug fix?

Root cause:       `COPILOT_MCP_SMOKE_STATUS_PATH` was writer-only, so the reader had no fixture seam and the budget test measured real `$HOME` state; separately, `report` was unbounded inside a budgeted response.
Bug class:        `unbounded-trusted-payload` — new class proposed in `docs/bugs/README.md`. A budgeted or validated surface embeds a value whose size or shape is guaranteed only by convention, because the only writer it has met is well-behaved. Same shape as #631 one layer up.
Detector added:   `tests/context-budget.test.ts` pins the status path for the whole suite (hermeticity) and adds a case measuring the populated branch against a maximal legitimate status, so 1900 is enforced against a true upper bound. Both mutation-verified — see below.
Siblings checked: Audited all three external-file readers in `src/`. `browser-token.ts` feeds auth, not a tool response. `transaction-meta-store.ts` is reached only via `live-database.ts`, which the cache-mode ratchet does not cover — adjacent rather than an instance, and it is the follow-up already on my list. `scheduled_smoke` is the only external file embedded in a budgeted cache-mode response today.
Ledger updated:   n/a — not an external-assumption bug.

## What changed

- `defaultScheduledSmokeStatusPath()` honours `COPILOT_MCP_SMOKE_STATUS_PATH`, so reader and writer resolve identically from one variable. `scripts/scheduled-smoke.ts` drops its own `??` and calls the shared helper, per your preference for env parity over a new knob or constructor injection.
- `report` is truncated on read at `SCHEDULED_SMOKE_REPORT_MAX_CHARS` (256) with an ellipsis marker, and the doc comment now says plainly that the intended payload is a path. Truncating rather than `z.string().max()` for the reason you gave: a schema max turns an oversized file into a parse failure, degrading the tool on exactly the machines whose state is most worth reporting.
- Budget suite pins the status path to a temp dir; new case exercises the populated branch, which had never been measured in the project's history.

## Mutation verification

Both detectors were verified by reintroducing the defect, not just by passing:

| Mutation | Result |
|---|---|
| Restore the oversized `~/.claude/copilot-money/scheduled-smoke.json`, run against upstream code | red — `Expected: <= 1900, Received: 4537` |
| Same file, patched code | green — 69 pass |
| Delete the `truncateReport` call, keep everything else | red — populated case, `Expected: <= 256, Received: 382` |
| Restore | green |

The populated case also asserts `scheduled_smoke` is non-null before measuring, so a broken seam cannot make it pass vacuously.

`bun run check`: 2673 pass, 20 skip, 0 fail.

## Note on the post-mortem

`docs/bugs/638-*.md` records this as `detected: incidental` and explicitly does **not** claim a point for CI. The gate fired locally, on a condition CI is structurally blind to, and what it found was its own non-hermeticity. The corpus tally in `README.md` is updated to 45 entries / `incidental: 7`, which I verified matches the frontmatter across all entries rather than incrementing by hand.

The `Detector` section is honest that coverage is class-level for this surface only: there is exactly one budgeted response embedding an external file today, so a general sweep would have one member and would be a regression test wearing a costume. The entry argues for building it when a second appears.
