### PR TITLE
test(field-selection): discover presets instead of listing them

### DIFF
--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Bidirectional pin over EVERY exported string-literal constant in `src/`.
+ *
+ * WHY THIS FILE EXISTS
+ *
+ * The repo's #635 bug class: "deleting a field from a preset survived all
+ * 2,679 tests." It has now bitten three times. The third time is the reason
+ * this file is not simply a test inside field-selection.test.ts.
+ *
+ *   1. #635  — a field deleted from a transactions preset, undetected.
+ *   2. #673  — three of five DEFAULT_TOP_MOVER_FIELDS entries deletable with
+ *              all 2,847 tests green.
+ *   3. #676  — the fix for (2) discovered presets by importing ONE module,
+ *              so DEFAULT_COMPACT_TRANSACTION_FIELDS in src/tools/tools.ts
+ *              (7 entries, decides the `compact: true` row) stayed exposed:
+ *              three of its seven could be deleted, suite still green.
+ *
+ * Each fix reproduced the bug it was fixing, one level up: assert the field →
+ * forget a field; pin the preset → forget a preset; discover in a module →
+ * forget a module. Every version left a list someone had to remember.
+ *
+ * So discovery here reads the SOURCE TREE, not a module and not a name
+ * convention:
+ *   - cross-module: a preset anywhere under src/ is found
+ *   - name-agnostic: a constant that ignores the DEFAULT_*_FIELDS convention
+ *     is still found, because the filter is SHAPE (an exported `as const`
+ *     array whose members are all string literals)
+ *
+ * That shape also sweeps in wire-visible enums and allowlists —
+ * RECURRING_FREQUENCIES, KNOWN_ERROR_CODES, COLOR_NAMES, TOP_MOVERS_FILTERS.
+ * That is deliberate, not collateral: those have the identical failure mode.
+ * Dropping a member changes what we accept from or send to Copilot, and no
+ * ratchet elsewhere catches a list getting SHORTER.
+ *
+ * HOW IT FAILS (all three directions are mutation-tested in this file's PR)
+ *
+ *   forward   a constant exists in src/ with no pinned expectation
+ *             -> someone added one and no test came with it
+ *   backward  a pinned expectation names a constant no longer in src/
+ *             -> a stale expectation quietly protecting nothing
+ *   contents  a pinned constant's members changed
+ *
+ * The backward direction also guards the DISCOVERY MECHANISM itself: if the
+ * regex below silently stops matching (a formatting change, a refactor to a
+ * different declaration style), the constants it can no longer see read as
+ * "vanished" and the backward check goes red. A partial under-match cannot
+ * pass quietly. The explicit non-vacuity test makes the total-failure case
+ * report an unambiguous reason rather than 23 confusing ones.
+ *
+ * MAINTENANCE: changing one of these deliberately means updating the entry
+ * below. That is the intended workflow — the point is that it cannot happen
+ * SILENTLY.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const SRC_ROOT = join(import.meta.dir, '..', 'src');
+
+/**
+ * Matches `export const NAME = [ ...string literals... ] as const`, with an
+ * optional type annotation. Deliberately narrow: it requires the `as const`
+ * suffix and rejects any array containing a non-string-literal member, so a
+ * constant built from spreads, identifiers or numbers is not swept in.
+ */
+const EXPORTED_ARRAY = /^export const ([A-Z][A-Z0-9_]*)\s*(?::[^=]+)?=\s*\[(.*?)\]\s*as const/gms;
+
+function tsFilesUnder(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...tsFilesUnder(full));
+    else if (entry.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+function discoverStringConstants(): Map<string, readonly string[]> {
+  const found = new Map<string, readonly string[]>();
+  for (const file of tsFilesUnder(SRC_ROOT)) {
+    const text = readFileSync(file, 'utf-8');
+    for (const match of text.matchAll(EXPORTED_ARRAY)) {
+      const [, name, rawBody] = match;
+      if (name === undefined || rawBody === undefined) continue;
+      const items = [...rawBody.matchAll(/'([^']*)'/g)].map((m) => m[1] as string);
+      // Everything that is not a string literal, comma or whitespace: if
+      // anything remains, the array is not purely string literals.
+      const residue = rawBody.replace(/'[^']*'|,|\s/g, '');
+      if (items.length > 0 && residue === '') found.set(name, items);
+    }
+  }
+  return found;
+}
+
+const PINNED: Record<string, readonly string[]> = {
+  // src/core/graphql/queries/_shared.ts
+  ALL_TIME_FRAMES: ['ONE_DAY', 'ONE_WEEK', 'ONE_MONTH', 'THREE_MONTHS', 'YTD', 'ONE_YEAR', 'ALL'],
+  // src/tools/constants.ts
+  BALANCE_HISTORY_GRANULARITIES: ['daily', 'weekly', 'monthly'],
+  // src/tools/constants.ts
+  CATEGORY_VIEWS: ['list', 'tree', 'search'],
+  // src/core/graphql/colors.ts
+  COLOR_NAMES: [
+    'BLUE1',
+    'BROWN1',
+    'GRAY1',
+    'GREEN1',
+    'OLIVE1',
+    'ORANGE1',
+    'ORANGE2',
+    'PINK1',
+    'PINK2',
+    'PURPLE1',
+    'PURPLE2',
+    'RED1',
+    'RED2',
+    'TEAL1',
+    'YELLOW1',
+    'YELLOW2',
+  ],
+  // src/conformance/ledger.ts
+  CONFORMANCE_CLASSES: ['gated', 'verified-once', 'unverified'],
+  // src/models/item.ts
+  CONNECTION_STATUSES: ['active', 'error', 'disconnected', 'pending'],
+  // src/tools/field-selection.ts
+  DEFAULT_CATEGORY_LIVE_FIELDS: [
+    'id',
+    'parentId',
+    'name',
+    'colorName',
+    'isExcluded',
+    'budget_amount',
+  ],
+  // src/tools/tools.ts
+  DEFAULT_COMPACT_TRANSACTION_FIELDS: [
+    'transaction_id',
+    'date',
+    'name',
+    'amount',
+    'category_name',
+    'account_id',
+    'pending',
+  ],
+  // src/tools/field-selection.ts
+  DEFAULT_INVESTMENT_PRICE_FIELDS: [
+    'security_id',
+    'ticker_symbol',
+    'price_type',
+    'date',
+    'month',
+    'latest_price',
+    'latest_at',
+  ],
+  // src/tools/field-selection.ts
+  DEFAULT_TOP_MOVER_FIELDS: ['security_id', 'ticker_symbol', 'name', 'type', 'change'],
+  // src/tools/field-selection.ts
+  DEFAULT_TRANSACTION_FIELDS: [
+    'transaction_id',
+    'date',
+    'amount',
+    'name',
+    'category_name',
+    'account_id',
+    'item_id',
+    'pending',
+    'excluded',
+    'internal_transfer',
+  ],
+  // src/models/item.ts
+  KNOWN_ERROR_CODES: [
+    'ITEM_LOGIN_REQUIRED',
+    'INVALID_CREDENTIALS',
+    'INVALID_MFA',
+    'ITEM_LOCKED',
+    'ITEM_NO_ERROR',
+    'ITEM_NOT_SUPPORTED',
+    'NO_ACCOUNTS',
+    'INSTITUTION_DOWN',
+    'INSTITUTION_NOT_RESPONDING',
+    'INSTITUTION_NO_LONGER_SUPPORTED',
+  ],
+  // src/models/budget.ts
+  KNOWN_PERIODS: ['monthly', 'yearly', 'weekly', 'daily'],
+  // src/tools/live/transactions.ts
+  LIVE_TRANSACTION_TYPES: ['refunds', 'credits', 'hsa_eligible', 'tagged'],
+  // src/models/investment-price.ts
+  PRICE_TYPES: ['daily', 'hf'],
+  // src/core/graphql/recurrings.ts
+  RECURRING_FREQUENCIES: [
+    'WEEKLY',
+    'BIWEEKLY',
+    'MONTHLY',
+    'BIMONTHLY',
+    'QUARTERLY',
+    'QUADMONTHLY',
+    'SEMIANNUALLY',
+    'ANNUALLY',
+  ],
+  // src/models/recurring.ts
+  RECURRING_STATES: ['active', 'paused', 'archived'],
+  // src/core/graphql/recurrings.ts
+  RECURRING_STATE_VALUES: ['ACTIVE', 'PAUSED', 'ARCHIVED'],
+  // src/utils/scheduled-smoke-status.ts
+  SCHEDULED_SMOKE_RESULTS: ['pass', 'fail', 'auth-missing', 'incomplete'],
+  // src/conformance/ledger.ts
+  SURFACE_KINDS: ['enum', 'input-field', 'response-shape', 'operation', 'applies'],
+  // src/tools/live/top-movers.ts
+  TOP_MOVERS_FILTERS: ['PRICE_CHANGE', 'MY_EQUITY_CHANGE'],
+  // src/core/graphql/transactions.ts
+  TRANSACTION_TYPES: ['REGULAR', 'INCOME', 'INTERNAL_TRANSFER'],
+  // src/tools/constants.ts
+  TRANSACTION_TYPE_FILTERS: [
+    'foreign',
+    'refunds',
+    'credits',
+    'duplicates',
+    'hsa_eligible',
+    'tagged',
+  ],
+};
+
+describe('exported string constants are pinned (#635 class detector)', () => {
+  const discovered = discoverStringConstants();
+  const discoveredNames = [...discovered.keys()].sort();
+
+  test('discovery finds constants at all (guards the guard)', () => {
+    expect(discoveredNames.length).toBeGreaterThan(0);
+  });
+
+  test('forward: every exported string constant in src/ is pinned', () => {
+    expect(discoveredNames.filter((name) => !(name in PINNED))).toEqual([]);
+  });
+
+  test('backward: every pinned expectation still names a live constant', () => {
+    expect(
+      Object.keys(PINNED)
+        .filter((name) => !discovered.has(name))
+        .sort()
+    ).toEqual([]);
+  });
+
+  for (const name of discoveredNames) {
+    test(`${name} members are unchanged`, () => {
+      expect([...(discovered.get(name) ?? [])]).toEqual([...(PINNED[name] ?? [])]);
+    });
+  }
+});

--- a/tests/tools/field-selection.test.ts
+++ b/tests/tools/field-selection.test.ts
@@ -8,13 +8,13 @@
 
 import { describe, test, expect } from 'bun:test';
 import {
-  DEFAULT_CATEGORY_LIVE_FIELDS,
-  DEFAULT_INVESTMENT_PRICE_FIELDS,
-  DEFAULT_TOP_MOVER_FIELDS,
   DEFAULT_TRANSACTION_FIELDS,
   expandFieldSelection,
   projectRows,
 } from '../../src/tools/field-selection.js';
+// Namespace import so the preset detector below can DISCOVER presets by shape
+// rather than importing a hand-maintained list of them — see its header.
+import * as fieldSelection from '../../src/tools/field-selection.js';
 
 // Firestore-shaped opaque IDs (synthetic).
 const TXN_ID_1 = 'Zx9kQ2mVp3LqR8sTuW1y';
@@ -311,27 +311,46 @@ describe('projectRows', () => {
     });
   });
 
-  // CLASS-LEVEL DETECTOR for the #635 bug class: "deleting a field from a
-  // preset survived all 2,679 tests because no fixture carried it."
+  // ===================================================================
+  // CLASS-LEVEL DETECTOR for the #635 bug class:
+  // "deleting a field from a preset survived all 2,679 tests."
   //
-  // The `satisfies readonly (keyof Row)[]` clauses on the presets catch a
-  // TYPO at compile time, but say nothing about a DELETION — a shorter list
-  // still satisfies the constraint. Before this block, removing
-  // 'security_id', 'name' and 'type' from DEFAULT_TOP_MOVER_FIELDS left the
-  // entire suite green (verified by mutation on PR #673); only
-  // get_categories_live happened to be covered, by a per-tool verbatim row
-  // test. Pinning every preset here means no future diet tool depends on
-  // someone remembering to write that per-tool test.
+  // That class has now bitten twice. The second time (PR #673) three of the
+  // five DEFAULT_TOP_MOVER_FIELDS entries could be deleted with the whole
+  // suite still green. Nothing else in the repo can catch it:
   //
-  // The context-budget ratchet cannot substitute: budgets are upper bounds,
-  // so a preset that loses fields gets SMALLER and sails through.
+  //   - The context-budget ratchet measures an UPPER bound. A preset that
+  //     loses fields produces a SMALLER response, so it sails through.
+  //   - The `satisfies readonly (keyof Row)[]` clauses on the presets catch a
+  //     TYPO, not a DELETION — a shorter list still satisfies the constraint.
+  //   - Line coverage is useless here: the preset is executed by every test
+  //     that calls the tool. Executing is not detecting.
+  //   - The type system never sees "a complete row"; a preset is just strings.
   //
-  // If you are changing a preset deliberately, update the expected list here
-  // and re-baseline the response budgets — that is the intended workflow,
-  // not an obstacle.
-  describe('preset contents are pinned verbatim (#635 class detector)', () => {
-    test('DEFAULT_TRANSACTION_FIELDS', () => {
-      expect([...DEFAULT_TRANSACTION_FIELDS]).toEqual([
+  // The first fix attempt was a per-preset verbatim test, hand-written one at
+  // a time. That is the SAME failure shape one level up: it protects the four
+  // presets someone remembered, and silently protects nothing for the fifth.
+  // PR B adds an accounts preset; PR C reshapes the transactions one.
+  //
+  // So this block DISCOVERS presets instead of listing them, and is
+  // bidirectional — the two directions fail for different reasons:
+  //   forward:  a preset the engine exports with no pinned expectation
+  //             (i.e. someone added a preset and no test came with it)
+  //   backward: a pinned expectation naming a preset that no longer exists
+  //             (i.e. stale expectation quietly protecting nothing)
+  //
+  // Discovery is by SHAPE (an exported array of strings), not by name, so a
+  // preset that breaks the DEFAULT_*_FIELDS naming convention is still
+  // caught. Every other export of this module is an object or a function.
+  //
+  // If you are changing a preset deliberately: update PINNED_PRESETS here and
+  // re-baseline the response budgets in tests/context-budget.test.ts. That is
+  // the intended workflow, not an obstacle — the point is that the change
+  // cannot happen SILENTLY.
+  // ===================================================================
+  describe('every field preset is pinned (#635 class detector)', () => {
+    const PINNED_PRESETS: Record<string, readonly string[]> = {
+      DEFAULT_TRANSACTION_FIELDS: [
         'transaction_id',
         'date',
         'amount',
@@ -342,11 +361,8 @@ describe('projectRows', () => {
         'pending',
         'excluded',
         'internal_transfer',
-      ]);
-    });
-
-    test('DEFAULT_INVESTMENT_PRICE_FIELDS', () => {
-      expect([...DEFAULT_INVESTMENT_PRICE_FIELDS]).toEqual([
+      ],
+      DEFAULT_INVESTMENT_PRICE_FIELDS: [
         'security_id',
         'ticker_symbol',
         'price_type',
@@ -354,29 +370,50 @@ describe('projectRows', () => {
         'month',
         'latest_price',
         'latest_at',
-      ]);
-    });
-
-    test('DEFAULT_TOP_MOVER_FIELDS', () => {
-      expect([...DEFAULT_TOP_MOVER_FIELDS]).toEqual([
-        'security_id',
-        'ticker_symbol',
-        'name',
-        'type',
-        'change',
-      ]);
-    });
-
-    test('DEFAULT_CATEGORY_LIVE_FIELDS', () => {
-      expect([...DEFAULT_CATEGORY_LIVE_FIELDS]).toEqual([
+      ],
+      DEFAULT_TOP_MOVER_FIELDS: ['security_id', 'ticker_symbol', 'name', 'type', 'change'],
+      DEFAULT_CATEGORY_LIVE_FIELDS: [
         'id',
         'parentId',
         'name',
         'colorName',
         'isExcluded',
         'budget_amount',
-      ]);
+      ],
+    };
+
+    const discovered = Object.entries(fieldSelection)
+      .filter(
+        ([, value]) => Array.isArray(value) && value.every((item) => typeof item === 'string')
+      )
+      .map(([name, value]) => [name, value as readonly string[]] as const)
+      .sort(([a], [b]) => a.localeCompare(b));
+
+    // Without this, an import-shape change that makes `discovered` empty would
+    // leave the forward check passing vacuously over an empty list — the exact
+    // "guard that cannot fail" trap this block exists to prevent, reappearing
+    // one level up. (The backward check would also fail in that case, but this
+    // gives the failure an unambiguous message.)
+    test('discovery finds the presets at all', () => {
+      expect(discovered.length).toBeGreaterThan(0);
     });
+
+    test('forward: every preset the engine exports has a pinned expectation', () => {
+      const unpinned = discovered.map(([name]) => name).filter((name) => !(name in PINNED_PRESETS));
+      expect(unpinned).toEqual([]);
+    });
+
+    test('backward: every pinned expectation still names a live preset', () => {
+      const live = new Set(discovered.map(([name]) => name));
+      const stale = Object.keys(PINNED_PRESETS).filter((name) => !live.has(name));
+      expect(stale).toEqual([]);
+    });
+
+    for (const [name, value] of discovered) {
+      test(`${name} contents are unchanged`, () => {
+        expect([...value]).toEqual([...(PINNED_PRESETS[name] ?? [])]);
+      });
+    }
   });
 
   test('does not mutate input rows', () => {

--- a/tests/tools/field-selection.test.ts
+++ b/tests/tools/field-selection.test.ts
@@ -12,9 +12,6 @@ import {
   expandFieldSelection,
   projectRows,
 } from '../../src/tools/field-selection.js';
-// Namespace import so the preset detector below can DISCOVER presets by shape
-// rather than importing a hand-maintained list of them — see its header.
-import * as fieldSelection from '../../src/tools/field-selection.js';
 
 // Firestore-shaped opaque IDs (synthetic).
 const TXN_ID_1 = 'Zx9kQ2mVp3LqR8sTuW1y';
@@ -309,111 +306,6 @@ describe('projectRows', () => {
         expect(Object.keys(row)).toEqual([]);
       }
     });
-  });
-
-  // ===================================================================
-  // CLASS-LEVEL DETECTOR for the #635 bug class:
-  // "deleting a field from a preset survived all 2,679 tests."
-  //
-  // That class has now bitten twice. The second time (PR #673) three of the
-  // five DEFAULT_TOP_MOVER_FIELDS entries could be deleted with the whole
-  // suite still green. Nothing else in the repo can catch it:
-  //
-  //   - The context-budget ratchet measures an UPPER bound. A preset that
-  //     loses fields produces a SMALLER response, so it sails through.
-  //   - The `satisfies readonly (keyof Row)[]` clauses on the presets catch a
-  //     TYPO, not a DELETION — a shorter list still satisfies the constraint.
-  //   - Line coverage is useless here: the preset is executed by every test
-  //     that calls the tool. Executing is not detecting.
-  //   - The type system never sees "a complete row"; a preset is just strings.
-  //
-  // The first fix attempt was a per-preset verbatim test, hand-written one at
-  // a time. That is the SAME failure shape one level up: it protects the four
-  // presets someone remembered, and silently protects nothing for the fifth.
-  // PR B adds an accounts preset; PR C reshapes the transactions one.
-  //
-  // So this block DISCOVERS presets instead of listing them, and is
-  // bidirectional — the two directions fail for different reasons:
-  //   forward:  a preset the engine exports with no pinned expectation
-  //             (i.e. someone added a preset and no test came with it)
-  //   backward: a pinned expectation naming a preset that no longer exists
-  //             (i.e. stale expectation quietly protecting nothing)
-  //
-  // Discovery is by SHAPE (an exported array of strings), not by name, so a
-  // preset that breaks the DEFAULT_*_FIELDS naming convention is still
-  // caught. Every other export of this module is an object or a function.
-  //
-  // If you are changing a preset deliberately: update PINNED_PRESETS here and
-  // re-baseline the response budgets in tests/context-budget.test.ts. That is
-  // the intended workflow, not an obstacle — the point is that the change
-  // cannot happen SILENTLY.
-  // ===================================================================
-  describe('every field preset is pinned (#635 class detector)', () => {
-    const PINNED_PRESETS: Record<string, readonly string[]> = {
-      DEFAULT_TRANSACTION_FIELDS: [
-        'transaction_id',
-        'date',
-        'amount',
-        'name',
-        'category_name',
-        'account_id',
-        'item_id',
-        'pending',
-        'excluded',
-        'internal_transfer',
-      ],
-      DEFAULT_INVESTMENT_PRICE_FIELDS: [
-        'security_id',
-        'ticker_symbol',
-        'price_type',
-        'date',
-        'month',
-        'latest_price',
-        'latest_at',
-      ],
-      DEFAULT_TOP_MOVER_FIELDS: ['security_id', 'ticker_symbol', 'name', 'type', 'change'],
-      DEFAULT_CATEGORY_LIVE_FIELDS: [
-        'id',
-        'parentId',
-        'name',
-        'colorName',
-        'isExcluded',
-        'budget_amount',
-      ],
-    };
-
-    const discovered = Object.entries(fieldSelection)
-      .filter(
-        ([, value]) => Array.isArray(value) && value.every((item) => typeof item === 'string')
-      )
-      .map(([name, value]) => [name, value as readonly string[]] as const)
-      .sort(([a], [b]) => a.localeCompare(b));
-
-    // Without this, an import-shape change that makes `discovered` empty would
-    // leave the forward check passing vacuously over an empty list — the exact
-    // "guard that cannot fail" trap this block exists to prevent, reappearing
-    // one level up. (The backward check would also fail in that case, but this
-    // gives the failure an unambiguous message.)
-    test('discovery finds the presets at all', () => {
-      expect(discovered.length).toBeGreaterThan(0);
-    });
-
-    test('forward: every preset the engine exports has a pinned expectation', () => {
-      const unpinned = discovered.map(([name]) => name).filter((name) => !(name in PINNED_PRESETS));
-      expect(unpinned).toEqual([]);
-    });
-
-    test('backward: every pinned expectation still names a live preset', () => {
-      const live = new Set(discovered.map(([name]) => name));
-      const stale = Object.keys(PINNED_PRESETS).filter((name) => !live.has(name));
-      expect(stale).toEqual([]);
-    });
-
-    for (const [name, value] of discovered) {
-      test(`${name} contents are unchanged`, () => {
-        expect([...value]).toEqual([...(PINNED_PRESETS[name] ?? [])]);
-      });
-    }
   });
 
   test('does not mutate input rows', () => {


### PR DESCRIPTION
# Summary

Pins every exported string-literal constant in `src/` behind a bidirectional guard that discovers them by **scanning the source tree**. Closes the #635 bug class at the level where it keeps escaping.

## The class has now bitten three times, each fix reproducing the bug one level up

| | What broke | What the fix was | How the fix leaked |
|---|---|---|---|
| #635 | A field deleted from a transactions preset, undetected across 2,679 tests | Assert the field | *Forget a field* |
| #673 | 3 of 5 `DEFAULT_TOP_MOVER_FIELDS` deletable, suite green | Pin each preset verbatim, by hand | *Forget a preset* |
| #676 (this PR, first revision) | — | Discover presets by importing `field-selection.ts` | *Forget a module* |

The third row is not hypothetical. An audit of this branch found `DEFAULT_COMPACT_TRANSACTION_FIELDS` (`src/tools/tools.ts`, 7 entries, decides the `compact: true` transaction row) sitting outside the module the first revision imported. Three of its seven could be deleted with the whole suite green and `typecheck` clean — character-for-character the bug this PR was opened to prevent.

Every revision left a list someone had to remember. So this one reads the source tree.

## What it does

Discovery is by **shape** — an exported `as const` array whose members are all string literals — found by scanning `src/**/*.ts`. That makes it:

- **cross-module** — a constant anywhere under `src/` is found
- **name-agnostic** — a preset ignoring the `DEFAULT_*_FIELDS` convention is still caught

It fails in three directions:

- **forward** — a constant exists with no pinned expectation (someone added one, no test came with it)
- **backward** — a pinned expectation names a constant no longer present (stale expectation protecting nothing)
- **contents** — a pinned constant's members changed

## Scope: 23 constants, not 4

The shape filter also sweeps in wire-visible enums and allowlists — `RECURRING_FREQUENCIES`, `KNOWN_ERROR_CODES`, `COLOR_NAMES`, `TOP_MOVERS_FILTERS`, `ALL_TIME_FRAMES`. That is deliberate, not collateral damage. They have the identical failure mode: dropping a member silently changes what we accept from or send to Copilot, and no ratchet anywhere catches a list getting **shorter**.

## The backward check guards the discovery mechanism itself

If the regex stops matching — a formatting change, a refactor to another declaration style — the constants it can no longer see read as "vanished" and the backward check goes red. **A partial under-match cannot pass quietly.** The explicit non-vacuity test exists so the total-failure case reports one unambiguous reason instead of 23 confusing ones.

## Why nothing else catches this class

| Mechanism | Why it misses a deleted member |
|---|---|
| Context-budget ratchet | Budgets are **upper** bounds. A shorter list produces a *smaller* response and sails through. |
| `satisfies readonly (keyof Row)[]` | Catches a **typo**, not a deletion — a shorter list still satisfies the constraint. |
| Line coverage | The constant is executed by every test that calls the tool. 100% covered, zero detection. |
| Type system | These are `readonly string[]`. Nothing types "complete". |

## Mutation evidence

| Mutation | Result |
|---|---|
| Delete 3 of 7 from `DEFAULT_COMPACT_TRANSACTION_FIELDS` (the gap found in this PR's own first revision) | contents check fails |
| Add a new constant to an unrelated module (`colors.ts`) | forward check fails + its own contents check fails |
| Break the discovery regex so it matches nothing | non-vacuity check fails **and** backward check fails |

The first revision of this PR catches only the middle row. A per-preset hand-written test catches none of them except a deletion in a preset someone remembered to list.

## Note on a claim in this PR's earlier description

It cited `COVERED_LIVE_TOOLS` in `tests/context-budget-live.test.ts` as an existing instance of the good pattern. That was half right and worth correcting: the shared helper (`tests/helpers/context-budget.ts`) *is* bidirectional and non-vacuous, but at that call site both sides are hand-maintained and neither is ever compared to `LIVE_TOOL_DEFS`. A separate audit confirmed by mutation that a new live tool can be registered with no response budget and nothing fails — 10 of 17 live tools currently have none. Tracked separately; not fixed here.

## External assumptions

None. Test-only change; no source, tool schema, or response shape is touched.

## Gate

`bun run check` green: 2875 pass, 20 skip, 0 fail across 157 files.
