### PR TITLE
chore(ci): run the post-merge audit reviewer on Sonnet 5

### DIFF
--- a/.github/workflows/audit-reviews.yml
+++ b/.github/workflows/audit-reviews.yml
@@ -171,6 +171,19 @@ jobs:
           # read-only by construction: `gh pr view` and `gh pr diff` cannot
           # write, and `gh api` — which can — is denied outright now that the
           # data it was fetching arrives via the pre-fetch step above.
+          # MODEL TIERING, deliberately different from claude-review.yml.
+          #
+          # That workflow reviews an open PR and is usually the ONLY reviewer
+          # one gets, so it runs on Opus: open-ended judgement, and a miss ships.
+          # This job is narrow by comparison — re-read a merged PR's review
+          # comments, check the final code against each suggestion, emit JSON
+          # against a fixed schema — and its output is schema-checked downstream
+          # (see the `jq -e` gate below), so a weaker result fails loudly rather
+          # than silently. Sonnet is the right tier for that shape of work.
+          #
+          # If you are here to change this line: the question is not "which is
+          # the best model" but "does this job still have a checked output
+          # contract". If that contract ever goes away, revisit the tier too.
           claude_args: |
             --model claude-sonnet-5
             --allowedTools "Bash(gh pr view*),Bash(gh pr diff*),Bash(git log*),Bash(git show*),Read,Grep,Glob,Write"

--- a/.github/workflows/audit-reviews.yml
+++ b/.github/workflows/audit-reviews.yml
@@ -172,7 +172,7 @@ jobs:
           # write, and `gh api` — which can — is denied outright now that the
           # data it was fetching arrives via the pre-fetch step above.
           claude_args: |
-            --model claude-sonnet-4-6
+            --model claude-sonnet-5
             --allowedTools "Bash(gh pr view*),Bash(gh pr diff*),Bash(git log*),Bash(git show*),Read,Grep,Glob,Write"
             --disallowedTools "Bash(gh api*),Bash(gh pr review*),Bash(gh pr merge*),Bash(gh pr close*),Bash(gh issue*),Bash(gh pr comment*)"
 

--- a/.github/workflows/audit-reviews.yml
+++ b/.github/workflows/audit-reviews.yml
@@ -171,6 +171,7 @@ jobs:
           # read-only by construction: `gh pr view` and `gh pr diff` cannot
           # write, and `gh api` — which can — is denied outright now that the
           # data it was fetching arrives via the pre-fetch step above.
+          #
           # MODEL TIERING, deliberately different from claude-review.yml.
           #
           # That workflow reviews an open PR and is usually the ONLY reviewer


### PR DESCRIPTION
# Summary

Bump the post-merge audit reviewer from `claude-sonnet-4-6` to `claude-sonnet-5` in `.github/workflows/audit-reviews.yml`. Workflow-only; no source, tests, or tool surface touched.

This completes the pair started in #674, which moved the per-PR reviewer to `claude-opus-5`. The two jobs are deliberately on different tiers:

| Workflow | Job | Model | Why |
|---|---|---|---|
| `claude-review.yml` | per-PR review, gates merge | `claude-opus-5` | open-ended judgement; usually the only reviewer |
| `audit-reviews.yml` | post-merge "was this suggestion applied?" | `claude-sonnet-5` | narrow, structured diff into JSON |

The audit job reads a merged PR's review comments, checks the final code against each suggestion, and emits JSON. That is a constrained task with a fixed output schema — it wants a current model, not necessarily the largest one.

## Why it matters more than it looks

`audit-reviews.yml` is the backstop for review suggestions that get acknowledged and then quietly not applied. Today's completeness-guard audit found 24 places where a guard silently covered less than it appeared to, so the job whose entire purpose is catching "said it was addressed, wasn't" is worth keeping current.

## Cost

This job runs once per merged PR, not per push, and produces a small structured artifact. The delta is minor either way.

## External assumptions

None. `--model` is passed through to `claude-code-action@v1`, which forwards it to the CLI. No assumption about Copilot's API, data, enums, or response shapes.
