### PR TITLE
chore: apply two recorded audit corrections and bound the review workflows

### DIFF
--- a/.github/workflows/audit-reviews.yml
+++ b/.github/workflows/audit-reviews.yml
@@ -25,6 +25,7 @@ jobs:
   audit:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       pull-requests: write
@@ -179,8 +180,9 @@ jobs:
           # This job is narrow by comparison — re-read a merged PR's review
           # comments, check the final code against each suggestion, emit JSON
           # against a fixed schema — and its output is schema-checked downstream
-          # (see the `jq -e` gate below), so a weaker result fails loudly rather
-          # than silently. Sonnet is the right tier for that shape of work.
+          # (see the `jq -e` gate in the "Create follow-up issue if
+          # suggestions remain" step below), so a weaker result fails loudly
+          # rather than silently. Sonnet is the right tier for that shape of work.
           #
           # If you are here to change this line: the question is not "which is
           # the best model" but "does this job still have a checked output

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,6 +9,7 @@ jobs:
     # Skip draft PRs, forked PRs, and Dependabot PRs (secrets are unavailable)
     if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write

--- a/docs/audits/2026-08-29-completeness-guard-audit.md
+++ b/docs/audits/2026-08-29-completeness-guard-audit.md
@@ -366,7 +366,7 @@ not reached — treat it as unexamined, not as cleared.
 - `tests/unit/tool-registry.test.ts:33-55` — `readOnly` ↔ `readOnlyHint`
   agreement and `requiresLiveReads` are quantified over `ALL_TOOL_DEFS`.
 - Reclassifying an existing write tool as a read is well defended: moving
-  `create_tag` to `READ_TOOL_DEFS` *with both counts bumped* still fails 26
+  `create_tag` to `READ_TOOL_DEFS` *with both counts bumped* still fails 22
   tests, including semantic ones (roundtrip coverage, stale ledger
   `toolParams`, manifest sync).
 - `tests/scripts/read-smoke-coverage.test.ts`,
@@ -401,7 +401,7 @@ the only CI gap is F18, on the release path.
 | 3 | F4, F6, F7 | Conformance ledger, one coherent surface |
 | 4 | F5, F9, F10, F15 | Docs + skills rot |
 | 5 | F8, F12, F14 | Test-infrastructure completeness |
-| 6 | F11, F13, F16, F17, F18 | Low-severity gate cleanups |
+| 6 | F11, F13, F17, F18 | Low-severity gate cleanups |
 | 0 | **D1, D2** | **Ahead of everything: silent financial-data loss** |
 | 7 | D3, D4, D5, D6 | Decoder routing, parity, mutation ratchet, Zod mirrors |
 | 8 | D7 | Model/decoder mirror gap |


### PR DESCRIPTION
# Summary

Clears four audit follow-up findings: two corrections that the 2026-08-29 audit
recorded in its own §7 but never applied in place, and two workflow-hygiene nits.

Closes #682
Closes #675
Closes #684

## What changed

**`docs/audits/2026-08-29-completeness-guard-audit.md`** — that document's convention is
that a §7 correction is applied in place in the earlier section *and* left recorded in §7.
Two were recorded but never applied:

- §5's remediation table still scheduled `F16`, which §3 struck as withdrawn. A reader
  executing §5 top-to-bottom went hunting for a finding that does not exist.
- §4 still said reclassifying `create_tag` "fails 26 tests" where §7 corrected it to 22.
  Every other §7 correction had been applied in place; this one was missed.

§7 itself is untouched — nothing was deleted, the correction record stays intact.

**`.github/workflows/claude-review.yml`** — the review job had no `timeout-minutes`, so a
hung run could block the auto-merge path and burn budget for up to the 360-minute default.
Bounded at 20.

**`.github/workflows/audit-reviews.yml`** — bounded at 15 rather than 20: this job is
post-merge and does not gate auto-merge, and it is retriable via `workflow_dispatch`, so a
false timeout is cheap. Also named the step that the MODEL TIERING comment's `jq -e` pointer
refers to — it points at a gate in a *different* step, which cost the next reader a scroll.

## External assumptions

None

## Verification

- `bun run check` — 3019 pass / 20 skip / 0 fail
- `actionlint` clean; both `timeout-minutes` keys confirmed at job level (sibling of
  `runs-on`), not step level, where they would be valid YAML and silently inert
- Swept the audit document for every withdrawal marker to confirm `F16` was the only one
  and that no other withdrawn finding leaks into §5
