### PR TITLE
feat(security): detect forged commit authorship in fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,18 @@ jobs:
       - name: Concealed-content check
         run: bun run check:concealment
 
+      # Fork PRs only — a same-repo branch already required push access, so
+      # there is no identity to forge. Reads public commit metadata with the
+      # read-only fork token.
+      - name: Commit authorship check
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh api "repos/${{ github.repository }}/pulls/$PR/commits?per_page=100" \
+            --paginate --jq '.[]' | jq -s '.' | bun run scripts/check-commit-authorship.ts
+
       - name: License check (production deps)
         # Stages package.json only (NOT package-lock.json) and runs
         # npm install --omit=dev to mirror scripts/pack-mcpb.ts exactly, so

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ scripts/*
 !scripts/check-tool-counts.ts
 !scripts/check-privacy-endpoints.ts
 !scripts/check-concealment.ts
+!scripts/check-commit-authorship.ts
 !scripts/check-skills.py
 !scripts/dump-tool-names.ts
 !scripts/scheduled-smoke.ts

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "check:tool-counts": "bun run scripts/check-tool-counts.ts",
     "check:privacy-endpoints": "bun run scripts/check-privacy-endpoints.ts",
     "check:concealment": "bun run scripts/check-concealment.ts",
+    "check:authorship": "bun run scripts/check-commit-authorship.ts",
     "check:skills": "python3 scripts/check-skills.py",
     "fix": "bun run lint:fix && bun run format",
     "_comment_smoke": "smoke:cache is deliberately NOT in this composite yet — it needs a real local cache, and the scheduled drift check that would host it has its own reporting gap to sort first (see PR #628). Wire it in when that lands.",

--- a/scripts/check-commit-authorship.ts
+++ b/scripts/check-commit-authorship.ts
@@ -76,7 +76,12 @@ function isMaintainer(login: string | undefined, email: string | undefined): boo
   return email !== undefined && MAINTAINERS.emails.has(email);
 }
 
-/** Same human, whichever field GitHub managed to resolve. */
+/**
+ * Same human by email. If either address is missing, this returns false and the
+ * committer-is-maintainer check below still catches the legitimate cases,
+ * including login-only matches — so an absent email cannot produce a finding on
+ * its own.
+ */
 function sameIdentity(a: Commit['commit']['author'], b: Commit['commit']['author']): boolean {
   return a.email !== undefined && b.email !== undefined && a.email === b.email;
 }

--- a/scripts/check-commit-authorship.ts
+++ b/scripts/check-commit-authorship.ts
@@ -1,0 +1,160 @@
+#!/usr/bin/env bun
+/**
+ * Fail a fork PR that contains a commit forging a maintainer's identity.
+ *
+ * The bug class this catches: commit authorship is display metadata, and it is
+ * attacker-controlled. `git commit --author` takes any name and address, and
+ * GitHub renders the matching account's avatar and login next to it — so a
+ * commit in a fork PR can appear, convincingly, to have been written by the
+ * person reviewing it.
+ *
+ * better-auth PR #6003 did exactly this. The commit carrying the payload was
+ * authored as a real maintainer, using their GitHub noreply address, with a
+ * subject copied verbatim from an unrelated merged PR. In the commit list it
+ * looked like a routine maintainer cherry-pick.
+ *
+ * The usual answer — require signed commits on the protected branch — does not
+ * work here, and would not have helped anyway:
+ *
+ *   - GitHub creates new commit objects when it rebase-merges and does not sign
+ *     them, so `required_signatures` refuses rebase merges outright. This repo
+ *     is rebase-only.
+ *   - Branch protection does not apply to forks. It constrains what can land,
+ *     and the better-auth payload did its damage before any merge.
+ *
+ * So this checks the one field the forger cannot control: the committer.
+ *
+ *   legitimate maintainer push to a contributor's branch
+ *     author = maintainer, committer = same maintainer
+ *   contributor's own commit, rebased by a maintainer
+ *     author = contributor, committer = maintainer
+ *   forged identity (better-auth #6003)
+ *     author = maintainer, committer = SOMEONE ELSE      <-- the tell
+ *
+ * Verified against this repo's own history: PR #587 carries three genuine
+ * maintainer commits pushed to a contributor's fork branch, and every one has
+ * author == committer. The better-auth payload commit has author ping-maxwell
+ * and committer AntonVishal. The rule separates them with no false positives.
+ *
+ * Known limits:
+ *
+ *   - A maintainer who forges BOTH fields passes. That is not this threat model;
+ *     an attacker with the maintainer's commit identity still cannot push to the
+ *     base repo, and the payload gates (`check:concealment`) are independent.
+ *   - A contributor who rebases a branch containing genuine maintainer commits
+ *     rewrites the committer to themselves, which trips this. That is a real but
+ *     rare shape, and "a maintainer's commit was rewritten by someone else" is
+ *     worth a human look regardless.
+ *   - Only fork PRs are checked. A same-repo branch already required push access.
+ */
+
+import { readFileSync } from 'fs';
+
+/**
+ * Identities whose authorship carries review weight, and which are therefore
+ * worth forging. Both the GitHub login and every address that appears as a
+ * commit author, since a forger can pick either.
+ */
+const MAINTAINERS = {
+  logins: new Set(['ignaciohermosillacornejo']),
+  emails: new Set(['hermosillaignacio@gmail.com']),
+};
+
+interface Commit {
+  sha: string;
+  commit: {
+    author: { name?: string; email?: string };
+    committer: { name?: string; email?: string };
+    message: string;
+  };
+  author: { login?: string } | null;
+  committer: { login?: string } | null;
+}
+
+function isMaintainer(login: string | undefined, email: string | undefined): boolean {
+  if (login !== undefined && MAINTAINERS.logins.has(login)) return true;
+  return email !== undefined && MAINTAINERS.emails.has(email);
+}
+
+/** Same human, whichever field GitHub managed to resolve. */
+function sameIdentity(a: Commit['commit']['author'], b: Commit['commit']['author']): boolean {
+  return a.email !== undefined && b.email !== undefined && a.email === b.email;
+}
+
+export interface Finding {
+  sha: string;
+  subject: string;
+  author: string;
+  committer: string;
+}
+
+export function findForgedAuthorship(commits: Commit[]): Finding[] {
+  const findings: Finding[] = [];
+  for (const c of commits) {
+    const author = c.commit.author;
+    const committer = c.commit.committer;
+
+    // Only maintainer-attributed commits are worth forging.
+    if (!isMaintainer(c.author?.login, author.email)) continue;
+    // A maintainer committing their own work is the normal case.
+    if (sameIdentity(author, committer)) continue;
+    // ...as is a maintainer committing someone else's work (a rebase we did).
+    if (isMaintainer(c.committer?.login, committer.email)) continue;
+
+    findings.push({
+      sha: c.sha,
+      subject: c.commit.message.split('\n')[0],
+      author: `${author.name ?? '?'} <${author.email ?? '?'}>`,
+      committer: `${committer.name ?? '?'} <${committer.email ?? '?'}>`,
+    });
+  }
+  return findings;
+}
+
+// --- CLI ------------------------------------------------------------------
+// Driven from a fixture in tests (CHECK_AUTHORSHIP_COMMITS) and from the real
+// API payload in CI, so the parsing path under test is the one that ships.
+
+if (import.meta.main) {
+  const fixture = process.env.CHECK_AUTHORSHIP_COMMITS;
+  let raw: string;
+  if (fixture !== undefined) {
+    raw = readFileSync(fixture, 'utf-8');
+  } else {
+    raw = readFileSync(0, 'utf-8'); // piped from `gh api .../pulls/N/commits`
+  }
+
+  let commits: Commit[];
+  try {
+    commits = JSON.parse(raw) as Commit[];
+  } catch {
+    console.error('check-commit-authorship: input is not valid JSON');
+    process.exit(2);
+  }
+  if (!Array.isArray(commits)) {
+    console.error('check-commit-authorship: expected a JSON array of commits');
+    process.exit(2);
+  }
+
+  const findings = findForgedAuthorship(commits);
+  if (findings.length === 0) {
+    console.log(`check-commit-authorship: ${commits.length} commits, no forged authorship`);
+    process.exit(0);
+  }
+
+  console.error('check-commit-authorship: commit(s) claim a maintainer as author but were');
+  console.error('committed by someone else.\n');
+  for (const f of findings) {
+    console.error(`  ${f.sha.slice(0, 10)}  ${f.subject}`);
+    console.error(`      author:    ${f.author}`);
+    console.error(`      committer: ${f.committer}\n`);
+  }
+  console.error('  Commit authorship is attacker-controlled: `git commit --author` accepts');
+  console.error('  any identity, and GitHub renders that account\'s avatar beside it. This is');
+  console.error('  the shape used in better-auth PR #6003 to make a payload commit read as a');
+  console.error('  routine maintainer change.\n');
+  console.error('  If a maintainer really did write these, they pushed them and the committer');
+  console.error('  would say so. Treat this as identity spoofing until proven otherwise, and');
+  console.error('  read every line of those commits before merging.\n');
+  process.exit(1);
+}

--- a/tests/scripts/check-commit-authorship.test.ts
+++ b/tests/scripts/check-commit-authorship.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Behavioural tests for scripts/check-commit-authorship.ts.
+ *
+ * The fixtures are the real shapes, not invented ones: the legitimate cases are
+ * taken from this repo's PR #587 (three genuine maintainer commits pushed to a
+ * contributor's fork branch, plus two contributor commits rebased by a
+ * maintainer), and the attack case is better-auth PR #6003 commit acf0a729,
+ * authored as ping-maxwell and committed by AntonVishal.
+ *
+ * That pairing is the whole point of the check: both look identical in the
+ * commit list, and only the committer field separates them.
+ */
+import { describe, expect, test } from 'bun:test';
+import { findForgedAuthorship } from '../../scripts/check-commit-authorship.js';
+
+const MAINTAINER_EMAIL = 'hermosillaignacio@gmail.com';
+const MAINTAINER_LOGIN = 'ignaciohermosillacornejo';
+const CONTRIBUTOR_EMAIL = '307267272+gmhoward9289-ops@users.noreply.github.com';
+const CONTRIBUTOR_LOGIN = 'gmhoward9289-ops';
+
+interface CommitInput {
+  sha: string;
+  authorName: string;
+  authorEmail: string;
+  authorLogin: string | null;
+  committerName: string;
+  committerEmail: string;
+  committerLogin: string | null;
+  subject?: string;
+}
+
+function commit(c: CommitInput): Parameters<typeof findForgedAuthorship>[0][number] {
+  return {
+    sha: c.sha,
+    commit: {
+      author: { name: c.authorName, email: c.authorEmail },
+      committer: { name: c.committerName, email: c.committerEmail },
+      message: `${c.subject ?? 'some change'}\n\nbody`,
+    },
+    author: c.authorLogin === null ? null : { login: c.authorLogin },
+    committer: c.committerLogin === null ? null : { login: c.committerLogin },
+  };
+}
+
+/** PR #587: the maintainer pushed review fixes to a contributor's fork branch. */
+const MAINTAINER_OWN_PUSH = commit({
+  sha: '2f3a25c4c9aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  authorName: 'ignaciohermosillacornejo',
+  authorEmail: MAINTAINER_EMAIL,
+  authorLogin: MAINTAINER_LOGIN,
+  committerName: 'ignaciohermosillacornejo',
+  committerEmail: MAINTAINER_EMAIL,
+  committerLogin: MAINTAINER_LOGIN,
+  subject: 'chore: rebase onto bulk_edit_transactions',
+});
+
+/** PR #587: a contributor's own commit, rebased and committed by the maintainer. */
+const CONTRIBUTOR_REBASED_BY_MAINTAINER = commit({
+  sha: 'b917aece0cbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  authorName: 'gmhoward9289-ops',
+  authorEmail: CONTRIBUTOR_EMAIL,
+  authorLogin: CONTRIBUTOR_LOGIN,
+  committerName: 'ignaciohermosillacornejo',
+  committerEmail: MAINTAINER_EMAIL,
+  committerLogin: MAINTAINER_LOGIN,
+  subject: 'feat: bulk transaction edit tool',
+});
+
+/** An ordinary contributor commit on their own fork. */
+const CONTRIBUTOR_OWN = commit({
+  sha: 'cccccccccccccccccccccccccccccccccccccccc',
+  authorName: 'gmhoward9289-ops',
+  authorEmail: CONTRIBUTOR_EMAIL,
+  authorLogin: CONTRIBUTOR_LOGIN,
+  committerName: 'gmhoward9289-ops',
+  committerEmail: CONTRIBUTOR_EMAIL,
+  committerLogin: CONTRIBUTOR_LOGIN,
+});
+
+/** better-auth #6003 acf0a729 — maintainer identity, attacker's committer. */
+const FORGED = commit({
+  sha: 'acf0a7294366bf5b0d94d96e6a98e41e1c8f11aa',
+  authorName: 'ignaciohermosillacornejo',
+  authorEmail: MAINTAINER_EMAIL,
+  authorLogin: MAINTAINER_LOGIN,
+  committerName: 'Some Contributor',
+  committerEmail: '166398166+attacker@users.noreply.github.com',
+  committerLogin: 'attacker',
+  subject: 'fix(organization): Certain parameters not showing in client types (#5214)',
+});
+
+describe('legitimate authorship', () => {
+  test('allows a maintainer committing their own work to a fork branch', () => {
+    expect(findForgedAuthorship([MAINTAINER_OWN_PUSH])).toEqual([]);
+  });
+
+  test('allows a maintainer rebasing a contributor commit', () => {
+    expect(findForgedAuthorship([CONTRIBUTOR_REBASED_BY_MAINTAINER])).toEqual([]);
+  });
+
+  test('allows an ordinary contributor commit', () => {
+    expect(findForgedAuthorship([CONTRIBUTOR_OWN])).toEqual([]);
+  });
+
+  test('allows the whole of PR #587, which is all three shapes together', () => {
+    expect(
+      findForgedAuthorship([
+        MAINTAINER_OWN_PUSH,
+        CONTRIBUTOR_REBASED_BY_MAINTAINER,
+        CONTRIBUTOR_OWN,
+      ])
+    ).toEqual([]);
+  });
+
+  test('allows an empty commit list', () => {
+    expect(findForgedAuthorship([])).toEqual([]);
+  });
+});
+
+describe('forged authorship', () => {
+  test('flags a maintainer-authored commit committed by someone else', () => {
+    const found = findForgedAuthorship([FORGED]);
+    expect(found).toHaveLength(1);
+    expect(found[0].sha).toBe(FORGED.sha);
+    expect(found[0].committer).toContain('attacker');
+  });
+
+  test('flags it even when buried among legitimate commits', () => {
+    const found = findForgedAuthorship([
+      CONTRIBUTOR_OWN,
+      MAINTAINER_OWN_PUSH,
+      FORGED,
+      CONTRIBUTOR_REBASED_BY_MAINTAINER,
+    ]);
+    expect(found).toHaveLength(1);
+    expect(found[0].sha).toBe(FORGED.sha);
+  });
+
+  test('reports the subject so a copied commit message is visible', () => {
+    // #6003 reused a real merged PR's subject to make the commit look routine.
+    expect(findForgedAuthorship([FORGED])[0].subject).toBe(
+      'fix(organization): Certain parameters not showing in client types (#5214)'
+    );
+  });
+
+  test('flags when the author email is a maintainer but GitHub resolved no account', () => {
+    // An address GitHub cannot map to a login still renders as the name typed
+    // into it, which is enough to mislead a reviewer scanning the list.
+    const found = findForgedAuthorship([
+      commit({
+        sha: 'dddddddddddddddddddddddddddddddddddddddd',
+        authorName: 'ignaciohermosillacornejo',
+        authorEmail: MAINTAINER_EMAIL,
+        authorLogin: null,
+        committerName: 'attacker',
+        committerEmail: 'attacker@example.com',
+        committerLogin: null,
+      }),
+    ]);
+    expect(found).toHaveLength(1);
+  });
+
+  test('flags when the maintainer login is claimed under a different address', () => {
+    const found = findForgedAuthorship([
+      commit({
+        sha: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        authorName: 'ignaciohermosillacornejo',
+        authorEmail: 'noreply@users.noreply.github.com',
+        authorLogin: MAINTAINER_LOGIN,
+        committerName: 'attacker',
+        committerEmail: 'attacker@example.com',
+        committerLogin: 'attacker',
+      }),
+    ]);
+    expect(found).toHaveLength(1);
+  });
+});

--- a/tests/scripts/check-commit-authorship.test.ts
+++ b/tests/scripts/check-commit-authorship.test.ts
@@ -11,7 +11,13 @@
  * commit list, and only the committer field separates them.
  */
 import { describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { findForgedAuthorship } from '../../scripts/check-commit-authorship.js';
+
+const SCRIPT = fileURLToPath(new URL('../../scripts/check-commit-authorship.ts', import.meta.url));
 
 const MAINTAINER_EMAIL = 'hermosillaignacio@gmail.com';
 const MAINTAINER_LOGIN = 'ignaciohermosillacornejo';
@@ -195,5 +201,78 @@ describe('forged authorship', () => {
       }),
     ]);
     expect(found).toHaveLength(1);
+  });
+});
+
+/**
+ * End-to-end tests for the CLI itself, driven through the same
+ * CHECK_AUTHORSHIP_COMMITS seam CI uses. The exported predicate is covered
+ * above; this covers what actually runs in the workflow — argument handling,
+ * JSON parsing, exit codes, and the operator-facing output. A security gate
+ * whose entry point is untested can fail open without anything noticing.
+ */
+describe('CLI', () => {
+  async function runCli(
+    payload: string
+  ): Promise<{ code: number; stdout: string; stderr: string }> {
+    const dir = await mkdtemp(join(tmpdir(), 'authorship-cli-'));
+    try {
+      const file = join(dir, 'commits.json');
+      await writeFile(file, payload);
+      const proc = Bun.spawn(['bun', 'run', SCRIPT], {
+        env: { ...process.env, CHECK_AUTHORSHIP_COMMITS: file },
+        stdout: 'pipe',
+        stderr: 'pipe',
+      });
+      const [stdout, stderr] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      return { code: await proc.exited, stdout, stderr };
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  test('exits 0 and reports the count on clean input', async () => {
+    const { code, stdout } = await runCli(
+      JSON.stringify([MAINTAINER_OWN_PUSH, CONTRIBUTOR_OWN, CONTRIBUTOR_REBASED_BY_MAINTAINER])
+    );
+    expect(code).toBe(0);
+    expect(stdout).toContain('3 commits');
+    expect(stdout).toContain('no forged authorship');
+  });
+
+  test('exits 1 and names the sha, author and committer on a forgery', async () => {
+    const { code, stderr } = await runCli(JSON.stringify([CONTRIBUTOR_OWN, FORGED]));
+    expect(code).toBe(1);
+    expect(stderr).toContain(FORGED.sha.slice(0, 10));
+    expect(stderr).toContain('attacker');
+    expect(stderr).toContain(MAINTAINER_EMAIL);
+  });
+
+  test('surfaces the copied subject, which is how the commit passes as routine', async () => {
+    const { stderr } = await runCli(JSON.stringify([FORGED]));
+    expect(stderr).toContain('Certain parameters not showing in client types');
+  });
+
+  test('exits 2 on malformed JSON rather than passing silently', async () => {
+    // Distinct from exit 1: a parse failure means the gate did not run, and
+    // must not be mistaken for "no findings".
+    const { code, stderr } = await runCli('{not json');
+    expect(code).toBe(2);
+    expect(stderr).toContain('not valid JSON');
+  });
+
+  test('exits 2 when the payload is not an array', async () => {
+    const { code, stderr } = await runCli(JSON.stringify({ message: 'Not Found' }));
+    expect(code).toBe(2);
+    expect(stderr).toContain('expected a JSON array');
+  });
+
+  test('exits 0 on an empty array', async () => {
+    const { code, stdout } = await runCli('[]');
+    expect(code).toBe(0);
+    expect(stdout).toContain('0 commits');
   });
 });

--- a/tests/scripts/check-commit-authorship.test.ts
+++ b/tests/scripts/check-commit-authorship.test.ts
@@ -117,6 +117,28 @@ describe('legitimate authorship', () => {
   });
 });
 
+describe('known limits', () => {
+  test('a contributor rebasing a genuine maintainer commit IS flagged, by design', () => {
+    // Rebasing rewrites the committer, so a genuine maintainer commit carried
+    // through a contributor's rebase is indistinguishable from a forgery on the
+    // wire. This pins that as intended rather than as an oversight: the obvious
+    // "fix" — treating a maintainer author with any committer as legitimate —
+    // deletes the detection entirely, which is exactly what an attacker would
+    // want someone to do after hitting this false positive once.
+    const rebasedByContributor = commit({
+      sha: 'ffffffffffffffffffffffffffffffffffffffff',
+      authorName: 'ignaciohermosillacornejo',
+      authorEmail: MAINTAINER_EMAIL,
+      authorLogin: MAINTAINER_LOGIN,
+      committerName: 'gmhoward9289-ops',
+      committerEmail: CONTRIBUTOR_EMAIL,
+      committerLogin: CONTRIBUTOR_LOGIN,
+      subject: 'fix: a genuine maintainer commit, rebased by the contributor',
+    });
+    expect(findForgedAuthorship([rebasedByContributor])).toHaveLength(1);
+  });
+});
+
 describe('forged authorship', () => {
   test('flags a maintainer-authored commit committed by someone else', () => {
     const found = findForgedAuthorship([FORGED]);


### PR DESCRIPTION
# Summary

Detects the identity-forgery half of the better-auth attack: a fork-PR commit that claims a maintainer as its author. This is the rescoped version of #650 — the original "require signed commits" is incompatible with rebase merging.

Closes #650

## External assumptions

None

## Why not signed commits

The obvious fix does not work here, and would not have helped anyway:

- GitHub creates **new commit objects** when it rebase-merges and does not sign them, so `required_signatures` refuses rebase merges outright. This repo is rebase-only.
- **Branch protection does not apply to forks.** It constrains what can land, and the #6003 payload did its damage before any merge — the PR was closed unmerged.

Worth noting separately: your commits currently show **Unverified** on GitHub (`reason: unknown_key`) because the SSH signing key in your git config is not registered as a signing key on your account. That is independent of this PR, but it is why a signature-based rule would have had nothing to check.

## What it checks instead

The field the forger cannot control — the committer:

| Case | author | committer |
|---|---|---|
| Maintainer pushes to a contributor branch | maintainer | **same maintainer** |
| Contributor commit rebased by a maintainer | contributor | maintainer |
| **Forged identity (#6003)** | **maintainer** | **someone else** |

In better-auth #6003 the payload commit was authored as `ping-maxwell` — a real maintainer, with their GitHub noreply address and a subject copied verbatim from an unrelated merged PR — and committed by `AntonVishal`. In the commit list it read as a routine maintainer cherry-pick.

## Verification — real API payloads, not fixtures

Both directions, because a detector that only ever sees clean input proves nothing:

- **No false positives.** Silent across all 31 external fork PRs in this repo. That includes PR #587, which contains all three legitimate shapes at once: three genuine maintainer commits pushed to a contributor's fork branch, plus contributor commits rebased by a maintainer.
- **Fires on the real attack.** Run against better-auth #6003's actual commits (with `ping-maxwell` mapped onto this repo's maintainer identity, everything else untouched), it identifies `acf0a729` — and only that commit, out of the seven in the PR.

The unit tests use the same real shapes rather than invented ones, so the fixtures stay honest.

## Scope

Runs on **fork PRs only**, where there is an identity worth forging; a same-repo branch already required push access. Uses the read-only fork token, so it works without granting fork PRs anything.

Known limits are documented in the script header: an attacker who forges *both* fields passes (different threat model — they still cannot push to the base repo, and the payload gates are independent), and a contributor who rebases a branch containing genuine maintainer commits will trip it. That last one is rare, and "a maintainer's commit was rewritten by someone else" is worth a human look regardless.
