### PR TITLE
fix(test): make exported-constant discovery model the grammar

### DIFF
--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -486,7 +486,9 @@ describe('exported string constants are pinned (#635 class detector)', () => {
   test('a non-as-const array is not itself discovered', () => {
     // CONFORMANCE_LEDGER (src/conformance/ledger.ts) is `readonly LedgerEntry[]`
     // with no `as const`; it must not consume the declarations that follow it.
-    // A shape pin only — the detector for the rule is the synthetic test below.
+    // A shape pin only. The detectors are the synthetic snippets below: the
+    // boundary one for the body bound, and the semicolon-free one for the
+    // annotation bound.
     expect(discovered.has('CONFORMANCE_LEDGER')).toBe(false);
   });
 
@@ -521,14 +523,48 @@ describe('exported string constants are pinned (#635 class detector)', () => {
     // declarations in src/ are exactly the 8 the grammar excludes for missing
     // `as const`, so no input from the tree reaches the accepting branch
     // today. Delete `(?::[^=]+)?` from the grammar and every other test in this
-    // file stays green; that was checked by deleting it, not assumed. Not a
-    // hypothetical shape: src/ writes it eight times today, and one of them
-    // acquiring `as const` is a plausible next commit — which would then leave
-    // discovery without a word, the #677 failure again.
+    // file stays green; that was checked by deleting it, not assumed.
+    //
+    // The shape is not hypothetical, though not for the obvious reason:
+    // adding `as const` to one of those 8 would change nothing either way,
+    // since none of them is a pure single-quoted string array — numbers,
+    // identifiers, object literals, spreads — so the purity check rejects
+    // them with or without this group. Checked by extracting all 8 bodies and
+    // applying the residue rule: zero pure. What the group is load-bearing
+    // for is the COMPOSITION of two shapes src/ already writes separately,
+    // the annotation (8 times) and the pure string-literal `as const` array
+    // (25 times), meeting in one declaration — `export const FOO: readonly
+    // string[] = ['a', 'b'] as const`. That is the commit that would
+    // otherwise leave discovery without a word, the #677 failure again.
     const found = collectStringConstants(
       "export const ANNOTATED: readonly string[] = ['a', 'b'] as const;"
     );
     expect([...(found.get('ANNOTATED') ?? [])]).toEqual(['a', 'b']);
+  });
+
+  test('an annotation cannot reach past its own declaration', () => {
+    // The other half of `(?::[^=]+)?`. The accepting half is pinned above;
+    // this is the bound: `[^=]+` cannot cross the declaration's own `=`, so an
+    // annotated NON-as-const declaration cannot reach a later string-literal
+    // `as const` declaration and take its members under the wrong name.
+    //
+    // The absent `;` is deliberate, and is why this is not the boundary
+    // snippet above. Loosening the bound to `[\s\S]+?` already turns that one
+    // red — checked, along with forward and one contents test — so what it
+    // leaves undetected is a bound that stops at a DIFFERENT character.
+    // `[^;]+` is the representative: it clears every other test in this file.
+    // With no `;` between these two declarations a `;`-bounded annotation
+    // crosses exactly like a dotall one, so this snippet is red for both.
+    const snippet = [
+      'export const ANNOTATED_NOT_A_PIN: readonly Thing[] = [',
+      '  { field: 1 },',
+      ']',
+      '',
+      "export const AFTER_IT = ['alpha'] as const;",
+    ].join('\n');
+    const found = collectStringConstants(snippet);
+    expect(found.has('ANNOTATED_NOT_A_PIN')).toBe(false);
+    expect([...(found.get('AFTER_IT') ?? [])]).toEqual(['alpha']);
   });
 
   test('forward: every exported string constant in src/ is pinned', () => {

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -93,7 +93,7 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * already coexist in one file though — src/tools/field-selection.ts has
  * `as const` arrays at :47 and :68 and bracket-carrying hint literals at :89,
  * :137 and :169 — so a `fields:`-hint list landing in one is a plausible next
- * commit rather than a hypothetical.
+ * commit rather than a hypothetical. Tracked as #696.
  */
 const EXPORTED_ARRAY =
   /^export const ([A-Z][A-Z0-9_]*)\s*(?::[^=]+)?=\s*\[([^[\]]*?)\]\s*as const/gms;

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -32,6 +32,14 @@
  * Dropping a member changes what we accept from or send to Copilot, and no
  * ratchet elsewhere catches a list getting SHORTER.
  *
+ * SCOPE: the grammar below is `export const NAME = [...] as const`, so all of
+ * that covers as-const ARRAYS only. A string-literal allowlist declared as
+ * `new Set([...])` is invisible to it — TRANSFER_CATEGORIES and
+ * INCOME_CATEGORIES (src/utils/categories.ts) are unpinned today for exactly
+ * that reason. Known gap, tracked separately. Said out loud because "no ratchet
+ * catches a list getting shorter" must not be read as "every list in src/ is
+ * ratcheted": a reader who believes the wider claim stops looking.
+ *
  * HOW IT FAILS (all three directions are mutation-tested in this file's PR)
  *
  *   forward   a constant exists in src/ with no pinned expectation
@@ -45,7 +53,7 @@
  * different declaration style), the constants it can no longer see read as
  * "vanished" and the backward check goes red. A partial under-match cannot
  * pass quietly. The explicit non-vacuity test makes the total-failure case
- * report an unambiguous reason rather than 23 confusing ones.
+ * report an unambiguous reason rather than 25 confusing ones.
  *
  * MAINTENANCE: changing one of these deliberately means updating the entry
  * below. That is the intended workflow — the point is that it cannot happen
@@ -303,10 +311,13 @@ describe('exported string constants are pinned (#635 class detector)', () => {
 
   test('discovery finds constants at all (guards the guard)', () => {
     expect(discoveredNames.length).toBeGreaterThan(0);
-    // Coverage floor, deliberately not an exact count: an exact one would churn
-    // on every constant added, while a floor still catches discovery collapsing
-    // to a handful — the failure this file exists to make loud.
-    expect(discovered.size).toBeGreaterThanOrEqual(25);
+    // Coverage floor, deliberately loose in BOTH directions. An exact count
+    // churns on every constant added; a floor flush against today's 25 churns
+    // on every legitimate deletion, where a constant leaves src/ and its pin
+    // together. The slack is what keeps this test about its one job —
+    // discovery collapsing to a handful, which is the failure that would make
+    // every other test in this file vacuous at once.
+    expect(discovered.size).toBeGreaterThanOrEqual(20);
   });
 
   test('comment-carrying arrays survive stripping', () => {
@@ -329,7 +340,7 @@ describe('exported string constants are pinned (#635 class detector)', () => {
     expect(discovered.has('IGNORED_ITEM_FIELDS')).toBe(true);
   });
 
-  test('a non-as-const array does not swallow the as-const arrays after it', () => {
+  test('a non-as-const array is not itself discovered', () => {
     // CONFORMANCE_LEDGER (src/conformance/ledger.ts) is `readonly LedgerEntry[]`
     // with no `as const`; it must not consume the declarations that follow it.
     // A shape pin only — the detector for the rule is the synthetic test below.

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -552,22 +552,32 @@ describe('exported string constants are pinned (#635 class detector)', () => {
     // any bound whose stop character does not appear between these two
     // declarations. A dotall is not in it — loosening to `[\s\S]+?` already
     // turns the boundary snippet, forward and one contents test red — but a
-    // bound that merely stops SOMEWHERE ELSE is. Sweeping 31 bounds (29
-    // `(?::[^X]+)?` variants plus both dotall forms) against the previous
-    // version of this snippet, whose decoy body was `{ field: 1 },`, left
-    // `[^{]+`, `[^}]+` and `[^,]+` green: one survivor per punctuation
-    // character the decoy happened to carry, exactly as `[^;]+` survived the
-    // boundary snippet's `;`.
+    // bound that merely stops SOMEWHERE ELSE is. The rule generates its own
+    // survivors, so whatever the decoy carries is a hole: with the previous
+    // decoy body `{ field: 1 },`, each of `[^{]+`, `[^}]+`, `[^,]+` and
+    // `[^:]+` cleared the whole file. Four characters it did not need, four
+    // holes.
     //
-    // Hence an empty decoy and a bare blank line. The rule is stronger than
-    // "no semicolon": this snippet must carry NO character a plausible bound
-    // would stop at. Do not restore `{ field: 1 },` to make it match the
-    // boundary snippet — that reopens the family. The same sweep now detects
-    // all 31 but `[^\n]+`, which is not in the class: a declaration starts at
-    // a line start, so a bound that cannot cross a newline cannot reach one.
-    // It narrows discovery rather than swallowing a neighbour.
+    // Hence a decoy with no punctuation in it at all. Sweeping 35 bounds — 33
+    // negated-class variants over ASCII punctuation, digits and newline, plus
+    // both dotall forms — mutated one at a time into the grammar and run
+    // against this file, this snippet detects 32. Of the rest, `[^ ]+` is
+    // caught by the accepting test above rather than here, and `[^_]+` and
+    // `[^\n]+` are caught by nothing: the first halts on the `_` in the
+    // constant NAMES, the second cannot cross a line start, which is where
+    // every declaration begins, so it narrows discovery instead of swallowing
+    // a neighbour. None of the three is a bound anyone would write — spaces,
+    // underscores and newlines are what a declaration is made of.
+    //
+    // The rule to preserve is that the decoy carries no character a plausible
+    // bound would stop at, beyond the `=` such a bound stops at by definition
+    // and the letters and spaces every declaration has. It is easy to lose:
+    // annotating it `readonly Thing[]` was enough to hand `[^[]+`, `[^\]]+`
+    // and `[^[\]]+` — the body bound copied up one line — to the accepting
+    // test rather than this one. Measured, and why the type here is bare. Do
+    // not give the decoy a body to make it match the boundary snippet.
     const snippet = [
-      'export const ANNOTATED_NOT_A_PIN: readonly Thing[] = []',
+      'export const ANNOTATED_NOT_A_PIN: Thing = x',
       '',
       "export const AFTER_IT = ['alpha'] as const;",
     ].join('\n');

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -36,7 +36,7 @@
  * that covers as-const ARRAYS only. A string-literal allowlist declared as
  * `new Set([...])` is invisible to it — TRANSFER_CATEGORIES and
  * INCOME_CATEGORIES (src/utils/categories.ts) are unpinned today for exactly
- * that reason. Known gap, tracked separately. Said out loud because "no ratchet
+ * that reason. Known gap, tracked in #695. Said out loud because "no ratchet
  * catches a list getting shorter" must not be read as "every list in src/ is
  * ratcheted": a reader who believes the wider claim stops looking.
  *
@@ -76,8 +76,24 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * that is NOT `as const` scan forward to the next `] as const` anywhere later
  * in the file and swallow every declaration in between, which drops them from
  * the pin silently. Bounding the body to bracket-free text stops the match at
- * its own declaration. Costs nothing here — a pure string-literal array holds
- * no brackets by construction.
+ * its own declaration.
+ *
+ * ASSUMPTION, same class as stripComments' below and silent in the same way:
+ * no member of an `as const` array CONTAINS a bracket character. The array
+ * holds no SYNTACTIC brackets by construction — that part is free — but a
+ * literal that carries one, say a `fields: ["default"]` hint string, stops the
+ * bounded body short of its own `] as const`. The declaration is then never
+ * matched, the forward check has nothing to complain about, and the constant
+ * leaves the pin without a word. Note the shape: that is #677's own failure,
+ * reintroduced by the bound that fixes the swallowing one, so the bound trades
+ * a multi-declaration silent drop for a single-declaration silent drop rather
+ * than eliminating the class.
+ *
+ * No such literal sits in an `as const` array in src/ today. The two shapes
+ * already coexist in one file though — src/tools/field-selection.ts has
+ * `as const` arrays at :47 and :68 and bracket-carrying hint literals at :89,
+ * :137 and :169 — so a `fields:`-hint list landing in one is a plausible next
+ * commit rather than a hypothetical.
  */
 const EXPORTED_ARRAY =
   /^export const ([A-Z][A-Z0-9_]*)\s*(?::[^=]+)?=\s*\[([^[\]]*?)\]\s*as const/gms;
@@ -108,7 +124,7 @@ function tsFilesUnder(dir: string): string[] {
  * BEFORE line comments, so a line comment that contains a block-comment opener
  * lets the block regex run forward to the next closer and delete the real
  * declarations in between. Neither case occurs in `src/` today; both are
- * tracked separately.
+ * tracked in #691.
  *
  * Same helper and same caveat as tests/core/decoder-field-completeness.test.ts,
  * duplicated on purpose rather than shared, so neither file's parsing rules can

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -1,5 +1,7 @@
 /**
- * Bidirectional pin over EVERY exported string-literal constant in `src/`.
+ * Bidirectional pin over the exported string-literal `as const` arrays in
+ * `src/` — 25 of them across 15 files today. Deliberately not "every constant":
+ * SCOPE below names what this grammar cannot see.
  *
  * WHY THIS FILE EXISTS
  *
@@ -24,7 +26,7 @@
  *   - cross-module: a preset anywhere under src/ is found
  *   - name-agnostic: a constant that ignores the DEFAULT_*_FIELDS convention
  *     is still found, because the filter is SHAPE (an exported `as const`
- *     array whose members are all string literals)
+ *     array whose members are all SINGLE-QUOTED string literals)
  *
  * That shape also sweeps in wire-visible enums and allowlists —
  * RECURRING_FREQUENCIES, KNOWN_ERROR_CODES, COLOR_NAMES, TOP_MOVERS_FILTERS.
@@ -34,9 +36,9 @@
  *
  * SCOPE: the grammar below is `export const NAME = [...] as const`, so all of
  * that covers as-const ARRAYS only. A string-literal allowlist declared as
- * `new Set([...])` is invisible to it — TRANSFER_CATEGORIES and
- * INCOME_CATEGORIES (src/utils/categories.ts) are unpinned today for exactly
- * that reason. Known gap, tracked in #695. Said out loud because "no ratchet
+ * `new Set([...])` is invisible to it — TRANSFER_CATEGORIES
+ * (src/utils/categories.ts:837) and INCOME_CATEGORIES (:886) are unpinned today
+ * for exactly that reason. Known gap, tracked in #695. Said out loud because "no ratchet
  * catches a list getting shorter" must not be read as "every list in src/ is
  * ratcheted": a reader who believes the wider claim stops looking.
  *
@@ -52,8 +54,11 @@
  * regex below silently stops matching (a formatting change, a refactor to a
  * different declaration style), the constants it can no longer see read as
  * "vanished" and the backward check goes red. A partial under-match cannot
- * pass quietly. The explicit non-vacuity test makes the total-failure case
- * report an unambiguous reason rather than 25 confusing ones.
+ * pass quietly. Total failure is the case worth naming: discovery returns
+ * nothing, so the forward check passes vacuously, no contents tests are
+ * generated at all, and the only signal is a 25-name diff on the backward
+ * check. The explicit non-vacuity test exists to report that as one
+ * unambiguous reason instead.
  *
  * MAINTENANCE: changing one of these deliberately means updating the entry
  * below. That is the intended workflow — the point is that it cannot happen
@@ -99,7 +104,9 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * a multi-declaration silent drop for a single-declaration silent drop rather
  * than eliminating the class.
  *
- * No such literal sits in an `as const` array in src/ today. The two shapes
+ * No such literal sits in an `as const` array in src/ today — checked by
+ * bracket-matching each `export const NAME = [ ... ] as const` body and
+ * scanning its literals: zero of 25. The two shapes
  * already coexist in one file though — src/tools/field-selection.ts declares
  * `as const` arrays at :36, :60, :121 and :151 (closing at :47, :68, :127 and
  * :158) and carries bracket-bearing hint literals at :89, :105-106, :137 and
@@ -107,9 +114,10 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * rather than a hypothetical. Tracked as #696.
  *
  * ASSUMPTION, another silent-drop mode and the likeliest of them to actually
- * happen: every member is written with SINGLE quotes. `.prettierrc.json` sets `singleQuote: true`, but Prettier's
- * fewer-escapes rule flips any string whose content holds an apostrophe to
- * double quotes, so `bun run format` itself produces:
+ * happen: every member is written with SINGLE quotes. `.prettierrc.json` sets
+ * `singleQuote: true`, but Prettier's fewer-escapes rule flips any string whose
+ * content holds an apostrophe to double quotes, so `bun run format` itself
+ * produces:
  *
  *     export const MSGS = ["can't", 'ok'] as const;
  *
@@ -120,9 +128,10 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * top: a double-quoted string IS a string literal, so a reader checking whether
  * their new constant is covered concludes that it is. Same shape as #677 — not
  * "the pin rejects this" but "the pin never saw it." Unlikely against today's
- * members, which are snake_case field names and SCREAMING_CASE enum values;
- * likely against the first human-readable list anyone adds. Tracked as #696
- * with the rest of the family.
+ * members: no member of any of the 25 arrays contains a quote character of any
+ * kind — checked, and the claim that matters, since the members are field names
+ * and enum values (a few kebab-cased, none prose). Likely against the first
+ * human-readable list anyone adds. Tracked as #696 with the rest of the family.
  */
 const EXPORTED_ARRAY =
   /^export const ([A-Z][A-Z0-9_]*)\s*(?::[^=]+)?=\s*\[([^[\]]*?)\]\s*as const/gms;
@@ -143,17 +152,22 @@ function tsFilesUnder(dir: string): string[] {
  * collectStringConstants rejects the array, and the constant drops out of the
  * pin without a word.
  *
- * ASSUMPTION: no string literal in `src/` contains `//` or a block-comment
- * opener. Stated rather than left implicit because the failure is SILENT in
- * exactly this file's own direction: mangling a literal makes the residue check
- * reject the array and drop it from the pin. That is a known limitation, not
- * something to work around here — a URL inside an exported `as const` array is
- * the realistic case, and making this string-aware is the fix if one ever
- * lands. A sibling hazard of the same shape: block comments are stripped
- * BEFORE line comments, so a line comment that contains a block-comment opener
- * lets the block regex run forward to the next closer and delete the real
- * declarations in between. Neither case occurs in `src/` today; both are
- * tracked in #691.
+ * ASSUMPTION: no string literal INSIDE an exported `as const` array contains
+ * `//` or a block-comment opener. Scoped on purpose, because the unscoped
+ * version is false — three URL literals in src/ do contain `//`
+ * (src/core/graphql/client.ts, src/core/auth/browser-token.ts,
+ * src/core/database.ts) and this helper mangles all three. They are harmless
+ * only because none sits in an `as const` array, which is the sole text the
+ * matcher reads. Checked that way: zero of the 25 array bodies contain `//`,
+ * and zero string literals anywhere in src/ contain a block-comment opener.
+ *
+ * Stated rather than left implicit because the failure is SILENT in exactly
+ * this file's own direction: mangling a literal makes the residue check reject
+ * the array and drop it from the pin. Making this string-aware is the fix when
+ * a URL eventually lands in one. A sibling hazard of the same shape: block
+ * comments are stripped BEFORE line comments, so a line comment containing a
+ * block-comment opener lets the block regex run to the next closer and delete
+ * the declarations in between. Both tracked in #691.
  *
  * Same helper and same caveat as tests/core/decoder-field-completeness.test.ts,
  * duplicated on purpose rather than shared, so neither file's parsing rules can
@@ -196,14 +210,20 @@ function collectStringConstants(source: string): Map<string, readonly string[]> 
  *
  * ASSUMPTION, and the one member of the family with teeth: constant names are
  * unique across src/. The map is keyed by name alone, so two files exporting
- * the same name collapse last-write-wins. All 25 are unique today.
+ * the same name collapse last-write-wins. Checked as two independently derived
+ * numbers: the grammar matches 25 declarations in src/, and they reduce to 25
+ * distinct map keys. Counting the map alone could never show this — collisions
+ * are precisely what the map hides, so `discovered.size === 25` would hold
+ * either way.
  *
- * Worse than its siblings in kind, not just degree. They DROP a constant, which
- * the backward check catches the moment it is pinned. This one SUBSTITUTES one:
- * the name stays present, the members silently become the other file's, and the
- * winner is decided by readdirSync order. So the contents test can be green on
- * one machine and red on another, with nothing in this file to explain why.
- * Tracked as #694.
+ * Two forms, and the likelier one is the quiet one. Usually the loser is simply
+ * never seen: the winner's members get pinned, the NAME is present either way so
+ * forward and backward are both satisfied, and the second declaration receives
+ * no coverage at all — stably, on every machine. Only when the two arrays DIFFER
+ * does readdirSync order start to decide anything, and then the contents test
+ * can be red on one machine and green on another. That form is at least loud
+ * where it fires. Unlike its siblings, neither form drops a NAME the backward
+ * check could notice: this one substitutes rather than drops. Tracked as #694.
  */
 function discoverStringConstants(): Map<string, readonly string[]> {
   const found = new Map<string, readonly string[]>();

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -55,10 +55,10 @@
  * different declaration style), the constants it can no longer see read as
  * "vanished" and the backward check goes red. A partial under-match cannot
  * pass quietly. Total failure is the case worth naming: discovery returns
- * nothing, so the forward check passes vacuously, no contents tests are
- * generated at all, and the only signal is a 25-name diff on the backward
- * check. The explicit non-vacuity test exists to report that as one
- * unambiguous reason instead.
+ * nothing, so the forward check passes vacuously and no contents tests are
+ * generated at all, leaving the backward check to report it as a 25-name diff.
+ * The explicit non-vacuity test exists so that case names one unambiguous
+ * reason instead.
  *
  * MAINTENANCE: changing one of these deliberately means updating the entry
  * below. That is the intended workflow — the point is that it cannot happen
@@ -128,9 +128,13 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * top: a double-quoted string IS a string literal, so a reader checking whether
  * their new constant is covered concludes that it is. Same shape as #677 — not
  * "the pin rejects this" but "the pin never saw it." Unlikely against today's
- * members: no member of any of the 25 arrays contains a quote character of any
- * kind — checked, and the claim that matters, since the members are field names
- * and enum values (a few kebab-cased, none prose). Likely against the first
+ * members — but the check has to be run over something other than the 25, since
+ * a member holding an apostrophe cannot appear among them BY CONSTRUCTION: that
+ * is the hazard itself, not evidence against it. The falsifiable form is to
+ * bracket-match every as-const array in src/, discoverable or not, and compare
+ * counts: 25 of them, the same 25 the pin holds, none written with a
+ * double-quoted or backtick member. Nothing is hidden today. Likely against the
+ * first
  * human-readable list anyone adds. Tracked as #696 with the rest of the family.
  */
 const EXPORTED_ARRAY =
@@ -158,8 +162,13 @@ function tsFilesUnder(dir: string): string[] {
  * (src/core/graphql/client.ts, src/core/auth/browser-token.ts,
  * src/core/database.ts) and this helper mangles all three. They are harmless
  * only because none sits in an `as const` array, which is the sole text the
- * matcher reads. Checked that way: zero of the 25 array bodies contain `//`,
- * and zero string literals anywhere in src/ contain a block-comment opener.
+ * matcher reads. Note WHAT was checked, because the distinction is the whole
+ * point of this helper: the count is over extracted member VALUES, after
+ * stripping. Two of the 25 raw bodies — IGNORED_ITEM_FIELDS and
+ * KNOWN_FREQUENCIES — do contain `//`, as the line comments this helper exists
+ * to remove and the live hole #677 fixed. Post-strip, zero of the 25 have a
+ * member whose CONTENT holds `//`, and zero string literals anywhere in src/
+ * hold a block-comment opener.
  *
  * Stated rather than left implicit because the failure is SILENT in exactly
  * this file's own direction: mangling a literal makes the residue check reject

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -96,7 +96,11 @@ function tsFilesUnder(dir: string): string[] {
  * reject the array and drop it from the pin. That is a known limitation, not
  * something to work around here — a URL inside an exported `as const` array is
  * the realistic case, and making this string-aware is the fix if one ever
- * lands. Tracked separately.
+ * lands. A sibling hazard of the same shape: block comments are stripped
+ * BEFORE line comments, so a line comment that contains a block-comment opener
+ * lets the block regex run forward to the next closer and delete the real
+ * declarations in between. Neither case occurs in `src/` today; both are
+ * tracked separately.
  *
  * Same helper and same caveat as tests/core/decoder-field-completeness.test.ts,
  * duplicated on purpose rather than shared, so neither file's parsing rules can
@@ -299,28 +303,49 @@ describe('exported string constants are pinned (#635 class detector)', () => {
 
   test('discovery finds constants at all (guards the guard)', () => {
     expect(discoveredNames.length).toBeGreaterThan(0);
+    // Coverage floor, deliberately not an exact count: an exact one would churn
+    // on every constant added, while a floor still catches discovery collapsing
+    // to a handful — the failure this file exists to make loud.
+    expect(discovered.size).toBeGreaterThanOrEqual(25);
   });
 
-  test('discovery sees arrays containing inline comments', () => {
-    const found = discoverStringConstants();
-    // Both carry inline `//` comments inside the array literal.
-    expect(found.has('KNOWN_FREQUENCIES')).toBe(true);
-    expect(found.has('IGNORED_ITEM_FIELDS')).toBe(true);
+  test('comment-carrying arrays survive stripping', () => {
+    // Synthetic rather than tree-derived, for the same reason
+    // collectStringConstants is split out at all: a routine cleanup that
+    // dropped the `// Every 2 weeks`-style comments from src/models/recurring.ts
+    // would leave a tree-based version of this test green while it exercised
+    // nothing.
+    const found = collectStringConstants(
+      ['export const WITH_NOTES = [', "  'a', // note", "  'b',", '] as const;'].join('\n')
+    );
+    expect([...(found.get('WITH_NOTES') ?? [])]).toEqual(['a', 'b']);
+  });
+
+  test('the constants whose literals carry inline comments are in the pin', () => {
+    // These two were outside the pin until #677, for exactly that reason. This
+    // is a membership check on the real tree, not a test of the stripping rule
+    // — that is the synthetic test above.
+    expect(discovered.has('KNOWN_FREQUENCIES')).toBe(true);
+    expect(discovered.has('IGNORED_ITEM_FIELDS')).toBe(true);
   });
 
   test('a non-as-const array does not swallow the as-const arrays after it', () => {
-    const found = discoverStringConstants();
     // CONFORMANCE_LEDGER (src/conformance/ledger.ts) is `readonly LedgerEntry[]`
     // with no `as const`; it must not consume the declarations that follow it.
-    expect(found.has('CONFORMANCE_LEDGER')).toBe(false);
-    expect(found.size).toBeGreaterThanOrEqual(25);
+    // A shape pin only — the detector for the rule is the synthetic test below.
+    expect(discovered.has('CONFORMANCE_LEDGER')).toBe(false);
   });
 
   test('declaration boundaries: a non-as-const array cannot reach a later `] as const`', () => {
-    // The tree-level assertion above can only catch this by accident — today no
-    // `as const` array happens to sit after a non-`as const` one in the same
-    // file, so the tree cannot tell a correct matcher from a greedy one. This
-    // snippet can, which is what makes the boundary rule mutation-detectable.
+    // The tree cannot detect this, and NOT because the greedy match fails to
+    // happen — it happens. In src/conformance/ledger.ts, CONFORMANCE_LEDGER at
+    // :305 is not `as const`, and the first `] as const` ahead of it is the
+    // INLINE `(['id', 'accountId', 'itemId'] as const)` at :493, so the old
+    // lazy body matched 305 -> 493 and the sweep resumed past the whole span.
+    // Nothing is lost from the pin only because that span happens to contain no
+    // exported string-literal declaration — an accident of today's tree, not a
+    // property of it. This snippet puts a declaration inside such a span, which
+    // is what makes the boundary rule mutation-detectable at all.
     const snippet = [
       'export const NOT_A_PIN: readonly Thing[] = [',
       '  { field: 1 },',

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -116,14 +116,19 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * No such literal sits in an `as const` array in src/ today. The denominator is
  * the load-bearing part: the scan bracket-matches EVERY
  * `export const NAME = [ ... ] as const` in src/, discoverable by this grammar
- * or not, which is a wider net than the matcher above casts. It is a CHECK, not
- * a proof: the walk counts brackets in raw text, so an UNBALANCED one inside a
- * literal (`['a]', 'b']`) closes it early and that declaration goes uncounted —
- * the same class of blind spot as the matcher it is meant to outperform. A
- * balanced pair split across concatenated literals is fine, since the walk never
- * needed them to be in the same literal. Today the net holds: 33 declarations
- * match `export const NAME = [`, 25 land on `as const` and 8 correctly do not,
- * and src/'s only two unbalanced-bracket literals
+ * or not, which is a wider net than the matcher above casts. Wider but for one
+ * direction: that opener is matched line by line where the grammar's `=\s*\[`
+ * crosses newlines, so a declaration wrapped after its `=` falls outside the
+ * census while staying inside the grammar — a hole only if it ALSO carries
+ * what the grammar rejects: a bracket literal here, a double-quoted member
+ * below. Run both ways over src/, the opener returns the same set today. It is
+ * a CHECK, not a proof: the walk counts brackets in raw text, so an UNBALANCED
+ * one inside a literal (`['a]', 'b']`) closes it early and that declaration
+ * goes uncounted — the same class of blind spot as the matcher it is meant to
+ * outperform. A balanced pair split across concatenated literals is fine, since
+ * the walk never needed them to be in the same literal. Today the net holds: 33
+ * declarations match `export const NAME = [`, 25 land on `as const` and 8
+ * correctly do not, and src/'s only two unbalanced-bracket literals
  * (src/tools/field-selection.ts:105 and :106, which balance each other) sit
  * inside an object literal the array walk never enters. That 25 is the same 25
  * the pin holds, and none of their literals carries a bracket. Counting only
@@ -189,14 +194,13 @@ function tsFilesUnder(dir: string): string[] {
  * line wherever it occurs. They are harmless because none of those three LINES
  * carries an `as const` declaration, so the text destroyed is text the matcher
  * would not have matched. Put a URL inside a member and the constant is gone:
- * `export const U = ['https://x'] as const` does not survive stripping.
- * Note WHAT was checked, because the distinction is the whole
- * point of this helper: the count is over extracted member VALUES, after
- * stripping. Two of the 25 raw bodies — IGNORED_ITEM_FIELDS and
- * KNOWN_FREQUENCIES — do contain `//`, as the line comments this helper exists
- * to remove and the live hole #677 fixed. Post-strip, zero of the 25 have a
- * member whose CONTENT holds `//`, and zero string literals anywhere in src/
- * hold a block-comment opener.
+ * `export const U = ['https://x'] as const` does not survive stripping. Note
+ * WHAT was checked, because the distinction is the whole point of this helper:
+ * the count is over extracted member VALUES, after stripping. Two of the 25 raw
+ * bodies — IGNORED_ITEM_FIELDS and KNOWN_FREQUENCIES — do contain `//`, as the
+ * line comments this helper exists to remove and the live hole #677 fixed.
+ * Post-strip, zero of the 25 have a member whose CONTENT holds `//`, and zero
+ * string literals anywhere in src/ hold a block-comment opener.
  *
  * Stated rather than left implicit because the failure is SILENT in exactly
  * this file's own direction: mangling a literal makes the residue check reject
@@ -259,20 +263,23 @@ function collectStringConstants(source: string): Map<string, readonly string[]> 
  * test can move:
  *
  *   arrays differ, pin matches the WINNER -> all three green, and the loser is a
- *     live declaration in src/ that no test touches. Silent, stable, indefinite.
- *     The dangerous one, and the one the workflow RATCHETS TOWARDS — see below.
+ *     live declaration in src/ that no test touches. Silent, stable and
+ *     indefinite on machines whose readdirSync order produces that winner;
+ *     elsewhere the same pin matches the LOSER instead. The dangerous one, and
+ *     the one the workflow RATCHETS TOWARDS — see below.
  *   arrays differ, pin matches the LOSER  -> contents red, but only on machines
  *     whose readdirSync order produces that winner. Loud where it fires.
  *   arrays identical                      -> quiet and stable; the loser is
  *     uncovered but currently says the same thing, until it drifts.
  *
- * The ratchet, which is why row 2 is not merely one outcome in three: `PINNED`
- * entries are authored from what discovery REPORTS. So row 3 does not persist —
- * the author sees contents red, reconciles the pin against the actual output,
- * i.e. against the winner, and lands in row 2. Row 3 decays into row 2 on
- * whichever machine last edited the pin, and that is also why row 2 presents as
- * a CROSS-MACHINE symptom: the same pin matches the winner here and the loser
- * on a machine whose readdirSync order differs. Not a probability argument — a
+ * The ratchet, which is why the pin-matches-WINNER branch is not merely one
+ * outcome in three: `PINNED` entries are authored from what discovery REPORTS.
+ * So pin-matches-LOSER does not persist — the author sees contents red,
+ * reconciles the pin against the actual output, i.e. against the winner, and
+ * lands in pin-matches-WINNER. The decay happens on whichever machine last
+ * edited the pin, which is also why pin-matches-LOSER presents as a
+ * CROSS-MACHINE symptom: the same pin matches the winner here and the loser on
+ * a machine whose readdirSync order differs. Not a probability argument — a
  * property of how the pin gets written.
  *
  * Unlike its siblings, no branch drops a NAME the backward check could notice:

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -548,17 +548,26 @@ describe('exported string constants are pinned (#635 class detector)', () => {
     // annotated NON-as-const declaration cannot reach a later string-literal
     // `as const` declaration and take its members under the wrong name.
     //
-    // The absent `;` is deliberate, and is why this is not the boundary
-    // snippet above. Loosening the bound to `[\s\S]+?` already turns that one
-    // red — checked, along with forward and one contents test — so what it
-    // leaves undetected is a bound that stops at a DIFFERENT character.
-    // `[^;]+` is the representative: it clears every other test in this file.
-    // With no `;` between these two declarations a `;`-bounded annotation
-    // crosses exactly like a dotall one, so this snippet is red for both.
+    // What survives the rest of the file is not one mutation but a family:
+    // any bound whose stop character does not appear between these two
+    // declarations. A dotall is not in it — loosening to `[\s\S]+?` already
+    // turns the boundary snippet, forward and one contents test red — but a
+    // bound that merely stops SOMEWHERE ELSE is. Sweeping 31 bounds (29
+    // `(?::[^X]+)?` variants plus both dotall forms) against the previous
+    // version of this snippet, whose decoy body was `{ field: 1 },`, left
+    // `[^{]+`, `[^}]+` and `[^,]+` green: one survivor per punctuation
+    // character the decoy happened to carry, exactly as `[^;]+` survived the
+    // boundary snippet's `;`.
+    //
+    // Hence an empty decoy and a bare blank line. The rule is stronger than
+    // "no semicolon": this snippet must carry NO character a plausible bound
+    // would stop at. Do not restore `{ field: 1 },` to make it match the
+    // boundary snippet — that reopens the family. The same sweep now detects
+    // all 31 but `[^\n]+`, which is not in the class: a declaration starts at
+    // a line start, so a bound that cannot cross a newline cannot reach one.
+    // It narrows discovery rather than swallowing a neighbour.
     const snippet = [
-      'export const ANNOTATED_NOT_A_PIN: readonly Thing[] = [',
-      '  { field: 1 },',
-      ']',
+      'export const ANNOTATED_NOT_A_PIN: readonly Thing[] = []',
       '',
       "export const AFTER_IT = ['alpha'] as const;",
     ].join('\n');

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -48,9 +48,9 @@
  * that covers as-const ARRAYS only. A string-literal allowlist declared as
  * `new Set([...])` is invisible to it — TRANSFER_CATEGORIES
  * (src/utils/categories.ts:837) and INCOME_CATEGORIES (:886) are unpinned today
- * for exactly that reason. Known gap, tracked in #695. Said out loud because "no ratchet
- * catches a list getting shorter" must not be read as "every list in src/ is
- * ratcheted": a reader who believes the wider claim stops looking.
+ * for exactly that reason. Known gap, tracked in #695. Said out loud because
+ * "no ratchet catches a list getting shorter" must not be read as "every list
+ * in src/ is ratcheted": a reader who believes the wider claim stops looking.
  *
  * HOW IT FAILS (all three directions are mutation-tested in this file's PR)
  *
@@ -116,17 +116,24 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * No such literal sits in an `as const` array in src/ today. The denominator is
  * the load-bearing part: the scan bracket-matches EVERY
  * `export const NAME = [ ... ] as const` in src/, discoverable by this grammar
- * or not — a balanced walk pairs an inner `[` with its inner `]` and still
- * reaches the real closer, so a bracket-carrying array cannot hide from it the
- * way it hides from the matcher above. That population is 25, the same 25 the
- * pin holds, and none of their literals carries a bracket. Counting only the
- * pin's 25 would prove nothing, for the reason spelled out below. The two
- * shapes already coexist in one file though — src/tools/field-selection.ts
+ * or not, which is a wider net than the matcher above casts. It is a CHECK, not
+ * a proof: the walk counts brackets in raw text, so an UNBALANCED one inside a
+ * literal (`['a]', 'b']`) closes it early and that declaration goes uncounted —
+ * the same class of blind spot as the matcher it is meant to outperform. A
+ * balanced pair split across concatenated literals is fine, since the walk never
+ * needed them to be in the same literal. Today the net holds: 33 declarations
+ * match `export const NAME = [`, 25 land on `as const` and 8 correctly do not,
+ * and src/'s only two unbalanced-bracket literals
+ * (src/tools/field-selection.ts:105 and :106, which balance each other) sit
+ * inside an object literal the array walk never enters. That 25 is the same 25
+ * the pin holds, and none of their literals carries a bracket. Counting only
+ * the pin's 25 would prove nothing, for the reason spelled out below.
+ *
+ * The two shapes already coexist in one file though — src/tools/field-selection.ts
  * declares `as const` arrays at :36, :60, :121 and :151 (closing at :47, :68,
  * :127 and :158) and carries bracket-bearing hint literals at :89, :105-106,
- * :137 and
- * :169 — so a `fields:`-hint list landing in one is a plausible next commit
- * rather than a hypothetical. Tracked as #696.
+ * :137 and :169 — so a `fields:`-hint list landing in one is a plausible next
+ * commit rather than a hypothetical. Tracked as #696.
  *
  * ASSUMPTION, another silent-drop mode and the likeliest of them to actually
  * happen: every member is written with SINGLE quotes. `.prettierrc.json` sets
@@ -148,7 +155,8 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * is the hazard itself, not evidence against it. The falsifiable form is to
  * bracket-match every as-const array in src/, discoverable or not, and compare
  * counts: 25 of them, the same 25 the pin holds, none written with a
- * double-quoted or backtick member. Nothing is hidden today. Likely against
+ * double-quoted or backtick member. Nothing is hidden today — subject to the
+ * same caveat as that scan above: it is a check, not a proof. Likely against
  * the first human-readable list anyone adds. Tracked as #696 with the rest of
  * the family.
  */
@@ -175,9 +183,14 @@ function tsFilesUnder(dir: string): string[] {
  * `//` or a block-comment opener. Scoped on purpose, because the unscoped
  * version is false — three URL literals in src/ do contain `//`
  * (src/core/graphql/client.ts, src/core/auth/browser-token.ts,
- * src/core/database.ts) and this helper mangles all three. They are harmless
- * only because none sits in an `as const` array, which is the sole text the
- * matcher reads. Note WHAT was checked, because the distinction is the whole
+ * src/core/database.ts) and this helper mangles all three. Note that the reason
+ * they are harmless is narrower than "they are not in an array": this helper is
+ * applied to the WHOLE file, so stripping deletes from each `//` to end of
+ * line wherever it occurs. They are harmless because none of those three LINES
+ * carries an `as const` declaration, so the text destroyed is text the matcher
+ * would not have matched. Put a URL inside a member and the constant is gone:
+ * `export const U = ['https://x'] as const` does not survive stripping.
+ * Note WHAT was checked, because the distinction is the whole
  * point of this helper: the count is over extracted member VALUES, after
  * stripping. Two of the 25 raw bodies — IGNORED_ITEM_FIELDS and
  * KNOWN_FREQUENCIES — do contain `//`, as the line comments this helper exists
@@ -247,12 +260,20 @@ function collectStringConstants(source: string): Map<string, readonly string[]> 
  *
  *   arrays differ, pin matches the WINNER -> all three green, and the loser is a
  *     live declaration in src/ that no test touches. Silent, stable, indefinite.
- *     This is the dangerous one, and the likeliest: a real collision is two
- *     unrelated lists sharing a name far more often than two copies of one list.
+ *     The dangerous one, and the one the workflow RATCHETS TOWARDS — see below.
  *   arrays differ, pin matches the LOSER  -> contents red, but only on machines
  *     whose readdirSync order produces that winner. Loud where it fires.
  *   arrays identical                      -> quiet and stable; the loser is
  *     uncovered but currently says the same thing, until it drifts.
+ *
+ * The ratchet, which is why row 2 is not merely one outcome in three: `PINNED`
+ * entries are authored from what discovery REPORTS. So row 3 does not persist —
+ * the author sees contents red, reconciles the pin against the actual output,
+ * i.e. against the winner, and lands in row 2. Row 3 decays into row 2 on
+ * whichever machine last edited the pin, and that is also why row 2 presents as
+ * a CROSS-MACHINE symptom: the same pin matches the winner here and the loser
+ * on a machine whose readdirSync order differs. Not a probability argument — a
+ * property of how the pin gets written.
  *
  * Unlike its siblings, no branch drops a NAME the backward check could notice:
  * this one substitutes rather than drops. Tracked as #694.

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -73,11 +73,14 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * whose members are all SINGLE-QUOTED string literals, so a constant built from
  * spreads, identifiers or numbers is not swept in.
  *
- * FLAGS: `m` is load-bearing — `^` anchors every attempt to a line start, which
- * is what stops a failed match from restarting mid-line. `s` is vestigial: no
- * `.` remains in the pattern, and `[^[\]]` / `[^=]` cross newlines by
- * themselves. The character class below is explained in enough detail to
- * suggest every flag was chosen; this one was not.
+ * FLAGS: `m` is load-bearing. Without it `^` matches only at index 0, so each
+ * file yields at most its first declaration and discovery collapses — measured,
+ * not assumed: dropping `m` takes the sweep from 25 constants to 0. With it,
+ * `^` also anchors every attempt to a line start, so a failed match cannot
+ * restart mid-line. `s` is vestigial: no `.` remains in the pattern, and
+ * `[^[\]]` / `[^=]` cross newlines by themselves. The character class below is
+ * explained in enough detail to suggest every flag was chosen; this one was
+ * not.
  *
  * The body is `[^[\]]*?`, not `.*?`: a lazy dotall body lets a declaration
  * that is NOT `as const` scan forward to the next `] as const` anywhere later
@@ -103,9 +106,8 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * :169 — so a `fields:`-hint list landing in one is a plausible next commit
  * rather than a hypothetical. Tracked as #696.
  *
- * ASSUMPTION, the fifth silent-drop mode this file has had to name and the
- * likeliest of them to actually happen: every member is written with SINGLE
- * quotes. `.prettierrc.json` sets `singleQuote: true`, but Prettier's
+ * ASSUMPTION, another silent-drop mode and the likeliest of them to actually
+ * happen: every member is written with SINGLE quotes. `.prettierrc.json` sets `singleQuote: true`, but Prettier's
  * fewer-escapes rule flips any string whose content holds an apostrophe to
  * double quotes, so `bun run format` itself produces:
  *
@@ -189,7 +191,20 @@ function collectStringConstants(source: string): Map<string, readonly string[]> 
   return found;
 }
 
-/** The tree-wide sweep: collectStringConstants applied to every .ts under src/. */
+/**
+ * The tree-wide sweep: collectStringConstants applied to every .ts under src/.
+ *
+ * ASSUMPTION, and the one member of the family with teeth: constant names are
+ * unique across src/. The map is keyed by name alone, so two files exporting
+ * the same name collapse last-write-wins. All 25 are unique today.
+ *
+ * Worse than its siblings in kind, not just degree. They DROP a constant, which
+ * the backward check catches the moment it is pinned. This one SUBSTITUTES one:
+ * the name stays present, the members silently become the other file's, and the
+ * winner is decided by readdirSync order. So the contents test can be green on
+ * one machine and red on another, with nothing in this file to explain why.
+ * Tracked as #694.
+ */
 function discoverStringConstants(): Map<string, readonly string[]> {
   const found = new Map<string, readonly string[]>();
   for (const file of tsFilesUnder(SRC_ROOT)) {

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -69,8 +69,15 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
 /**
  * Matches `export const NAME = [ ...string literals... ] as const`, with an
  * optional type annotation. Deliberately narrow: it requires the `as const`
- * suffix and rejects any array containing a non-string-literal member, so a
- * constant built from spreads, identifiers or numbers is not swept in.
+ * suffix, and the purity check in collectStringConstants keeps only arrays
+ * whose members are all SINGLE-QUOTED string literals, so a constant built from
+ * spreads, identifiers or numbers is not swept in.
+ *
+ * FLAGS: `m` is load-bearing — `^` anchors every attempt to a line start, which
+ * is what stops a failed match from restarting mid-line. `s` is vestigial: no
+ * `.` remains in the pattern, and `[^[\]]` / `[^=]` cross newlines by
+ * themselves. The character class below is explained in enough detail to
+ * suggest every flag was chosen; this one was not.
  *
  * The body is `[^[\]]*?`, not `.*?`: a lazy dotall body lets a declaration
  * that is NOT `as const` scan forward to the next `] as const` anywhere later
@@ -90,10 +97,30 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * than eliminating the class.
  *
  * No such literal sits in an `as const` array in src/ today. The two shapes
- * already coexist in one file though — src/tools/field-selection.ts has
- * `as const` arrays at :47 and :68 and bracket-carrying hint literals at :89,
- * :137 and :169 — so a `fields:`-hint list landing in one is a plausible next
- * commit rather than a hypothetical. Tracked as #696.
+ * already coexist in one file though — src/tools/field-selection.ts declares
+ * `as const` arrays at :36, :60, :121 and :151 (closing at :47, :68, :127 and
+ * :158) and carries bracket-bearing hint literals at :89, :105-106, :137 and
+ * :169 — so a `fields:`-hint list landing in one is a plausible next commit
+ * rather than a hypothetical. Tracked as #696.
+ *
+ * ASSUMPTION, the fifth silent-drop mode this file has had to name and the
+ * likeliest of them to actually happen: every member is written with SINGLE
+ * quotes. `.prettierrc.json` sets `singleQuote: true`, but Prettier's
+ * fewer-escapes rule flips any string whose content holds an apostrophe to
+ * double quotes, so `bun run format` itself produces:
+ *
+ *     export const MSGS = ["can't", 'ok'] as const;
+ *
+ * The item extractor then pairs the apostrophe in `can't` with the quote that
+ * opens `ok` — items come back as `["t\", "]`, residue as `"canok'` — the
+ * purity check fails, and the constant is dropped. Backtick members behave the
+ * same way. This is NOT the "not a string literal" rejection described at the
+ * top: a double-quoted string IS a string literal, so a reader checking whether
+ * their new constant is covered concludes that it is. Same shape as #677 — not
+ * "the pin rejects this" but "the pin never saw it." Unlikely against today's
+ * members, which are snake_case field names and SCREAMING_CASE enum values;
+ * likely against the first human-readable list anyone adds. Tracked as #696
+ * with the rest of the family.
  */
 const EXPORTED_ARRAY =
   /^export const ([A-Z][A-Z0-9_]*)\s*(?::[^=]+)?=\s*\[([^[\]]*?)\]\s*as const/gms;

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -127,12 +127,17 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * goes uncounted — the same class of blind spot as the matcher it is meant to
  * outperform. A balanced pair split across concatenated literals is fine, since
  * the walk never needed them to be in the same literal. Today the net holds: 33
- * declarations match `export const NAME = [`, 25 land on `as const` and 8
- * correctly do not, and src/'s only two unbalanced-bracket literals
- * (src/tools/field-selection.ts:105 and :106, which balance each other) sit
- * inside an object literal the array walk never enters. That 25 is the same 25
- * the pin holds, and none of their literals carries a bracket. Counting only
- * the pin's 25 would prove nothing, for the reason spelled out below.
+ * declarations match `export const NAME = [` — run WITH the optional type
+ * annotation the grammar allows (`NAME: readonly T[] =`, the shape
+ * CONFORMANCE_LEDGER uses), which is not a detail: run without it the same
+ * opener returns 25, the grammar's own population exactly, and the check cannot
+ * fail, because the 8 that miss `as const` ARE the 8 annotated declarations.
+ * Of the 33, 25 land on `as const` and 8 correctly do not, and src/'s only two
+ * unbalanced-bracket literals (src/tools/field-selection.ts:105 and :106, which
+ * balance each other) sit inside an object literal the array walk never enters.
+ * That 25 is the same 25 the pin holds, and none of their literals carries a
+ * bracket. Counting only the pin's 25 would prove nothing, for the reason
+ * spelled out below.
  *
  * The two shapes already coexist in one file though — src/tools/field-selection.ts
  * declares `as const` arrays at :36, :60, :121 and :151 (closing at :47, :68,
@@ -267,8 +272,8 @@ function collectStringConstants(source: string): Map<string, readonly string[]> 
  *     indefinite on machines whose readdirSync order produces that winner;
  *     elsewhere the same pin matches the LOSER instead. The dangerous one, and
  *     the one the workflow RATCHETS TOWARDS — see below.
- *   arrays differ, pin matches the LOSER  -> contents red, but only on machines
- *     whose readdirSync order produces that winner. Loud where it fires.
+ *   arrays differ, pin matches the LOSER  -> contents red, but only where
+ *     readdirSync order makes the OTHER file win. Loud where it fires.
  *   arrays identical                      -> quiet and stable; the loser is
  *     uncovered but currently says the same thing, until it drifts.
  *
@@ -506,6 +511,24 @@ describe('exported string constants are pinned (#635 class detector)', () => {
     const found = collectStringConstants(snippet);
     expect(found.has('NOT_A_PIN')).toBe(false);
     expect([...(found.get('AFTER_THE_LEDGER') ?? [])]).toEqual(['alpha', 'beta']);
+  });
+
+  test('an annotated declaration is still discovered', () => {
+    // The complement of the boundary snippet above, and the reason it is
+    // needed: an annotation appears nowhere else in this file except on a
+    // declaration asserted ABSENT (NOT_A_PIN there, CONFORMANCE_LEDGER above),
+    // and nothing in the tree exercises it either — the 8 annotated
+    // declarations in src/ are exactly the 8 the grammar excludes for missing
+    // `as const`, so no input from the tree reaches the accepting branch
+    // today. Delete `(?::[^=]+)?` from the grammar and every other test in this
+    // file stays green; that was checked by deleting it, not assumed. Not a
+    // hypothetical shape: src/ writes it eight times today, and one of them
+    // acquiring `as const` is a plausible next commit — which would then leave
+    // discovery without a word, the #677 failure again.
+    const found = collectStringConstants(
+      "export const ANNOTATED: readonly string[] = ['a', 'b'] as const;"
+    );
+    expect([...(found.get('ANNOTATED') ?? [])]).toEqual(['a', 'b']);
   });
 
   test('forward: every exported string constant in src/ is pinned', () => {

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -3,6 +3,16 @@
  * `src/` — 25 of them across 15 files today. Deliberately not "every constant":
  * SCOPE below names what this grammar cannot see.
  *
+ * On the number 25, which these comments quote in several places: it is a
+ * SNAPSHOT as of this PR, not an invariant. No test enforces it — the floor is
+ * `>= 20` on purpose (see the guards-the-guard test), so adding the 26th
+ * constant makes every "25" here stale at once and nothing goes red. The
+ * workflow gives no prompt either: forward fails, you add a `PINNED` entry,
+ * forward passes, and no comment is touched. Treat the counts as "true when
+ * written" and the CHECKS beside them as the evidence; where a count is
+ * load-bearing it is stated as a comparison between two numbers derived
+ * separately, which stays meaningful whatever the totals become.
+ *
  * WHY THIS FILE EXISTS
  *
  * The repo's #635 bug class: "deleting a field from a preset survived all
@@ -84,8 +94,7 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * `^` also anchors every attempt to a line start, so a failed match cannot
  * restart mid-line. `s` is vestigial: no `.` remains in the pattern, and
  * `[^[\]]` / `[^=]` cross newlines by themselves. The character class below is
- * explained in enough detail to suggest every flag was chosen; this one was
- * not.
+ * explained in enough detail to suggest every flag was chosen; this one was not.
  *
  * The body is `[^[\]]*?`, not `.*?`: a lazy dotall body lets a declaration
  * that is NOT `as const` scan forward to the next `] as const` anywhere later
@@ -104,12 +113,18 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * a multi-declaration silent drop for a single-declaration silent drop rather
  * than eliminating the class.
  *
- * No such literal sits in an `as const` array in src/ today — checked by
- * bracket-matching each `export const NAME = [ ... ] as const` body and
- * scanning its literals: zero of 25. The two shapes
- * already coexist in one file though — src/tools/field-selection.ts declares
- * `as const` arrays at :36, :60, :121 and :151 (closing at :47, :68, :127 and
- * :158) and carries bracket-bearing hint literals at :89, :105-106, :137 and
+ * No such literal sits in an `as const` array in src/ today. The denominator is
+ * the load-bearing part: the scan bracket-matches EVERY
+ * `export const NAME = [ ... ] as const` in src/, discoverable by this grammar
+ * or not — a balanced walk pairs an inner `[` with its inner `]` and still
+ * reaches the real closer, so a bracket-carrying array cannot hide from it the
+ * way it hides from the matcher above. That population is 25, the same 25 the
+ * pin holds, and none of their literals carries a bracket. Counting only the
+ * pin's 25 would prove nothing, for the reason spelled out below. The two
+ * shapes already coexist in one file though — src/tools/field-selection.ts
+ * declares `as const` arrays at :36, :60, :121 and :151 (closing at :47, :68,
+ * :127 and :158) and carries bracket-bearing hint literals at :89, :105-106,
+ * :137 and
  * :169 — so a `fields:`-hint list landing in one is a plausible next commit
  * rather than a hypothetical. Tracked as #696.
  *
@@ -133,9 +148,9 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * is the hazard itself, not evidence against it. The falsifiable form is to
  * bracket-match every as-const array in src/, discoverable or not, and compare
  * counts: 25 of them, the same 25 the pin holds, none written with a
- * double-quoted or backtick member. Nothing is hidden today. Likely against the
- * first
- * human-readable list anyone adds. Tracked as #696 with the rest of the family.
+ * double-quoted or backtick member. Nothing is hidden today. Likely against
+ * the first human-readable list anyone adds. Tracked as #696 with the rest of
+ * the family.
  */
 const EXPORTED_ARRAY =
   /^export const ([A-Z][A-Z0-9_]*)\s*(?::[^=]+)?=\s*\[([^[\]]*?)\]\s*as const/gms;
@@ -225,14 +240,22 @@ function collectStringConstants(source: string): Map<string, readonly string[]> 
  * are precisely what the map hides, so `discovered.size === 25` would hold
  * either way.
  *
- * Two forms, and the likelier one is the quiet one. Usually the loser is simply
- * never seen: the winner's members get pinned, the NAME is present either way so
- * forward and backward are both satisfied, and the second declaration receives
- * no coverage at all — stably, on every machine. Only when the two arrays DIFFER
- * does readdirSync order start to decide anything, and then the contents test
- * can be red on one machine and green on another. That form is at least loud
- * where it fires. Unlike its siblings, neither form drops a NAME the backward
- * check could notice: this one substitutes rather than drops. Tracked as #694.
+ * The branch that decides how bad it gets is WHICH FILE WINS RELATIVE TO WHAT
+ * THE PIN HOLDS — not whether the two arrays agree. The name is present either
+ * way, so forward and backward are satisfied in every case and only the contents
+ * test can move:
+ *
+ *   arrays differ, pin matches the WINNER -> all three green, and the loser is a
+ *     live declaration in src/ that no test touches. Silent, stable, indefinite.
+ *     This is the dangerous one, and the likeliest: a real collision is two
+ *     unrelated lists sharing a name far more often than two copies of one list.
+ *   arrays differ, pin matches the LOSER  -> contents red, but only on machines
+ *     whose readdirSync order produces that winner. Loud where it fires.
+ *   arrays identical                      -> quiet and stable; the loser is
+ *     uncovered but currently says the same thing, until it drifts.
+ *
+ * Unlike its siblings, no branch drops a NAME the backward check could notice:
+ * this one substitutes rather than drops. Tracked as #694.
  */
 function discoverStringConstants(): Map<string, readonly string[]> {
   const found = new Map<string, readonly string[]>();

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -85,6 +85,28 @@ function tsFilesUnder(dir: string): string[] {
 }
 
 /**
+ * Strip line and block comments so the matcher can see the array literal
+ * underneath. Without this an inline `//` leaves residue, the purity check in
+ * collectStringConstants rejects the array, and the constant drops out of the
+ * pin without a word.
+ *
+ * ASSUMPTION: no string literal in `src/` contains `//` or a block-comment
+ * opener. Stated rather than left implicit because the failure is SILENT in
+ * exactly this file's own direction: mangling a literal makes the residue check
+ * reject the array and drop it from the pin. That is a known limitation, not
+ * something to work around here — a URL inside an exported `as const` array is
+ * the realistic case, and making this string-aware is the fix if one ever
+ * lands. Tracked separately.
+ *
+ * Same helper and same caveat as tests/core/decoder-field-completeness.test.ts,
+ * duplicated on purpose rather than shared, so neither file's parsing rules can
+ * be changed out from under the other.
+ */
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
+/**
  * Collect every exported string-literal `as const` array in ONE file's source
  * text.
  *
@@ -93,20 +115,6 @@ function tsFilesUnder(dir: string): string[] {
  * of what that tree happens to contain today. Feeding it a synthetic snippet
  * lets the tests below pin the parsing rules themselves.
  */
-/**
- * ASSUMPTION: no string literal in `src/` contains `//` or a block-comment
- * opener. Stated rather than left implicit because the failure is SILENT in
- * exactly this file's own direction: mangling a literal makes the residue
- * check reject the array and drop it from the pin. Making this string-aware is
- * the fix if a URL ever lands in an exported `as const` array. Same helper and
- * same caveat as tests/core/decoder-field-completeness.test.ts; duplicated on
- * purpose rather than shared, so neither file's parsing rules can be changed
- * out from under the other.
- */
-function stripComments(text: string): string {
-  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
-}
-
 function collectStringConstants(source: string): Map<string, readonly string[]> {
   const found = new Map<string, readonly string[]>();
   // Strip comments before matching: an inline `//` inside an array literal
@@ -126,6 +134,7 @@ function collectStringConstants(source: string): Map<string, readonly string[]> 
   return found;
 }
 
+/** The tree-wide sweep: collectStringConstants applied to every .ts under src/. */
 function discoverStringConstants(): Map<string, readonly string[]> {
   const found = new Map<string, readonly string[]>();
   for (const file of tsFilesUnder(SRC_ROOT)) {

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -76,18 +76,35 @@ function tsFilesUnder(dir: string): string[] {
   return out;
 }
 
+/**
+ * Collect every exported string-literal `as const` array in ONE file's source
+ * text.
+ *
+ * Split out from the tree walk on purpose: a discovery mechanism whose only
+ * input is the real source tree can only be mutation-tested by the accidents
+ * of what that tree happens to contain today. Feeding it a synthetic snippet
+ * lets the tests below pin the parsing rules themselves.
+ */
+function collectStringConstants(source: string): Map<string, readonly string[]> {
+  const found = new Map<string, readonly string[]>();
+  const text = source;
+  for (const match of text.matchAll(EXPORTED_ARRAY)) {
+    const [, name, rawBody] = match;
+    if (name === undefined || rawBody === undefined) continue;
+    const items = [...rawBody.matchAll(/'([^']*)'/g)].map((m) => m[1] as string);
+    // Everything that is not a string literal, comma or whitespace: if
+    // anything remains, the array is not purely string literals.
+    const residue = rawBody.replace(/'[^']*'|,|\s/g, '');
+    if (items.length > 0 && residue === '') found.set(name, items);
+  }
+  return found;
+}
+
 function discoverStringConstants(): Map<string, readonly string[]> {
   const found = new Map<string, readonly string[]>();
   for (const file of tsFilesUnder(SRC_ROOT)) {
-    const text = readFileSync(file, 'utf-8');
-    for (const match of text.matchAll(EXPORTED_ARRAY)) {
-      const [, name, rawBody] = match;
-      if (name === undefined || rawBody === undefined) continue;
-      const items = [...rawBody.matchAll(/'([^']*)'/g)].map((m) => m[1] as string);
-      // Everything that is not a string literal, comma or whitespace: if
-      // anything remains, the array is not purely string literals.
-      const residue = rawBody.replace(/'[^']*'|,|\s/g, '');
-      if (items.length > 0 && residue === '') found.set(name, items);
+    for (const [name, items] of collectStringConstants(readFileSync(file, 'utf-8'))) {
+      found.set(name, items);
     }
   }
   return found;
@@ -226,6 +243,39 @@ describe('exported string constants are pinned (#635 class detector)', () => {
 
   test('discovery finds constants at all (guards the guard)', () => {
     expect(discoveredNames.length).toBeGreaterThan(0);
+  });
+
+  test('discovery sees arrays containing inline comments', () => {
+    const found = discoverStringConstants();
+    // Both carry inline `//` comments inside the array literal.
+    expect(found.has('KNOWN_FREQUENCIES')).toBe(true);
+    expect(found.has('IGNORED_ITEM_FIELDS')).toBe(true);
+  });
+
+  test('a non-as-const array does not swallow the as-const arrays after it', () => {
+    const found = discoverStringConstants();
+    // CONFORMANCE_LEDGER (src/conformance/ledger.ts) is `readonly LedgerEntry[]`
+    // with no `as const`; it must not consume the declarations that follow it.
+    expect(found.has('CONFORMANCE_LEDGER')).toBe(false);
+    expect(found.size).toBeGreaterThanOrEqual(25);
+  });
+
+  test('declaration boundaries: a non-as-const array cannot reach a later `] as const`', () => {
+    // The tree-level assertion above can only catch this by accident — today no
+    // `as const` array happens to sit after a non-`as const` one in the same
+    // file, so the tree cannot tell a correct matcher from a greedy one. This
+    // snippet can, which is what makes the boundary rule mutation-detectable.
+    const snippet = [
+      'export const NOT_A_PIN: readonly Thing[] = [',
+      '  { field: 1 },',
+      '];',
+      '',
+      "export const AFTER_THE_LEDGER = ['alpha', 'beta'] as const;",
+      '',
+    ].join('\n');
+    const found = collectStringConstants(snippet);
+    expect(found.has('NOT_A_PIN')).toBe(false);
+    expect([...(found.get('AFTER_THE_LEDGER') ?? [])]).toEqual(['alpha', 'beta']);
   });
 
   test('forward: every exported string constant in src/ is pinned', () => {

--- a/tests/exported-constants.test.ts
+++ b/tests/exported-constants.test.ts
@@ -63,8 +63,16 @@ const SRC_ROOT = join(import.meta.dir, '..', 'src');
  * optional type annotation. Deliberately narrow: it requires the `as const`
  * suffix and rejects any array containing a non-string-literal member, so a
  * constant built from spreads, identifiers or numbers is not swept in.
+ *
+ * The body is `[^[\]]*?`, not `.*?`: a lazy dotall body lets a declaration
+ * that is NOT `as const` scan forward to the next `] as const` anywhere later
+ * in the file and swallow every declaration in between, which drops them from
+ * the pin silently. Bounding the body to bracket-free text stops the match at
+ * its own declaration. Costs nothing here — a pure string-literal array holds
+ * no brackets by construction.
  */
-const EXPORTED_ARRAY = /^export const ([A-Z][A-Z0-9_]*)\s*(?::[^=]+)?=\s*\[(.*?)\]\s*as const/gms;
+const EXPORTED_ARRAY =
+  /^export const ([A-Z][A-Z0-9_]*)\s*(?::[^=]+)?=\s*\[([^[\]]*?)\]\s*as const/gms;
 
 function tsFilesUnder(dir: string): string[] {
   const out: string[] = [];
@@ -85,9 +93,27 @@ function tsFilesUnder(dir: string): string[] {
  * of what that tree happens to contain today. Feeding it a synthetic snippet
  * lets the tests below pin the parsing rules themselves.
  */
+/**
+ * ASSUMPTION: no string literal in `src/` contains `//` or a block-comment
+ * opener. Stated rather than left implicit because the failure is SILENT in
+ * exactly this file's own direction: mangling a literal makes the residue
+ * check reject the array and drop it from the pin. Making this string-aware is
+ * the fix if a URL ever lands in an exported `as const` array. Same helper and
+ * same caveat as tests/core/decoder-field-completeness.test.ts; duplicated on
+ * purpose rather than shared, so neither file's parsing rules can be changed
+ * out from under the other.
+ */
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
 function collectStringConstants(source: string): Map<string, readonly string[]> {
   const found = new Map<string, readonly string[]>();
-  const text = source;
+  // Strip comments before matching: an inline `//` inside an array literal
+  // leaves residue that the purity check below rejects, so a commented array
+  // is dropped from the pin without a word. An under-reporting pin is
+  // indistinguishable from a passing one.
+  const text = stripComments(source);
   for (const match of text.matchAll(EXPORTED_ARRAY)) {
     const [, name, rawBody] = match;
     if (name === undefined || rawBody === undefined) continue;
@@ -185,6 +211,15 @@ const PINNED: Record<string, readonly string[]> = {
     'internal_transfer',
   ],
   // src/models/item.ts
+  IGNORED_ITEM_FIELDS: [
+    'access_token',
+    'deleted_access_token',
+    'akoya',
+    'available_products',
+    'billed_products',
+    'optional_products',
+  ],
+  // src/models/item.ts
   KNOWN_ERROR_CODES: [
     'ITEM_LOGIN_REQUIRED',
     'INVALID_CREDENTIALS',
@@ -196,6 +231,18 @@ const PINNED: Record<string, readonly string[]> = {
     'INSTITUTION_DOWN',
     'INSTITUTION_NOT_RESPONDING',
     'INSTITUTION_NO_LONGER_SUPPORTED',
+  ],
+  // src/models/recurring.ts
+  KNOWN_FREQUENCIES: [
+    'daily',
+    'weekly',
+    'biweekly',
+    'monthly',
+    'bimonthly',
+    'quarterly',
+    'quadmonthly',
+    'semiannually',
+    'yearly',
   ],
   // src/models/budget.ts
   KNOWN_PERIODS: ['monthly', 'yearly', 'weekly', 'daily'],


### PR DESCRIPTION
# Summary

`tests/exported-constants.test.ts` pins every exported string-literal array in `src/` so a
member cannot be added or removed unnoticed. Its discovery step could not see past a `//`,
so two constants were never in the pinned set at all — the guard reported success over a
set it had silently under-collected.

Closes #677

## What was wrong

**Live:** discovery ran on raw source, so any array containing an inline comment failed the
"is this purely string literals?" residue check and was dropped. Two real constants were
outside the pin: `KNOWN_FREQUENCIES` (`src/models/recurring.ts`, six inline comments) and
`IGNORED_ITEM_FIELDS` (`src/models/item.ts`, three). Discovery now covers 25 constants, up
from 23.

**Latent:** the array-body matcher used a lazy dotall `(.*?)`, so an array without `as const`
could scan forward to the next `] as const` and swallow the declarations between.

The audit finding was **correct about the mechanism**, and an earlier draft of this PR said
otherwise — that draft is wrong and has been corrected. Tracing the old matcher from
`src/conformance/ledger.ts:305`: the `as const` arrays at `:59` and `:78` are behind the sweep
cursor by then, so the first `] as const` ahead is the *inline*
`(['id', 'accountId', 'itemId'] as const)` at `:493`. The match fires, spanning 305 to 493.

Nothing is lost from the pin only because that swallowed span contains no exported
string-literal `as const` **declaration** — verified with
`awk 'NR>=305 && NR<=493 && /^export const/'`, which returns line 305 itself and nothing else.
That is an accident of today's tree, not a property of it. So the fix is hardening rather than
a live-hole repair, but the reason is "the swallowed span happens to be empty of declarations",
not "the match never happens".

## Bug fix?

Root cause:       Discovery parsed raw source, so a `//` inside an array literal made the residue check reject the whole declaration and drop the constant.
Bug class:        A discovery regex that under-reports silently — the pinned set is derived from a scan that cannot see everything it claims to cover, so a passing guard and an incomplete guard are indistinguishable.
Detector added:   `collectStringConstants(source)` split out of the tree walk, with tests that run it against synthetic snippets: one pinning that inline comments are seen, one pinning the declaration boundary. Both fail if their fix is reverted.
Siblings checked: `tests/core/decoder-field-completeness.test.ts` already strips comments before its census scan — but only for that one scan; its other scanners still run on raw source. That is the same class and is being fixed separately in this batch (#685). No other discovery-style scanner in `tests/` parses source without stripping.
Ledger updated:   n/a — not an external-assumption bug.

## External assumptions

None

## Verification

- `bun run check` — 3024 pass / 20 skip / 0 fail
- Both new `PINNED` entries compared member-for-member against their source arrays; exact match, same order. No pre-existing entry changed.
- 25 confirmed as the correct total by independent enumeration: 33 exported uppercase array constants in `src/`, 8 legitimately outside the grammar (not pure string-literal `as const`).
- **Mutation-checked, both directions.** Comment-stripping neutered → 3 tests red. Boundary matcher reverted to `(.*?)` → 1 test red. That second mutation is the reason for the `collectStringConstants` split: neither of the two tests originally specified for this fix detects it, so without the split this PR would have shipped a change that survives its own deletion — in a PR about a guard that survived its own deletion.

## Known limitation

The comment stripper is not string-aware, so a literal containing `//` (a URL) would drop
its constant from discovery. No such literal exists in `src/` today and the assumption is
stated in the helper's doc comment. Tracked as #691 rather than expanded here.
