### PR TITLE
fix(scheduled-smoke): reserve `fail` for observed drift, add `incomplete` for runs that never finished

### DIFF
--- a/docs/bugs/661-non-completion-classified-as-drift.md
+++ b/docs/bugs/661-non-completion-classified-as-drift.md
@@ -130,7 +130,11 @@ already applied to auth, extended: absence of completion is not presence of drif
   `incomplete`, not `fail`, because the class-level fix already removed the drift claim.
 - `summarizeSmokeOutput` describes how an incomplete run ended (`killed by SIGTERM after
   the 10m timeout`) instead of quoting the last log line, which for a truncated run is
-  debris.
+  debris. Running the fixed runner for real then showed the same defect on the *pass*
+  path — a clean run summarized itself as `[smoke] done {`, because the composite smoke
+  ends with the refresh scripts and the heuristic took the last prefixed line rather
+  than the last verdict. Fixed in the same PR; found only by reading real output, which
+  is this corpus's most reliable mechanism and was the point of the exercise.
 - `runScheduledSmoke` retries once on `incomplete`. The observed kill fires just after
   the machine wakes, so the retry runs on an awake laptop and passes in ~20s — turning
   the common false alarm into a silent pass rather than into better-worded noise. It is

--- a/docs/bugs/661-non-completion-classified-as-drift.md
+++ b/docs/bugs/661-non-completion-classified-as-drift.md
@@ -6,7 +6,7 @@ status: fixed
 detected: dogfooding # the macOS notification fired; reading the report it pointed at showed every gate inside it had passed
 fixed_in: https://github.com/ignaciohermosillacornejo/copilot-money-mcp/pull/661
 issue: none — found and fixed directly
-date: 2026-08-19
+date: 2026-08-20
 ---
 
 ## Symptom

--- a/docs/bugs/661-non-completion-classified-as-drift.md
+++ b/docs/bugs/661-non-completion-classified-as-drift.md
@@ -1,0 +1,185 @@
+---
+id: 661
+title: The weekly drift check reported "conformance failure" for runs that were killed, and for a logged-out machine
+class: alarm-by-fallthrough
+status: fixed
+detected: dogfooding # the macOS notification fired; reading the report it pointed at showed every gate inside it had passed
+fixed_in: https://github.com/ignaciohermosillacornejo/copilot-money-mcp/pull/661
+issue: none — found and fixed directly
+date: 2026-08-19
+---
+
+## Symptom
+
+A macOS notification on Monday 2026-08-17:
+
+> **Copilot MCP drift check FAILED**
+> Scheduled smoke found a conformance failure. Report: …-smoke-failure.txt
+
+The report it pointed at contained no conformance failure. Every gate inside it had
+passed — 20/20 conformance surfaces, 19/19 read operations, `[smoke] PASS — all 5 enums
+and 15 input types match the server`. The run then stopped mid-way through
+`smoke:refresh` with:
+
+```
+error: script "smoke" was terminated by signal SIGTERM (Polite quit request)
+```
+
+The recorded one-line summary was `[smoke] months_window=1 {` — an object dump cut off
+mid-sentence, presented where a finding belongs.
+
+Re-running `bun run smoke` on the same commit: exit 0, everything PASS, **17.9 seconds**.
+
+The seven notifications before it — every previous failure this job had ever sent, weekly
+from 2026-06-15 to 2026-07-27 — were the same false alarm with a different cause: a
+logged-out machine, which the job is explicitly designed to report as `auth-missing`.
+
+**Eight of eight failure notifications this detector has produced were false alarms.
+It has never once reported real drift.**
+
+## How it was detected
+
+Dogfooding, and only barely. The notification was indistinguishable from a true positive;
+it was caught because someone opened the report it linked and noticed the contents said
+PASS. Nothing in the system flagged the contradiction between "found a conformance
+failure" and a report whose every line said otherwise.
+
+The seven earlier alarms were *not* detected at the time. They were found retroactively
+while investigating this one, by running the runner's own `AUTH_MISSING_PATTERNS` over the
+archived reports and getting zero matches on all seven.
+
+This is the failure mode that makes the class expensive: a detector that cries wolf is
+usually discovered by someone eventually ignoring it, not by a gate.
+
+## Root cause
+
+Two defects, one cause.
+
+`scripts/scheduled-smoke.ts` classified an outcome from an exit code and a pattern list:
+
+```ts
+const exitCode = run.status ?? 1;                       // scheduled-smoke.ts:75
+...
+export function classifySmokeOutcome(exitCode: number, output: string) {
+  if (exitCode === 0) return 'pass';
+  return AUTH_MISSING_PATTERNS.some((p) => p.test(output)) ? 'auth-missing' : 'fail';
+}
+```
+
+`fail` was the fallthrough. Anything the classifier did not recognize became "Copilot's
+API drifted", which is the one conclusion the job exists to draw and the most expensive
+one to act on.
+
+1. **The killed run.** `spawnSync(..., { timeout: 10 * 60 * 1000 })` returns
+   `status: null, signal: 'SIGTERM', errorCode: 'ETIMEDOUT'` when its timeout fires
+   (probe-verified under bun). Line 75 coalesced that to `status ?? 1` and discarded
+   `signal` and `error` entirely, so a killed run was indistinguishable from a run that
+   exited 1 on purpose.
+
+   The kill itself is environmental and benign. The laptop was asleep at the Mon 10:00
+   slot (`pmset` shows sleep/dark-wake cycling from 09:57). launchd coalesced the missed
+   run onto a dark wake, where the network is throttled — the report carries a
+   `[graphql] Categories failed: code=NETWORK` retry that a normal awake run does not.
+   The system then kept returning to sleep, freezing parent and child while the
+   *wall-clock* timeout kept ticking. A 17.9-second job consumed the full 10-minute
+   budget across sleep cycles. The lid opened at 10:41:18; twelve seconds later the
+   resumed `spawnSync` noticed the deadline had passed, SIGTERM'd the child, and wrote
+   the status file at 10:41:30.883Z.
+
+2. **The logged-out runs.** The smoke's own auth-failure wording — `[smoke] FAIL — could
+   not acquire an authenticated Copilot session, no probes were sent` — was absent from
+   `AUTH_MISSING_PATTERNS`, whose five entries all matched deeper library errors instead.
+   So the auth path fell through to `fail` too, weekly, for seven weeks.
+
+Both are the same mistake: the alarming state was the default, so it collected every case
+nobody had modelled.
+
+## Why the tests didn't catch it
+
+`tests/scripts/scheduled-smoke.test.ts` had five classification tests. Every one of them
+asserted a mapping the author had already thought of — exit 0 → pass, and four auth
+signatures → auth-missing. The `fail` case was asserted with a hand-written
+`'[smoke] FAIL: bogus_value REJECTED by server'` string, which is not a string the smoke
+ever prints.
+
+Nothing tested the *shape* of the classifier: that its default branch is the alarming
+one. A test suite built from "does each known input map correctly?" cannot see that,
+because the bug lives entirely in the inputs nobody listed. The auth-pattern tests are
+the sharpest illustration — all four passed while the one auth message the smoke
+actually emits was unmatched, because the fixtures were written from the pattern list
+rather than from the smoke's real output.
+
+The runner also had no test that executed `runScheduledSmoke()` end to end; it spawned a
+real process, so nothing exercised the report/notify/exit-code flow at all.
+
+## The fix
+
+PR #661.
+
+**Root-cause fix:** `fail` now requires positive evidence. `classifySmokeOutcome` takes
+the whole run — `status`, `signal`, `errorCode`, `output` — and returns `fail` only when
+the output carries one of the two drift verdicts the smoke prints before exiting
+(`DRIFT_VERDICT_MARKERS`). A fourth state, `incomplete`, is the new fallthrough: killed,
+timed out, could not spawn, or failed in a way the runner does not model. It notifies
+with its own wording and never borrows the drift copy. The reasoning is the one the file
+already applied to auth, extended: absence of completion is not presence of drift.
+
+**Downstream:**
+- `AUTH_MISSING_PATTERNS` gained the smoke's own auth-failure wording, closing the
+  seven-week case. Note it is now belt-and-braces: without it that output classifies as
+  `incomplete`, not `fail`, because the class-level fix already removed the drift claim.
+- `summarizeSmokeOutput` describes how an incomplete run ended (`killed by SIGTERM after
+  the 10m timeout`) instead of quoting the last log line, which for a truncated run is
+  debris.
+- `runScheduledSmoke` retries once on `incomplete`. The observed kill fires just after
+  the machine wakes, so the retry runs on an awake laptop and passes in ~20s — turning
+  the common false alarm into a silent pass rather than into better-worded noise. It is
+  injectable (`spawn`/`write`/`notify`), so the full flow is now tested in-process.
+- `incomplete` threaded through `SCHEDULED_SMOKE_RESULTS`, the status reader's Zod enum,
+  the `get_connection_status` description, and `docs/scheduled-smoke.md`.
+
+The 10-minute timeout is unchanged — a healthy run is 17.9s, so headroom was never the
+problem. Wall clock that counts system sleep is not something a timeout can fix; the
+retry is the mechanism that handles it.
+
+## Detector
+
+`tests/scripts/scheduled-smoke.test.ts` asserts the class-level invariant:
+
+> `classifySmokeOutcome(run) === 'fail'` implies the output contains a drift-verdict
+> marker
+
+evaluated over a corpus of every non-drift failure mode this job has actually produced —
+the timeout kill, a bare signal kill, a failed spawn, both auth wordings, an unmodelled
+crash, and a network failure — plus a non-vacuity assertion that exactly the three drift
+fixtures do classify as `fail`. Adding a new unmodelled failure mode to that corpus
+cannot silently become an alarm.
+
+**Mutation-verified**, five mutations, all detected:
+
+| Mutation | Tests red |
+|---|---|
+| revert to fallthrough-`fail` (drop the drift-verdict requirement) | 11 |
+| drop the widened auth pattern (restore the 7-week bug) | 1 |
+| drop the retry on non-completion | 2 |
+| let an incomplete run reuse the `fail` alarm copy | 1 |
+| summarize incomplete runs from the last log line again | 2 |
+
+Plus, in `tests/tools/scheduled-smoke-status.test.ts`, `incomplete` must survive the
+reader as its own state — mutation-verified by removing it from the enum (1 red).
+
+The detector is scoped to this classifier. The class is broader: any place that maps a
+recognized set to specific outcomes and dumps the remainder into a serious one. No sweep
+exists for that, and it is not obvious one is affordable.
+
+## Lesson
+
+When a detector has a most-alarming state, that state must be reached by evidence and
+never by `else`. The cheap version of this habit is a single test per classifier —
+"the alarming outcome implies the evidence for it" — which costs three lines and would
+have caught both defects here on the day they were written.
+
+The corollary is about trust: this job's alarm had a 0/8 precision record before anyone
+looked closely. A detector nobody believes is worse than no detector, because it also
+consumes the attention a real alarm would need. Worth counting alarm precision for
+anything that fires unattended.

--- a/docs/bugs/README.md
+++ b/docs/bugs/README.md
@@ -96,16 +96,17 @@ a class yet.
 | `unsettled-promise` | An async operation has a completion path where neither resolve nor reject fires, hanging callers forever. | none |
 | `deferred-cleanup-never-runs` | Releasing a resource is deferred to a timer or callback that only fires if the process outlives it — in a process that routinely exits first. The resource is acquired eagerly and released never, while every same-process test still observes correct bookkeeping. | none — instance-only; the class is a deployment property (does this process outlive its own timers?) that no static check here can evaluate |
 | `unbounded-trusted-payload` | A budgeted or validated surface embeds a value whose size or shape is guaranteed only by convention, because the only writer it has met is well-behaved. The guarantee holds until something else writes the file. | partial — `tests/context-budget.test.ts` measures the populated branch against a maximal legitimate input, for this surface only; no sweep across budgeted responses that embed external files |
+| `alarm-by-fallthrough` | A classifier recognizes a few signatures and routes *everything else* into its most alarming state, so any unmodelled failure is reported as the specific serious condition the detector exists to find. The inverse of `silent-failure-masking`: unknown becomes red rather than green, and the alarm stops correlating with the condition it names. | `tests/scripts/scheduled-smoke.test.ts` (mutation-verified): `fail` is reachable only when the output carries a drift-verdict marker, asserted over a corpus of every real non-drift failure mode |
 | `overbroad-precondition-gate` | A precondition for one resource is checked at a shared chokepoint (dispatch, startup) for all requests, including those whose handling never uses the resource — so any configuration where the resource is legitimately absent is fully locked out. | registry-walk sweep in `tests/integration/live-reads.test.ts` (mutation-verified): every live tool and live-mode write must dispatch past the local-cache gate with the cache absent |
 
 ## How we find bugs
 
 Recorded per entry, using a fixed vocabulary so the corpus stays countable. Here is what
-this corpus actually says, across all 46 entries:
+this corpus actually says, across all 47 entries:
 
 | Found by | Count | |
 |---|---|---|
-| `dogfooding` — used the tool, noticed the answer disagreed with the Copilot app | 14 | ████████████ |
+| `dogfooding` — used the tool, noticed the answer disagreed with the Copilot app | 15 | █████████████ |
 | `live-probe` — a probe or smoke against the real backend | 7 | ██████ |
 | `audit-sweep` — a deliberate cross-cutting audit | 7 | ██████ |
 | `incidental` — found while working on something else | 7 | ██████ |

--- a/docs/scheduled-smoke.md
+++ b/docs/scheduled-smoke.md
@@ -15,7 +15,12 @@ scripts/uninstall-scheduled-smoke.sh
 ```
 
 launchd coalesces missed runs: a laptop asleep at the scheduled time runs the
-check on next wake. Manual trigger:
+check on next wake. That wake is often a *dark* wake, where the network is
+throttled and the system returns to sleep within seconds — freezing the run
+mid-flight while its 10-minute wall-clock timeout keeps ticking. A run killed
+that way is reported as `incomplete` and retried once; by the time the timeout
+fires the machine is usually awake, and the ~20s retry simply passes. Manual
+trigger:
 
 ```bash
 launchctl kickstart -k gui/$(id -u)/com.copilot-money-mcp.scheduled-smoke
@@ -26,8 +31,19 @@ launchctl kickstart -k gui/$(id -u)/com.copilot-money-mcp.scheduled-smoke
 | Result | Meaning | Behavior |
 | --- | --- | --- |
 | `pass` | All gated surfaces match the server | Silent |
-| `fail` | Conformance failure — likely API drift | macOS notification + dated report under `~/.claude/copilot-money/smoke-reports/` |
+| `fail` | The smoke printed a drift verdict — Copilot's API changed | macOS notification + dated report under `~/.claude/copilot-money/smoke-reports/` |
 | `auth-missing` | No Copilot browser session — **drift NOT checked** | Recorded distinctly; absence of auth must never look like absence of drift |
+| `incomplete` | The run never reached a verdict: killed, timed out, or failed unmodelled — **drift NOT checked** | Retried once first; if the retry also fails to complete, notification + report, worded as a non-completion |
+
+The states are ordered by *evidence*, not by severity. `fail` is reachable
+only when the output carries one of the drift-verdict markers the smoke prints
+before exiting (`DRIFT_VERDICT_MARKERS` in `scripts/scheduled-smoke.ts`);
+everything unrecognized falls to `incomplete`. That direction matters: `fail`
+is the state that sends a reader hunting for an API change, so it must never
+be the fallthrough bucket. Before this rule existed, every one of the job's
+first eight failure notifications was a false alarm — seven logged-out
+machines and one that slept through its run. See
+[`docs/bugs/661-non-completion-classified-as-drift.md`](bugs/661-non-completion-classified-as-drift.md).
 
 Every run writes `~/.claude/copilot-money/scheduled-smoke.json`
 (`last_run`, `result`, `summary`, `report`). The `get_connection_status` MCP

--- a/scripts/scheduled-smoke.ts
+++ b/scripts/scheduled-smoke.ts
@@ -5,12 +5,27 @@
  * where the next dev session can see it (get_connection_status reads the
  * status file via src/utils/scheduled-smoke-status.ts).
  *
- * Outcomes are three-state on purpose: a machine with no Copilot browser
- * session must report `auth-missing`, never `pass` — absence of auth is not
- * absence of drift.
+ * Outcomes are four-state on purpose, and the reasoning is the same each time:
+ * a state that fires an alarm must be reached by *evidence*, never by
+ * fallthrough.
  *
- * On failure: a macOS notification + a dated report file under
- * ~/.claude/copilot-money/smoke-reports/. On pass: silent.
+ *   - `auth-missing`: a machine with no Copilot browser session must never
+ *     report `pass` — absence of auth is not absence of drift.
+ *   - `incomplete`: a run that was killed, could not start, or failed in a way
+ *     this runner does not model must never report `fail` — absence of
+ *     completion is not presence of drift.
+ *   - `fail` therefore requires a drift verdict in the output. It is the one
+ *     state that means "Copilot changed their API", so nothing else may
+ *     borrow its wording.
+ *
+ * The `incomplete` state exists because of a real false alarm: a laptop asleep
+ * at the scheduled slot had its run frozen mid-flight, burned the 10-minute
+ * *wall-clock* budget across sleep cycles, and was SIGTERM'd on the next wake —
+ * after every gate inside it had already passed. See
+ * docs/bugs/661-non-completion-classified-as-drift.md.
+ *
+ * On failure or non-completion: a macOS notification + a dated report file
+ * under ~/.claude/copilot-money/smoke-reports/. On pass: silent.
  */
 import { mkdirSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
@@ -20,6 +35,22 @@ import {
   type ScheduledSmokeResult,
 } from '../src/utils/scheduled-smoke-status.js';
 
+/** Wall-clock ceiling for one `bun run smoke` attempt. A healthy run takes
+ * ~20s; this is a runaway backstop, not a performance budget. It is wall
+ * clock, so system sleep counts against it — hence the retry below. */
+const SMOKE_TIMEOUT_MINUTES = 10;
+
+/**
+ * The only outputs that mean "the smoke reached a verdict and the verdict was
+ * drift". Both are printed by the smoke immediately before it exits nonzero
+ * (`scripts/smoke/conformance.ts`, `scripts/smoke/reads.ts`). Requiring one of
+ * these is what keeps `fail` from becoming the fallthrough bucket.
+ */
+export const DRIFT_VERDICT_MARKERS = [
+  '[smoke] FAIL — conformance drift detected',
+  '[smoke] FAIL — read-surface drift detected',
+] as const;
+
 /** Signatures that mean "could not authenticate", not "the API drifted". */
 const AUTH_MISSING_PATTERNS = [
   /No Copilot Money session found/i,
@@ -27,26 +58,120 @@ const AUTH_MISSING_PATTERNS = [
   /PROJECT_NUMBER_MISMATCH/,
   /UNAUTHENTICATED/,
   /expired or unauthenticated session/i,
+  // The smoke's own wording when it gives up before sending any probe. Its
+  // absence from this list is why seven consecutive weekly runs on a
+  // logged-out machine were reported as API drift.
+  /could not acquire an authenticated Copilot session/i,
 ];
 
-export function classifySmokeOutcome(exitCode: number, output: string): ScheduledSmokeResult {
-  if (exitCode === 0) return 'pass';
-  return AUTH_MISSING_PATTERNS.some((p) => p.test(output)) ? 'auth-missing' : 'fail';
+/**
+ * One `bun run smoke` attempt, flattened from `SpawnSyncReturns`.
+ *
+ * `status` is `null` whenever the child never produced an exit code — killed
+ * by a signal, or never spawned at all. The previous version of this runner
+ * collapsed that to `status ?? 1` and dropped `signal`/`errorCode` on the
+ * floor, which is precisely how a SIGTERM became "conformance failure".
+ */
+export interface SmokeRunResult {
+  /** Child exit code; null when killed by a signal or never started. */
+  status: number | null;
+  /** Signal that killed the child, if any. */
+  signal: NodeJS.Signals | null;
+  /** spawnSync's own error code: ETIMEDOUT when the timeout fired, ENOENT when bun is missing. */
+  errorCode: string | null;
+  /** Combined stdout + stderr. */
+  output: string;
 }
 
-/** Last [smoke]/[ledger] line of output — a one-line human summary. */
-export function summarizeSmokeOutput(result: ScheduledSmokeResult, output: string): string {
+export function classifySmokeOutcome(run: SmokeRunResult): ScheduledSmokeResult {
+  if (run.status === 0) return 'pass';
+  // Evidence first: a drift verdict counts even if the run was killed after
+  // printing it — the drift was genuinely observed.
+  if (DRIFT_VERDICT_MARKERS.some((m) => run.output.includes(m))) return 'fail';
+  if (AUTH_MISSING_PATTERNS.some((p) => p.test(run.output))) return 'auth-missing';
+  return 'incomplete';
+}
+
+/** How an incomplete run ended, in the fewest words that stay actionable. */
+function describeTermination(run: SmokeRunResult): string {
+  if (run.signal) {
+    const cause = run.errorCode === 'ETIMEDOUT' ? ` after the ${SMOKE_TIMEOUT_MINUTES}m timeout` : '';
+    return `killed by ${run.signal}${cause}`;
+  }
+  if (run.errorCode) return `could not run (${run.errorCode})`;
+  return `exit ${String(run.status ?? 'unknown')}`;
+}
+
+/** One-line human summary of a run, appropriate to its outcome. */
+export function summarizeSmokeOutput(result: ScheduledSmokeResult, run: SmokeRunResult): string {
   if (result === 'auth-missing') {
     return 'no Copilot browser session — drift NOT checked (log into app.copilot.money)';
   }
-  const lines = output.trim().split('\n');
+  if (result === 'incomplete') {
+    // Never quote the last log line here: a run cut off mid-sentence ends on
+    // debris like `[smoke] months_window=1 {`, which reads as a finding.
+    return `drift check did not complete — ${describeTermination(run)}; drift NOT checked`.slice(
+      0,
+      300
+    );
+  }
+  const lines = run.output.trim().split('\n');
   const marker = [...lines].reverse().find((l) => l.startsWith('[smoke]'));
   return (marker ?? lines[0] ?? '').slice(0, 300);
 }
 
-function notify(title: string, message: string): void {
-  // COPILOT_MCP_SMOKE_QUIET suppresses the popup (tests exercise the fail
-  // path; they must not spam real notifications).
+/** Notification copy per outcome. `fail` is the only one allowed to say drift. */
+const ALARMS: Partial<Record<ScheduledSmokeResult, { title: string; describe: string }>> = {
+  fail: {
+    title: 'Copilot MCP drift check FAILED',
+    describe: 'Scheduled smoke found a conformance failure.',
+  },
+  incomplete: {
+    title: 'Copilot MCP drift check DID NOT COMPLETE',
+    describe: 'Scheduled smoke was cut off before reaching a verdict; drift was NOT checked.',
+  },
+};
+
+/** Injection seam so the retry/report/notify flow is testable without spawning. */
+export interface ScheduledSmokeDeps {
+  /** Runs one `bun run smoke` attempt. */
+  spawn: () => SmokeRunResult;
+  /** Persists the status record; `output` is non-null when a report should be spilled. */
+  write: (status: Record<string, unknown>, output: string | null) => void;
+  notify: (title: string, message: string) => void;
+}
+
+function defaultSpawn(): SmokeRunResult {
+  const repoDir = process.env.COPILOT_MCP_REPO ?? join(import.meta.dir, '..');
+  const run = spawnSync(process.execPath, ['run', 'smoke'], {
+    cwd: repoDir,
+    encoding: 'utf-8',
+    timeout: SMOKE_TIMEOUT_MINUTES * 60 * 1000,
+  });
+  return {
+    status: run.status,
+    signal: run.signal,
+    errorCode: (run.error as NodeJS.ErrnoException | undefined)?.code ?? null,
+    output: `${run.stdout ?? ''}${run.stderr ?? ''}`,
+  };
+}
+
+function defaultWrite(status: Record<string, unknown>, output: string | null): void {
+  // The override lives in defaultScheduledSmokeStatusPath(), so reader and
+  // writer resolve the same path from the same variable (#638).
+  const statusPath = defaultScheduledSmokeStatusPath();
+  mkdirSync(dirname(statusPath), { recursive: true });
+  const report = status.report;
+  if (output !== null && typeof report === 'string') {
+    mkdirSync(dirname(report), { recursive: true });
+    writeFileSync(report, output);
+  }
+  writeFileSync(statusPath, JSON.stringify(status, null, 2));
+}
+
+function defaultNotify(title: string, message: string): void {
+  // COPILOT_MCP_SMOKE_QUIET suppresses the popup (tests exercise the alarm
+  // paths; they must not spam real notifications).
   if (process.env.COPILOT_MCP_SMOKE_QUIET) return;
   // Best-effort; a failed or hung notification must not mask the status write.
   spawnSync(
@@ -56,50 +181,51 @@ function notify(title: string, message: string): void {
   );
 }
 
-/** Runs one drift check and returns the process exit code (importable so
- * tests can execute the full flow in-process, where coverage is visible). */
-export function runScheduledSmoke(): number {
-  const repoDir = process.env.COPILOT_MCP_REPO ?? join(import.meta.dir, '..');
-  // The override now lives in defaultScheduledSmokeStatusPath(), so reader and
-  // writer resolve the same path from the same variable (#638).
-  const statusPath = defaultScheduledSmokeStatusPath();
-  const reportsDir = join(dirname(statusPath), 'smoke-reports');
-  mkdirSync(dirname(statusPath), { recursive: true });
-
-  const run = spawnSync(process.execPath, ['run', 'smoke'], {
-    cwd: repoDir,
-    encoding: 'utf-8',
-    timeout: 10 * 60 * 1000,
-  });
-  const output = `${run.stdout ?? ''}${run.stderr ?? ''}`;
-  const exitCode = run.status ?? 1;
-  const result = classifySmokeOutcome(exitCode, output);
-  const lastRun = new Date().toISOString();
-
-  let report: string | null = null;
-  if (result === 'fail') {
-    mkdirSync(reportsDir, { recursive: true });
-    // Full timestamp so same-day failures (manual kickstarts) never overwrite.
-    report = join(reportsDir, `${lastRun.replace(/[:.]/g, '-')}-smoke-failure.txt`);
-    writeFileSync(report, output);
-    notify(
-      'Copilot MCP drift check FAILED',
-      `Scheduled smoke found a conformance failure. Report: ${report}`
-    );
+/**
+ * Runs the drift check and returns the process exit code (importable so tests
+ * can execute the full flow in-process, where coverage is visible).
+ *
+ * A first attempt that never completed is retried once. The observed failure
+ * mode is a laptop that slept through its run and SIGTERM'd it on wake — by
+ * which point the machine is awake and a ~20s retry simply passes, so the
+ * retry converts the common false alarm into a silent pass rather than into
+ * better-worded noise.
+ */
+export function runScheduledSmoke(deps: ScheduledSmokeDeps = DEFAULT_DEPS): number {
+  let run = deps.spawn();
+  let result = classifySmokeOutcome(run);
+  if (result === 'incomplete') {
+    run = deps.spawn();
+    result = classifySmokeOutcome(run);
   }
 
-  writeFileSync(
-    statusPath,
-    JSON.stringify(
-      { last_run: lastRun, result, summary: summarizeSmokeOutput(result, output), report },
-      null,
-      2
-    )
+  const lastRun = new Date().toISOString();
+  const alarm = ALARMS[result];
+
+  let report: string | null = null;
+  if (alarm) {
+    const reportsDir = join(dirname(defaultScheduledSmokeStatusPath()), 'smoke-reports');
+    // Full timestamp so same-day failures (manual kickstarts) never overwrite.
+    report = join(reportsDir, `${lastRun.replace(/[:.]/g, '-')}-smoke-failure.txt`);
+  }
+
+  deps.write(
+    { last_run: lastRun, result, summary: summarizeSmokeOutput(result, run), report },
+    alarm ? run.output : null
   );
 
-  // launchd treats nonzero exit as job failure; auth-missing is an expected
-  // state (machine logged out), recorded in the status file, so exit 0.
-  return result === 'fail' ? 1 : 0;
+  if (alarm) deps.notify(alarm.title, `${alarm.describe} Report: ${report ?? 'none'}`);
+
+  // launchd treats nonzero exit as job failure. `auth-missing` is an expected
+  // state (machine logged out) recorded in the status file, so it exits 0;
+  // `incomplete` survived a retry and means the job did not do its job.
+  return alarm ? 1 : 0;
 }
+
+const DEFAULT_DEPS: ScheduledSmokeDeps = {
+  spawn: defaultSpawn,
+  write: defaultWrite,
+  notify: defaultNotify,
+};
 
 if (import.meta.main) process.exit(runScheduledSmoke());

--- a/scripts/scheduled-smoke.ts
+++ b/scripts/scheduled-smoke.ts
@@ -115,8 +115,13 @@ export function summarizeSmokeOutput(result: ScheduledSmokeResult, run: SmokeRun
       300
     );
   }
+  // Track the last *verdict*, not the last prefixed line. The composite smoke
+  // ends with the refresh scripts, whose final line is an object-open brace —
+  // which is how a clean run once summarized itself as `[smoke] done {`.
   const lines = run.output.trim().split('\n');
-  const marker = [...lines].reverse().find((l) => l.startsWith('[smoke]'));
+  const reversed = [...lines].reverse();
+  const verdict = reversed.find((l) => /^\[smoke\] (PASS|FAIL) —/.test(l));
+  const marker = verdict ?? reversed.find((l) => l.startsWith('[smoke]'));
   return (marker ?? lines[0] ?? '').slice(0, 300);
 }
 

--- a/src/tools/registry/accounts-system.ts
+++ b/src/tools/registry/accounts-system.ts
@@ -102,8 +102,9 @@ export const getConnectionStatusTool = defineTool({
       'Use this to check when accounts were last synced or to identify connections needing attention. ' +
       'Also reports decode_health: per-collection counts of cached documents dropped on schema ' +
       'validation failure (a "degraded" status means some documents are missing from results). ' +
-      'Also reports scheduled_smoke: the last scheduled API-drift check (pass / fail / ' +
-      'auth-missing with timestamp), or null if the weekly job is not installed.',
+      'Also reports scheduled_smoke: the last scheduled API-drift check with timestamp, or null ' +
+      'if the weekly job is not installed. Only "fail" means the API drifted; "auth-missing" ' +
+      'and "incomplete" mean drift is unknown.',
     inputSchema: {
       type: 'object',
       properties: {},

--- a/src/utils/scheduled-smoke-status.ts
+++ b/src/utils/scheduled-smoke-status.ts
@@ -16,7 +16,14 @@ import { homedir } from 'os';
 import { join } from 'path';
 import { z } from 'zod';
 
-export const SCHEDULED_SMOKE_RESULTS = ['pass', 'fail', 'auth-missing'] as const;
+/**
+ * `fail` is reserved for a drift verdict the smoke actually printed;
+ * `incomplete` covers every run that never reached a verdict (killed, timed
+ * out, crashed unmodelled). Keeping them distinct is what stops a frozen
+ * laptop from reading as an API change — see
+ * `docs/bugs/661-non-completion-classified-as-drift.md`.
+ */
+export const SCHEDULED_SMOKE_RESULTS = ['pass', 'fail', 'auth-missing', 'incomplete'] as const;
 export type ScheduledSmokeResult = (typeof SCHEDULED_SMOKE_RESULTS)[number];
 
 /**

--- a/tests/scripts/scheduled-smoke-e2e.test.ts
+++ b/tests/scripts/scheduled-smoke-e2e.test.ts
@@ -67,15 +67,59 @@ describe('scheduled-smoke runner (full flow, stub smoke)', () => {
     expect(typeof status.last_run).toBe('string');
   });
 
-  test('failing smoke → result fail, dated report with full output, exit 1', () => {
+  // The stub must print a marker the real smoke actually prints. An invented
+  // one ("[smoke] FAIL — synthetic drift detected") is how the original suite
+  // convinced itself the fail path worked while the wordings the smoke really
+  // emits went unmatched — the same mistake as the bug this file guards.
+  test('drift verdict → result fail, dated report with full output, exit 1', () => {
     const { exitCode, status } = runWithStubSmoke(
-      "echo '[smoke] FAIL — synthetic drift detected' && exit 1"
+      "echo '[smoke] FAIL — conformance drift detected:' && exit 1"
     );
     expect(exitCode).toBe(1);
     expect(status.result).toBe('fail');
     expect(typeof status.report).toBe('string');
     expect(existsSync(status.report as string)).toBe(true);
-    expect(readFileSync(status.report as string, 'utf-8')).toContain('synthetic drift detected');
+    expect(readFileSync(status.report as string, 'utf-8')).toContain('conformance drift detected');
+  });
+
+  test('read-surface drift verdict → result fail, exit 1', () => {
+    const { exitCode, status } = runWithStubSmoke(
+      "echo '[smoke] FAIL — read-surface drift detected:' && exit 1"
+    );
+    expect(exitCode).toBe(1);
+    expect(status.result).toBe('fail');
+  });
+
+  test('a nonzero exit with no verdict → result incomplete, not fail', () => {
+    const { exitCode, status } = runWithStubSmoke("echo 'error: unmodelled explosion' && exit 1");
+    expect(exitCode).toBe(1);
+    expect(status.result).toBe('incomplete');
+    expect(status.summary).toContain('drift NOT checked');
+    // The report is still written — an unexplained non-completion is worth
+    // keeping; what changed is that it no longer claims the API drifted.
+    expect(existsSync(status.report as string)).toBe(true);
+  });
+
+  test('a run killed by a signal → result incomplete, and the runner retried', () => {
+    // Each attempt appends a line, so the file length counts real spawns.
+    dir = mkdtempSync(join(tmpdir(), 'sched-smoke-e2e-'));
+    const attempts = join(dir, 'attempts.log');
+    const statusPath = join(dir, 'status.json');
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ scripts: { smoke: `echo x >> ${attempts} && kill -TERM $$` } })
+    );
+    process.env.COPILOT_MCP_REPO = dir;
+    process.env.COPILOT_MCP_SMOKE_STATUS_PATH = statusPath;
+    process.env.COPILOT_MCP_SMOKE_QUIET = '1';
+
+    const exitCode = runScheduledSmoke();
+    const status = JSON.parse(readFileSync(statusPath, 'utf-8')) as Record<string, unknown>;
+
+    expect(readFileSync(attempts, 'utf-8').trim().split('\n')).toHaveLength(2);
+    expect(exitCode).toBe(1);
+    expect(status.result).toBe('incomplete');
+    expect(status.summary).toContain('drift NOT checked');
   });
 
   test('auth failure → result auth-missing, no report, exit 0', () => {

--- a/tests/scripts/scheduled-smoke.test.ts
+++ b/tests/scripts/scheduled-smoke.test.ts
@@ -213,6 +213,44 @@ describe('summarizeSmokeOutput', () => {
     );
   });
 
+  /**
+   * Captured from a real full `bun run smoke`: the composite ends with the
+   * refresh smokes, whose last line is an object-open brace. Picking "the last
+   * [smoke] line" therefore summarized a clean run as `[smoke] done {`. The
+   * summary must track the last *verdict*, not the last line that happens to
+   * carry the prefix.
+   */
+  test('a clean full run summarizes to its last verdict, not its last log line', () => {
+    const out = [
+      '[smoke] PASS — all 5 enums and 15 input types match the server.',
+      '[smoke] accounts {',
+      '[smoke] PASS — 19/19 read operations verified against the server.',
+      '[smoke] cold {',
+      '[smoke] recold {',
+      '[smoke] done {',
+    ].join('\n');
+    expect(summarizeSmokeOutput('pass', completed(0, out))).toBe(
+      '[smoke] PASS — 19/19 read operations verified against the server.'
+    );
+  });
+
+  test('a drift verdict wins over later log lines too', () => {
+    const out = [
+      '[smoke] PASS — all 5 enums and 15 input types match the server.',
+      '[smoke] FAIL — read-surface drift detected:',
+      '[smoke] trailing debris {',
+    ].join('\n');
+    expect(summarizeSmokeOutput('fail', completed(1, out))).toBe(
+      '[smoke] FAIL — read-surface drift detected:'
+    );
+  });
+
+  test('falls back to the last [smoke] line when no verdict was printed', () => {
+    expect(summarizeSmokeOutput('pass', completed(0, '[smoke] something unusual'))).toBe(
+      '[smoke] something unusual'
+    );
+  });
+
   test('truncates summaries to 300 chars', () => {
     const out = `[smoke] ${'x'.repeat(500)}`;
     expect(summarizeSmokeOutput('fail', completed(1, out)).length).toBe(300);

--- a/tests/scripts/scheduled-smoke.test.ts
+++ b/tests/scripts/scheduled-smoke.test.ts
@@ -1,69 +1,318 @@
 /**
- * Outcome classification for the scheduled drift check (#440). The critical
- * property: auth failures classify as `auth-missing`, never `pass` (absence
- * of auth is not absence of drift) and never `fail` (logged-out is not
- * drift).
+ * Outcome classification for the scheduled drift check (#440).
+ *
+ * Two critical properties, both learned the hard way (see
+ * docs/bugs/661-non-completion-classified-as-drift.md):
+ *
+ *  1. `fail` means "the smoke reached a verdict and the verdict was drift".
+ *     It is never the fallthrough bucket. A run that was killed, crashed, or
+ *     failed in a way this classifier does not model is `incomplete` —
+ *     absence of completion is not presence of drift.
+ *  2. Auth failures classify as `auth-missing`, never `pass` (absence of auth
+ *     is not absence of drift) and never `fail` (logged-out is not drift).
  */
 import { describe, expect, test } from 'bun:test';
-import { classifySmokeOutcome, summarizeSmokeOutput } from '../../scripts/scheduled-smoke.js';
+import {
+  DRIFT_VERDICT_MARKERS,
+  classifySmokeOutcome,
+  runScheduledSmoke,
+  summarizeSmokeOutput,
+  type SmokeRunResult,
+} from '../../scripts/scheduled-smoke.js';
+
+/** A completed run: spawnSync reports a numeric exit code and no signal. */
+function completed(status: number, output: string): SmokeRunResult {
+  return { status, signal: null, errorCode: null, output };
+}
+
+const CONFORMANCE_DRIFT = [
+  '[smoke] value { enum: "RecurringFrequency", value: "WEEKLY", serverValid: true }',
+  '[smoke] FAIL — conformance drift detected:',
+  '  - [RecurringFrequency] BIWEEKLY REJECTED by server',
+].join('\n');
+
+const READ_DRIFT = [
+  '[smoke] Read smoke summary:',
+  '[smoke] FAIL — read-surface drift detected:',
+  '  - [Networth] response missing required field',
+].join('\n');
+
+/**
+ * Real non-drift failure modes, reproduced in shape from the archived reports
+ * under ~/.claude/copilot-money/smoke-reports/. Figures are synthetic — the
+ * real reports embed live balances and budget totals (PII).
+ */
+const NON_DRIFT_FAILURES: Array<{ name: string; run: SmokeRunResult }> = [
+  {
+    // The 2026-08-17 report: laptop asleep at the scheduled slot, launchd
+    // coalesced the run onto a dark wake, system sleep froze the process, and
+    // the 10-minute *wall-clock* timeout fired on the next full wake.
+    name: 'killed by the spawnSync timeout mid-run, after every gate had passed',
+    run: {
+      status: null,
+      signal: 'SIGTERM',
+      errorCode: 'ETIMEDOUT',
+      output: [
+        '[smoke] PASS — all 5 enums and 15 input types match the server.',
+        '[smoke] PASS — 19/19 read operations verified against the server.',
+        '[smoke] cold { rows: 10, total: 100, hit: false, ms: 100 }',
+        'error: script "smoke" was terminated by signal SIGTERM (Polite quit request)',
+        '[smoke] months_window=1 {',
+      ].join('\n'),
+    },
+  },
+  {
+    name: 'killed by a signal with no spawn-level error',
+    run: { status: null, signal: 'SIGKILL', errorCode: null, output: '[smoke] value ...' },
+  },
+  {
+    name: 'the runner could not spawn bun at all',
+    run: { status: null, signal: null, errorCode: 'ENOENT', output: '' },
+  },
+  {
+    // The 2026-06-15 .. 2026-07-27 reports: seven consecutive weeks of
+    // "drift check FAILED" that were really "you are logged out".
+    name: "the smoke's own auth-failure wording (#530 candidates.slice era)",
+    run: completed(
+      1,
+      [
+        '[smoke] FAIL — could not acquire an authenticated Copilot session, no probes were sent.',
+        '        The conformance smoke needs a logged-in app.copilot.money browser session',
+        "        Underlying error: undefined is not an object (evaluating 'candidates.slice')",
+      ].join('\n')
+    ),
+  },
+  {
+    name: 'the read smoke could not acquire a session',
+    run: completed(
+      1,
+      '[smoke] FAIL — could not acquire an authenticated Copilot session, no reads were sent.'
+    ),
+  },
+  {
+    name: 'no browser session found',
+    run: completed(1, 'error: No Copilot Money session found. Searched: Chrome, Safari'),
+  },
+  {
+    name: 'foreign Firebase token (#454)',
+    run: completed(
+      1,
+      'error: Firebase token exchange failed (400): {"error":{"message":"PROJECT_NUMBER_MISMATCH"}}'
+    ),
+  },
+  {
+    name: 'mid-run session expiry',
+    run: completed(
+      1,
+      'error: validation probe got a non-JSON response (HTTP 401) — likely an expired or unauthenticated session'
+    ),
+  },
+  {
+    name: 'an unmodelled crash with no verdict of any kind',
+    run: completed(1, 'error: Cannot find module "../../src/tools/live/budgets.js"'),
+  },
+  {
+    name: 'the machine lost the network before any probe landed',
+    run: completed(1, '[graphql] Categories failed: code=NETWORK\nerror: fetch failed'),
+  },
+];
 
 describe('classifySmokeOutcome', () => {
-  test('exit 0 is a pass', () => {
-    expect(classifySmokeOutcome(0, '[smoke] PASS — all good')).toBe('pass');
+  test('a clean exit is a pass', () => {
+    expect(classifySmokeOutcome(completed(0, '[smoke] PASS — all good'))).toBe('pass');
   });
 
-  test('nonzero exit with a conformance failure is a fail', () => {
-    expect(classifySmokeOutcome(1, '[smoke] FAIL: bogus_value REJECTED by server')).toBe('fail');
+  test('a conformance drift verdict is a fail', () => {
+    expect(classifySmokeOutcome(completed(1, CONFORMANCE_DRIFT))).toBe('fail');
   });
 
-  test('no-browser-session output is auth-missing, not fail', () => {
+  test('a read-surface drift verdict is a fail', () => {
+    expect(classifySmokeOutcome(completed(1, READ_DRIFT))).toBe('fail');
+  });
+
+  test('a drift verdict already printed before the kill still counts as drift', () => {
     expect(
-      classifySmokeOutcome(1, 'error: No Copilot Money session found. Searched: Chrome, Safari')
-    ).toBe('auth-missing');
+      classifySmokeOutcome({
+        status: null,
+        signal: 'SIGTERM',
+        errorCode: 'ETIMEDOUT',
+        output: CONFORMANCE_DRIFT,
+      })
+    ).toBe('fail');
   });
 
-  test('token-exchange failures are auth-missing (incl. foreign-token #454 case)', () => {
+  test('a run killed by the wall-clock timeout is incomplete, not drift', () => {
+    const timedOut = NON_DRIFT_FAILURES[0]!.run;
+    expect(classifySmokeOutcome(timedOut)).toBe('incomplete');
+  });
+
+  test("the smoke's own auth-failure wording is auth-missing, not drift", () => {
     expect(
       classifySmokeOutcome(
-        1,
-        'error: Firebase token exchange failed (400): {"error":{"message":"PROJECT_NUMBER_MISMATCH"}}'
+        completed(
+          1,
+          '[smoke] FAIL — could not acquire an authenticated Copilot session, no probes were sent.'
+        )
       )
     ).toBe('auth-missing');
   });
 
-  test('mid-run session expiry (non-JSON probe response) is auth-missing', () => {
-    expect(
-      classifySmokeOutcome(
-        1,
-        'error: validation probe got a non-JSON response (HTTP 401) — likely an expired or unauthenticated session'
-      )
-    ).toBe('auth-missing');
+  test('an unmodelled nonzero exit is incomplete, not drift', () => {
+    expect(classifySmokeOutcome(completed(1, 'error: something nobody predicted'))).toBe(
+      'incomplete'
+    );
+  });
+
+  describe.each(NON_DRIFT_FAILURES)('non-drift failure: $name', ({ run }) => {
+    test('never classifies as drift', () => {
+      expect(classifySmokeOutcome(run)).not.toBe('fail');
+    });
+
+    test('never classifies as pass', () => {
+      expect(classifySmokeOutcome(run)).not.toBe('pass');
+    });
+  });
+
+  /**
+   * The class-level invariant, not another instance. `fail` is the state that
+   * fires a "conformance failure" alarm and sends the reader hunting for API
+   * drift; it must be reachable only with positive evidence that the smoke
+   * printed a drift verdict. Delete the marker check in the classifier and
+   * this goes red for every fixture above.
+   */
+  test('fail is reachable only when the output carries a drift verdict', () => {
+    const corpus: SmokeRunResult[] = [
+      ...NON_DRIFT_FAILURES.map((f) => f.run),
+      completed(0, '[smoke] PASS'),
+      completed(1, CONFORMANCE_DRIFT),
+      completed(1, READ_DRIFT),
+      completed(2, ''),
+      { status: null, signal: 'SIGTERM', errorCode: 'ETIMEDOUT', output: CONFORMANCE_DRIFT },
+    ];
+    for (const run of corpus) {
+      if (classifySmokeOutcome(run) === 'fail') {
+        expect(DRIFT_VERDICT_MARKERS.some((m) => run.output.includes(m))).toBe(true);
+      }
+    }
+    // Guard against the invariant holding vacuously.
+    expect(corpus.filter((r) => classifySmokeOutcome(r) === 'fail')).toHaveLength(3);
   });
 });
 
 describe('summarizeSmokeOutput', () => {
   test('uses the last [smoke] marker line', () => {
     const out = '[smoke] value ...\n[ledger] distribution ...\n[smoke] PASS — all 3 enums match.';
-    expect(summarizeSmokeOutput('pass', out)).toBe('[smoke] PASS — all 3 enums match.');
+    expect(summarizeSmokeOutput('pass', completed(0, out))).toBe(
+      '[smoke] PASS — all 3 enums match.'
+    );
   });
 
   test('fail summaries also come from the last [smoke] marker line', () => {
-    const out = '[smoke] value ...\n[smoke] FAIL — conformance drift detected:\ndetail line';
-    expect(summarizeSmokeOutput('fail', out)).toBe('[smoke] FAIL — conformance drift detected:');
+    expect(summarizeSmokeOutput('fail', completed(1, CONFORMANCE_DRIFT))).toBe(
+      '[smoke] FAIL — conformance drift detected:'
+    );
   });
 
   test('truncates summaries to 300 chars', () => {
     const out = `[smoke] ${'x'.repeat(500)}`;
-    expect(summarizeSmokeOutput('fail', out).length).toBe(300);
-  });
-
-  test('falls back to the first line when no [smoke] marker exists', () => {
-    expect(summarizeSmokeOutput('fail', 'error: something exploded\nstack')).toBe(
-      'error: something exploded'
-    );
+    expect(summarizeSmokeOutput('fail', completed(1, out)).length).toBe(300);
   });
 
   test('auth-missing has a fixed actionable summary', () => {
-    expect(summarizeSmokeOutput('auth-missing', 'whatever')).toContain('drift NOT checked');
+    expect(summarizeSmokeOutput('auth-missing', completed(1, 'whatever'))).toContain(
+      'drift NOT checked'
+    );
+  });
+
+  /**
+   * The pre-fix summary for the timed-out run was `[smoke] months_window=1 {`
+   * — the last [smoke] line of a run that was cut off mid-sentence. An
+   * incomplete run must describe how it ended, not quote its own debris.
+   */
+  test('incomplete summaries name the termination, not the last log line', () => {
+    const summary = summarizeSmokeOutput('incomplete', NON_DRIFT_FAILURES[0]!.run);
+    expect(summary).toContain('SIGTERM');
+    expect(summary).toContain('drift NOT checked');
+    expect(summary).not.toContain('months_window');
+  });
+
+  test('incomplete summaries report a plain nonzero exit when no signal fired', () => {
+    const summary = summarizeSmokeOutput('incomplete', completed(3, 'error: unmodelled'));
+    expect(summary).toContain('exit 3');
+    expect(summary).toContain('drift NOT checked');
+  });
+});
+
+describe('runScheduledSmoke', () => {
+  /** Builds a fake spawn that returns the queued results in order. */
+  function spawnQueue(results: SmokeRunResult[]): {
+    spawn: () => SmokeRunResult;
+    calls: () => number;
+  } {
+    let i = 0;
+    return {
+      spawn: () => results[i++] ?? results[results.length - 1]!,
+      calls: () => i,
+    };
+  }
+
+  const PASSING = completed(0, '[smoke] PASS — all 5 enums and 15 input types match the server.');
+  const TIMED_OUT = NON_DRIFT_FAILURES[0]!.run;
+
+  test('retries once when the first attempt never completed', () => {
+    const q = spawnQueue([TIMED_OUT, PASSING]);
+    const written: Record<string, unknown>[] = [];
+    const code = runScheduledSmoke({
+      spawn: q.spawn,
+      write: (s) => written.push(s),
+      notify: () => {},
+    });
+    expect(q.calls()).toBe(2);
+    expect(code).toBe(0);
+    expect(written.at(-1)?.result).toBe('pass');
+  });
+
+  test('does not retry a completed run', () => {
+    const q = spawnQueue([completed(1, CONFORMANCE_DRIFT), PASSING]);
+    const code = runScheduledSmoke({ spawn: q.spawn, write: () => {}, notify: () => {} });
+    expect(q.calls()).toBe(1);
+    expect(code).toBe(1);
+  });
+
+  test('does not retry a logged-out machine', () => {
+    const q = spawnQueue([
+      completed(1, 'error: No Copilot Money session found. Searched: Chrome, Safari'),
+      PASSING,
+    ]);
+    const code = runScheduledSmoke({ spawn: q.spawn, write: () => {}, notify: () => {} });
+    expect(q.calls()).toBe(1);
+    expect(code).toBe(0);
+  });
+
+  test('reports incomplete when the retry also fails to complete', () => {
+    const q = spawnQueue([TIMED_OUT, TIMED_OUT]);
+    const written: Record<string, unknown>[] = [];
+    const notified: string[] = [];
+    const code = runScheduledSmoke({
+      spawn: q.spawn,
+      write: (s) => written.push(s),
+      notify: (title) => notified.push(title),
+    });
+    expect(q.calls()).toBe(2);
+    expect(code).toBe(1);
+    expect(written.at(-1)?.result).toBe('incomplete');
+    expect(notified.join(' ')).not.toContain('conformance failure');
+  });
+
+  test('an incomplete run never announces a conformance failure', () => {
+    const q = spawnQueue([TIMED_OUT, TIMED_OUT]);
+    const notified: Array<{ title: string; message: string }> = [];
+    runScheduledSmoke({
+      spawn: q.spawn,
+      write: () => {},
+      notify: (title, message) => notified.push({ title, message }),
+    });
+    expect(notified).toHaveLength(1);
+    expect(notified[0]!.title).toContain('DID NOT COMPLETE');
   });
 });

--- a/tests/tools/scheduled-smoke-status.test.ts
+++ b/tests/tools/scheduled-smoke-status.test.ts
@@ -73,6 +73,20 @@ describe('readScheduledSmokeStatus', () => {
     expect(readScheduledSmokeStatus(file)?.result).toBe('auth-missing');
   });
 
+  test('incomplete is a distinct result, not a fail', () => {
+    // A run that was killed before reaching a verdict must be readable as its
+    // own state; collapsing it into `fail` is what sent a dev session hunting
+    // for API drift that had never been observed.
+    const file = statusFile(
+      JSON.stringify({
+        last_run: '2026-08-17T17:41:30Z',
+        result: 'incomplete',
+        summary: 'drift check did not complete — killed by SIGTERM after the 10m timeout',
+      })
+    );
+    expect(readScheduledSmokeStatus(file)?.result).toBe('incomplete');
+  });
+
   test('returns null on malformed JSON instead of throwing', () => {
     const file = statusFile('not json {');
     expect(readScheduledSmokeStatus(file)).toBeNull();


### PR DESCRIPTION
# Summary

The weekly drift check sent a "conformance failure" notification on 2026-08-17 for a run whose report says PASS on every gate inside it. Investigating that turned up a second, older instance of the same defect: the seven notifications before it were a logged-out machine, which the job is explicitly designed to report as `auth-missing`.

**All eight failure notifications this job has ever produced were false alarms. It has never once reported real drift.**

The cause in both cases is that `fail` was the classifier's fallthrough — so every failure mode nobody had modelled arrived labelled as "Copilot changed their API", the one conclusion the job exists to draw and the most expensive to act on.

## External assumptions

None — this PR touches only the local scheduled-runner and its status plumbing. No new assumption about Copilot's API or data. The live smoke was run against the real endpoint to verify the runner end to end (`pass`, ~18s, 20/20 conformance surfaces + 19/19 reads), but it asserts the same surfaces as before.

## Bug fix?

```text
Root cause:       `classifySmokeOutcome` returned `fail` as its default branch, and the
                  runner collapsed `spawnSync`'s result to `status ?? 1` — discarding
                  `signal` and `error` — so a SIGTERM'd run and an unrecognized auth
                  message were both indistinguishable from a deliberate drift verdict.
Bug class:        alarm-by-fallthrough (new class, added to docs/bugs/README.md) — a
                  classifier recognizes a few signatures and routes everything else into
                  its most alarming state, so the alarm stops correlating with the
                  condition it names. The inverse of `silent-failure-masking`.
Detector added:   tests/scripts/scheduled-smoke.test.ts — the invariant
                  `classify(run) === 'fail'` ⇒ the output carries a drift-verdict marker,
                  asserted over a corpus of every non-drift failure mode this job has
                  actually produced, plus a non-vacuity check. Mutation-verified, 5
                  mutations, all detected (table below).
Siblings checked: `classifyExtensionCodes` / `classifyHttpError` in src/core/graphql/client.ts
                  — clean: their fallthrough is `UNKNOWN`, which is the correct shape. The
                  one narrow fallthrough there (400 with no recognizable extension code →
                  `SCHEMA_ERROR`) is scoped to a status that genuinely means "our request
                  was rejected" and is documented in place; left as is. The read-zod-warn
                  drift counters and `decode_health` are counters, not classifiers, so the
                  class does not apply.
Ledger updated:   n/a — not an external-assumption bug.
```

## What changed

**Root-cause fix.** `fail` now requires positive evidence: one of the two drift verdicts the smoke prints immediately before exiting (`DRIFT_VERDICT_MARKERS`). A fourth state, `incomplete`, takes the fallthrough — killed, timed out, could not spawn, or unmodelled. It notifies with its own copy and never borrows the drift wording. This extends the reasoning the file already applied to auth: *absence of completion is not presence of drift.*

`classifySmokeOutcome` now receives the whole run (`status` / `signal` / `errorCode` / `output`) rather than a coalesced exit code.

**Downstream:**

- `AUTH_MISSING_PATTERNS` gained the smoke's own auth-failure wording, closing the seven-week case. It's belt-and-braces now — without it that output classifies as `incomplete`, not `fail`.
- `runScheduledSmoke` retries once on `incomplete`, and takes injectable `spawn`/`write`/`notify` so the full flow is tested in-process instead of only through a stub repo.
- `summarizeSmokeOutput` reports how an incomplete run ended (`killed by SIGTERM after the 10m timeout`) instead of quoting the last log line.
- Second commit: running the fixed runner for real showed the *same* positional-heuristic defect on the pass path — a clean run recorded `summary: "[smoke] done {"`, because the composite smoke ends with the refresh scripts. The summary now tracks the last `PASS —`/`FAIL —` verdict. Found only by reading real output.
- `incomplete` threaded through `SCHEDULED_SMOKE_RESULTS`, the reader's Zod enum, the `get_connection_status` description, and `docs/scheduled-smoke.md`.

The 10-minute timeout is unchanged — a healthy run is ~18s, so headroom was never the problem.

## Why the run was killed

Environmental, and benign. The laptop was asleep at the Mon 10:00 slot; launchd coalesced the missed run onto a dark wake (the report carries a `code=NETWORK` retry an awake run doesn't have); the system kept returning to sleep, freezing the process while the *wall-clock* timeout kept ticking. An 18-second job burned the full 10 minutes across sleep cycles. The lid opened at 10:41:18 and the resumed `spawnSync` killed the child twelve seconds later.

That's why the fix is a retry rather than a bigger timeout: by the time the kill fires the machine is awake, so the retry just passes.

## Verification

- `bun run check` — 2744 pass, 0 fail, 20 skip (typecheck + lint + format + version-sync + server-json + deps-pinned + full suite).
- Live end-to-end: ran `scripts/scheduled-smoke.ts` against the real endpoint on this branch. Exit 0, `result: "pass"`, no notification — which also cleared the stale false-alarm status file.
- Mutation verification of the detector:

| Mutation | Tests red |
|---|---|
| revert to fallthrough-`fail` (drop the drift-verdict requirement) | 11 |
| drop the widened auth pattern (restore the 7-week bug) | 1 |
| drop the retry on non-completion | 2 |
| let an incomplete run reuse the `fail` alarm copy | 1 |
| summarize incomplete runs from the last log line again | 2 |
| remove `incomplete` from the status reader's enum | 1 |

Post-mortem: `docs/bugs/661-non-completion-classified-as-drift.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
