### PR TITLE
chore(ci): run the AI code review on Opus 5

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -53,7 +53,7 @@ jobs:
 
           # SECURITY: Allow read-only gh commands — block approve/merge
           claude_args: |
-            --model claude-sonnet-4-6
+            --model claude-opus-5
             --allowedTools "Bash(gh pr diff*),Bash(gh pr view*),Read,Grep,Glob"
             --disallowedTools "Bash(gh pr review --approve*),Bash(gh pr merge*),Bash(gh pr close*)"
 


### PR DESCRIPTION
# Summary

Switch the AI Code Review workflow from `claude-sonnet-4-6` to `claude-opus-5`. Review quality on this repo is load-bearing — the automated review is the only reviewer on most PRs, and the repo's whole conformance posture (mutation-tested guards, class-level detectors, the bug-class ledger) depends on it catching what a human maintainer would. Opus is the stronger model for that job.

Workflow-only change; no source, tests, or tool surface touched.

## Scope

Only `.github/workflows/claude-review.yml` — the per-PR reviewer that runs on `pull_request`.

`.github/workflows/audit-reviews.yml:175` still pins `claude-sonnet-4-6`. That job is a different thing: it runs post-merge and mechanically diffs "what the reviewer suggested" against "what the merged code does," emitting JSON. Left alone deliberately — it's a narrower, more structured task, and bumping it is a separate call. Easy follow-up if wanted.

## Cost note

The review job runs on every non-draft, non-fork, non-Dependabot PR. Opus costs more per run than Sonnet. Flagging it as a deliberate trade rather than an oversight.

## External assumptions

None. `--model` is passed through to `claude-code-action@v1`, which forwards it to the Claude CLI; no assumption about Copilot's API, data, enums, or response shapes is involved.
