### PR TITLE
fix(accounts): use Copilot nicknames in account responses

### DIFF
--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -1245,6 +1245,10 @@ export class CopilotMoneyTools {
       accounts = accounts.filter((acc) => acc.user_deleted !== true && acc.user_hidden !== true);
     }
 
+    accounts = accounts.map((account) =>
+      account.nickname ? { ...account, name: account.nickname } : account
+    );
+
     // Calculate totals by asset/liability classification
     let totalAssets = 0;
     let totalLiabilities = 0;

--- a/tests/tools/tools.test.ts
+++ b/tests/tools/tools.test.ts
@@ -822,6 +822,22 @@ describe('CopilotMoneyTools', () => {
       expect(result.accounts).toHaveLength(2);
     });
 
+    test('uses the Copilot nickname as the account display name', async () => {
+      db._injectDataForTesting({
+        accounts: [
+          {
+            ...mockAccounts[0],
+            name: 'Provider Checking',
+            nickname: 'Household Checking',
+          },
+        ],
+      });
+
+      const result = await tools.getAccounts();
+
+      expect(result.accounts[0].name).toBe('Household Checking');
+    });
+
     test('filters by account type', async () => {
       const result = await tools.getAccounts({ account_type: 'checking' });
       expect(result.count).toBe(1);


### PR DESCRIPTION
## What changed

`get_accounts` now returns an account's Copilot `nickname` as its `name` when a nickname is present.

## Why

The local cache keeps the provider label in `name` and the user-visible Copilot label in `nickname`, so renamed accounts were returned with generic provider labels.

## Validation

- Added a regression test for nickname precedence.
- `bun test` (2709 passed, 20 real-cache integration tests skipped by the suite)
- `bun run build`
- `bun run typecheck`
- `bun run lint` (existing warnings only; no errors)
- `bun run format:check`

## External assumptions

None. `nickname` is already a decoded field on the cached account document
(`src/models/account.ts:40`, `src/core/decoder.ts:956`) and this change only
selects between two fields we already read. No new assumption about Copilot's
API or data shape.

## Bug fix?

Root cause:       `getAccounts` returned the institution-supplied `name` and never consulted the user-set `nickname`, so renamed accounts surfaced under provider labels.
Bug class:        `path-divergence` — the nickname→display-name rule already existed in `CopilotDatabase.getAccountNameMap()` (`src/core/database.ts:1357`) and fed `get_balance_history`, but `get_accounts` never applied it, so which name a caller saw depended on which tool they called.
Detector added:   None at class level — this PR adds an instance regression test only (`tests/tools/tools.test.ts`). The class-level fix is to resolve the display name in ONE place and have both call sites use it; that unification is tracked as part of the v3 accounts work (#597 Tier 2) rather than asked of the contributor.
Siblings checked: `getAccountNameMap()` (`src/core/database.ts:1357`) already applies `nickname ?? name` — the two paths now agree in behaviour, though they remain two implementations that differ on an empty-string nickname (`??` vs truthiness). `get_accounts_live` cannot apply the rule at all: Copilot's GraphQL `AccountNode` (`src/core/graphql/queries/accounts.ts:17-45`) exposes no `nickname` field, so cache mode and live mode now disagree on `name` — a parity gap to close alongside the shared accounts preset.
Ledger updated:   n/a — local-cache read path, not an external-assumption bug.
