### PR TITLE
fix(security): repair the scoping regressions #679 introduced

### DIFF
--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -134,21 +134,6 @@ const SKIP_FILES = new Set(['package-lock.json', 'bun.lock', 'bun.lockb', 'yarn.
  * reported and a human adds it. The reverse — the old behaviour — meant a
  * payload ran with nobody looking.
  */
-const BINARY_EXTENSIONS = new Set([
-  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.ico', '.icns', '.bmp', '.tiff',
-  '.pdf', '.zip', '.gz', '.tgz', '.bz2', '.xz', '.7z', '.tar',
-  '.woff', '.woff2', '.ttf', '.otf', '.eot',
-  '.mp3', '.mp4', '.wav', '.mov', '.webm', '.ogg',
-  '.mcpb', '.node', '.wasm', '.ldb', '.sst', '.dylib', '.so', '.dll', '.exe',
-]);
-
-/** Extension of the BASENAME — `docs/v1.2/README` has no extension, not `.2/README`. */
-function extensionOf(rel: string): string {
-  const name = rel.slice(rel.lastIndexOf(sep) + 1);
-  const dot = name.lastIndexOf('.');
-  return dot > 0 ? name.slice(dot).toLowerCase() : '';
-}
-
 /**
  * Binary formats that are inert: media, fonts, archives, documents. A diff of
  * one of these was never readable, so suppressing it hides nothing — which is
@@ -161,6 +146,22 @@ const INERT_BINARY_EXTENSIONS = new Set([
   '.woff', '.woff2', '.ttf', '.otf', '.eot',
   '.mp3', '.mp4', '.wav', '.mov', '.webm', '.ogg',
 ]);
+
+const BINARY_EXTENSIONS = new Set([
+  ...INERT_BINARY_EXTENSIONS,
+  // Executable formats. These belong in the NUL-expected set but NOT in the
+  // inert one: `*.wasm binary` must not be auto-approved, because suppressing
+  // the diff of something that runs is the concealment this gate exists for.
+  '.mcpb', '.node', '.wasm', '.ldb', '.sst', '.dylib', '.so', '.dll', '.exe',
+]);
+
+/** Extension of the BASENAME — `docs/v1.2/README` has no extension, not `.2/README`. */
+function extensionOf(rel: string): string {
+  const name = rel.slice(rel.lastIndexOf(sep) + 1);
+  const dot = name.lastIndexOf('.');
+  return dot > 0 ? name.slice(dot).toLowerCase() : '';
+}
+
 
 function isExpectedBinary(rel: string): boolean {
   return BINARY_EXTENSIONS.has(extensionOf(rel));
@@ -403,7 +404,8 @@ function checkLine(
  * `*.pdf binary` are the standard boilerplate for marking real binaries, and
  * this repo tracks .png and .mp4 files. Suppressing the diff of a file that is
  * genuinely binary hides nothing a reviewer could have read anyway, so a
- * pattern whose extension is in BINARY_EXTENSIONS is allowed. Everything else
+ * pattern whose extension is in INERT_BINARY_EXTENSIONS is allowed — NOT
+ * BINARY_EXTENSIONS, which also covers executable formats. Everything else
  * is refused rather than allow-listed — `text=auto`, `eol=lf` and
  * `linguist-language=...` do not hide content, so they need no exemption.
  */
@@ -434,7 +436,12 @@ function checkGitAttributes(contents: string, rel: string): void {
     // execute. Auto-approving `*.wasm binary` would bless diff suppression on
     // exactly the formats that run. An author who genuinely needs it writes
     // the exemption, which is what this gate's failure message asks for.
-    const pattern = stripped.split(/\s+/)[0] ?? '';
+    // git separates the pattern from its attributes on spaces and tabs only,
+    // the same blank set as the leading-comment test above. `\s` here would
+    // split on NBSP and friends, so a pattern containing one would tokenize
+    // short and could land in the allowance below — the blank-set mismatch
+    // surviving one statement past its own fix, and this one fails OPEN.
+    const pattern = stripped.split(/[ \t]+/)[0] ?? '';
     if (INERT_BINARY_EXTENSIONS.has(extensionOf(pattern))) return;
     for (const re of DIFF_SUPPRESSING_ATTRS) {
       if (!re.test(stripped)) continue;

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -147,6 +147,15 @@ const INERT_BINARY_EXTENSIONS = new Set([
   '.mp3', '.mp4', '.wav', '.mov', '.webm', '.ogg',
 ]);
 
+/**
+ * Extensions where a NUL byte is EXPECTED, so a NUL there is not a finding.
+ * This is a superset of the inert set: it also covers executable binaries,
+ * which legitimately contain NULs but must never have their diffs suppressed
+ * by an attribute — see DIFF_SUPPRESSING_ATTRS, which checks the inert set.
+ *
+ * Note the direction: forgetting an extension here means a real binary gets
+ * reported and a human adds it, rather than a payload running unwatched.
+ */
 const BINARY_EXTENSIONS = new Set([
   ...INERT_BINARY_EXTENSIONS,
   // Executable formats. These belong in the NUL-expected set but NOT in the
@@ -161,7 +170,6 @@ function extensionOf(rel: string): string {
   const dot = name.lastIndexOf('.');
   return dot > 0 ? name.slice(dot).toLowerCase() : '';
 }
-
 
 function isExpectedBinary(rel: string): boolean {
   return BINARY_EXTENSIONS.has(extensionOf(rel));
@@ -441,7 +449,15 @@ function checkGitAttributes(contents: string, rel: string): void {
     // split on NBSP and friends, so a pattern containing one would tokenize
     // short and could land in the allowance below — the blank-set mismatch
     // surviving one statement past its own fix, and this one fails OPEN.
-    const pattern = stripped.split(/[ \t]+/)[0] ?? '';
+    // gitattributes patterns may be QUOTED to contain blanks — verified:
+    // `"evil run.ts" binary` really does set binary on `evil run.ts`. Naive
+    // tokenizing gives `"cover.png` for `"cover.png run.ts" binary`, whose
+    // extension reads as inert, so the allowance would pass a .ts file. That
+    // is the third variation of this same mismatch, and like the last it fails
+    // OPEN — so anything that is not an unambiguous bare pattern gets no
+    // allowance at all.
+    const quoted = /^"((?:[^"\\]|\\.)*)"/.exec(stripped);
+    const pattern = quoted ? (quoted[1] as string) : (stripped.split(/[ \t]+/)[0] ?? '');
     if (INERT_BINARY_EXTENSIONS.has(extensionOf(pattern))) return;
     for (const re of DIFF_SUPPRESSING_ATTRS) {
       if (!re.test(stripped)) continue;

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -299,7 +299,6 @@ function walk(dir: string, out: string[]): string[] {
     return out;
   }
   for (const entry of entries) {
-    if (SKIP_DIRS.has(entry)) continue;
     const p = join(dir, entry);
     let isDir: boolean;
     try {
@@ -307,6 +306,9 @@ function walk(dir: string, out: string[]): string[] {
     } catch {
       continue;
     }
+    // Tested AFTER isDirectory, so a FILE named `build` or `dist` is scanned.
+    // Testing the entry name first dropped extensionless executables by name.
+    if (isDir && SKIP_DIRS.has(entry)) continue;
     if (isDir) walk(p, out);
     else if (inScope(p)) out.push(p);
   }
@@ -384,16 +386,29 @@ function checkLine(
  * instead of the content. `linguist-generated=true` collapses the file behind a
  * "Load diff" fold in the Files-changed view — the view maintainers review from.
  *
- * Refused rather than allow-listed, for the reason this gate keeps relearning:
- * the legitimate entries (`text=auto`, `eol=lf`, `linguist-language=...`) do
- * not hide content, so none of them needs an exemption.
+ * One legitimate use is refused-by-default and must not be: `*.png binary` and
+ * `*.pdf binary` are the standard boilerplate for marking real binaries, and
+ * this repo tracks .png and .mp4 files. Suppressing the diff of a file that is
+ * genuinely binary hides nothing a reviewer could have read anyway, so a
+ * pattern whose extension is in BINARY_EXTENSIONS is allowed. Everything else
+ * is refused rather than allow-listed — `text=auto`, `eol=lf` and
+ * `linguist-language=...` do not hide content, so they need no exemption.
  */
 const DIFF_SUPPRESSING_ATTRS = [/(^|\s)binary(\s|$)/, /(^|\s)-diff(\s|$)/, /linguist-generated/];
 
 function checkGitAttributes(contents: string, rel: string): void {
   contents.split('\n').forEach((line, i) => {
-    const stripped = line.replace(/#.*$/, '').trim();
-    if (stripped === '') return;
+    // gitattributes(5): "Lines that begin with # are ignored." ONLY at line
+    // start — a mid-line `#` is literal and part of the pattern. Stripping
+    // from any `#` discarded content git honours, so `src/pay#load.ts binary`
+    // parsed down to `src/pay`, matched nothing, and still marked the real
+    // file binary for every reviewer. A parser in this gate must not discard
+    // more than the grammar it models.
+    const stripped = line.trim();
+    if (stripped === '' || stripped.startsWith('#')) return;
+    // `*.png binary` targets something with no readable diff to suppress.
+    const pattern = stripped.split(/\s+/)[0] ?? '';
+    if (isExpectedBinary(pattern)) return;
     for (const re of DIFF_SUPPRESSING_ATTRS) {
       if (!re.test(stripped)) continue;
       report(
@@ -490,7 +505,7 @@ function checkLifecycleScripts(contents: string, rel: string): void {
  * tests drive it (synthetic trees under CHECK_CONCEALMENT_ROOT). Both paths
  * are covered: see 'file list' in tests/scripts/check-concealment.test.ts.
  */
-function gitFiles(root: string): string[] | undefined {
+function gitFiles(root: string): { tracked: string[]; untracked: string[] } | undefined {
   // Strip inherited git plumbing vars before shelling out. A pre-push hook runs
   // with GIT_DIR set, and `git -C <dir>` does NOT override it — so without this,
   // `git ls-files` inside a scratch directory silently answers about the AMBIENT
@@ -532,19 +547,31 @@ function gitFiles(root: string): string[] | undefined {
   // Untracked-but-not-ignored files can be `git add`ed into the next diff, so
   // they are in scope too. Ignored files are not.
   const untracked = run(['ls-files', '-z', '--others', '--exclude-standard']) ?? [];
-  return [...new Set([...tracked, ...untracked])].map((rel) => join(root, rel));
+  const abs = (list: string[]): string[] => list.map((rel) => join(root, rel));
+  return { tracked: abs(tracked), untracked: abs(untracked.filter((f) => !tracked.includes(f))) };
 }
 
 function listFiles(root: string): string[] {
   const fromGit = gitFiles(root);
   if (fromGit === undefined) return walk(root, []);
-  // `git ls-files` does not traverse directories, so SKIP_DIRS never applied on
-  // this path — a tracked file under a vendored directory would be scanned here
-  // but skipped by the walk. Apply the same exclusions to both, so behaviour
-  // does not depend on which path ran.
-  return fromGit.filter(
-    (file) => !relative(root, file).split(sep).some((segment) => SKIP_DIRS.has(segment))
-  );
+  // SKIP_DIRS exists for UNREVIEWED LOCAL ARTIFACTS, so it applies to the
+  // untracked half only. A tracked file is in a diff by definition, which is
+  // this gate's entire threat model — excluding `build/loader.ts` because of
+  // its directory name would turn a list of vendored-output names into a list
+  // of places a payload may sit unwatched. A previous revision did exactly
+  // that, in a PR arguing against that shape.
+  return [...fromGit.tracked, ...fromGit.untracked.filter((f) => !underSkippedDir(root, f))];
+}
+
+/**
+ * True when a DIRECTORY segment of the path is in SKIP_DIRS. The final segment
+ * is the filename and is excluded: an extensionless `scripts/build` is a shell
+ * script — the exact shape of `.husky/pre-push` that this gate's scoping fix
+ * was written about — and dropping it for its name would be that bug surviving
+ * inside its own fix.
+ */
+function underSkippedDir(root: string, file: string): boolean {
+  return relative(root, file).split(sep).slice(0, -1).some((seg) => SKIP_DIRS.has(seg));
 }
 
 const files = listFiles(ROOT).filter((f) => inScope(f));

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -149,6 +149,19 @@ function extensionOf(rel: string): string {
   return dot > 0 ? name.slice(dot).toLowerCase() : '';
 }
 
+/**
+ * Binary formats that are inert: media, fonts, archives, documents. A diff of
+ * one of these was never readable, so suppressing it hides nothing — which is
+ * what makes `*.png binary` legitimate boilerplate. Deliberately excludes the
+ * executable formats in BINARY_EXTENSIONS.
+ */
+const INERT_BINARY_EXTENSIONS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.ico', '.icns', '.bmp', '.tiff',
+  '.pdf', '.zip', '.gz', '.tgz', '.bz2', '.xz', '.7z', '.tar',
+  '.woff', '.woff2', '.ttf', '.otf', '.eot',
+  '.mp3', '.mp4', '.wav', '.mov', '.webm', '.ogg',
+]);
+
 function isExpectedBinary(rel: string): boolean {
   return BINARY_EXTENSIONS.has(extensionOf(rel));
 }
@@ -404,11 +417,25 @@ function checkGitAttributes(contents: string, rel: string): void {
     // parsed down to `src/pay`, matched nothing, and still marked the real
     // file binary for every reviewer. A parser in this gate must not discard
     // more than the grammar it models.
-    const stripped = line.trim();
+    // git's parse_attr_line skips ONLY spaces and tabs before the `#` test
+    // (`strspn(line, blank)`, `blank[] = " \t"`). JS .trim() also strips NBSP,
+    // \f, \v, the unicode space separators and U+FEFF — so `<NBSP># p.ts binary`
+    // is a real pattern to git and was dropped here as a comment. That is the
+    // mirror of the bug this function just fixed: the old code discarded
+    // content AFTER a `#`, this discarded a whole line that is not a comment.
+    // Trailing \s is still stripped, for CRLF checkouts.
+    const stripped = line.replace(/^[ \t]+/, '').replace(/\s+$/, '');
     if (stripped === '' || stripped.startsWith('#')) return;
     // `*.png binary` targets something with no readable diff to suppress.
+    //
+    // Checked against INERT_BINARY_EXTENSIONS, NOT BINARY_EXTENSIONS. The
+    // latter answers a different question — where a NUL byte is expected — and
+    // includes .node/.wasm/.so/.dll/.exe, whose whole point is that they
+    // execute. Auto-approving `*.wasm binary` would bless diff suppression on
+    // exactly the formats that run. An author who genuinely needs it writes
+    // the exemption, which is what this gate's failure message asks for.
     const pattern = stripped.split(/\s+/)[0] ?? '';
-    if (isExpectedBinary(pattern)) return;
+    if (INERT_BINARY_EXTENSIONS.has(extensionOf(pattern))) return;
     for (const re of DIFF_SUPPRESSING_ATTRS) {
       if (!re.test(stripped)) continue;
       report(

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -158,9 +158,12 @@ const INERT_BINARY_EXTENSIONS = new Set([
  */
 const BINARY_EXTENSIONS = new Set([
   ...INERT_BINARY_EXTENSIONS,
-  // Executable formats. These belong in the NUL-expected set but NOT in the
-  // inert one: `*.wasm binary` must not be auto-approved, because suppressing
-  // the diff of something that runs is the concealment this gate exists for.
+  // Formats that carry NULs but are NOT inert, so they stay out of the
+  // allowance above. Two disqualifying reasons:
+  //   - they execute: .node, .wasm, .dylib, .so, .dll, .exe
+  //   - they are containers whose contents a reviewer might genuinely need to
+  //     see, and which can carry code: .mcpb bundles this server, .ldb/.sst
+  //     are LevelDB tables holding cached user data
   '.mcpb', '.node', '.wasm', '.ldb', '.sst', '.dylib', '.so', '.dll', '.exe',
 ]);
 
@@ -454,10 +457,27 @@ function checkGitAttributes(contents: string, rel: string): void {
     // tokenizing gives `"cover.png` for `"cover.png run.ts" binary`, whose
     // extension reads as inert, so the allowance would pass a .ts file. That
     // is the third variation of this same mismatch, and like the last it fails
-    // OPEN — so anything that is not an unambiguous bare pattern gets no
-    // allowance at all.
+    // OPEN. So the quoted form is PARSED rather than refused: refusing it would
+    // fail the gate on `"my docs/logo.png" binary`, which is legitimate, and
+    // this rule already learned that lesson with *.png.
+    //
+    // git unquotes the pattern before matching (unquote_c_style), so the
+    // backslash strip below moves the extension we read toward the one git
+    // resolves. It is an APPROXIMATION of that function, not a port: it does
+    // not decode \n, \t or \xNN. Called out rather than left implied, because
+    // this rule's failures so far have all been a parser quietly diverging
+    // from the grammar it models. The divergence that remains is narrow and
+    // fails CLOSED — an undecoded escape leaves a stranger-looking extension,
+    // which misses the inert allowance and gets reported.
+    //
+    // No test pins the strip: every payload I could construct resolves to the
+    // same extension with or without it, so a test would execute the line
+    // without detecting its removal. Left unpinned and said so, rather than
+    // shipping an assertion that cannot fail.
     const quoted = /^"((?:[^"\\]|\\.)*)"/.exec(stripped);
-    const pattern = quoted ? (quoted[1] as string) : (stripped.split(/[ \t]+/)[0] ?? '');
+    const pattern = quoted
+      ? (quoted[1] as string).replace(/\\(.)/g, '$1')
+      : (stripped.split(/[ \t]+/)[0] ?? '');
     if (INERT_BINARY_EXTENSIONS.has(extensionOf(pattern))) return;
     for (const re of DIFF_SUPPRESSING_ATTRS) {
       if (!re.test(stripped)) continue;

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -573,6 +573,14 @@ describe('scoping follow-ups (review of #679)', () => {
     );
   });
 
+  test('a legitimately quoted binary path is still allowed', async () => {
+    // The quoted form is parsed, not refused: `"my docs/logo.png" binary` is
+    // legitimate, and refusing every quoted pattern would fail the gate on it.
+    await withTree({ '.gitattributes': '"my docs/logo.png" binary\n' }, ({ code }) =>
+      expect(code).toBe(0)
+    );
+  });
+
   test('an executable binary format is NOT auto-approved', async () => {
     // BINARY_EXTENSIONS answers "where is a NUL expected"; it includes .wasm,
     // .node, .so, .exe. Reusing it here would bless diff suppression on the

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -552,6 +552,18 @@ describe('scoping follow-ups (review of #679)', () => {
     );
   });
 
+  test('an NBSP in the pattern does not tokenize it into the allowance', async () => {
+    // git splits pattern from attributes on spaces and tabs ONLY, so the real
+    // pattern here is `evil.png<NBSP>run.ts` — a .ts file, not inert, and its
+    // diff must not be suppressed. Splitting on JS \s truncated it to
+    // `evil.png`, which IS inert, and the allowance let it through. Fails
+    // open, which is why it is pinned.
+    const nbsp = String.fromCharCode(0x00a0);
+    await withTree({ '.gitattributes': `evil.png${nbsp}run.ts binary\n` }, ({ code }) =>
+      expect(code).toBe(1)
+    );
+  });
+
   test('an executable binary format is NOT auto-approved', async () => {
     // BINARY_EXTENSIONS answers "where is a NUL expected"; it includes .wasm,
     // .node, .so, .exe. Reusing it here would bless diff suppression on the

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -564,6 +564,15 @@ describe('scoping follow-ups (review of #679)', () => {
     );
   });
 
+  test('a quoted pattern does not tokenize into the allowance', async () => {
+    // Verified against real git: `"evil run.ts" binary` sets binary on
+    // `evil run.ts`. Naive tokenizing yields `"cover.png`, whose extension
+    // reads as inert, so the allowance would wave through a .ts file.
+    await withTree({ '.gitattributes': '"cover.png run.ts" binary\n' }, ({ code }) =>
+      expect(code).toBe(1)
+    );
+  });
+
   test('an executable binary format is NOT auto-approved', async () => {
     // BINARY_EXTENSIONS answers "where is a NUL expected"; it includes .wasm,
     // .node, .so, .exe. Reusing it here would bless diff suppression on the

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -85,6 +85,51 @@ async function withTree(
 
 const CLEAN = 'export const answer = 42;\n';
 
+async function withGitTree(
+  files: Record<string, string>,
+  assertions: (result: Result) => void | Promise<void>,
+  // Written AFTER the commit. `git add -A` honours .gitignore, so a file
+  // listed in it at seed time is never tracked at all — which is a different
+  // scenario from "tracked, then later ignored".
+  afterCommit: Record<string, string> = {}
+): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'concealment-git-'));
+  try {
+    for (const [name, contents] of Object.entries(files)) {
+      const path = join(dir, name);
+      await mkdir(join(path, '..'), { recursive: true });
+      await writeFile(path, contents);
+    }
+    // Clear inherited git plumbing vars for the same reason the gate does:
+    // under a pre-push hook GIT_DIR is set, and `git -C <dir>` does NOT
+    // override it — `git init` here would operate on the ambient repo
+    // instead of this scratch tree, and the tests would silently describe
+    // the wrong repository.
+    const cleanEnv: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (k.startsWith('GIT_')) continue;
+      if (v !== undefined) cleanEnv[k] = v;
+    }
+    const git = (...args: string[]): void => {
+      const r = Bun.spawnSync(['git', '-C', dir, ...args], { env: cleanEnv });
+      if (r.exitCode !== 0) throw new Error(`git ${args.join(' ')} failed`);
+    };
+    git('init', '-q');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'test');
+    git('add', '-A');
+    git('commit', '-qm', 'seed', '--no-gpg-sign');
+    for (const [name, contents] of Object.entries(afterCommit)) {
+      const path = join(dir, name);
+      await mkdir(join(path, '..'), { recursive: true });
+      await writeFile(path, contents);
+    }
+    await assertions(await runCheck(dir));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
 describe('clean input', () => {
   test('passes on an ordinary source tree', async () => {
     await withTree({ 'src/a.ts': CLEAN, 'src/nested/b.ts': CLEAN }, ({ code, stdout }) => {
@@ -217,51 +262,6 @@ describe('scope', () => {
  */
 describe('file list comes from git when available (review follow-up)', () => {
   const concealed = `echo ok${' '.repeat(60)}eval("x")${' # '}${'x'.repeat(80)}\n`;
-
-  async function withGitTree(
-    files: Record<string, string>,
-    assertions: (result: Result) => void | Promise<void>,
-    // Written AFTER the commit. `git add -A` honours .gitignore, so a file
-    // listed in it at seed time is never tracked at all — which is a different
-    // scenario from "tracked, then later ignored".
-    afterCommit: Record<string, string> = {}
-  ): Promise<void> {
-    const dir = await mkdtemp(join(tmpdir(), 'concealment-git-'));
-    try {
-      for (const [name, contents] of Object.entries(files)) {
-        const path = join(dir, name);
-        await mkdir(join(path, '..'), { recursive: true });
-        await writeFile(path, contents);
-      }
-      // Clear inherited git plumbing vars for the same reason the gate does:
-      // under a pre-push hook GIT_DIR is set, and `git -C <dir>` does NOT
-      // override it — `git init` here would operate on the ambient repo
-      // instead of this scratch tree, and the tests would silently describe
-      // the wrong repository.
-      const cleanEnv: Record<string, string> = {};
-      for (const [k, v] of Object.entries(process.env)) {
-        if (k.startsWith('GIT_')) continue;
-        if (v !== undefined) cleanEnv[k] = v;
-      }
-      const git = (...args: string[]): void => {
-        const r = Bun.spawnSync(['git', '-C', dir, ...args], { env: cleanEnv });
-        if (r.exitCode !== 0) throw new Error(`git ${args.join(' ')} failed`);
-      };
-      git('init', '-q');
-      git('config', 'user.email', 'test@example.com');
-      git('config', 'user.name', 'test');
-      git('add', '-A');
-      git('commit', '-qm', 'seed', '--no-gpg-sign');
-      for (const [name, contents] of Object.entries(afterCommit)) {
-        const path = join(dir, name);
-        await mkdir(join(path, '..'), { recursive: true });
-        await writeFile(path, contents);
-      }
-      await assertions(await runCheck(dir));
-    } finally {
-      await rm(dir, { recursive: true, force: true });
-    }
-  }
 
   test('a gitignored tree is not scanned', async () => {
     // The real exposure: removing the extension allowlist put snapshots/,
@@ -481,6 +481,76 @@ describe('diff-suppressing gitattributes (Fable review, item 1)', () => {
   test('checks a nested .gitattributes too', async () => {
     await withTree({ 'src/.gitattributes': 'payload.ts binary\n' }, ({ code }) =>
       expect(code).toBe(1)
+    );
+  });
+});
+
+describe('scoping follow-ups (review of #679)', () => {
+  const concealed = `echo ok${' '.repeat(60)}eval("x")${' # '}${'x'.repeat(80)}\n`;
+
+  test('a tracked file under a SKIP_DIRS name is still scanned', async () => {
+    // SKIP_DIRS is for UNREVIEWED LOCAL ARTIFACTS. A tracked file is in a diff
+    // by definition — excluding build/loader.ts by directory name would turn a
+    // list of vendored-output names into a list of places a payload can sit
+    // unwatched, which is the shape this gate argues against.
+    await withGitTree({ 'build/loader.ts': concealed }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('build/loader.ts');
+    });
+  });
+
+  test('an untracked file under a SKIP_DIRS name is skipped', async () => {
+    // The other half: local build output must not produce findings nobody can fix.
+    await withGitTree({ 'src/a.ts': 'const a = 1;\n' }, ({ code }) => expect(code).toBe(0), {
+      'build/generated.ts': concealed,
+    });
+  });
+
+  test('a FILE named like a skipped directory is scanned', async () => {
+    // An extensionless `scripts/build` is a shell script — the same shape as
+    // .husky/pre-push. Matching SKIP_DIRS against the basename dropped it.
+    await withTree({ 'scripts/build': concealed }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('scripts/build');
+    });
+  });
+
+  test('an untracked FILE named like a skipped directory is scanned (git path)', async () => {
+    // The sibling test above covers the walk. This covers the git path's own
+    // segment test, which must also mean "directory segment" — `scripts/build`
+    // is a shell script, not a build directory.
+    await withGitTree(
+      { 'src/a.ts': 'const a = 1;\n' },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('scripts/build');
+      },
+      { 'scripts/build': concealed }
+    );
+  });
+
+  test('a mid-line # in a gitattributes path is not a comment', async () => {
+    // gitattributes(5): only lines BEGINNING with # are ignored. Stripping
+    // from any # parsed `src/pay#load.ts binary` down to `src/pay`, matched
+    // nothing, and left the real file diff-suppressed.
+    await withTree({ '.gitattributes': 'src/pay#load.ts binary\n' }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('gitattribute');
+    });
+  });
+
+  test('a leading # in gitattributes is still a comment', async () => {
+    await withTree({ '.gitattributes': '# src/payload.ts binary\n' }, ({ code }) =>
+      expect(code).toBe(0)
+    );
+  });
+
+  test('marking a genuinely binary type is allowed', async () => {
+    // *.png binary is standard boilerplate and suppresses a diff nobody could
+    // read anyway. Refusing it would fail the gate with advice the author
+    // cannot act on.
+    await withTree({ '.gitattributes': '*.png binary\n*.pdf binary\n' }, ({ code }) =>
+      expect(code).toBe(0)
     );
   });
 });

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -39,6 +39,9 @@ const VS16 = String.fromCharCode(0xfe0f);
 const SOFT_HYPHEN = String.fromCharCode(0x00ad);
 const NUL = String.fromCharCode(0);
 
+/** A line carrying both a 60-space gap and an eval() — trips two rules at once. */
+const concealed = `echo ok${' '.repeat(60)}eval("x")${' # '}${'x'.repeat(80)}\n`;
+
 interface Result {
   code: number;
   stdout: string;
@@ -261,8 +264,6 @@ describe('scope', () => {
  * hole the audit that prompted these tests was about.
  */
 describe('file list comes from git when available (review follow-up)', () => {
-  const concealed = `echo ok${' '.repeat(60)}eval("x")${' # '}${'x'.repeat(80)}\n`;
-
   test('a gitignored tree is not scanned', async () => {
     // The real exposure: removing the extension allowlist put snapshots/,
     // local fixture databases and .env.local in scope on developer machines.
@@ -313,8 +314,6 @@ describe('file list comes from git when available (review follow-up)', () => {
 });
 
 describe('scope is not an extension allowlist (audit F2)', () => {
-  const concealed = `echo ok${' '.repeat(60)}eval("x")${' # '}${'x'.repeat(80)}\n`;
-
   test('scans a file with no extension at all', async () => {
     // The live exposure was .husky/pre-push, which runs on every developer
     // push. Under the old SCOPED_EXTENSIONS allowlist, inScope() required a
@@ -456,6 +455,9 @@ describe('diff-suppressing gitattributes (Fable review, item 1)', () => {
     ['binary', 'src/payload.ts binary'],
     ['-diff', 'src/payload.ts -diff'],
     ['linguist-generated', 'src/payload.ts linguist-generated=true'],
+    // A glob, since the binary allowance operates on globs — this is the shape
+    // the rule actually has to keep rejecting.
+    ['a glob pattern', '*.ts binary'],
   ])('flags %s', async (_label, line) => {
     // The same class as the NUL bypass reached without a NUL: one tracked
     // .gitattributes line makes git and GitHub print "Binary files differ" (or
@@ -486,8 +488,6 @@ describe('diff-suppressing gitattributes (Fable review, item 1)', () => {
 });
 
 describe('scoping follow-ups (review of #679)', () => {
-  const concealed = `echo ok${' '.repeat(60)}eval("x")${' # '}${'x'.repeat(80)}\n`;
-
   test('a tracked file under a SKIP_DIRS name is still scanned', async () => {
     // SKIP_DIRS is for UNREVIEWED LOCAL ARTIFACTS. A tracked file is in a diff
     // by definition — excluding build/loader.ts by directory name would turn a
@@ -537,6 +537,26 @@ describe('scoping follow-ups (review of #679)', () => {
       expect(code).toBe(1);
       expect(stderr).toContain('gitattribute');
     });
+  });
+
+  test.each([
+    ['NBSP', String.fromCharCode(0x00a0)],
+    ['form feed', '\f'],
+    ['vertical tab', '\v'],
+  ])('a line starting with %s then # is NOT a comment to git', async (_label, lead) => {
+    // git skips only spaces and tabs before the `#` test, so this is a real
+    // pattern to git. JS .trim() stripped these and read it as a comment —
+    // the mirror image of the mid-line-# bug fixed alongside it.
+    await withTree({ '.gitattributes': `${lead}# payload.ts binary\n` }, ({ code }) =>
+      expect(code).toBe(1)
+    );
+  });
+
+  test('an executable binary format is NOT auto-approved', async () => {
+    // BINARY_EXTENSIONS answers "where is a NUL expected"; it includes .wasm,
+    // .node, .so, .exe. Reusing it here would bless diff suppression on the
+    // formats whose whole point is that they execute.
+    await withTree({ '.gitattributes': '*.wasm binary\n' }, ({ code }) => expect(code).toBe(1));
   });
 
   test('a leading # in gitattributes is still a comment', async () => {


### PR DESCRIPTION
# Summary

Fixes five findings the review raised on #679 **after I had already merged it**. Three are regressions that PR introduced; two are defects in the `.gitattributes` rule it added.

I merged #679 on its `APPROVED` line without reading the six new findings underneath it. That was my error, and it is the reason this is a follow-up PR instead of another round on #679.

## Regressions introduced by #679

**`SKIP_DIRS` was applied to tracked files.** #679 aligned the git path with the walk by filtering both through `SKIP_DIRS` — closing a local-noise problem by making the git path *less* thorough. The effect: a tracked, committed `build/loader.ts` became permanently unscannable. `SKIP_DIRS` exists for **unreviewed local artifacts**; a tracked file is in a diff by definition, which is this gate's entire threat model. Turning a list of vendored-output directory names into a list of places a payload can sit unwatched is the exact shape #679 argued against.

Fixed by splitting on the justification rather than the path: `SKIP_DIRS` applies to the **untracked** half only.

**The segment test matched the basename.** Both paths asked whether *any* path segment was in `SKIP_DIRS`, including the filename — so an extensionless `scripts/build` was silently dropped. That is F2's own class surviving inside F2's fix: extensionless executables, exactly the `.husky/pre-push` shape, discarded at the last step. The walk had the same defect from testing the entry name *before* `isDirectory()`.

**No test covered the `SKIP_DIRS` change at all.** Deleting the filter failed nothing — in the commit that was the fix for a merge blocker, whose own comment argued that an untested git path *is* the audit's shape of hole.

## Defects in the new `.gitattributes` rule

**`#` is a comment only at line start.** `gitattributes(5)`: *"Lines that begin with `#` are ignored."* Stripping from any `#` discarded content git honours — `src/pay#load.ts binary` parsed down to `src/pay`, matched nothing, and left the real file diff-suppressed for every reviewer. A `#` in a filename is legal and unremarkable (`note#1.ts`). The deviation is the defect regardless of exploitability: a parser in this gate must not discard more than the grammar it models.

**`*.png binary` is legitimate and was refused.** Standard boilerplate for marking real binaries, and this repo tracks `.png` and `.mp4` files. The next person adding it would have hit a gate failure whose only advice is *"add a narrow, justified exemption — do not widen a threshold."* Suppressing the diff of a genuinely binary file hides nothing a reviewer could read, so a pattern whose extension is in `BINARY_EXTENSIONS` is allowed. Everything else stays refused.

## Mutation evidence

| Reverted fix | Result |
|---|---|
| mid-line `#` strip restored | 1 fail |
| `*.png binary` refused again | 1 fail |
| basename counted as a directory (git path) | 1 fail |
| `SKIP_DIRS` applied to tracked files | 1 fail |

Files scanned: 531 → **533** — two files were being dropped.

## External assumptions

None. `gitattributes(5)`'s comment rule and npm's lifecycle set are documented behavior, not assumptions about Copilot.

## Bug fix?

Root cause:       #679 aligned two code paths by narrowing the stricter one, and its new gitattributes parser modelled a grammar it did not match — `#` anywhere rather than `#` at line start.
Bug class:        Completeness guard whose coverage is a hand-maintained list, and its cousin: a parser that discards more than the grammar it models. Same lineage as the audit's F1/F2.
Detector added:   Seven tests covering both halves of the `SKIP_DIRS` split, both paths' basename handling, both `#` positions, and the binary-extension allowance. Each was mutation-verified by reverting the corresponding fix.
Siblings checked: `checkLifecycleScripts` parses with `JSON.parse` — the real grammar — so it has no equivalent defect. The walk and git paths are now the only two scoping paths and both are tested.
Ledger updated:   n/a — not an external-assumption bug.

## Gate

`bun run check` green: 2994 pass, 20 skip, 0 fail.
