### PR TITLE
fix(server): set isError on the db-unavailable dispatch refusal (#645)

### DIFF
--- a/docs/bugs/MINOR.md
+++ b/docs/bugs/MINOR.md
@@ -5,7 +5,7 @@ release plumbing, packaging, and latent defects fixed before anyone hit them.
 
 They are here for two reasons: a class with only minor instances still shows up in the
 [class list](README.md#bug-classes), and a run of minor bugs in one area is often the
-early signal for a major one. `silent-failure-masking` appears **seven** times below and
+early signal for a major one. `silent-failure-masking` appears **eight** times below and
 has no full entry — a class that has never once produced a bug worth a post-mortem, yet
 keeps costing us release and audit incidents, is exactly the pattern this ledger exists to
 make visible.
@@ -54,3 +54,4 @@ Promote a row to a full entry if a later instance turns out to be user-visible.
 | #588 | Stale tool-count figures in `package.json` and two docs | `doc-reality-drift` | #588 |
 | #612 | Decoder unread-field drift: the server added a `_migration_backfill` marker | `external-api-drift` | #612 |
 | #619 | The privacy-endpoint scanner's comment stripper could be blinded by delimiters inside string literals — a false negative in a brand-new detector | `vacuous-assertion` | #619 |
+| #645 | The db-unavailable dispatch refusal omitted `isError`, so MCP clients saw a successful call carrying an error message — the one green guard among four | `silent-failure-masking` | #646 |

--- a/src/server.ts
+++ b/src/server.ts
@@ -241,6 +241,7 @@ export class CopilotMoneyServer {
               'and has created local data, or provide a custom database path.',
           },
         ],
+        isError: true,
       };
     }
 

--- a/tests/e2e/server.test.ts
+++ b/tests/e2e/server.test.ts
@@ -807,16 +807,16 @@ describe('handleCallTool — error handling', () => {
     expect(firstText(result)).toContain('--write');
   });
 
-  test('database unavailable returns informative message', async () => {
+  test('database unavailable returns informative message with isError', async () => {
     const badDb = new CopilotDatabase('/nonexistent/path');
     const server = new CopilotMoneyServer(FAKE_DB_DIR);
     server._injectForTesting(badDb, new CopilotMoneyTools(badDb));
 
     const result = await server.handleCallTool('get_cache_info');
     expect(firstText(result)).toContain('Database not available');
-    // Server intentionally omits isError for unavailable DB (server.ts:134-145)
-    // so the LLM receives the message as guidance rather than a hard error.
-    expect(result.isError).toBeUndefined();
+    // The guidance text reaches the model either way; isError additionally
+    // tells the MCP client the call failed (#645).
+    expect(result.isError).toBe(true);
   });
 
   test('malformed args to write tool returns isError', async () => {

--- a/tests/unit/server-protocol.test.ts
+++ b/tests/unit/server-protocol.test.ts
@@ -206,6 +206,27 @@ describe('CopilotMoneyServer.handleCallTool - database unavailable', () => {
       expect(response.content[0].text).toContain('Database not available');
     }
   });
+
+  // #645 class detector: a dispatch guard that refuses a call must say so via
+  // isError — a green result carrying an error message is silent-failure
+  // masking. One case per guard in handleCallTool; a new guard added without
+  // isError shows up here as a missing case, and removing isError from any
+  // existing guard goes red.
+  test('every dispatch-guard refusal sets isError: true', async () => {
+    const server = setupServerWithUnavailableDb();
+
+    const guardCases: Array<{ guard: string; tool: string }> = [
+      { guard: 'write tools without --write', tool: 'update_transaction' },
+      { guard: 'live tools without --live-reads', tool: 'get_transactions_live' },
+      { guard: 'unknown tool', tool: 'no_such_tool' },
+      { guard: 'database unavailable', tool: 'get_transactions' },
+    ];
+
+    for (const { guard, tool } of guardCases) {
+      const response = await server.handleCallTool(tool, {});
+      expect({ guard, isError: response.isError }).toEqual({ guard, isError: true });
+    }
+  });
 });
 
 describe('CopilotMoneyServer.handleCallTool - basic tools', () => {


### PR DESCRIPTION
# Summary

The db-unavailable dispatch refusal was the only one of the four guards in `handleCallTool()` that returned a green result — MCP clients saw a *successful* call carrying an error message. It now sets `isError: true` like its siblings (write-mode block, live-reads block, unknown tool). Closes #645

The old behavior was intentional and pinned by an e2e test ("so the LLM receives the message as guidance rather than a hard error"), but the rationale doesn't hold up: the guidance text reaches the model in both cases — `isError` only adds the failure signal for the client. Flagged by the reviewer on #644 as worth a separate decision; this PR makes it.

## What changed

- `src/server.ts`: `isError: true` on the db-gate refusal (one line).
- `tests/e2e/server.test.ts`: the pinning assertion flipped, comment updated.
- `tests/unit/server-protocol.test.ts`: new guard-sweep detector — every dispatch-guard refusal (all four) must set `isError: true`.
- `docs/bugs/MINOR.md`: row filed under `silent-failure-masking` (now its eighth instance — still the ledger's most frequent class with no full post-mortem).

## External assumptions

None — internal MCP response shaping only; no new assumptions about Copilot's API/data.

## Bug fix?

Root cause:       the db-gate refusal predates the sibling guards' isError convention and was pinned as "guidance not error" by a test, though isError never hid the guidance text from the model
Bug class:        `silent-failure-masking` (existing class — an error-handling construct turns a real failure into a green signal)
Detector added:   guard-sweep test in `tests/unit/server-protocol.test.ts`: one case per dispatch guard in `handleCallTool`, each refusal must set `isError: true`; mutation-verified (removing the flag from the db gate goes red)
Siblings checked: the other three dispatch guards (write-mode block, live-reads block, unknown tool) already set `isError: true`; handler exceptions set it in the catch path — the db gate was the only green refusal
Ledger updated:   n/a — not an external-assumption bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7FqwcaijCVcJe5vhtVb72
