### PR TITLE
fix(server): scope the db-availability gate to tools that read the local cache (#640)

### DIFF
--- a/docs/bugs/640-live-tools-blocked-by-cache-gate.md
+++ b/docs/bugs/640-live-tools-blocked-by-cache-gate.md
@@ -1,0 +1,76 @@
+---
+id: 640
+title: Every tool call — including pure-GraphQL live tools — blocked on machines without the native app's local cache
+class: overbroad-precondition-gate
+status: fixed
+detected: user-report # issue #640 — a --write user on a machine that never had the native app installed
+fixed_in: https://github.com/ignaciohermosillacornejo/copilot-money-mcp/pull/644
+issue: https://github.com/ignaciohermosillacornejo/copilot-money-mcp/issues/640
+date: 2026-08-15
+---
+
+## Symptom
+
+On a machine where the native Copilot Money macOS app was never installed (no LevelDB
+cache on disk), every tool call returned:
+
+```
+Database not available. Please ensure Copilot Money is installed and has created
+local data, or provide a custom database path.
+```
+
+This included `get_accounts_live` and the rest of the `_live` family under
+`--write`/`--live-reads` with a fully valid, logged-in browser session — tools whose
+handlers never touch the local cache at all. The reporter worked around it by pointing
+`--db-path` at a directory containing a dummy `MANIFEST-000001` file.
+
+## How it was detected
+
+User report (issue #640), with the diagnosis already done: the reporter read
+`dist/cli.js`, found the unconditional `db.isAvailable()` check in `handleCallTool()`,
+confirmed from `TOOL_REGISTRY` that live handlers call `ctx.live.*` and never read
+`this.db`, and included a working dummy-file workaround.
+
+## Root cause
+
+`handleCallTool()` (`src/server.ts:210` at the time) applied the `db.isAvailable()`
+gate to every dispatch, before consulting the tool's registry classification. The gate
+predates live mode — when it was written, every tool did read the cache — and was never
+rescoped when `requiresLiveReads` tools arrived. A precondition for one resource
+(the local LevelDB cache) sat at a shared chokepoint and silently asserted "all
+requests need this."
+
+## Why the tests didn't catch it
+
+Live-mode tests built servers either with mock databases whose `isAvailable()` returns
+true, or with paths on dev machines where the real cache exists. The db-unavailable
+tests (`server-protocol.test.ts`, `e2e/server.test.ts`) only ever called cache-mode
+tools, where the gate is correct. The failing configuration — cache absent *and* live
+mode on, i.e. exactly a live-only user's machine — was never constructed, because every
+contributor machine has the native app installed.
+
+## The fix
+
+PR #644. Root-cause fix: the gate is now scoped by the same registry classification
+that drives listing and dispatch — it fires only for tools whose dispatch actually
+reads the cache (`!requiresLiveReads && (readOnly || no live layer)`). Live tools run
+entirely on GraphQL; live-mode writes resolve live-first and touch the cache only via
+null-guarded `patchCached*` write-through, which no-ops when the cache never loaded.
+Downstream cleanup: the gate moved after tool resolution, so an unknown tool name now
+reports `Unknown tool` instead of the database message when the cache is absent.
+
+## Detector
+
+Registry-walk tests in `tests/integration/live-reads.test.ts`: on a server built with
+a nonexistent db path and live+write mode, every `LIVE_TOOL_DEFS` and
+`WRITE_TOOL_DEFS` entry must dispatch past the gate (its response must not be the
+db-unavailable message). New tools join the sweep through registry membership, so the
+detector covers the class, not the instance. Mutation-verified: reverting the gate to
+unconditional sends three tests red.
+
+## Lesson
+
+A precondition checked at a shared chokepoint carries an implicit "every request needs
+this" claim that rots as tool classes diversify. When a registry already classifies
+what each tool needs, derive every gate from it — a gate that isn't registry-derived
+is a parallel list waiting to drift.

--- a/docs/bugs/README.md
+++ b/docs/bugs/README.md
@@ -96,11 +96,12 @@ a class yet.
 | `unsettled-promise` | An async operation has a completion path where neither resolve nor reject fires, hanging callers forever. | none |
 | `deferred-cleanup-never-runs` | Releasing a resource is deferred to a timer or callback that only fires if the process outlives it — in a process that routinely exits first. The resource is acquired eagerly and released never, while every same-process test still observes correct bookkeeping. | none — instance-only; the class is a deployment property (does this process outlive its own timers?) that no static check here can evaluate |
 | `unbounded-trusted-payload` | A budgeted or validated surface embeds a value whose size or shape is guaranteed only by convention, because the only writer it has met is well-behaved. The guarantee holds until something else writes the file. | partial — `tests/context-budget.test.ts` measures the populated branch against a maximal legitimate input, for this surface only; no sweep across budgeted responses that embed external files |
+| `overbroad-precondition-gate` | A precondition for one resource is checked at a shared chokepoint (dispatch, startup) for all requests, including those whose handling never uses the resource — so any configuration where the resource is legitimately absent is fully locked out. | registry-walk sweep in `tests/integration/live-reads.test.ts` (mutation-verified): every live tool and live-mode write must dispatch past the local-cache gate with the cache absent |
 
 ## How we find bugs
 
 Recorded per entry, using a fixed vocabulary so the corpus stays countable. Here is what
-this corpus actually says, across all 45 entries:
+this corpus actually says, across all 46 entries:
 
 | Found by | Count | |
 |---|---|---|
@@ -108,7 +109,7 @@ this corpus actually says, across all 45 entries:
 | `live-probe` — a probe or smoke against the real backend | 7 | ██████ |
 | `audit-sweep` — a deliberate cross-cutting audit | 7 | ██████ |
 | `incidental` — found while working on something else | 7 | ██████ |
-| `user-report` | 6 | █████ |
+| `user-report` | 7 | ██████ |
 | `adversarial-review` — a reviewer tried to refute a claim or mutation-tested a guard | 2 | █ |
 | `detector-first` — a detector was built, and then found bugs | 1 | ▌ |
 | `code-review` | 1 | ▌ |
@@ -298,4 +299,10 @@ record near-misses.
 **`unbounded-trusted-payload`** — 1
 
 - [#638 — a context-budget assertion counted bytes it did not own](638-unbounded-trusted-payload-in-budgeted-response.md)
+
+**`overbroad-precondition-gate`** — 1
+
+| | Bug | Found by | Date |
+|---|---|---|---|
+| #640 | [Every tool call — including pure-GraphQL live tools — blocked on machines without the native app's local cache](640-live-tools-blocked-by-cache-gate.md) | `user-report` | 2026-08-15 |
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -224,7 +224,12 @@ export class CopilotMoneyServer {
     // null-guarded patchCached* write-through, which no-ops when the cache
     // never loaded. Cache-mode reads and degraded-mode writes (write tools
     // with no live layer — test-only, since --write implies --live-reads)
-    // still need the cache present.
+    // still need the cache present. `this.live` rather than
+    // `this.liveReadsEnabled` on purpose: the skip is justified by the live
+    // resolution layer existing (the object handlers and the write path
+    // actually use), not by the flag that requests it — the constructor
+    // makes them equivalent today, but if that ever drifts, the object is
+    // the one that degrades safely.
     const needsLocalCache = !toolDef.requiresLiveReads && (toolDef.readOnly || !this.live);
     if (needsLocalCache && !this.db.isAvailable()) {
       return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -206,20 +206,6 @@ export class CopilotMoneyServer {
       };
     }
 
-    // Check if database is available
-    if (!this.db.isAvailable()) {
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text:
-              'Database not available. Please ensure Copilot Money is installed ' +
-              'and has created local data, or provide a custom database path.',
-          },
-        ],
-      };
-    }
-
     if (!toolDef) {
       return {
         content: [
@@ -229,6 +215,27 @@ export class CopilotMoneyServer {
           },
         ],
         isError: true,
+      };
+    }
+
+    // The local-cache gate is scoped to tools whose dispatch actually reads
+    // the LevelDB cache (#640): live tools run entirely on GraphQL, and
+    // live-mode writes resolve live-first — they touch the cache only via
+    // null-guarded patchCached* write-through, which no-ops when the cache
+    // never loaded. Cache-mode reads and degraded-mode writes (write tools
+    // with no live layer — test-only, since --write implies --live-reads)
+    // still need the cache present.
+    const needsLocalCache = !toolDef.requiresLiveReads && (toolDef.readOnly || !this.live);
+    if (needsLocalCache && !this.db.isAvailable()) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text:
+              'Database not available. Please ensure Copilot Money is installed ' +
+              'and has created local data, or provide a custom database path.',
+          },
+        ],
       };
     }
 

--- a/tests/integration/live-reads.test.ts
+++ b/tests/integration/live-reads.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, mock } from 'bun:test';
 import { CopilotMoneyServer } from '../../src/server.js';
 import type { GraphQLClient } from '../../src/core/graphql/client.js';
+import { LIVE_TOOL_DEFS, WRITE_TOOL_DEFS } from '../../src/tools/registry/index.js';
 
 describe('CopilotMoneyServer with --live-reads', () => {
   test('swaps get_transactions for get_transactions_live in handleListTools', () => {
@@ -34,5 +35,78 @@ describe('CopilotMoneyServer with --live-reads', () => {
     const server = new CopilotMoneyServer();
     const result = await server.handleCallTool('get_transactions_live', {});
     expect(result.isError).toBe(true);
+  });
+});
+
+// #640: the db.isAvailable() gate must be scoped to tools whose dispatch
+// actually reads the local LevelDB cache. Live tools run entirely on GraphQL,
+// and live-mode writes resolve live-first (the cache is only touched via
+// null-guarded patchCached* write-through) — so on a machine without the
+// native Copilot app, both must dispatch past the gate.
+describe('db gate scoping without local cache (#640)', () => {
+  const NO_CACHE_PATH = '/nonexistent/no-native-app-installed';
+  const DB_GATE_MESSAGE = 'Database not available';
+
+  function firstText(result: { content: { text?: string }[] }): string {
+    return result.content[0]?.text ?? '';
+  }
+
+  function liveServer(): CopilotMoneyServer {
+    const mockClient = {
+      mutate: mock(() => Promise.resolve({})),
+      query: mock(() => Promise.resolve({ accounts: [] })),
+    } as unknown as GraphQLClient;
+    return new CopilotMoneyServer(NO_CACHE_PATH, undefined, true, true, mockClient);
+  }
+
+  test('get_accounts_live succeeds end-to-end with no local cache', async () => {
+    const result = await liveServer().handleCallTool('get_accounts_live', {});
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(firstText(result)) as { count: number };
+    expect(parsed.count).toBe(0);
+  });
+
+  test('no live tool is blocked by the db gate (class detector)', async () => {
+    const server = liveServer();
+    for (const def of LIVE_TOOL_DEFS) {
+      const result = await server.handleCallTool(def.name, {});
+      // Handlers may reject the stub client's response shape — that's fine;
+      // the invariant is that the db gate never fires before dispatch.
+      expect(firstText(result)).not.toContain(DB_GATE_MESSAGE);
+    }
+  });
+
+  test('no write tool is blocked by the db gate in live mode (class detector)', async () => {
+    const server = liveServer();
+    for (const def of WRITE_TOOL_DEFS) {
+      const result = await server.handleCallTool(def.name, {});
+      expect(firstText(result)).not.toContain(DB_GATE_MESSAGE);
+    }
+  });
+
+  test('cache-backed reads remain gated in live mode', async () => {
+    const server = liveServer();
+    for (const name of ['get_cache_info', 'get_transactions', 'get_goals']) {
+      const result = await server.handleCallTool(name, {});
+      expect(firstText(result)).toContain(DB_GATE_MESSAGE);
+    }
+  });
+
+  test('write tools remain gated in degraded mode (no live layer)', async () => {
+    const mockClient = { mutate: mock(), query: mock() } as unknown as GraphQLClient;
+    const server = new CopilotMoneyServer(NO_CACHE_PATH, undefined, true, false, mockClient);
+    const result = await server.handleCallTool('update_transaction', {
+      transaction_id: 'txn1',
+      category_id: 'cat1',
+    });
+    expect(firstText(result)).toContain(DB_GATE_MESSAGE);
+  });
+
+  test('unknown tool reports "Unknown tool", not the db gate', async () => {
+    const server = new CopilotMoneyServer(NO_CACHE_PATH);
+    const result = await server.handleCallTool('no_such_tool', {});
+    expect(result.isError).toBe(true);
+    expect(firstText(result)).toContain('Unknown tool');
   });
 });

--- a/tests/integration/live-reads.test.ts
+++ b/tests/integration/live-reads.test.ts
@@ -81,6 +81,8 @@ describe('db gate scoping without local cache (#640)', () => {
     const server = liveServer();
     for (const def of WRITE_TOOL_DEFS) {
       const result = await server.handleCallTool(def.name, {});
+      // As above: handlers erroring on empty args or the stub client's
+      // response shape is fine — only the db gate firing is a failure.
       expect(firstText(result)).not.toContain(DB_GATE_MESSAGE);
     }
   });


### PR DESCRIPTION
# Summary

`handleCallTool()` gated **every** tool call on `db.isAvailable()`, which only checks for the native app's local LevelDB cache — so on a machine without the native Copilot Money app, pure-GraphQL live tools (and live-mode writes) returned "Database not available" even with a valid browser session. The gate is now derived from the registry classification and fires only for tools whose dispatch actually reads the cache. Closes #640

Reproduced exactly as reported (live+write server on a nonexistent db path, working GraphQL client): `get_accounts_live` hit the gate before its handler ran; after the fix it completes end-to-end. Credit to @mykemetzger for the precise diagnosis in the issue — the root cause was exactly where they pointed.

## What changed

- `src/server.ts`: the db gate moved after tool resolution and is scoped to `!requiresLiveReads && (readOnly || no live layer)`:
  - **live tools** run entirely on GraphQL (`LiveCopilotDatabase.getCache()` has zero consumers) — never gated;
  - **write tools in live mode** (all production writes, since `--write` implies `--live-reads`) resolve routing/validation live-first and touch the cache only via null-guarded `patchCached*` write-through no-ops — never gated;
  - **cache-mode reads** and **degraded-mode writes** (write without live layer — test-only config) still need the cache — gated as before, same message.
  - Side effect of the reorder: an unknown tool name now reports `Unknown tool` instead of the database message when the cache is absent.
- The db-unavailable response intentionally still omits `isError` (pinned by an existing e2e test) — unchanged.
- `tests/integration/live-reads.test.ts`: instance regression + class-level registry sweeps + pins on unchanged gating.
- `docs/bugs/`: post-mortem entry and a new `overbroad-precondition-gate` class.

## External assumptions

None — this PR touches only dispatch gating; no new assumptions about Copilot's API/data. (The claim that live handlers never read the local cache is internal and verified against the registry: `getCache()` has no callers.)

## Bug fix?

Root cause:       `handleCallTool()` applied the local-cache availability check to every dispatch, blind to the per-tool registry classification that already records which tools need the cache
Bug class:        `overbroad-precondition-gate` (new — a one-resource precondition checked at a shared chokepoint for all requests, locking out configurations where the resource is legitimately absent)
Detector added:   registry-walk sweep in `tests/integration/live-reads.test.ts` — every `LIVE_TOOL_DEFS` and `WRITE_TOOL_DEFS` entry must dispatch past the gate on a cache-less live server; new tools join via registry membership; mutation-verified (reverting the gate to unconditional sends 3 tests red)
Siblings checked: `handleListTools` (no resource gate), CLI startup (no db check — nothing to moot the fix), `preflightLiveAuth` (scoped to live mode, the resource its users need), per-tool handlers (`get_cache_info`, `refresh_database`, `get_connection_status` legitimately read the cache and stay gated) — none overbroad
Ledger updated:   n/a — not an external-assumption bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7FqwcaijCVcJe5vhtVb72
