### PR TITLE
test(guards): make the decoder and dedup guards able to fail

### DIFF
--- a/docs/bugs/662-account-dedup-drops-documents.md
+++ b/docs/bugs/662-account-dedup-drops-documents.md
@@ -106,7 +106,7 @@ allocation — and pins the **key expression** it tests. A block that is new, re
 whose key changes from an id to a content field fails there, and every block must be
 twin-tested, structural, or explicitly listed as untested-by-choice.
 
-That shape was reached over four revisions, each of which review showed was narrower than
+That shape was reached over five revisions, each of which review showed was narrower than
 its own comment claimed:
 
 | Revision | Discovered by | What it missed |
@@ -114,7 +114,8 @@ its own comment claimed:
 | 1 | nothing — five hand-written tests | claimed "every collection"; covered five |
 | 2 | `// Label: dedupe by` comments | the nine standalone decoders, which write `// Deduplicate by` |
 | 3 | both comment forms, keyed by label | three blocks share one comment; a duplicate label overwrote rather than added |
-| 4 | dedup blocks, pinning the key expression | — |
+| 4 | dedup blocks, pinning the key expression | three blocks pinned the local name `key` rather than what it resolves to — a bare identifier that pins nothing, since changing what `key` is built from would not move it |
+| 5 | bare identifiers resolved to their assigned expression, and asserted never to appear | — |
 
 The revision-3 gap is worth recording because it is this bug's own shape: one comment
 above three blocks meant `acSeen.has(ac.change_id)` could become `acSeen.has(ac.description)`
@@ -123,9 +124,12 @@ with the whole suite green. And revision 2 could not see
 the previous instance of this exact class, invisible to the detector written for it.
 
 **Mutation-verified** at each revision, and the mutations are the record of what each one
-actually caught. At revision 4: reintroducing the old account key turns three tests red;
+actually caught. At revision 5: reintroducing the old account key turns three tests red;
 changing the investment-prices key, the `acSeen` key, or adding an uncommented dedup block
-each fail the coverage guard. All three of those passed before revision 4.
+each fail the coverage guard; a new block keyed on an unresolvable identifier now fails
+too. All of those passed before revision 5 — the last is the gap revision 4 itself left
+open, closed by resolving bare identifiers to their assignment and asserting one never
+survives unresolved.
 
 Note what this detector still cannot see: it proves distinct documents survive, not that
 true storage duplicates are collapsed. `createTestDb` writes one row per id, so a genuine

--- a/docs/bugs/662-account-dedup-drops-documents.md
+++ b/docs/bugs/662-account-dedup-drops-documents.md
@@ -106,7 +106,7 @@ allocation — and pins the **key expression** it tests. A block that is new, re
 whose key changes from an id to a content field fails there, and every block must be
 twin-tested, structural, or explicitly listed as untested-by-choice.
 
-That shape was reached over six revisions, each of which review showed was narrower than
+That shape was reached over seven revisions, each of which review showed was narrower than
 its own comment claimed:
 
 | Revision | Discovered by | What it missed |
@@ -117,6 +117,7 @@ its own comment claimed:
 | 4 | dedup blocks, pinning the key expression | three blocks pinned the local name `key` rather than what it resolves to — a bare identifier that pins nothing, since changing what `key` is built from would not move it |
 | 5 | bare identifiers resolved to their assigned expression, and asserted never to appear | a RESOLVED expression can still pin nothing: `key = keyFor(row)` is not a bare word, so it passed, but reimplementing `keyFor` to hash a different property leaves that exact string unchanged — the resolution closed the literal-bare-word case, not the opaque-call case |
 | 6 | resolved expressions required to contain a property access (`.someField`), not just be non-bare | the check is on the call SITE's text, not on what the call actually returns: `key = keyFor(row.id)` contains `.id`, so it passes, even though `keyFor` could compute anything from that argument — narrows the opaque-call class rather than closing it |
+| 7 | the scanner itself: `discoverDedupBlocks` matches against a comment-stripped window and takes a `source` seam, so revisions 5 and 6 are pinned by committed fixtures | the enclosing-function scan still reads raw source, and `stripComments`'s own string-literal assumption is unchanged — a string containing `//` inside a scanned window would still eat the rest of that line |
 
 The revision-3 gap is worth recording because it is this bug's own shape: one comment
 above three blocks meant `acSeen.has(ac.change_id)` could become `acSeen.has(ac.description)`
@@ -134,6 +135,18 @@ itself left open: resolving a bare identifier to its assignment closed the "pins
 case for a literal bare word, but a resolved call with no property access pins nothing
 just as surely, and nothing caught that until revision 6 required the resolved expression
 to name a field.
+
+Revision 7's mutations, each run as `bun test tests/core/dedup-identity.test.ts` with the
+mutation applied and then restored: dropping `stripComments` from `discoverDedupBlocks`'s
+window turns 2 tests red; deleting its duplicate-block throw, 1; deleting its bare-identifier
+resolution, 5; adding a 26th dedup block to `decodeAllCollections` in the real decoder, 3.
+The one worth recording is gutting `fieldFreeBlocks` to `return []` — the live "no block is
+pinned to a bare identifier or a field-free expression" test **stays green**, because real
+decoder source contains no violation for it to find, and only the new fixture goes red. That
+is this PR's whole subject in one line: a test can execute a guard and still not detect the
+guard's deletion. The 26th-block mutation also shows why the count pin was tightened from
+`>= 25` to `toBe(25)`: run against the same mutated decoder, the old one-sided assertion
+stayed green while the new one fails at `Expected: 25, Received: 26`.
 
 Note what this detector still cannot see: it proves distinct documents survive, not that
 true storage duplicates are collapsed. `createTestDb` writes one row per id, so a genuine

--- a/docs/bugs/662-account-dedup-drops-documents.md
+++ b/docs/bugs/662-account-dedup-drops-documents.md
@@ -106,7 +106,7 @@ allocation — and pins the **key expression** it tests. A block that is new, re
 whose key changes from an id to a content field fails there, and every block must be
 twin-tested, structural, or explicitly listed as untested-by-choice.
 
-That shape was reached over seven revisions, each of which review showed was narrower than
+That shape was reached over eight revisions, each of which review showed was narrower than
 its own comment claimed:
 
 | Revision | Discovered by | What it missed |
@@ -117,7 +117,8 @@ its own comment claimed:
 | 4 | dedup blocks, pinning the key expression | three blocks pinned the local name `key` rather than what it resolves to — a bare identifier that pins nothing, since changing what `key` is built from would not move it |
 | 5 | bare identifiers resolved to their assigned expression, and asserted never to appear | a RESOLVED expression can still pin nothing: `key = keyFor(row)` is not a bare word, so it passed, but reimplementing `keyFor` to hash a different property leaves that exact string unchanged — the resolution closed the literal-bare-word case, not the opaque-call case |
 | 6 | resolved expressions required to contain a property access (`.someField`), not just be non-bare | the check is on the call SITE's text, not on what the call actually returns: `key = keyFor(row.id)` contains `.id`, so it passes, even though `keyFor` could compute anything from that argument — narrows the opaque-call class rather than closing it |
-| 7 | the scanner itself: `discoverDedupBlocks` matches against a comment-stripped window and takes a `source` seam, so revisions 5 and 6 are pinned by committed fixtures | the enclosing-function scan still reads raw source, and `stripComments`'s own string-literal assumption is unchanged — a string containing `//` inside a scanned window would still eat the rest of that line |
+| 7 | the scanner itself: `discoverDedupBlocks` matches against a comment-stripped window and takes a `source` seam, so revisions 5 and 6 are pinned by committed fixtures | the window was still bounded only by a character count, so it ran off the end of its own function and could pin a Set from the *next* function's guard; and the collision message it added named a cause (`two same-named Sets in one function`) the scanner cannot actually distinguish |
+| 8 | the window bounded at the next top-level declaration as well as by `DISCOVERY_WINDOW` — 18 of the 36 real windows overran their own function — plus two prose claims corrected to match what the code can tell | attribution is still top-level-`function`-only: a Set inside an arrow function, method, or nested `function` is credited to the preceding top-level declaration and bounded by the following one. And `stripComments`'s own string-literal assumption is unchanged — a string containing `//` inside a scanned window would still eat the rest of that line |
 
 The revision-3 gap is worth recording because it is this bug's own shape: one comment
 above three blocks meant `acSeen.has(ac.change_id)` could become `acSeen.has(ac.description)`
@@ -147,6 +148,19 @@ is this PR's whole subject in one line: a test can execute a guard and still not
 guard's deletion. The 26th-block mutation also shows why the count pin was tightened from
 `>= 25` to `toBe(25)`: run against the same mutated decoder, the old one-sided assertion
 stayed green while the new one fails at `Expected: 25, Received: 26`.
+
+Revision 8 was verified the same way, and twice in the other direction first. Before
+tightening the window bound, the char-bounded and declaration-bounded resolutions were
+compared across all 36 real blocks: **18 windows overrun their own function, and 0 resolved
+keys differ** — so the bound closes a hole without moving a single pin. Then, with the
+bound in place: reverting it to a bare character count turns 2 tests red; reverting the
+softened collision message, 1; reverting `Object.create(null)` to `{}` in
+`discoverAggregatePushTargets`, 1. Reverting that same line in `discoverDedupBlocks` turns
+**nothing** red — its keys are always `enclosing|variable`, so they always contain a `|`
+and can never be the literal `__proto__` that the drop requires. That one is kept for
+symmetry between the two scanners and labelled unreachable in place, rather than left
+carrying a comment describing a guard that cannot fire: the mutation is what showed the
+comment was overclaiming, which is the same test the rest of this file is built to apply.
 
 Note what this detector still cannot see: it proves distinct documents survive, not that
 true storage duplicates are collapsed. `createTestDb` writes one row per id, so a genuine

--- a/docs/bugs/662-account-dedup-drops-documents.md
+++ b/docs/bugs/662-account-dedup-drops-documents.md
@@ -106,7 +106,7 @@ allocation — and pins the **key expression** it tests. A block that is new, re
 whose key changes from an id to a content field fails there, and every block must be
 twin-tested, structural, or explicitly listed as untested-by-choice.
 
-That shape was reached over eight revisions, each of which review showed was narrower than
+That shape was reached over nine revisions, each of which review showed was narrower than
 its own comment claimed:
 
 | Revision | Discovered by | What it missed |
@@ -118,7 +118,8 @@ its own comment claimed:
 | 5 | bare identifiers resolved to their assigned expression, and asserted never to appear | a RESOLVED expression can still pin nothing: `key = keyFor(row)` is not a bare word, so it passed, but reimplementing `keyFor` to hash a different property leaves that exact string unchanged — the resolution closed the literal-bare-word case, not the opaque-call case |
 | 6 | resolved expressions required to contain a property access (`.someField`), not just be non-bare | the check is on the call SITE's text, not on what the call actually returns: `key = keyFor(row.id)` contains `.id`, so it passes, even though `keyFor` could compute anything from that argument — narrows the opaque-call class rather than closing it |
 | 7 | the scanner itself: `discoverDedupBlocks` matches against a comment-stripped window and takes a `source` seam, so revisions 5 and 6 are pinned by committed fixtures | the window was still bounded only by a character count, so it ran off the end of its own function and could pin a Set from the *next* function's guard; and the collision message it added named a cause (`two same-named Sets in one function`) the scanner cannot actually distinguish |
-| 8 | the window bounded at the next top-level declaration as well as by `DISCOVERY_WINDOW` — 18 of the 36 real windows overran their own function — plus two prose claims corrected to match what the code can tell | attribution is still top-level-`function`-only: a Set inside an arrow function, method, or nested `function` is credited to the preceding top-level declaration and bounded by the following one. And `stripComments`'s own string-literal assumption is unchanged — a string containing `//` inside a scanned window would still eat the rest of that line |
+| 8 | the window bounded at the next top-level declaration as well as by `DISCOVERY_WINDOW` — 18 of the 36 real windows overran their own function — plus two prose claims corrected to match what the code can tell | the *name* the window then matched was still un-anchored, so a Set could borrow a longer identifier's guard — and the bound cannot help inside `decodeAllCollections`, where 25 of the 36 Sets share one function and the windows overlap freely |
+| 9 | the matched name anchored to an identifier boundary (`(?<![\w$])`), so `catSeen` no longer matches `subcatSeen.has(`; and the `'NONE'` sentinel taken out of band, so a `const NONE = row.id` can no longer rewrite "unguarded" into a field-bearing key that passes the field-free invariant | revision 6's opaque-call class (`keyFor(row.id)`) is still open; attribution is still top-level-`function`-only; and `discoverAggregatePushTargets`'s per-Set window is still a bare slice — safe because its `if (!`-anchored regex makes a run-off either throw or fail the `toBe(25)` pin, which is a reason rather than a construction |
 
 The revision-3 gap is worth recording because it is this bug's own shape: one comment
 above three blocks meant `acSeen.has(ac.change_id)` could become `acSeen.has(ac.description)`
@@ -161,6 +162,18 @@ and can never be the literal `__proto__` that the drop requires. That one is kep
 symmetry between the two scanners and labelled unreachable in place, rather than left
 carrying a comment describing a guard that cannot fire: the mutation is what showed the
 comment was overclaiming, which is the same test the rest of this file is built to apply.
+
+Revision 9's two fixtures were written **before** either fix, and all four assertions went
+red against the shipped scanner — the defects reproduce rather than being argued for. The
+verify-before-tighten check ran first here too, and came back stronger than expected: of the
+36 Sets (27 distinct names), **no name is a proper suffix of another**, so the un-anchored
+match had no live collision available to it, and anchoring changes 0 of the 36 resolved
+keys. With the fixes in, removing the `(?<![\w$])` anchor turns 2 tests red and removing the
+`use &&` sentinel gate turns 2 red. The sentinel one is the more interesting failure: it is a
+fail-**open**, where an unguarded block reports as guarded and therefore satisfies the very
+invariant this detector is named for — reached through the sentinel rather than through the
+scan, which is why "no source declares `const NONE`" was a guarantee worth removing from the
+load path rather than documenting.
 
 Note what this detector still cannot see: it proves distinct documents survive, not that
 true storage duplicates are collapsed. `createTestDb` writes one row per id, so a genuine

--- a/docs/bugs/662-account-dedup-drops-documents.md
+++ b/docs/bugs/662-account-dedup-drops-documents.md
@@ -106,7 +106,7 @@ allocation — and pins the **key expression** it tests. A block that is new, re
 whose key changes from an id to a content field fails there, and every block must be
 twin-tested, structural, or explicitly listed as untested-by-choice.
 
-That shape was reached over nine revisions, each of which review showed was narrower than
+That shape was reached over ten revisions, each of which review showed was narrower than
 its own comment claimed:
 
 | Revision | Discovered by | What it missed |
@@ -120,6 +120,7 @@ its own comment claimed:
 | 7 | the scanner itself: `discoverDedupBlocks` matches against a comment-stripped window and takes a `source` seam, so revisions 5 and 6 are pinned by committed fixtures | the window was still bounded only by a character count, so it ran off the end of its own function and could pin a Set from the *next* function's guard; and the collision message it added named a cause (`two same-named Sets in one function`) the scanner cannot actually distinguish |
 | 8 | the window bounded at the next top-level declaration as well as by `DISCOVERY_WINDOW` — 18 of the 36 real windows overran their own function — plus two prose claims corrected to match what the code can tell | the *name* the window then matched was still un-anchored, so a Set could borrow a longer identifier's guard — and the bound cannot help inside `decodeAllCollections`, where 25 of the 36 Sets share one function and the windows overlap freely |
 | 9 | the matched name anchored to an identifier boundary (`(?<![\w$])`), so `catSeen` no longer matches `subcatSeen.has(`; and the `'NONE'` sentinel taken out of band, so a `const NONE = row.id` can no longer rewrite "unguarded" into a field-bearing key that passes the field-free invariant | revision 6's opaque-call class (`keyFor(row.id)`) is still open; attribution is still top-level-`function`-only; and `discoverAggregatePushTargets`'s per-Set window is still a bare slice — safe because its `if (!`-anchored regex makes a run-off either throw or fail the `toBe(25)` pin, which is a reason rather than a construction |
+| 10 | the anchor widened to `(?<![\w$.])`, closing the member-expression half (`ctx.seen.has(...)` no longer credited to a local `seen`); and `stripComments` given a third pass, so a window truncating inside a block comment can no longer leave that comment's text being scanned as code | the lazy `[^;]*?` capture still truncates on a nested paren, pinning unparseable text such as `String(row.id` — documented at the regex rather than fixed, because capturing with `balanced()` is a behaviour change with no failing case behind it. Everything revision 9 left is also still open |
 
 The revision-3 gap is worth recording because it is this bug's own shape: one comment
 above three blocks meant `acSeen.has(ac.change_id)` could become `acSeen.has(ac.description)`
@@ -174,6 +175,20 @@ fail-**open**, where an unguarded block reports as guarded and therefore satisfi
 invariant this detector is named for — reached through the sentinel rather than through the
 scan, which is why "no source declares `const NONE`" was a guarantee worth removing from the
 load path rather than documenting.
+
+Revision 10 is the first one in this table whose defect had a **live instance** rather than
+being latent. Checking every window before tightening — the habit established four revisions
+earlier — turned up `decodeAllCollections|tagSeen`, whose `DISCOVERY_WINDOW` ends inside the
+docblock above `getDecodeTimeoutMs`: `stripComments`' block-comment pass needs the closing
+`*/`, the window does not contain one, and that prose was therefore sitting in the scanned
+string as if it were code. Harmless only because it happens to contain no `.has(` and no
+`const x = ...;`. The review that raised the shape had recorded "no live instance"; the
+check is what found otherwise, which is the argument for running it rather than reasoning
+about it. Both revision-10 fixes were again confirmed to move nothing: 0 of 36 resolved keys
+change from excluding `.` in the anchor, 0 change from the new strip pass, and 0 windows
+still hold an unterminated opener afterwards. Its three fixtures were written before either
+fix and all three went red; with the fixes in, narrowing the anchor back turns 2 red and
+dropping the strip pass turns 1 red.
 
 Note what this detector still cannot see: it proves distinct documents survive, not that
 true storage duplicates are collapsed. `createTestDb` writes one row per id, so a genuine

--- a/docs/bugs/662-account-dedup-drops-documents.md
+++ b/docs/bugs/662-account-dedup-drops-documents.md
@@ -116,7 +116,7 @@ its own comment claimed:
 | 3 | both comment forms, keyed by label | three blocks share one comment; a duplicate label overwrote rather than added |
 | 4 | dedup blocks, pinning the key expression | three blocks pinned the local name `key` rather than what it resolves to — a bare identifier that pins nothing, since changing what `key` is built from would not move it |
 | 5 | bare identifiers resolved to their assigned expression, and asserted never to appear | a RESOLVED expression can still pin nothing: `key = keyFor(row)` is not a bare word, so it passed, but reimplementing `keyFor` to hash a different property leaves that exact string unchanged — the resolution closed the literal-bare-word case, not the opaque-call case |
-| 6 | resolved expressions required to contain a property access (`.someField`), not just be non-bare | — |
+| 6 | resolved expressions required to contain a property access (`.someField`), not just be non-bare | the check is on the call SITE's text, not on what the call actually returns: `key = keyFor(row.id)` contains `.id`, so it passes, even though `keyFor` could compute anything from that argument — narrows the opaque-call class rather than closing it |
 
 The revision-3 gap is worth recording because it is this bug's own shape: one comment
 above three blocks meant `acSeen.has(ac.change_id)` could become `acSeen.has(ac.description)`

--- a/docs/bugs/662-account-dedup-drops-documents.md
+++ b/docs/bugs/662-account-dedup-drops-documents.md
@@ -106,7 +106,7 @@ allocation — and pins the **key expression** it tests. A block that is new, re
 whose key changes from an id to a content field fails there, and every block must be
 twin-tested, structural, or explicitly listed as untested-by-choice.
 
-That shape was reached over five revisions, each of which review showed was narrower than
+That shape was reached over six revisions, each of which review showed was narrower than
 its own comment claimed:
 
 | Revision | Discovered by | What it missed |
@@ -115,7 +115,8 @@ its own comment claimed:
 | 2 | `// Label: dedupe by` comments | the nine standalone decoders, which write `// Deduplicate by` |
 | 3 | both comment forms, keyed by label | three blocks share one comment; a duplicate label overwrote rather than added |
 | 4 | dedup blocks, pinning the key expression | three blocks pinned the local name `key` rather than what it resolves to — a bare identifier that pins nothing, since changing what `key` is built from would not move it |
-| 5 | bare identifiers resolved to their assigned expression, and asserted never to appear | — |
+| 5 | bare identifiers resolved to their assigned expression, and asserted never to appear | a RESOLVED expression can still pin nothing: `key = keyFor(row)` is not a bare word, so it passed, but reimplementing `keyFor` to hash a different property leaves that exact string unchanged — the resolution closed the literal-bare-word case, not the opaque-call case |
+| 6 | resolved expressions required to contain a property access (`.someField`), not just be non-bare | — |
 
 The revision-3 gap is worth recording because it is this bug's own shape: one comment
 above three blocks meant `acSeen.has(ac.change_id)` could become `acSeen.has(ac.description)`
@@ -124,12 +125,15 @@ with the whole suite green. And revision 2 could not see
 the previous instance of this exact class, invisible to the detector written for it.
 
 **Mutation-verified** at each revision, and the mutations are the record of what each one
-actually caught. At revision 5: reintroducing the old account key turns three tests red;
+actually caught. At revision 6: reintroducing the old account key turns three tests red;
 changing the investment-prices key, the `acSeen` key, or adding an uncommented dedup block
-each fail the coverage guard; a new block keyed on an unresolvable identifier now fails
-too. All of those passed before revision 5 — the last is the gap revision 4 itself left
-open, closed by resolving bare identifiers to their assignment and asserting one never
-survives unresolved.
+each fail the coverage guard; a new block keyed on an unresolvable identifier fails too;
+and a new block keyed on a RESOLVED but field-free expression (`key = keyFor(row)`) now
+fails as well. All of those passed before revision 6 — the last is the gap revision 5
+itself left open: resolving a bare identifier to its assignment closed the "pins nothing"
+case for a literal bare word, but a resolved call with no property access pins nothing
+just as surely, and nothing caught that until revision 6 required the resolved expression
+to name a field.
 
 Note what this detector still cannot see: it proves distinct documents survive, not that
 true storage duplicates are collapsed. `createTestDb` writes one row per id, so a genuine

--- a/tests/core/decoder-field-completeness.test.ts
+++ b/tests/core/decoder-field-completeness.test.ts
@@ -186,17 +186,24 @@ function stripComments(text: string): string {
  * Members of a pure string-literal array, or null if the array holds anything
  * else. Deliberately narrow, same rationale as tests/exported-constants.test.ts:
  * an array built from identifiers or numbers is not a field allow-list.
+ *
+ * `raw` is always a slice of `body` (see discoverProcessors), which is
+ * stripped once at the top of that function — no `stripComments()` call
+ * needed here, the same leftover this file's own `spec()` fix removed.
  */
 function stringLiteralMembers(raw: string): string[] | null {
-  const text = stripComments(raw);
-  const items = [...text.matchAll(/'([^']*)'/g)].map((m) => m[1] as string);
-  const residue = text.replace(/'[^']*'|,|\s/g, '');
+  const items = [...raw.matchAll(/'([^']*)'/g)].map((m) => m[1] as string);
+  const residue = raw.replace(/'[^']*'|,|\s/g, '');
   return residue === '' && items.length > 0 ? items : null;
 }
 
-/** Top-level keys of an object literal body, ignoring nested groups. */
+/**
+ * Top-level keys of an object literal body, ignoring nested groups. `literal`
+ * is always a slice of `body` (see discoverProcessors), already stripped —
+ * no `stripComments()` call needed here either.
+ */
 function topLevelKeys(literal: string): string[] {
-  let text = stripComments(literal);
+  let text = literal;
   let previous: string;
   do {
     previous = text;

--- a/tests/core/decoder-field-completeness.test.ts
+++ b/tests/core/decoder-field-completeness.test.ts
@@ -413,6 +413,18 @@ function discoverProcessors(src: string = SRC): DiscoveredProcessor[] {
         // block's brace (a bare-statement loop with no braces of its own,
         // followed later by an unconnected `if (...) { ... }`) and silently
         // scan the wrong loop's body for this array's members.
+        // KNOWN BOUND, stated rather than left to be rediscovered (review nit
+        // on #688): `^\s*\)\s*\{` allows only whitespace between the array's
+        // `]` and the header's `)`, so `for (const k of ['a', 'b'] as const)`
+        // does not match and its members never enter `surfaced`. That is the
+        // same "loud but misleading" shape the paragraph above criticises in
+        // the old 500-char cap — recorded here so it is a known bound rather
+        // than a surprise. It fails CLOSED (members go unsurfaced, the check
+        // goes red) rather than open, and no live instance exists: none of the
+        // decoder's five array-literal for-ofs (2571, 2634, 2650, 2684, 2689)
+        // uses `as const`. Left as a documented bound rather than widened,
+        // since widening a matcher with no failing case behind it is how the
+        // sibling file's residuals got recorded too.
         const after = /^\s*\)\s*\{/.exec(body.slice(end + 1));
         if (after === null) continue;
         const brace = end + 1 + after[0].length - 1;

--- a/tests/core/decoder-field-completeness.test.ts
+++ b/tests/core/decoder-field-completeness.test.ts
@@ -220,27 +220,42 @@ function topLevelKeys(literal: string): string[] {
  * catches loudly, so it is safe rather than silent. Verified: no processor has
  * one today. Same class of assumption as `balanced` and `stripComments` above.
  */
-function functionBody(parenIdx: number): string {
+function functionBody(src: string, parenIdx: number): string {
   let i = parenIdx;
   let depth = 0;
-  while (i < SRC.length) {
-    const ch = SRC[i];
+  while (i < src.length) {
+    const ch = src[i];
     if (ch === '(') depth++;
     else if (ch === ')') depth--;
     else if (ch === '{' && depth === 0) break;
     i++;
   }
-  return balanced(SRC, i, '{', '}')[0];
+  return balanced(src, i, '{', '}')[0];
 }
 
-function discoverProcessors(): DiscoveredProcessor[] {
+/**
+ * `src` defaults to the real decoder so every call site in this file scans
+ * production code unless it deliberately overrides it. The override exists
+ * so a regression fixture (a synthetic source snippet reproducing exactly
+ * one discovery hazard) can be run through the SAME discovery logic the real
+ * pin uses, rather than a hand-duplicated copy that could drift from it.
+ */
+function discoverProcessors(src: string = SRC): DiscoveredProcessor[] {
   const found: DiscoveredProcessor[] = [];
   const declaration = /function (process\w+)(?:<[^>]*>)?\s*\(/g;
   let match: RegExpExecArray | null;
 
-  while ((match = declaration.exec(SRC)) !== null) {
+  while ((match = declaration.exec(src)) !== null) {
     const name = match[1] as string;
-    const body = functionBody(match.index + match[0].length - 1);
+    // Stripped ONCE, here, and used for every scan below — the list/rowIdent/
+    // surfacing scans and the warnUnreadFields census used to run on two
+    // different texts (raw body vs. a separately-stripped copy only the
+    // census used), so a commented-out line was invisible to one half and
+    // load-bearing to the other. `balanced()`'s bracket/brace counting is
+    // safe against the shift stripping introduces because every index this
+    // function computes downstream is relative to THIS `body`, never to raw
+    // source positions.
+    const body = stripComments(functionBody(src, match.index + match[0].length - 1));
     const unresolved: string[] = [];
 
     // --- every string-literal field list in the body ---------------------
@@ -262,12 +277,12 @@ function discoverProcessors(): DiscoveredProcessor[] {
     // --- every warnUnreadFields call -------------------------------------
     const calls: WarnCallSpec[] = [];
     const consumedFields = new Set<string>();
-    // Stripped, so the two sides of the census agree: the census counts on
-    // stripComments(SRC), and counting here on the RAW body would let a
-    // commented-out call inflate this processor's pin AND the census total.
-    const scanBody = stripComments(body);
-    for (const m of scanBody.matchAll(/warnUnreadFields\(/g)) {
-      const [args] = balanced(scanBody, m.index + m[0].length - 1, '(', ')');
+    // `body` is already stripped (see above), so this agrees with the census
+    // total below, which counts on stripComments(SRC) — counting a RAW body
+    // here would let a commented-out call inflate this processor's pin AND
+    // the census total.
+    for (const m of body.matchAll(/warnUnreadFields\(/g)) {
+      const [args] = balanced(body, m.index + m[0].length - 1, '(', ')');
       const spec = (key: 'consumed' | 'ignored'): string[] => {
         const keyMatch = args.match(new RegExp(`${key}:\\s*`));
         // `=== undefined`, not falsy: offset 0 is a valid match position, and
@@ -381,8 +396,16 @@ function discoverProcessors(): DiscoveredProcessor[] {
         // `surfaced`, and the surfacing check went red for a reason having
         // nothing to do with the decoder. Loud, but misleading — and this file
         // exists to make coverage bounds explicit.
-        const brace = body.indexOf('{', end);
-        if (brace === -1) continue;
+        //
+        // The `{` must be ADJACENT to the `)` that closes this for-of header —
+        // `body.indexOf('{', end)` used to search forward for the next `{`
+        // ANYWHERE in the body, which can latch onto an unrelated later
+        // block's brace (a bare-statement loop with no braces of its own,
+        // followed later by an unconnected `if (...) { ... }`) and silently
+        // scan the wrong loop's body for this array's members.
+        const after = /^\s*\)\s*\{/.exec(body.slice(end + 1));
+        if (after === null) continue;
+        const brace = end + 1 + after[0].length - 1;
         const [loopBody] = balanced(body, brace, '{', '}');
         if (!new RegExp(`\\b${ident}\\[${m[1] as string}\\]\\s*=`).test(loopBody)) continue;
         for (const member of members) surfaced.add(member);
@@ -1153,6 +1176,24 @@ const NOT_SURFACED: Record<string, Record<string, string>> = {
  * Processors whose surfacing check is skipped because a passthrough loop
  * copies every raw key, so there is no allow-list to compare against.
  *
+ * Not a complete inventory of passthrough-shaped loops in the decoder — only
+ * of the ones the `passthrough` flag can SEE. Detection requires the loop to
+ * write `row[key] = ...` onto an identifier `rowIdents` already tracks, which
+ * in turn requires that identifier to be a NAMED `const row = {...}` later
+ * passed to `validateOrWarn` or returned. `processInvestmentSplit` has an
+ * equivalent loop (`for (const [key, value] of fields.entries())`), but
+ * writes into a local `adjustments` object that is embedded directly in an
+ * INLINE return literal (`validateOrWarn(Schema, { security_id: docId,
+ * adjustments }, ...)`) — there is no named row variable for `rowIdents` to
+ * capture, so this processor's copy loop is invisible to `passthrough`
+ * detection and it never enters this set. Its surfacing check is still
+ * skipped, but for an unrelated reason: its `consumed` spec is computed
+ * (`@Object.keys(adjustments)`), so `consumedFields` stays empty and no
+ * surfacing test is generated for it at all (see the
+ * `consumedFields.length > 0` guard below). Eleven processors in the decoder
+ * copy raw keys through a loop with no allow-list to check them against; this
+ * set names the ten `passthrough` can actually see.
+ *
  * Pinned as a SET rather than asserted inside the skip. A previous revision
  * did `if (found.passthrough) { expect(found.passthrough).toBe(true); return; }`
  * — which is `expect(true).toBe(true)` inside a branch that already guarantees
@@ -1351,5 +1392,45 @@ describe('decoder field completeness (silent-drop class detector)', () => {
       }
       expect(unreasoned).toEqual([]);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: the `for (const key of [...])` scanner's brace must be adjacent
+// ---------------------------------------------------------------------------
+
+describe('surfacing scan for a bare for-of loop requires an adjacent brace (#685)', () => {
+  // A `for (const key of ['ghost_field']) consume(key);` header with NO
+  // braces of its own — a legal single-statement for-of — immediately
+  // followed by an UNRELATED `for (const key of ['real_field']) { ... }`
+  // block that reuses the same loop-variable name and does write `row[key] =`.
+  // The pre-fix scanner searched forward for the next `{` from ANYWHERE in
+  // the body, found the second loop's brace, and credited 'ghost_field' as
+  // surfaced because the SECOND loop's body happens to satisfy the
+  // `row[key] =` check — even though 'ghost_field' is never written to row.
+  const FIXTURE_SRC = `
+function processFixture(fields: Map<string, unknown>): unknown {
+  const row: Record<string, unknown> = {};
+  for (const key of ['ghost_field'])
+    consume(key);
+  for (const key of ['real_field']) {
+    row[key] = fields.get(key);
+  }
+  return row;
+}
+`;
+
+  const [fixture] = discoverProcessors(FIXTURE_SRC);
+
+  test('fixture is discovered at all (non-vacuity)', () => {
+    expect(fixture?.name).toBe('processFixture');
+  });
+
+  test('the unrelated later block is not credited to the bare loop', () => {
+    expect(fixture?.surfaced.has('ghost_field')).toBe(false);
+  });
+
+  test('the real, adjacent loop still surfaces its own field', () => {
+    expect(fixture?.surfaced.has('real_field')).toBe(true);
   });
 });

--- a/tests/core/decoder-field-completeness.test.ts
+++ b/tests/core/decoder-field-completeness.test.ts
@@ -308,13 +308,16 @@ function discoverProcessors(src: string = SRC): DiscoveredProcessor[] {
           }
           return [`@${args.slice(at, end).trim()}`];
         }
+        // `args` (and therefore `raw`, sliced from it) is already stripped —
+        // `body` is stripped once at the top of discoverProcessors and every
+        // downstream slice inherits that, so re-stripping here would be a
+        // redundant no-op leftover from before that single-convention fix.
         const [raw] = balanced(args, at, '[', ']');
-        const text = stripComments(raw);
         const tokens: Array<[number, string]> = [];
-        for (const lit of text.matchAll(/'([^']*)'/g)) tokens.push([lit.index, lit[1] as string]);
-        for (const sp of text.matchAll(/\.\.\.(\w+)/g))
+        for (const lit of raw.matchAll(/'([^']*)'/g)) tokens.push([lit.index, lit[1] as string]);
+        for (const sp of raw.matchAll(/\.\.\.(\w+)/g))
           tokens.push([sp.index, `...${sp[1] as string}`]);
-        const residue = text.replace(/'[^']*'|\.\.\.\w+|,|\s/g, '');
+        const residue = raw.replace(/'[^']*'|\.\.\.\w+|,|\s/g, '');
         if (residue !== '') unresolved.push(`${name}: ${key} residue ${JSON.stringify(residue)}`);
         return tokens.sort((a, b) => a[0] - b[0]).map(([, token]) => token);
       };

--- a/tests/core/dedup-identity.test.ts
+++ b/tests/core/dedup-identity.test.ts
@@ -31,7 +31,7 @@
  * or explicitly listed as untested-by-choice.
  *
  * Note "block", not "comment", and "expression", not "name". Both distinctions
- * were bought the hard way — five revisions, each one narrower than its own
+ * were bought the hard way — six revisions, each one narrower than its own
  * comment claimed, each narrowing found by review rather than by the suite:
  *
  *   1. five hand-written tests, claiming "every collection"
@@ -40,7 +40,11 @@
  *      a duplicate label overwrote rather than added
  *   4. blocks, pinning the key — but three pinned the local name `key`, which
  *      pins nothing
- *   5. bare identifiers resolved, and asserted never to appear
+ *   5. bare identifiers resolved, and asserted never to appear — but a
+ *      RESOLVED expression can still pin nothing (`key = keyFor(row)` is not
+ *      a bare word, yet names no field)
+ *   6. resolved expressions required to contain a property access, not just
+ *      be non-bare
  *
  * Revision 2 could not see `dedupeAndSortInvestmentPrices`, which carries no
  * comment — the site that shipped #622, the previous instance of this exact
@@ -331,6 +335,30 @@ const UNTESTED_BY_CHOICE = new Set([
 ]);
 
 /**
+ * Slice out `open`..`close` starting at `openIdx`, counting nesting depth.
+ * Mirrors the identically-named helper in decoder-field-completeness.test.ts.
+ * Kept local rather than shared — the two discovery scripts read the source
+ * independently by design (see discoverAggregatePushTargets's own doc) — but
+ * the same bounding requirement applies here: without it, a scan can walk
+ * past the guarded block's own closing brace and misattribute a LATER,
+ * unrelated `.push(` call, which is exactly the #685 Step 1 defect in the
+ * sibling file. Bounding here is what keeps this file from shipping that
+ * same class of bug next door to its own fix.
+ */
+function balanced(text: string, openIdx: number, open: string, close: string): [string, number] {
+  let depth = 0;
+  for (let i = openIdx; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === open) depth++;
+    else if (ch === close) {
+      depth--;
+      if (depth === 0) return [text.slice(openIdx + 1, i), i];
+    }
+  }
+  return ['', text.length];
+}
+
+/**
  * For each dedup block, the name of the array its guarded `.push()` feeds.
  * `decodeAllCollections` builds every inline-block collection with the
  * identical shape — `if (!XSeen.has(id)) { XSeen.add(id); arr.push(item); }`
@@ -340,6 +368,11 @@ const UNTESTED_BY_CHOICE = new Set([
  * function. Read independently of `discoverDedupBlocks`, on its own pass over
  * the source, so a bug in one discovery function cannot mask a bug in the
  * other.
+ *
+ * The `.push(` search is bounded to the guard's OWN braced body via
+ * `balanced()`, not a forward scan across the whole window — a forward scan
+ * for the next `.push(` anywhere ahead can cross the guard's closing brace
+ * and credit an unrelated later block's push to this Set variable.
  */
 function discoverAggregatePushTargets(): Record<string, string> {
   const source = fs.readFileSync(
@@ -353,9 +386,11 @@ function discoverAggregatePushTargets(): Record<string, string> {
       (m.index as number) + m[0].length,
       (m.index as number) + m[0].length + 3000
     );
-    const push = new RegExp(
-      `if \\(!${setVar}\\.has\\([^)]*\\)\\)\\s*\\{[\\s\\S]*?(\\w+)\\.push\\(`
-    ).exec(window);
+    const guard = new RegExp(`if \\(!${setVar}\\.has\\([^)]*\\)\\)\\s*\\{`).exec(window);
+    if (!guard) continue;
+    const braceIdx = guard.index + guard[0].length - 1;
+    const [guardBody] = balanced(window, braceIdx, '{', '}');
+    const push = /(\w+)\.push\(/.exec(guardBody);
     if (push) found[push[1] as string] = setVar;
   }
   return found;

--- a/tests/core/dedup-identity.test.ts
+++ b/tests/core/dedup-identity.test.ts
@@ -31,7 +31,7 @@
  * or explicitly listed as untested-by-choice.
  *
  * Note "block", not "comment", and "expression", not "name". Both distinctions
- * were bought the hard way — seven revisions, each one narrower than its own
+ * were bought the hard way — eight revisions, each one narrower than its own
  * comment claimed, each narrowing found by review rather than by the suite:
  *
  *   1. five hand-written tests, claiming "every collection"
@@ -52,9 +52,18 @@
  *      comment-stripped window, so a dead `seen.has(...)` line above a live
  *      block can no longer win the match, and takes a `source` seam, so
  *      revisions 5 and 6 are pinned by committed fixtures instead of a
- *      mutation described in a PR body — but the enclosing-function scan
- *      still reads raw source, and stripComments's own string-literal
- *      ASSUMPTION (below) is unchanged
+ *      mutation described in a PR body — but the window it scans was still
+ *      bounded only by a character count, so it ran off the end of its own
+ *      function, and the collision message it added named a cause the
+ *      scanner cannot distinguish
+ *   8. the window bounded at the next top-level declaration as well as by
+ *      DISCOVERY_WINDOW (18 of 36 real windows overran their function), and
+ *      two claims corrected to match what the code can tell: the collision
+ *      message, and the non-vacuity floor's stated reason — but attribution
+ *      is still top-level-`function`-only, so a Set in an arrow function or
+ *      a method is credited to the preceding declaration and bounded by the
+ *      following one, and stripComments's string-literal ASSUMPTION (below)
+ *      is unchanged
  *
  * Revision 2 could not see `dedupeAndSortInvestmentPrices`, which carries no
  * comment — the site that shipped #622, the previous instance of this exact
@@ -575,7 +584,12 @@ function discoverAggregatePushTargets(
   minPlausibleLength: number = MIN_PLAUSIBLE_BODY_LENGTH
 ): Record<string, string> {
   const scoped = decodeAllCollectionsBody(source, minPlausibleLength);
-  const found: Record<string, string> = {};
+  // `Object.create(null)` for the same reason as in discoverDedupBlocks below:
+  // on a plain `{}`, `found['__proto__'] = setVar` creates no own property at
+  // all, so `Object.hasOwn` never sees it and the target is dropped in silence
+  // instead of throwing — the half of the `in` nit that `Object.hasOwn` alone
+  // does not close.
+  const found: Record<string, string> = Object.create(null);
   for (const m of scoped.matchAll(/const (\w+) = new Set<string>\(\)/g)) {
     const setVar = m[1] as string;
     const window = stripComments(
@@ -592,10 +606,11 @@ function discoverAggregatePushTargets(
     if (!push) continue;
     const pushTarget = push[1] as string;
     // `Object.hasOwn`, not `in` (review nit): `in` walks the prototype chain,
-    // so a push target named `constructor`/`toString` would throw spuriously
-    // and `__proto__` would not register as an own property at all. Not
-    // reachable with real collection names — same reason the identical swap
-    // below is a nit and not a bug — but the check costs the same either way.
+    // so a push target named `constructor`/`toString` would throw spuriously.
+    // The `__proto__` half of that nit needed the null-prototype `found`
+    // above, not this call — `Object.hasOwn` reports the truth there, and the
+    // truth on a plain `{}` was that the write never landed. Not reachable
+    // with real collection names, but the two lines now agree with each other.
     if (Object.hasOwn(found, pushTarget)) {
       throw new Error(
         `discoverAggregatePushTargets: push target "${pushTarget}" already attributed to Set variable "${found[pushTarget]}"; also matched by "${setVar}" — cannot tell which one owns it`
@@ -680,6 +695,31 @@ const TWIN_TESTED = new Set(
  * the sibling exactly, only the window is stripped, keeping stripComments's
  * own string-literal ASSUMPTION scoped to a few hundred characters rather
  * than the whole 3 000-line decoder.
+ *
+ * The window is bounded by the NEXT function declaration as well as by
+ * DISCOVERY_WINDOW (second review follow-up on #688 review). A character
+ * count is not a syntactic boundary, and 18 of the decoder's 36 blocks have
+ * a 3 000-character window that reaches past the end of their own function
+ * today — so a Set whose own guard is removed or refactored away would be
+ * pinned from the NEXT function's guard instead of reported as unguarded.
+ * That is a plausible-looking wrong answer, and it is the same unbounded
+ * forward scan this file's sibling closed with `balanced()` and
+ * `decodeAllCollectionsBody()`; this was the last instance of it left in
+ * either file. Bounding it changed no pin: comparing the char-bounded and
+ * declaration-bounded resolution across all 36 real blocks yields 0
+ * differences, so it closes a hole rather than moving a pin.
+ *
+ * ATTRIBUTION LIMIT, shared by `enclosing` and by the bound above, since
+ * both read the same `declarations` list: that list comes from
+ * `/^(?:export )?(?:async )?function (\w+)/gm`, which matches only
+ * TOP-LEVEL `function` declarations. A Set inside an arrow function, a
+ * class or object method, or an indented nested `function` is attributed to
+ * whichever top-level function precedes it, and its window would extend to
+ * the next top-level declaration rather than to the end of its real
+ * enclosing scope. Not reachable in the decoder today — all 36 blocks sit
+ * at one indent level directly inside a top-level `function` — but it is
+ * why the duplicate-block throw below says "the same enclosing declaration"
+ * rather than "the same function": the scanner cannot tell the difference.
  */
 function discoverDedupBlocks(
   source: string = fs.readFileSync(
@@ -688,14 +728,28 @@ function discoverDedupBlocks(
   )
 ): Record<string, string> {
   const declarations = [...source.matchAll(/^(?:export )?(?:async )?function (\w+)/gm)].map(
-    (m) => [m.index, m[1] as string] as const
+    (m) => [m.index as number, m[1] as string] as const
   );
-  const found: Record<string, string> = {};
+  // `Object.create(null)` for symmetry with discoverAggregatePushTargets —
+  // but NOT, unlike there, because it closes anything reachable here, and
+  // saying otherwise would be this file's own defect. The `__proto__`
+  // silent-drop needs the literal key `__proto__`, and every key this
+  // function writes is `${enclosing}|${variable}`, so it always contains a
+  // `|` and can never be that string. Mutation-checked: reverting this one
+  // line to `{}` leaves all tests green, which is why the pinned fixture for
+  // the drop lives on the sibling scanner (whose keys ARE bare identifiers)
+  // and not here. Kept so the two scanners read the same way; recorded as
+  // unreachable so nobody later mistakes it for a live guard.
+  const found: Record<string, string> = Object.create(null);
   for (const m of source.matchAll(/const (\w+) = new Set<string>\(\)/g)) {
     const variable = m[1] as string;
     const enclosing = declarations.filter(([at]) => at < (m.index as number)).pop();
-    const after = source.slice((m.index as number) + m[0].length);
-    const window = stripComments(after.slice(0, DISCOVERY_WINDOW));
+    // Bounded by the next declaration as well as by DISCOVERY_WINDOW — see
+    // the docblock above for why a character count alone is not enough.
+    const start = (m.index as number) + m[0].length;
+    const nextDecl = declarations.find(([at]) => at > (m.index as number));
+    const end = Math.min(start + DISCOVERY_WINDOW, nextDecl ? nextDecl[0] : source.length);
+    const window = stripComments(source.slice(start, end));
     const use = new RegExp(`${variable}\\.has\\(([^;]*?)\\)\\s*\\)`).exec(window);
     let key = use ? (use[1] as string).replace(/\s+/g, ' ').trim() : 'NONE';
     // Resolve a bare identifier to the expression it is assigned from. Three
@@ -716,9 +770,17 @@ function discoverDedupBlocks(
     // the pinned-equality test fails — but a scanner that silently discards
     // half its own input should say so where the discarding happens, not
     // leave a maintainer to infer it from a diff two tests away.
+    //
+    // The message says "the same enclosing declaration", not "the same
+    // function" (second review follow-up): `enclosing` resolves only
+    // top-level `function` declarations, so two Sets in two different arrow
+    // functions would collide here too, and calling that "one function" would
+    // claim more than the scanner can tell — see the ATTRIBUTION LIMIT in the
+    // docblock. That matters more now the collision is fatal rather than a
+    // silent overwrite: a throw's text is the only thing whoever hits it has.
     if (Object.hasOwn(found, block)) {
       throw new Error(
-        `discoverDedupBlocks: block "${block}" discovered twice (keys "${found[block]}" and "${key}") — two same-named Sets in one function; cannot tell which one the pin refers to`
+        `discoverDedupBlocks: block "${block}" discovered twice (keys "${found[block]}" and "${key}") — two same-named Sets under the same enclosing declaration; cannot tell which one the pin refers to`
       );
     }
     found[block] = key;
@@ -773,7 +835,25 @@ describe('dedup coverage is declared, not assumed (#668 review)', () => {
   });
 
   test('discovery finds the dedup blocks at all', () => {
-    // Non-vacuity: the exact comparison below would pass over an empty object.
+    // The justification here used to read "the exact comparison below would
+    // pass over an empty object." That is false, and saying so was the same
+    // defect this file exists to remove: `expect(discovered).toEqual(
+    // DEDUP_BLOCKS)` compares against a populated 36-entry literal, so `{}`
+    // fails it loudly. Corrected rather than deleted, because the floor does
+    // earn its place — for a different reason (second review follow-up).
+    //
+    // What it actually catches is the two-step workflow: discovery breaks,
+    // AND a maintainer regenerates DEDUP_BLOCKS from the broken output to get
+    // green again. The pinned comparison cannot see that — the pin and the
+    // scan agree, both on nothing — and every downstream test that reads
+    // `discovered` (the field-free invariant, the twin-tested check) is
+    // vacuously satisfied by an empty map. A floor is the one assertion in
+    // this describe that survives regenerating the pin, which is the same
+    // argument the `toBe(25)` count pin makes two tests down.
+    //
+    // `>= 30` against 36 real IS a margin here, unlike that pin: this scan
+    // covers blocks the file does not otherwise enumerate one by one, and the
+    // exact count is already pinned by DEDUP_BLOCKS itself.
     expect(Object.keys(discovered).length).toBeGreaterThanOrEqual(30);
   });
 
@@ -982,6 +1062,33 @@ export async function someOtherFunction(): Promise<unknown> {
     expect(() => discoverAggregatePushTargets(FIXTURE_SRC)).toThrow(
       /could not locate `decodeAllCollections`/
     );
+  });
+
+  test('a push target named __proto__ collides loudly rather than vanishing', () => {
+    // Pins the `Object.create(null)` half of the `in` -> `Object.hasOwn` nit.
+    // On a plain `{}` both writes to `found['__proto__']` are silent no-ops:
+    // no own property is created, `Object.hasOwn` stays false, nothing
+    // throws, and the block is simply absent from the result — the same
+    // silence the nit was raised about, one step later. Unreachable with real
+    // collection names; pinned anyway, because an unreachable fix that no
+    // test can detect being reverted is exactly what this PR exists to stop
+    // shipping.
+    const FIXTURE_SRC = `
+export async function decodeAllCollections(dbPath: string): Promise<unknown> {
+  const aSeen = new Set<string>();
+  const __proto__: string[] = [];
+  if (!aSeen.has(item.id)) {
+    aSeen.add(item.id);
+    __proto__.push(item);
+  }
+  const bSeen = new Set<string>();
+  if (!bSeen.has(item.id)) {
+    bSeen.add(item.id);
+    __proto__.push(item);
+  }
+}
+`;
+    expect(() => discoverAggregatePushTargets(FIXTURE_SRC, 0)).toThrow(/push target "__proto__"/);
   });
 });
 
@@ -1228,5 +1335,65 @@ export function decodeTwoScopes(): unknown {
 }
 `;
     expect(() => discoverDedupBlocks(FIXTURE_SRC)).toThrow(/block "decodeTwoScopes\|seen"/);
+    // And the message says only what the scanner can tell: `enclosing`
+    // resolves top-level `function` declarations only, so two Sets in two
+    // different arrow functions collide here as well, and calling that "two
+    // same-named Sets in one function" — as this message did — would claim
+    // more than the code knows. Pinned, because a message that overclaims is
+    // the same defect as a test name that overclaims, and this one is fatal.
+    expect(() => discoverDedupBlocks(FIXTURE_SRC)).toThrow(/same enclosing declaration/);
+  });
+});
+
+describe('discoverDedupBlocks bounds its window at the next declaration (#688 review)', () => {
+  test('a Set whose own guard is gone reports NONE, not a key from the next function', () => {
+    // DISCOVERY_WINDOW is a character count, not a syntactic boundary, and 18
+    // of the decoder's 36 real blocks have a 3 000-character window that
+    // reaches past the end of their own function. So a Set whose guard was
+    // removed or refactored away does not come back as unguarded — the scan
+    // walks into the NEXT function and pins it to a guard that belongs to
+    // something else. `decodeUnguarded|seen` would be pinned to `row.row_id`,
+    // which looks like a perfectly good answer and is the wrong one; the
+    // field-free invariant would pass it, and the maintainer who regenerates
+    // DEDUP_BLOCKS from it bakes in a claim about code that does not exist.
+    // Same unbounded-forward-scan class `balanced()` and
+    // decodeAllCollectionsBody() close for the sibling scanner.
+    const FIXTURE_SRC = `
+export function decodeUnguarded(): unknown {
+  const seen = new Set<string>();
+  const ids = raw.map((r) => r.thing_id);
+}
+
+export function decodeGuarded(): unknown {
+  const seen = new Set<string>();
+  if (!seen.has(row.row_id)) {
+    seen.add(row.row_id);
+  }
+}
+`;
+    expect(discoverDedupBlocks(FIXTURE_SRC)).toEqual({
+      'decodeUnguarded|seen': 'NONE',
+      'decodeGuarded|seen': 'row.row_id',
+    });
+  });
+
+  test('an unguarded Set is then reported by the field-free invariant', () => {
+    // The bound is only useful because `NONE` is a state the live invariant
+    // rejects: bounding the window turns a plausible wrong key into a loud
+    // one rather than into a different kind of silence.
+    const FIXTURE_SRC = `
+export function decodeUnguarded(): unknown {
+  const seen = new Set<string>();
+  const ids = raw.map((r) => r.thing_id);
+}
+
+export function decodeGuarded(): unknown {
+  const seen = new Set<string>();
+  if (!seen.has(row.row_id)) {
+    seen.add(row.row_id);
+  }
+}
+`;
+    expect(fieldFreeBlocks(discoverDedupBlocks(FIXTURE_SRC))).toEqual(['decodeUnguarded|seen']);
   });
 });

--- a/tests/core/dedup-identity.test.ts
+++ b/tests/core/dedup-identity.test.ts
@@ -47,16 +47,27 @@
  * bug class, invisible to the detector written for it. That is the sharpest
  * argument for why this guard reads code and not prose.
  *
- * Two of the omissions are structural rather than "not done yet":
+ * Four of the coverage guard's blocks are excluded from the twin tests for a
+ * structural reason rather than "not done yet" — two distinct reasons,
+ * spanning those four blocks (see STRUCTURAL_KEYS below):
  *
- * - `goal_history` (keyed on goal_id + month) and `investment_prices` (keyed on
- *   security + price_type + period) are excluded because their keys ARE their
- *   identities — those collections store one document per tuple, and the tuple
- *   is what the Firestore path encodes. "Two documents identical in content but
- *   differing by id" is not expressible for them.
- * - This proves distinct documents survive, not that true storage duplicates are
- *   collapsed. `createTestDb` writes one row per id, so a genuinely double-stored
- *   document cannot be built in a fixture — the same limitation #122 had.
+ * - `goal_history` (keyed on goal_id + month, both its standalone
+ *   `decodeGoalHistory|seen` block and its aggregate `histSeen` twin) and
+ *   `investment_prices` (keyed on security + price_type + period) are
+ *   excluded because their keys ARE their identities — those collections
+ *   store one document per tuple, and the tuple is what the Firestore path
+ *   encodes. "Two documents identical in content but differing by id" is not
+ *   expressible for them. Three blocks.
+ * - `reconcilePendingTransactions|supersededPendingIds` is not a dedup at
+ *   all — it tracks pending rows superseded by a posted twin, not document
+ *   identity, and is listed only because the discovery regex finds every
+ *   `new Set<string>()` and this one has to be accounted for somewhere. One
+ *   block.
+ *
+ * Separately: the twin tests that DO run prove distinct documents survive,
+ * not that true storage duplicates are collapsed. `createTestDb` writes one
+ * row per id, so a genuinely double-stored document cannot be built in a
+ * fixture — the same limitation #122 had.
  */
 
 import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
@@ -320,6 +331,37 @@ const UNTESTED_BY_CHOICE = new Set([
 ]);
 
 /**
+ * For each dedup block, the name of the array its guarded `.push()` feeds.
+ * `decodeAllCollections` builds every inline-block collection with the
+ * identical shape — `if (!XSeen.has(id)) { XSeen.add(id); arr.push(item); }`
+ * — and returns `arr` under the field name that shape's own
+ * `const arr: T[] = []` declares, so the push target names the collection as
+ * reliably as `standaloneName` (below) names the standalone decoder's
+ * function. Read independently of `discoverDedupBlocks`, on its own pass over
+ * the source, so a bug in one discovery function cannot mask a bug in the
+ * other.
+ */
+function discoverAggregatePushTargets(): Record<string, string> {
+  const source = fs.readFileSync(
+    path.join(import.meta.dir, '..', '..', 'src', 'core', 'decoder.ts'),
+    'utf-8'
+  );
+  const found: Record<string, string> = {};
+  for (const m of source.matchAll(/const (\w+) = new Set<string>\(\)/g)) {
+    const setVar = m[1] as string;
+    const window = source.slice(
+      (m.index as number) + m[0].length,
+      (m.index as number) + m[0].length + 3000
+    );
+    const push = new RegExp(
+      `if \\(!${setVar}\\.has\\([^)]*\\)\\)\\s*\\{[\\s\\S]*?(\\w+)\\.push\\(`
+    ).exec(window);
+    if (push) found[push[1] as string] = setVar;
+  }
+  return found;
+}
+
+/**
  * Blocks the twin tests exercise, DERIVED from COLLECTIONS rather than listed.
  *
  * `standaloneName` existed on each entry and nothing read it — the vestige of
@@ -329,15 +371,24 @@ const UNTESTED_BY_CHOICE = new Set([
  * being tested; remove one and the set silently over-claims.
  *
  * The aggregate half is keyed by the `<name>Seen` variable in
- * decodeAllCollections. Transactions and accounts route through the shared
- * helpers instead of their own Set, so their aggregate coverage IS the helper
- * block — which is why AGGREGATE_SET_VAR has no entry for them.
+ * decodeAllCollections, DERIVED via discoverAggregatePushTargets rather than
+ * hand-written (review follow-up on #688) — a hand-written map here could
+ * only ever be checked for EXISTENCE downstream (a wrong-but-real variable
+ * name still "names a live block" in the staleness test below); it could
+ * never be checked for whether it names the RIGHT variable, and swapping two
+ * entries (`goals: 'budgetSeen'`, `budgets: 'goalSeen'`) produces the exact
+ * same TWIN_TESTED set either way, so nothing would have noticed. Transactions
+ * and accounts route through the shared helpers instead of their own Set, so
+ * their aggregate coverage IS the helper block, and they never appear as a
+ * push target here — which is why AGGREGATE_SET_VAR has no entry for them.
  */
-const AGGREGATE_SET_VAR: Record<string, string> = {
-  recurring: 'recSeen',
-  budgets: 'budgetSeen',
-  goals: 'goalSeen',
-};
+const AGGREGATE_PUSH_TARGETS = discoverAggregatePushTargets();
+const AGGREGATE_SET_VAR: Record<string, string> = Object.fromEntries(
+  COLLECTIONS.filter((c) => c.name in AGGREGATE_PUSH_TARGETS).map((c) => [
+    c.name,
+    AGGREGATE_PUSH_TARGETS[c.name] as string,
+  ])
+);
 
 const TWIN_TESTED = new Set(
   COLLECTIONS.flatMap((c) => {
@@ -383,14 +434,22 @@ function discoverDedupBlocks(): Record<string, string> {
 describe('dedup coverage is declared, not assumed (#668 review)', () => {
   const discovered = discoverDedupBlocks();
 
-  test('no block is pinned to a bare identifier', () => {
+  test('no block is pinned to a bare identifier or a field-free expression', () => {
     // The `key` resolution repaired three instances, but both of its fallbacks
     // land on a bare word — and a bare word is the "pins nothing" state that
     // repair removed. Recording it as an invariant turns a state a maintainer
     // could accidentally re-enter into one the suite rejects, which is the
     // ritual this repo runs on its own bugs.
+    //
+    // A resolved-but-opaque call is the same failure one layer down: `const
+    // key = keyFor(row);` is not a bare word, so it survived the check above,
+    // but pins the literal STRING "key = keyFor(row)" rather than any field —
+    // reimplementing `keyFor` to hash `row.name` instead of `row.account_id`
+    // changes what gets deduped without moving this string at all. Require at
+    // least one property access (`.someField`) in the resolved expression, so
+    // a pin has to name the field it claims to key on.
     const unpinned = Object.entries(DEDUP_BLOCKS)
-      .filter(([, key]) => key === 'NONE' || /^\w+$/.test(key))
+      .filter(([, key]) => key === 'NONE' || /^\w+$/.test(key) || !/\.\w+/.test(key))
       .map(([block]) => block);
     expect(unpinned).toEqual([]);
   });
@@ -398,6 +457,27 @@ describe('dedup coverage is declared, not assumed (#668 review)', () => {
   test('discovery finds the dedup blocks at all', () => {
     // Non-vacuity: the exact comparison below would pass over an empty object.
     expect(Object.keys(discovered).length).toBeGreaterThanOrEqual(30);
+  });
+
+  test('aggregate push-target discovery finds blocks at all', () => {
+    // Same non-vacuity concern one level down: if the push-target regex ever
+    // stops matching, AGGREGATE_PUSH_TARGETS silently becomes `{}`,
+    // AGGREGATE_SET_VAR silently becomes `{}` too, and the aggregate half of
+    // TWIN_TESTED silently drops to nothing — the exact "hand-written and
+    // unverified" state this derivation exists to close, just reintroduced
+    // one layer down instead of fixed.
+    expect(Object.keys(AGGREGATE_PUSH_TARGETS).length).toBeGreaterThanOrEqual(3);
+  });
+
+  test('derived AGGREGATE_SET_VAR is unchanged', () => {
+    // Pinned like PASSTHROUGH_PROCESSORS in the sibling file: a collection's
+    // aggregate dedup block entering or leaving derivation's view is a
+    // visible diff, not a silent one.
+    expect(AGGREGATE_SET_VAR).toEqual({
+      recurring: 'recSeen',
+      budgets: 'budgetSeen',
+      goals: 'goalSeen',
+    });
   });
 
   test('every dedup block and its key expression are unchanged', () => {

--- a/tests/core/dedup-identity.test.ts
+++ b/tests/core/dedup-identity.test.ts
@@ -31,7 +31,7 @@
  * or explicitly listed as untested-by-choice.
  *
  * Note "block", not "comment", and "expression", not "name". Both distinctions
- * were bought the hard way — six revisions, each one narrower than its own
+ * were bought the hard way — seven revisions, each one narrower than its own
  * comment claimed, each narrowing found by review rather than by the suite:
  *
  *   1. five hand-written tests, claiming "every collection"
@@ -48,6 +48,13 @@
  *      keyFor(row.id)` contains `.id` and passes, though `keyFor` could
  *      compute anything from that argument; narrows the opaque-call class
  *      rather than closing it
+ *   7. the SCANNER made checkable: `discoverDedupBlocks` reads a
+ *      comment-stripped window, so a dead `seen.has(...)` line above a live
+ *      block can no longer win the match, and takes a `source` seam, so
+ *      revisions 5 and 6 are pinned by committed fixtures instead of a
+ *      mutation described in a PR body — but the enclosing-function scan
+ *      still reads raw source, and stripComments's own string-literal
+ *      ASSUMPTION (below) is unchanged
  *
  * Revision 2 could not see `dedupeAndSortInvestmentPrices`, which carries no
  * comment — the site that shipped #622, the previous instance of this exact
@@ -584,7 +591,12 @@ function discoverAggregatePushTargets(
     const push = /(\w+)\.push\(/.exec(guardBody);
     if (!push) continue;
     const pushTarget = push[1] as string;
-    if (pushTarget in found) {
+    // `Object.hasOwn`, not `in` (review nit): `in` walks the prototype chain,
+    // so a push target named `constructor`/`toString` would throw spuriously
+    // and `__proto__` would not register as an own property at all. Not
+    // reachable with real collection names — same reason the identical swap
+    // below is a nit and not a bug — but the check costs the same either way.
+    if (Object.hasOwn(found, pushTarget)) {
       throw new Error(
         `discoverAggregatePushTargets: push target "${pushTarget}" already attributed to Set variable "${found[pushTarget]}"; also matched by "${setVar}" — cannot tell which one owns it`
       );
@@ -625,7 +637,7 @@ function discoverAggregatePushTargets(
 // whoever hits it and sees the whole file red instead of one test.
 const AGGREGATE_PUSH_TARGETS = discoverAggregatePushTargets();
 const AGGREGATE_SET_VAR: Record<string, string> = Object.fromEntries(
-  COLLECTIONS.filter((c) => c.name in AGGREGATE_PUSH_TARGETS).map((c) => [
+  COLLECTIONS.filter((c) => Object.hasOwn(AGGREGATE_PUSH_TARGETS, c.name)).map((c) => [
     c.name,
     AGGREGATE_PUSH_TARGETS[c.name] as string,
   ])
@@ -641,12 +653,40 @@ const TWIN_TESTED = new Set(
   })
 );
 
-/** Discover dedup blocks and their key expressions from the decoder source. */
-function discoverDedupBlocks(): Record<string, string> {
-  const source = fs.readFileSync(
+/**
+ * Discover dedup blocks and their key expressions from the decoder source.
+ *
+ * `source` defaults to the real decoder so the one production call site below
+ * is unaffected; the override exists so a regression fixture can be run
+ * through the SAME discovery logic, the way `discoverAggregatePushTargets`
+ * above and Step 1's `discoverProcessors(src)` in the sibling file already
+ * are. Without the seam, the two narrowings this file is named after —
+ * revision 5's `const key = ...` resolution and revision 6's `.field`
+ * requirement — could only ever run against real decoder source, which by
+ * construction contains no violation, so neither could be shown to fail
+ * (review follow-up on #688 review).
+ *
+ * The window is passed through `stripComments` for the same reason the
+ * sibling's is: without it, a commented-out `seen.has(...)` or `const key =`
+ * line sitting between the Set declaration and the live guard is matched in
+ * preference to the live one — the regexes take the FIRST match in the
+ * window, and a dead line above a live block is a normal thing to write. The
+ * result is a key pinned to code that no longer runs, which is this file's
+ * own documented bug class (revision 3: "prose about a key can go stale")
+ * with a comment standing in for the label. No live instance today — none of
+ * the comments above the real blocks contain `.has(` — but this function
+ * feeds every other test in the file, so it is the worst place to leave it
+ * open. Note the enclosing-function scan still reads raw `source`: matching
+ * the sibling exactly, only the window is stripped, keeping stripComments's
+ * own string-literal ASSUMPTION scoped to a few hundred characters rather
+ * than the whole 3 000-line decoder.
+ */
+function discoverDedupBlocks(
+  source: string = fs.readFileSync(
     path.join(import.meta.dir, '..', '..', 'src', 'core', 'decoder.ts'),
     'utf-8'
-  );
+  )
+): Record<string, string> {
   const declarations = [...source.matchAll(/^(?:export )?(?:async )?function (\w+)/gm)].map(
     (m) => [m.index, m[1] as string] as const
   );
@@ -655,7 +695,7 @@ function discoverDedupBlocks(): Record<string, string> {
     const variable = m[1] as string;
     const enclosing = declarations.filter(([at]) => at < (m.index as number)).pop();
     const after = source.slice((m.index as number) + m[0].length);
-    const window = after.slice(0, DISCOVERY_WINDOW);
+    const window = stripComments(after.slice(0, DISCOVERY_WINDOW));
     const use = new RegExp(`${variable}\\.has\\(([^;]*?)\\)\\s*\\)`).exec(window);
     let key = use ? (use[1] as string).replace(/\s+/g, ' ').trim() : 'NONE';
     // Resolve a bare identifier to the expression it is assigned from. Three
@@ -667,9 +707,39 @@ function discoverDedupBlocks(): Record<string, string> {
       const assigned = new RegExp(`const ${key} = ([^;]+);`).exec(window);
       if (assigned) key = `${key} = ${(assigned[1] as string).replace(/\s+/g, ' ').trim()}`;
     }
-    found[`${enclosing ? enclosing[1] : '?'}|${variable}`] = key;
+    const block = `${enclosing ? enclosing[1] : '?'}|${variable}`;
+    // Same collision class discoverAggregatePushTargets now throws on, and
+    // for the same reason (review follow-up on #688 review). Two
+    // `new Set<string>()` with the same name in two different block scopes of
+    // one function is legal TS, and last-write-wins would make one of them
+    // invisible here. It IS caught downstream — `discovered` drops a key and
+    // the pinned-equality test fails — but a scanner that silently discards
+    // half its own input should say so where the discarding happens, not
+    // leave a maintainer to infer it from a diff two tests away.
+    if (Object.hasOwn(found, block)) {
+      throw new Error(
+        `discoverDedupBlocks: block "${block}" discovered twice (keys "${found[block]}" and "${key}") — two same-named Sets in one function; cannot tell which one the pin refers to`
+      );
+    }
+    found[block] = key;
   }
   return found;
+}
+
+/**
+ * Blocks whose pinned key expression names no field at all — the "pins
+ * nothing" states revisions 4-6 successively narrowed (see the test below for
+ * what each of them was and why one dot-check now covers all three).
+ *
+ * A function rather than an inline filter in the test so the fixture below
+ * asserts against the SAME implementation the live invariant runs, instead of
+ * a copy of it that could drift from it silently — which is the failure this
+ * whole file is a detector for.
+ */
+function fieldFreeBlocks(blocks: Record<string, string>): string[] {
+  return Object.entries(blocks)
+    .filter(([, key]) => !/\.\w+/.test(key))
+    .map(([block]) => block);
 }
 
 describe('dedup coverage is declared, not assumed (#668 review)', () => {
@@ -699,10 +769,7 @@ describe('dedup coverage is declared, not assumed (#668 review)', () => {
     // separate sync test below — a two-step ratchet a maintainer could stop
     // partway through. Filtering `discovered` makes it fail here directly,
     // in the test whose name actually describes the invariant.
-    const unpinned = Object.entries(discovered)
-      .filter(([, key]) => !/\.\w+/.test(key))
-      .map(([block]) => block);
-    expect(unpinned).toEqual([]);
+    expect(fieldFreeBlocks(discovered)).toEqual([]);
   });
 
   test('discovery finds the dedup blocks at all', () => {
@@ -713,24 +780,30 @@ describe('dedup coverage is declared, not assumed (#668 review)', () => {
   test('aggregate push-target discovery finds exactly 25 blocks (count pin, not a loose floor)', () => {
     // Renamed from "...finds blocks at all" (review follow-up): that name
     // described a non-vacuity check, but the value — 25, the real count —
-    // behaves as an exact-count PIN with zero headroom. Removing one
-    // legitimate collection from decodeAllCollections turns this red at
-    // "Expected >= 25, Received 24", not just at total collapse. That is
-    // deliberate, not an oversight — do not "fix" the apparent tightness by
-    // loosening it back toward a wide margin (contrast the sibling
-    // `discovered` floor at `>= 30` against 36 real, which genuinely IS a
-    // margin, chosen because that scan covers blocks this file does not
-    // otherwise pin one by one). The tightness here is what turns
-    // decodeAllCollectionsBody's two silent-partial-slice failure modes —
-    // an anchor matching an embedded brace in the return type, or a
-    // balanced() run-off — into loud ones: both now throw before this test
-    // even runs (see decodeAllCollectionsBody's own assertion), but if that
-    // assertion were ever removed, THIS floor is the last line of defense,
-    // and a floor of 3 (this test's original value, sized only to cover the
-    // 3 collections AGGREGATE_SET_VAR filters down to) would not have
-    // caught a scan that regressed to finding just those three, silently
-    // losing visibility into the other 22.
-    expect(Object.keys(AGGREGATE_PUSH_TARGETS).length).toBeGreaterThanOrEqual(25);
+    // behaves as an exact-count PIN with zero headroom.
+    //
+    // Asserted with `toBe`, not `toBeGreaterThanOrEqual` (second review
+    // follow-up): "exactly 25" is a TWO-sided claim and a floor is one-sided,
+    // so a 26th aggregate dedup block used to pass this test in silence — a
+    // test whose name asserted more than its expression did, which is the
+    // exact defect this file exists to remove. Now removing a legitimate
+    // collection from decodeAllCollections turns this red at "Expected: 25,
+    // Received: 24" and adding one at "Received: 26". That tightness is
+    // deliberate, not an oversight — do not "fix" it by loosening back toward
+    // a wide margin (contrast the sibling `discovered` floor at `>= 30`
+    // against 36 real, which genuinely IS a margin, chosen because that scan
+    // covers blocks this file does not otherwise pin one by one). The
+    // tightness here is what turns decodeAllCollectionsBody's two
+    // silent-partial-slice failure modes — an anchor matching an embedded
+    // brace in the return type, or a balanced() run-off — into loud ones:
+    // both now throw before this test even runs (see
+    // decodeAllCollectionsBody's own assertion), but if that assertion were
+    // ever removed, THIS count is the last line of defense, and the floor of
+    // 3 this test originally carried (sized only to cover the 3 collections
+    // AGGREGATE_SET_VAR filters down to) would not have caught a scan that
+    // regressed to finding just those three, silently losing visibility into
+    // the other 22.
+    expect(Object.keys(AGGREGATE_PUSH_TARGETS).length).toBe(25);
   });
 
   test('derived AGGREGATE_SET_VAR is unchanged', () => {
@@ -1022,5 +1095,138 @@ export async function decodeAllCollections(dbPath: string): Promise<{ marker: 'c
     // AGGREGATE_SET_VAR pin would both catch downstream. Silently WRONG
     // slice, but not silently PASSING.
     expect(found).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: discoverDedupBlocks' OWN scan (review follow-up on #688 review)
+//
+// Until this round it was the one scanner in either file with no `source`
+// seam and no stripComments on its window — so the two narrowings this file
+// is named after, revision 5's `const key = ...` resolution and revision 6's
+// `.field` requirement, could only ever run against real decoder source,
+// which by construction violates neither. Their non-vacuity rested on a
+// manual mutation described in a PR body, which is a coverage claim that is
+// not in the repo and cannot survive the next refactor. These fixtures make
+// both narrowings, and the comment strip they depend on, fail on demand.
+// ---------------------------------------------------------------------------
+
+describe('discoverDedupBlocks strips comments before matching (#688 review)', () => {
+  test('a commented-out guard above the live one does not win the key', () => {
+    // Both regexes take the FIRST match in the window, and a dead line kept
+    // above a live block is a normal thing to write. Unstripped, the `.has(`
+    // match lands on the comment and the block is pinned to `thing.name` — a
+    // key nothing dedups on. A maintainer then updates DEDUP_BLOCKS to match
+    // "what the scan found", bakes the dead key in, and from then on changing
+    // the LIVE key never moves the pin: revision 3's stale-prose defect with
+    // a comment standing in for the label.
+    const FIXTURE_SRC = `
+export function decodeThings(): unknown {
+  const seen = new Set<string>();
+  // superseded, kept for context: if (!seen.has(thing.name)) {
+  for (const thing of raw) {
+    if (!seen.has(thing.thing_id)) {
+      seen.add(thing.thing_id);
+    }
+  }
+}
+`;
+    expect(discoverDedupBlocks(FIXTURE_SRC)).toEqual({ 'decodeThings|seen': 'thing.thing_id' });
+  });
+
+  test('a commented-out const key above the live one does not win the resolution', () => {
+    // The other half of the same exposure, one layer down: the guard here is
+    // unambiguous (`seen.has(key)` appears once), but resolving the bare
+    // identifier `key` re-scans the window for `const key = ...;` and,
+    // unstripped, finds the superseded line first — resolving to a field the
+    // live code never reads.
+    const FIXTURE_SRC = `
+export function decodeKeyed(): unknown {
+  const seen = new Set<string>();
+  for (const row of raw) {
+    // superseded, kept for context: const key = \`\${row.legacy_name}\`;
+    const key = \`\${row.owner_id}:\${row.month}\`;
+    if (!seen.has(key)) {
+      seen.add(key);
+    }
+  }
+}
+`;
+    expect(discoverDedupBlocks(FIXTURE_SRC)).toEqual({
+      'decodeKeyed|seen': 'key = `${row.owner_id}:${row.month}`',
+    });
+  });
+});
+
+describe('discoverDedupBlocks resolves and grades a bare key (#688 review)', () => {
+  // Two blocks whose guards both read a bare `key`, differing only in what
+  // that key is built from: one from an opaque call, one from two fields.
+  // Between them they exercise revision 5 (resolve the identifier at all) and
+  // revision 6 (the resolved text must still name a field) on source that
+  // actually contains a violation, which the real decoder never does.
+  const FIXTURE_SRC = `
+export function decodeOpaque(): unknown {
+  const seen = new Set<string>();
+  for (const row of raw) {
+    const key = keyFor(row);
+    if (!seen.has(key)) {
+      seen.add(key);
+    }
+  }
+}
+
+export function decodeComposite(): unknown {
+  const seen = new Set<string>();
+  for (const row of raw) {
+    const key = \`\${row.owner_id}:\${row.month}\`;
+    if (!seen.has(key)) {
+      seen.add(key);
+    }
+  }
+}
+`;
+
+  test('a bare identifier is resolved to the expression it is assigned from', () => {
+    // Revision 5. Without the resolution both blocks would pin the string
+    // "key", and rewriting what the key is built from would not move either.
+    expect(discoverDedupBlocks(FIXTURE_SRC)).toEqual({
+      'decodeOpaque|seen': 'key = keyFor(row)',
+      'decodeComposite|seen': 'key = `${row.owner_id}:${row.month}`',
+    });
+  });
+
+  test('a resolved-but-field-free key is reported; a field-bearing one is not', () => {
+    // Revision 6, run through the SAME fieldFreeBlocks the live invariant
+    // above uses. `key = keyFor(row)` is not a bare word, so revision 5's
+    // check passed it, yet it names no field: reimplementing `keyFor` to hash
+    // a different column changes what gets deduped without moving the pin.
+    expect(fieldFreeBlocks(discoverDedupBlocks(FIXTURE_SRC))).toEqual(['decodeOpaque|seen']);
+  });
+});
+
+describe('discoverDedupBlocks fails loudly on a duplicate block key (#688 review)', () => {
+  test('two same-named Sets in one function throw instead of overwriting', () => {
+    // Legal TS, and before the check the second simply overwrote the first in
+    // `found` — one real dedup block invisible to every test in this file.
+    // It was caught downstream (the pinned-equality test would show a missing
+    // key), but the collision belongs where the collision happens, which is
+    // the standard discoverAggregatePushTargets already holds.
+    const FIXTURE_SRC = `
+export function decodeTwoScopes(): unknown {
+  {
+    const seen = new Set<string>();
+    if (!seen.has(a.a_id)) {
+      seen.add(a.a_id);
+    }
+  }
+  {
+    const seen = new Set<string>();
+    if (!seen.has(b.b_id)) {
+      seen.add(b.b_id);
+    }
+  }
+}
+`;
+    expect(() => discoverDedupBlocks(FIXTURE_SRC)).toThrow(/block "decodeTwoScopes\|seen"/);
   });
 });

--- a/tests/core/dedup-identity.test.ts
+++ b/tests/core/dedup-identity.test.ts
@@ -44,7 +44,10 @@
  *      RESOLVED expression can still pin nothing (`key = keyFor(row)` is not
  *      a bare word, yet names no field)
  *   6. resolved expressions required to contain a property access, not just
- *      be non-bare
+ *      be non-bare — but the check is on the call SITE's text: `key =
+ *      keyFor(row.id)` contains `.id` and passes, though `keyFor` could
+ *      compute anything from that argument; narrows the opaque-call class
+ *      rather than closing it
  *
  * Revision 2 could not see `dedupeAndSortInvestmentPrices`, which carries no
  * comment — the site that shipped #622, the previous instance of this exact
@@ -335,14 +338,28 @@ const UNTESTED_BY_CHOICE = new Set([
 ]);
 
 /**
+ * ASSUMPTION: no string literal in a scanned region contains `//` or a block
+ * comment opener. Mirrors the identically-named helper in
+ * decoder-field-completeness.test.ts. Applied to the WINDOW below before
+ * `balanced()` ever sees it — an unstripped comment containing an unbalanced
+ * `{` or `}` would otherwise shift where `balanced()` thinks the guard body
+ * ends, in either direction.
+ */
+function stripComments(text: string): string {
+  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
+/**
  * Slice out `open`..`close` starting at `openIdx`, counting nesting depth.
- * Mirrors the identically-named helper in decoder-field-completeness.test.ts.
- * Kept local rather than shared — the two discovery scripts read the source
- * independently by design (see discoverAggregatePushTargets's own doc) — but
- * the same bounding requirement applies here: without it, a scan can walk
- * past the guarded block's own closing brace and misattribute a LATER,
- * unrelated `.push(` call, which is exactly the #685 Step 1 defect in the
- * sibling file. Bounding here is what keeps this file from shipping that
+ * Mirrors the identically-named helper in decoder-field-completeness.test.ts,
+ * including running only on already-stripped text (see stripComments above) —
+ * an earlier revision of this copy ran on raw source, which the sibling file
+ * never does. Kept local rather than shared — the two discovery scripts read
+ * the source independently by design (see discoverAggregatePushTargets's own
+ * doc) — but the same bounding requirement applies here: without it, a scan
+ * can walk past the guarded block's own closing brace and misattribute a
+ * LATER, unrelated `.push(` call, which is exactly the #685 Step 1 defect in
+ * the sibling file. Bounding here is what keeps this file from shipping that
  * same class of bug next door to its own fix.
  */
 function balanced(text: string, openIdx: number, open: string, close: string): [string, number] {
@@ -372,19 +389,24 @@ function balanced(text: string, openIdx: number, open: string, close: string): [
  * The `.push(` search is bounded to the guard's OWN braced body via
  * `balanced()`, not a forward scan across the whole window — a forward scan
  * for the next `.push(` anywhere ahead can cross the guard's closing brace
- * and credit an unrelated later block's push to this Set variable.
+ * and credit an unrelated later block's push to this Set variable. `source`
+ * defaults to the real decoder so the one production call site below is
+ * unaffected; the override exists so a regression fixture (a synthetic
+ * source snippet reproducing exactly this hazard) can be run through the
+ * SAME discovery logic, the way Step 1's `discoverProcessors(src)` does in
+ * the sibling file.
  */
-function discoverAggregatePushTargets(): Record<string, string> {
-  const source = fs.readFileSync(
+function discoverAggregatePushTargets(
+  source: string = fs.readFileSync(
     path.join(import.meta.dir, '..', '..', 'src', 'core', 'decoder.ts'),
     'utf-8'
-  );
+  )
+): Record<string, string> {
   const found: Record<string, string> = {};
   for (const m of source.matchAll(/const (\w+) = new Set<string>\(\)/g)) {
     const setVar = m[1] as string;
-    const window = source.slice(
-      (m.index as number) + m[0].length,
-      (m.index as number) + m[0].length + 3000
+    const window = stripComments(
+      source.slice((m.index as number) + m[0].length, (m.index as number) + m[0].length + 3000)
     );
     const guard = new RegExp(`if \\(!${setVar}\\.has\\([^)]*\\)\\)\\s*\\{`).exec(window);
     if (!guard) continue;
@@ -552,4 +574,30 @@ describe('dedup keys on identity, not content (#662)', () => {
       );
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// Regression: the aggregate push-target scan must not cross the guard's brace
+// ---------------------------------------------------------------------------
+
+describe('aggregate push-target scan does not cross the guard boundary (#688 review)', () => {
+  // A guard whose OWN braced body has no `.push(` call at all, immediately
+  // followed by an UNRELATED `.push(` outside it. The pre-bound scanner
+  // searched forward for the next `.push(` anywhere in the window and would
+  // credit `unrelatedArray` to `xSeen` even though `xSeen`'s own guard never
+  // pushes anything.
+  const FIXTURE_SRC = `
+const xSeen = new Set<string>();
+const unrelatedArray: string[] = [];
+for (const item of rawItems) {
+  if (!xSeen.has(item.id)) {
+    xSeen.add(item.id);
+  }
+}
+unrelatedArray.push(item);
+`;
+
+  test('the unrelated later push is not credited to the bounded guard', () => {
+    expect(discoverAggregatePushTargets(FIXTURE_SRC)).toEqual({});
+  });
 });

--- a/tests/core/dedup-identity.test.ts
+++ b/tests/core/dedup-identity.test.ts
@@ -351,15 +351,38 @@ function stripComments(text: string): string {
 
 /**
  * Slice out `open`..`close` starting at `openIdx`, counting nesting depth.
+ *
+ * ASSUMPTION: no string literal inside the region contains an unbalanced
+ * bracket or brace. True for guard bodies today — zero of the 36 real dedup
+ * blocks contain one — but unlike the comment half of this same risk (closed
+ * outright by stripComments above, applied to the window before balanced()
+ * ever sees it), the string half is not fixed here, only unexercised so far.
+ * The failure direction is NOT symmetric: a stray `{` inside a string FAILS
+ * OPEN — depth never returns to 0 where the real guard closes, the boundary
+ * shifts outward, and a later unrelated `.push(` can be mis-credited to this
+ * Set variable, the exact class Step 1 fixed in the sibling file (and that
+ * this file's own fixture above pins for the comment-free case). A stray `}`
+ * FAILS CLOSED — depth reaches 0 early, the guard body truncates, and a real
+ * push inside it goes missing, which is loud rather than silent: the dropped
+ * block fails the `discoverAggregatePushTargets` non-vacuity floor and the
+ * pinned-equality test below. Same class of assumption as stripComments
+ * above.
+ *
  * Mirrors the identically-named helper in decoder-field-completeness.test.ts,
- * including running only on already-stripped text (see stripComments above) —
- * an earlier revision of this copy ran on raw source, which the sibling file
- * never does. Kept local rather than shared — the two discovery scripts read
- * the source independently by design (see discoverAggregatePushTargets's own
- * doc) — but the same bounding requirement applies here: without it, a scan
- * can walk past the guarded block's own closing brace and misattribute a
- * LATER, unrelated `.push(` call, which is exactly the #685 Step 1 defect in
- * the sibling file. Bounding here is what keeps this file from shipping that
+ * including this same ASSUMPTION, carried here rather than left to diverge
+ * from it. One place the two DO differ: the sibling's own `functionBody()`
+ * calls `balanced()` on raw, UNSTRIPPED `src` to find a `process*` function's
+ * outer body extent, stripping only the RESULT afterward — so "the sibling
+ * never runs balanced() on raw source" is not true of it in general. This
+ * copy is narrower: `discoverAggregatePushTargets` strips the window before
+ * `balanced()` ever runs on it, so THIS copy never sees raw text at all.
+ *
+ * Kept local rather than shared — the two discovery scripts read the source
+ * independently by design (see discoverAggregatePushTargets's own doc) — but
+ * the same bounding requirement applies here: without it, a scan can walk
+ * past the guarded block's own closing brace and misattribute a LATER,
+ * unrelated `.push(` call, which is exactly the #685 Step 1 defect in the
+ * sibling file. Bounding here is what keeps this file from shipping that
  * same class of bug next door to its own fix.
  */
 function balanced(text: string, openIdx: number, open: string, close: string): [string, number] {
@@ -598,6 +621,50 @@ unrelatedArray.push(item);
 `;
 
   test('the unrelated later push is not credited to the bounded guard', () => {
+    expect(discoverAggregatePushTargets(FIXTURE_SRC)).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Documented, accepted residual: string-literal braces (not comments) in a
+// guard body are still unhandled — see balanced()'s ASSUMPTION above. These
+// are NOT regression guards for a bug this PR fixes; they are a permanent,
+// executable record of the two failure directions that ASSUMPTION names,
+// verified against the real scanner rather than left as prose alone.
+// ---------------------------------------------------------------------------
+
+describe('string-literal braces in a guard body are an accepted, open residual (#688 review)', () => {
+  test('a stray { inside a string literal fails OPEN: the boundary can shift past the guard and mis-credit a later push', () => {
+    // The extra unmatched `{` inside `'{'` leaves balanced() one level of
+    // depth short when it reaches the guard's real closing `}`, so it keeps
+    // scanning — and the next `}` in the source (here, an enclosing block's)
+    // closes it one level too late, sweeping in the unrelated push between.
+    const FIXTURE_SRC = `
+const ySeen = new Set<string>();
+const unrelatedY: string[] = [];
+{
+  if (!ySeen.has(item.id)) {
+    const legacyShape = '{';
+    ySeen.add(item.id);
+  }
+  unrelatedY.push(item);
+}
+`;
+    expect(discoverAggregatePushTargets(FIXTURE_SRC)).toEqual({ unrelatedY: 'ySeen' });
+  });
+
+  test('a stray } inside a string literal fails CLOSED: the guard body truncates and a real push goes missing rather than misattributed', () => {
+    // The extra unmatched `}` inside `'}'` satisfies balanced()'s depth
+    // check early, before the guard's own real close — the returned body is
+    // truncated mid-string, and the genuine push after it is never seen.
+    const FIXTURE_SRC = `
+const zSeen = new Set<string>();
+if (!zSeen.has(item.id)) {
+  const legacyShape = '}';
+  zSeen.add(item.id);
+  zArray.push(item);
+}
+`;
     expect(discoverAggregatePushTargets(FIXTURE_SRC)).toEqual({});
   });
 });

--- a/tests/core/dedup-identity.test.ts
+++ b/tests/core/dedup-identity.test.ts
@@ -399,15 +399,61 @@ function balanced(text: string, openIdx: number, open: string, close: string): [
 }
 
 /**
- * For each dedup block, the name of the array its guarded `.push()` feeds.
- * `decodeAllCollections` builds every inline-block collection with the
- * identical shape — `if (!XSeen.has(id)) { XSeen.add(id); arr.push(item); }`
- * — and returns `arr` under the field name that shape's own
- * `const arr: T[] = []` declares, so the push target names the collection as
- * reliably as `standaloneName` (below) names the standalone decoder's
- * function. Read independently of `discoverDedupBlocks`, on its own pass over
- * the source, so a bug in one discovery function cannot mask a bug in the
- * other.
+ * How far past a `new Set<string>()` declaration a discovery scan looks for
+ * its `.has(` guard (and, below, the guarded block's `.push(`). Shared by
+ * both discovery functions in this file so the assumption is stated once
+ * instead of twice: a guard further than this from its Set declaration is
+ * skipped in silence, not reported. Every real block today sits within a
+ * few dozen characters of its Set — this is a generous margin, not a tight
+ * one.
+ */
+const DISCOVERY_WINDOW = 3000;
+
+/**
+ * The body of `decodeAllCollections`, sliced out of `source` so
+ * `discoverAggregatePushTargets` only ever scans that one function — not the
+ * whole file, which an earlier revision did despite documenting itself as
+ * scoped to `decodeAllCollections`. That mismatch was not just inaccurate
+ * prose: the file-wide scan already collides today. Ten standalone
+ * decode-prefixed/dedupe-prefixed functions each build their own local
+ * `seen` guard pushing into a locally-scoped array every one of them names
+ * `unique` — ten functions, one shared array name, silently overwriting
+ * `found['unique']` nine times over (harmless only because no `COLLECTIONS`
+ * name is `'unique'`). Scoping to `decodeAllCollections` removes that
+ * collision class outright rather than merely tolerating it.
+ */
+function decodeAllCollectionsBody(source: string): string {
+  const decl = /^export async function decodeAllCollections\([^)]*\)[^{]*\{/m.exec(source);
+  if (!decl) {
+    throw new Error(
+      'discoverAggregatePushTargets: could not locate `decodeAllCollections` in the given source — the scan is scoped to its body and cannot run without it'
+    );
+  }
+  const braceIdx = (decl.index as number) + decl[0].length - 1;
+  return balanced(source, braceIdx, '{', '}')[0];
+}
+
+/**
+ * For each dedup block INSIDE `decodeAllCollections`, the name of the array
+ * its guarded `.push()` feeds. `decodeAllCollections` builds every
+ * inline-block collection with the identical shape — `if (!XSeen.has(id)) {
+ * XSeen.add(id); arr.push(item); }` — and returns `arr` under the field name
+ * that shape's own `const arr: T[] = []` declares, so the push target names
+ * the collection as reliably as `standaloneName` (below) names the
+ * standalone decoder's function. Read independently of `discoverDedupBlocks`,
+ * on its own pass over the source, so a bug in one discovery function cannot
+ * mask a bug in the other.
+ *
+ * Scoped via `decodeAllCollectionsBody` above (review follow-up: an earlier
+ * revision scanned the whole file, which both misdescribed itself and
+ * depended on no two blocks anywhere in decoder.ts ever sharing a push-target
+ * name — untrue today, see that function's doc). A push target seen twice
+ * WITHIN the scoped body still throws rather than silently overwriting —
+ * belt and suspenders against a future block inside `decodeAllCollections`
+ * colliding with another, the way `deduplicateAccounts` and
+ * `deduplicateTransactions` already route their standalone dedup logic in
+ * from outside; if a collection's dedup were ever inlined the same way,
+ * a name collision here should fail the run, not the wrong test pass.
  *
  * The `.push(` search is bounded to the guard's OWN braced body via
  * `balanced()`, not a forward scan across the whole window — a forward scan
@@ -417,7 +463,9 @@ function balanced(text: string, openIdx: number, open: string, close: string): [
  * unaffected; the override exists so a regression fixture (a synthetic
  * source snippet reproducing exactly this hazard) can be run through the
  * SAME discovery logic, the way Step 1's `discoverProcessors(src)` does in
- * the sibling file.
+ * the sibling file. A fixture's synthetic source must wrap its guard in a
+ * `decodeAllCollections`-shaped declaration, the same way real source is
+ * scoped — see the fixtures below.
  */
 function discoverAggregatePushTargets(
   source: string = fs.readFileSync(
@@ -425,18 +473,29 @@ function discoverAggregatePushTargets(
     'utf-8'
   )
 ): Record<string, string> {
+  const scoped = decodeAllCollectionsBody(source);
   const found: Record<string, string> = {};
-  for (const m of source.matchAll(/const (\w+) = new Set<string>\(\)/g)) {
+  for (const m of scoped.matchAll(/const (\w+) = new Set<string>\(\)/g)) {
     const setVar = m[1] as string;
     const window = stripComments(
-      source.slice((m.index as number) + m[0].length, (m.index as number) + m[0].length + 3000)
+      scoped.slice(
+        (m.index as number) + m[0].length,
+        (m.index as number) + m[0].length + DISCOVERY_WINDOW
+      )
     );
-    const guard = new RegExp(`if \\(!${setVar}\\.has\\([^)]*\\)\\)\\s*\\{`).exec(window);
+    const guard = new RegExp(`if \\(!${setVar}\\.has\\([^;]*?\\)\\)\\s*\\{`).exec(window);
     if (!guard) continue;
     const braceIdx = guard.index + guard[0].length - 1;
     const [guardBody] = balanced(window, braceIdx, '{', '}');
     const push = /(\w+)\.push\(/.exec(guardBody);
-    if (push) found[push[1] as string] = setVar;
+    if (!push) continue;
+    const pushTarget = push[1] as string;
+    if (pushTarget in found) {
+      throw new Error(
+        `discoverAggregatePushTargets: push target "${pushTarget}" already attributed to Set variable "${found[pushTarget]}"; also matched by "${setVar}" — cannot tell which one owns it`
+      );
+    }
+    found[pushTarget] = setVar;
   }
   return found;
 }
@@ -494,7 +553,7 @@ function discoverDedupBlocks(): Record<string, string> {
     const variable = m[1] as string;
     const enclosing = declarations.filter(([at]) => at < (m.index as number)).pop();
     const after = source.slice((m.index as number) + m[0].length);
-    const window = after.slice(0, 3000);
+    const window = after.slice(0, DISCOVERY_WINDOW);
     const use = new RegExp(`${variable}\\.has\\(([^;]*?)\\)\\s*\\)`).exec(window);
     let key = use ? (use[1] as string).replace(/\s+/g, ' ').trim() : 'NONE';
     // Resolve a bare identifier to the expression it is assigned from. Three
@@ -522,14 +581,24 @@ describe('dedup coverage is declared, not assumed (#668 review)', () => {
     // ritual this repo runs on its own bugs.
     //
     // A resolved-but-opaque call is the same failure one layer down: `const
-    // key = keyFor(row);` is not a bare word, so it survived the check above,
-    // but pins the literal STRING "key = keyFor(row)" rather than any field —
-    // reimplementing `keyFor` to hash `row.name` instead of `row.account_id`
-    // changes what gets deduped without moving this string at all. Require at
-    // least one property access (`.someField`) in the resolved expression, so
-    // a pin has to name the field it claims to key on.
-    const unpinned = Object.entries(DEDUP_BLOCKS)
-      .filter(([, key]) => key === 'NONE' || /^\w+$/.test(key) || !/\.\w+/.test(key))
+    // key = keyFor(row);` is not a bare word, but pins the literal STRING
+    // "key = keyFor(row)" rather than any field — reimplementing `keyFor` to
+    // hash `row.name` instead of `row.account_id` changes what gets deduped
+    // without moving this string at all. Requiring a property access
+    // (`.someField`) in the resolved expression subsumes the two earlier,
+    // narrower checks this test used to spell out as separate disjuncts —
+    // `key === 'NONE'` and a bare `/^\w+$/` word — since neither ever
+    // contains a dot; a single check now covers all three revisions' worth
+    // of "pins nothing" shapes.
+    //
+    // Filters `discovered`, the LIVE scan, not `DEDUP_BLOCKS`, the pin: on a
+    // genuinely new field-free block, `DEDUP_BLOCKS` hasn't been told about
+    // it yet, so filtering the pin would pass here and fail only in the
+    // separate sync test below — a two-step ratchet a maintainer could stop
+    // partway through. Filtering `discovered` makes it fail here directly,
+    // in the test whose name actually describes the invariant.
+    const unpinned = Object.entries(discovered)
+      .filter(([, key]) => !/\.\w+/.test(key))
       .map(([block]) => block);
     expect(unpinned).toEqual([]);
   });
@@ -540,13 +609,19 @@ describe('dedup coverage is declared, not assumed (#668 review)', () => {
   });
 
   test('aggregate push-target discovery finds blocks at all', () => {
-    // Same non-vacuity concern one level down: if the push-target regex ever
-    // stops matching, AGGREGATE_PUSH_TARGETS silently becomes `{}`,
-    // AGGREGATE_SET_VAR silently becomes `{}` too, and the aggregate half of
-    // TWIN_TESTED silently drops to nothing — the exact "hand-written and
-    // unverified" state this derivation exists to close, just reintroduced
-    // one layer down instead of fixed.
-    expect(Object.keys(AGGREGATE_PUSH_TARGETS).length).toBeGreaterThanOrEqual(3);
+    // Non-vacuity, raised to the real count rather than a loose margin
+    // (review follow-up): `decodeAllCollections` has 25 inline dedup blocks
+    // today, and a floor of 3 — this test's original value, chosen only to
+    // cover the 3 collections AGGREGATE_SET_VAR filters down to — would stay
+    // green even if the scan regressed to finding just those three, silently
+    // dropping visibility into the other 22 the duplicate-push-target check
+    // in discoverAggregatePushTargets also depends on seeing. If the
+    // push-target regex ever stops matching at all, AGGREGATE_PUSH_TARGETS
+    // silently becomes `{}`, AGGREGATE_SET_VAR silently becomes `{}` too, and
+    // the aggregate half of TWIN_TESTED silently drops to nothing — the
+    // exact "hand-written and unverified" state this derivation exists to
+    // close, just reintroduced one layer down instead of fixed.
+    expect(Object.keys(AGGREGATE_PUSH_TARGETS).length).toBeGreaterThanOrEqual(25);
   });
 
   test('derived AGGREGATE_SET_VAR is unchanged', () => {
@@ -608,16 +683,20 @@ describe('aggregate push-target scan does not cross the guard boundary (#688 rev
   // followed by an UNRELATED `.push(` outside it. The pre-bound scanner
   // searched forward for the next `.push(` anywhere in the window and would
   // credit `unrelatedArray` to `xSeen` even though `xSeen`'s own guard never
-  // pushes anything.
+  // pushes anything. Wrapped in a synthetic decodeAllCollections — the real
+  // scan is scoped to it (see decodeAllCollectionsBody), so a fixture must
+  // supply one too.
   const FIXTURE_SRC = `
-const xSeen = new Set<string>();
-const unrelatedArray: string[] = [];
-for (const item of rawItems) {
-  if (!xSeen.has(item.id)) {
-    xSeen.add(item.id);
+export async function decodeAllCollections(dbPath: string): Promise<unknown> {
+  const xSeen = new Set<string>();
+  const unrelatedArray: string[] = [];
+  for (const item of rawItems) {
+    if (!xSeen.has(item.id)) {
+      xSeen.add(item.id);
+    }
   }
+  unrelatedArray.push(item);
 }
-unrelatedArray.push(item);
 `;
 
   test('the unrelated later push is not credited to the bounded guard', () => {
@@ -639,15 +718,23 @@ describe('string-literal braces in a guard body are an accepted, open residual (
     // depth short when it reaches the guard's real closing `}`, so it keeps
     // scanning — and the next `}` in the source (here, an enclosing block's)
     // closes it one level too late, sweeping in the unrelated push between.
+    // Wrapped in a synthetic decodeAllCollections (same reason as above),
+    // with one further trailing `}`: decodeAllCollectionsBody's OWN scan
+    // starts even further back, at the function's own brace, so IT also
+    // needs one extra close to reach depth 0 before running off the fixture
+    // — the same shift, one level further out, and the same fix.
     const FIXTURE_SRC = `
-const ySeen = new Set<string>();
-const unrelatedY: string[] = [];
-{
-  if (!ySeen.has(item.id)) {
-    const legacyShape = '{';
-    ySeen.add(item.id);
+export async function decodeAllCollections(dbPath: string): Promise<unknown> {
+  const ySeen = new Set<string>();
+  const unrelatedY: string[] = [];
+  {
+    if (!ySeen.has(item.id)) {
+      const legacyShape = '{';
+      ySeen.add(item.id);
+    }
+    unrelatedY.push(item);
   }
-  unrelatedY.push(item);
+}
 }
 `;
     expect(discoverAggregatePushTargets(FIXTURE_SRC)).toEqual({ unrelatedY: 'ySeen' });
@@ -657,14 +744,86 @@ const unrelatedY: string[] = [];
     // The extra unmatched `}` inside `'}'` satisfies balanced()'s depth
     // check early, before the guard's own real close — the returned body is
     // truncated mid-string, and the genuine push after it is never seen.
+    // Wrapped in a synthetic decodeAllCollections, same reason as above.
     const FIXTURE_SRC = `
-const zSeen = new Set<string>();
-if (!zSeen.has(item.id)) {
-  const legacyShape = '}';
-  zSeen.add(item.id);
-  zArray.push(item);
+export async function decodeAllCollections(dbPath: string): Promise<unknown> {
+  const zSeen = new Set<string>();
+  if (!zSeen.has(item.id)) {
+    const legacyShape = '}';
+    zSeen.add(item.id);
+    zArray.push(item);
+  }
 }
 `;
     expect(discoverAggregatePushTargets(FIXTURE_SRC)).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: scope and collision safety (review follow-up on #688 review)
+// ---------------------------------------------------------------------------
+
+describe('discoverAggregatePushTargets fails loudly rather than silently (#688 review)', () => {
+  test('a push target seen twice in the scoped body throws instead of overwriting', () => {
+    // Two independent guards, both feeding an array named `shared`. Before
+    // scoping + this check, `found['shared']` would just silently end up
+    // pointing at whichever Set variable came last in file order.
+    const FIXTURE_SRC = `
+export async function decodeAllCollections(dbPath: string): Promise<unknown> {
+  const aSeen = new Set<string>();
+  const shared: string[] = [];
+  if (!aSeen.has(item.id)) {
+    aSeen.add(item.id);
+    shared.push(item);
+  }
+  const bSeen = new Set<string>();
+  if (!bSeen.has(item.id)) {
+    bSeen.add(item.id);
+    shared.push(item);
+  }
+}
+`;
+    expect(() => discoverAggregatePushTargets(FIXTURE_SRC)).toThrow(/push target "shared"/);
+  });
+
+  test('a source with no decodeAllCollections throws rather than silently scanning nothing (or everything)', () => {
+    const FIXTURE_SRC = `
+export async function someOtherFunction(): Promise<unknown> {
+  const aSeen = new Set<string>();
+  const arr: string[] = [];
+  if (!aSeen.has(item.id)) {
+    aSeen.add(item.id);
+    arr.push(item);
+  }
+}
+`;
+    expect(() => discoverAggregatePushTargets(FIXTURE_SRC)).toThrow(
+      /could not locate `decodeAllCollections`/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: the guard regex must survive a nested paren in `.has(...)`
+// (review follow-up on #688 review — aligning the two `.has(` patterns)
+// ---------------------------------------------------------------------------
+
+describe('guard regex handles a nested paren in .has(...) (#688 review)', () => {
+  test('if (!seen.has(String(x))) is still matched, not silently skipped', () => {
+    // Before aligning with discoverDedupBlocks's `[^;]*?` shape, the guard
+    // regex used `[^)]*`, which cannot consume the inner `)` of `String(x)`
+    // at all — the whole guard match failed, and the block was skipped in
+    // silence rather than reported.
+    const FIXTURE_SRC = `
+export async function decodeAllCollections(dbPath: string): Promise<unknown> {
+  const nestedSeen = new Set<string>();
+  const nestedArr: string[] = [];
+  if (!nestedSeen.has(String(x))) {
+    nestedSeen.add(String(x));
+    nestedArr.push(x);
+  }
+}
+`;
+    expect(discoverAggregatePushTargets(FIXTURE_SRC)).toEqual({ nestedArr: 'nestedSeen' });
   });
 });

--- a/tests/core/dedup-identity.test.ts
+++ b/tests/core/dedup-identity.test.ts
@@ -421,16 +421,54 @@ const DISCOVERY_WINDOW = 3000;
  * `found['unique']` nine times over (harmless only because no `COLLECTIONS`
  * name is `'unique'`). Scoping to `decodeAllCollections` removes that
  * collision class outright rather than merely tolerating it.
+ *
+ * Two failure modes, both closed HERE rather than left for the floor test or
+ * the AGGREGATE_SET_VAR pin two layers downstream to catch by accident
+ * (review follow-up — mutation-verified both were only caught that far away
+ * before this fix):
+ *
+ *   - The anchor requires a `:` before the first `{`, so it needs an actual
+ *     return type annotation — but that alone does NOT rule out a return
+ *     type whose own annotation contains a brace, e.g.
+ *     `Promise<{ ok: boolean } & AllCollectionsResult>`. The anchor would
+ *     then match early, on the TYPE LITERAL's own `{`, and `balanced()`
+ *     would faithfully return that bracket's contents: short, non-empty,
+ *     structurally plausible-looking text containing none of
+ *     `decodeAllCollections`'s real dedup blocks.
+ *   - A `balanced()` run-off (no matching close found before the source
+ *     ends) fails the same way one level further: an EMPTY string.
+ *
+ * Both are "a parser silently returns an empty or partial slice" — the exact
+ * construct the sibling PR (#685/#688 test-guard cleanup) has spent several
+ * revisions closing elsewhere in this repo. The regex tightening narrows
+ * WHICH shapes can trigger this; the length assertion is what actually
+ * closes it, because it does not depend on anticipating every shape that
+ * can go wrong — only on the fact that a real function body this large does
+ * not shrink to a sliver. The real body is ~18,000 characters; the floor
+ * below is set with a wide margin under that, wide enough to never trip on
+ * a legitimate edit, tight enough that no degenerate slice can sneak under
+ * it undetected.
  */
-function decodeAllCollectionsBody(source: string): string {
-  const decl = /^export async function decodeAllCollections\([^)]*\)[^{]*\{/m.exec(source);
+const MIN_PLAUSIBLE_BODY_LENGTH = 5000;
+
+function decodeAllCollectionsBody(
+  source: string,
+  minPlausibleLength: number = MIN_PLAUSIBLE_BODY_LENGTH
+): string {
+  const decl = /^export async function decodeAllCollections\([^)]*\)\s*:[^{]*\{/m.exec(source);
   if (!decl) {
     throw new Error(
       'discoverAggregatePushTargets: could not locate `decodeAllCollections` in the given source — the scan is scoped to its body and cannot run without it'
     );
   }
   const braceIdx = (decl.index as number) + decl[0].length - 1;
-  return balanced(source, braceIdx, '{', '}')[0];
+  const [body] = balanced(source, braceIdx, '{', '}');
+  if (body.length < minPlausibleLength) {
+    throw new Error(
+      `discoverAggregatePushTargets: decodeAllCollectionsBody extracted an implausibly short body (${body.length} chars, expected at least ${minPlausibleLength}) — the anchor likely matched a brace embedded in the return type instead of the function's own opening brace, or balanced() ran off the end of the source without finding a match`
+    );
+  }
+  return body;
 }
 
 /**
@@ -471,9 +509,15 @@ function discoverAggregatePushTargets(
   source: string = fs.readFileSync(
     path.join(import.meta.dir, '..', '..', 'src', 'core', 'decoder.ts'),
     'utf-8'
-  )
+  ),
+  // Passed through to decodeAllCollectionsBody. Defaults to the real
+  // production floor; fixtures below that are testing something OTHER than
+  // the length assertion itself override it down, since a synthetic snippet
+  // a few hundred characters long is not — and should not have to
+  // pretend to be — a plausible decodeAllCollections body.
+  minPlausibleLength: number = MIN_PLAUSIBLE_BODY_LENGTH
 ): Record<string, string> {
-  const scoped = decodeAllCollectionsBody(source);
+  const scoped = decodeAllCollectionsBody(source, minPlausibleLength);
   const found: Record<string, string> = {};
   for (const m of scoped.matchAll(/const (\w+) = new Set<string>\(\)/g)) {
     const setVar = m[1] as string;
@@ -521,6 +565,14 @@ function discoverAggregatePushTargets(
  * their aggregate coverage IS the helper block, and they never appear as a
  * push target here — which is why AGGREGATE_SET_VAR has no entry for them.
  */
+// Runs at MODULE SCOPE, not inside a test — so any of the throws inside
+// discoverAggregatePushTargets / decodeAllCollectionsBody (missing
+// declaration, implausibly short slice, duplicate push target) fails to
+// even LOAD this file, taking down every test in it, not just the
+// aggregate-specific ones below. That is the intended behavior — a throw
+// here means the guard cannot do its job at all, and a module that fails to
+// load is about as loud as a failure can get — but it should not surprise
+// whoever hits it and sees the whole file red instead of one test.
 const AGGREGATE_PUSH_TARGETS = discoverAggregatePushTargets();
 const AGGREGATE_SET_VAR: Record<string, string> = Object.fromEntries(
   COLLECTIONS.filter((c) => c.name in AGGREGATE_PUSH_TARGETS).map((c) => [
@@ -608,19 +660,26 @@ describe('dedup coverage is declared, not assumed (#668 review)', () => {
     expect(Object.keys(discovered).length).toBeGreaterThanOrEqual(30);
   });
 
-  test('aggregate push-target discovery finds blocks at all', () => {
-    // Non-vacuity, raised to the real count rather than a loose margin
-    // (review follow-up): `decodeAllCollections` has 25 inline dedup blocks
-    // today, and a floor of 3 — this test's original value, chosen only to
-    // cover the 3 collections AGGREGATE_SET_VAR filters down to — would stay
-    // green even if the scan regressed to finding just those three, silently
-    // dropping visibility into the other 22 the duplicate-push-target check
-    // in discoverAggregatePushTargets also depends on seeing. If the
-    // push-target regex ever stops matching at all, AGGREGATE_PUSH_TARGETS
-    // silently becomes `{}`, AGGREGATE_SET_VAR silently becomes `{}` too, and
-    // the aggregate half of TWIN_TESTED silently drops to nothing — the
-    // exact "hand-written and unverified" state this derivation exists to
-    // close, just reintroduced one layer down instead of fixed.
+  test('aggregate push-target discovery finds exactly 25 blocks (count pin, not a loose floor)', () => {
+    // Renamed from "...finds blocks at all" (review follow-up): that name
+    // described a non-vacuity check, but the value — 25, the real count —
+    // behaves as an exact-count PIN with zero headroom. Removing one
+    // legitimate collection from decodeAllCollections turns this red at
+    // "Expected >= 25, Received 24", not just at total collapse. That is
+    // deliberate, not an oversight — do not "fix" the apparent tightness by
+    // loosening it back toward a wide margin (contrast the sibling
+    // `discovered` floor at `>= 30` against 36 real, which genuinely IS a
+    // margin, chosen because that scan covers blocks this file does not
+    // otherwise pin one by one). The tightness here is what turns
+    // decodeAllCollectionsBody's two silent-partial-slice failure modes —
+    // an anchor matching an embedded brace in the return type, or a
+    // balanced() run-off — into loud ones: both now throw before this test
+    // even runs (see decodeAllCollectionsBody's own assertion), but if that
+    // assertion were ever removed, THIS floor is the last line of defense,
+    // and a floor of 3 (this test's original value, sized only to cover the
+    // 3 collections AGGREGATE_SET_VAR filters down to) would not have
+    // caught a scan that regressed to finding just those three, silently
+    // losing visibility into the other 22.
     expect(Object.keys(AGGREGATE_PUSH_TARGETS).length).toBeGreaterThanOrEqual(25);
   });
 
@@ -700,7 +759,7 @@ export async function decodeAllCollections(dbPath: string): Promise<unknown> {
 `;
 
   test('the unrelated later push is not credited to the bounded guard', () => {
-    expect(discoverAggregatePushTargets(FIXTURE_SRC)).toEqual({});
+    expect(discoverAggregatePushTargets(FIXTURE_SRC, 0)).toEqual({});
   });
 });
 
@@ -737,7 +796,7 @@ export async function decodeAllCollections(dbPath: string): Promise<unknown> {
 }
 }
 `;
-    expect(discoverAggregatePushTargets(FIXTURE_SRC)).toEqual({ unrelatedY: 'ySeen' });
+    expect(discoverAggregatePushTargets(FIXTURE_SRC, 0)).toEqual({ unrelatedY: 'ySeen' });
   });
 
   test('a stray } inside a string literal fails CLOSED: the guard body truncates and a real push goes missing rather than misattributed', () => {
@@ -755,7 +814,7 @@ export async function decodeAllCollections(dbPath: string): Promise<unknown> {
   }
 }
 `;
-    expect(discoverAggregatePushTargets(FIXTURE_SRC)).toEqual({});
+    expect(discoverAggregatePushTargets(FIXTURE_SRC, 0)).toEqual({});
   });
 });
 
@@ -783,7 +842,7 @@ export async function decodeAllCollections(dbPath: string): Promise<unknown> {
   }
 }
 `;
-    expect(() => discoverAggregatePushTargets(FIXTURE_SRC)).toThrow(/push target "shared"/);
+    expect(() => discoverAggregatePushTargets(FIXTURE_SRC, 0)).toThrow(/push target "shared"/);
   });
 
   test('a source with no decodeAllCollections throws rather than silently scanning nothing (or everything)', () => {
@@ -824,6 +883,36 @@ export async function decodeAllCollections(dbPath: string): Promise<unknown> {
   }
 }
 `;
-    expect(discoverAggregatePushTargets(FIXTURE_SRC)).toEqual({ nestedArr: 'nestedSeen' });
+    expect(discoverAggregatePushTargets(FIXTURE_SRC, 0)).toEqual({ nestedArr: 'nestedSeen' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: an embedded brace in the return type must not silently
+// produce a partial slice (review follow-up on #688 review)
+// ---------------------------------------------------------------------------
+
+describe('decodeAllCollectionsBody rejects an implausibly short slice (#688 review)', () => {
+  test('a return type containing a brace makes the anchor match early — caught by the length assertion, not silently returning zero targets', () => {
+    // `Promise<{ ok: boolean } & AllCollectionsResult>` — the anchor's
+    // `[^{]*` stops at the type literal's OWN `{`, not the function body's,
+    // so balanced() faithfully extracts just the few characters of ` ok:
+    // boolean ` as `scoped` if nothing catches it. Before the length
+    // assertion, this returned `{}` silently, detected only two layers
+    // downstream by the non-vacuity floor and the AGGREGATE_SET_VAR pin.
+    // No override on the call below — this fixture exercises the REAL
+    // production default (5000), not a relaxed one, since the whole point
+    // is proving that default actually protects the real call site.
+    const FIXTURE_SRC = `
+export async function decodeAllCollections(dbPath: string): Promise<{ ok: boolean } & AllCollectionsResult> {
+  const xSeen = new Set<string>();
+  const arr: string[] = [];
+  if (!xSeen.has(item.id)) {
+    xSeen.add(item.id);
+    arr.push(item);
+  }
+}
+`;
+    expect(() => discoverAggregatePushTargets(FIXTURE_SRC)).toThrow(/implausibly short body/);
   });
 });

--- a/tests/core/dedup-identity.test.ts
+++ b/tests/core/dedup-identity.test.ts
@@ -31,7 +31,7 @@
  * or explicitly listed as untested-by-choice.
  *
  * Note "block", not "comment", and "expression", not "name". Both distinctions
- * were bought the hard way — nine revisions, each one narrower than its own
+ * were bought the hard way — ten revisions, each one narrower than its own
  * comment claimed, each narrowing found by review rather than by the suite:
  *
  *   1. five hand-written tests, claiming "every collection"
@@ -73,7 +73,19 @@
  *      6's opaque-call class (`keyFor(row.id)`) is still open, attribution
  *      is still top-level-`function`-only, and the sibling scanner's
  *      per-Set window is still a bare slice, safe because its `if (!`
- *      anchor makes a run-off loud rather than because it is bounded
+ *      anchor makes a run-off loud rather than because it is bounded — and
+ *      the anchor it added excluded `\w` and `$` but not `.`, so a member
+ *      expression still got through
+ *  10. the anchor widened to `(?<![\w$.])`, closing the member-expression
+ *      half (`ctx.seen.has(...)` no longer credited to a local `seen`), and
+ *      stripComments given a third pass so a window that truncates inside a
+ *      block comment cannot leave that comment's text being scanned as code
+ *      — the one residual in this list with a LIVE instance, not a
+ *      hypothetical: `decodeAllCollections|tagSeen`'s window ends inside the
+ *      docblock above `getDecodeTimeoutMs`. Still open afterwards: the lazy
+ *      `[^;]*?` capture truncates on a nested paren and pins unparseable
+ *      text (documented at the regex, no live instance, deliberately not
+ *      changed), plus everything revision 9 left
  *
  * Revision 2 could not see `dedupeAndSortInvestmentPrices`, which carries no
  * comment — the site that shipped #622, the previous instance of this exact
@@ -370,9 +382,37 @@ const UNTESTED_BY_CHOICE = new Set([
  * `balanced()` ever sees it — an unstripped comment containing an unbalanced
  * `{` or `}` would otherwise shift where `balanced()` thinks the guard body
  * ends, in either direction.
+ *
+ * The THIRD pass is what makes that safe on a windowed input, and is why this
+ * copy has diverged from the sibling's (fourth review follow-up on the #688
+ * review). The block-comment pass needs the closing `*\/`; both scanners here
+ * slice a DISCOVERY_WINDOW first and strip second, so a window whose end lands
+ * inside a block comment leaves that comment's text in the scanned string,
+ * where it can match the guard regex or the `const key = ...;` resolution
+ * exactly like live code. That is precisely the failure revision 7's strip was
+ * added to prevent, reached through the window boundary rather than through a
+ * `//` line. Since the first pass has already removed every TERMINATED block
+ * comment, any `/*` still present is unterminated within this text, so
+ * dropping from it to the end is exact rather than heuristic. It runs after
+ * the line pass so that a `/*` appearing inside a `//` comment is already gone
+ * and cannot trigger it.
+ *
+ * This was not theoretical: `decodeAllCollections|tagSeen`'s window ends
+ * inside the docblock above `getDecodeTimeoutMs`, so that prose was being
+ * scanned as code — harmless only because it happens to contain no `.has(`
+ * and no `const x = ...;`. Adding the pass changes 0 of the 36 resolved keys
+ * and leaves 0 windows holding an unterminated opener.
+ *
+ * The sibling file's copy does NOT need this pass and deliberately does not
+ * have it: there `stripComments` is applied to a `balanced()` function body or
+ * to the whole source, never to a truncated character window, so its block
+ * comments always arrive with their closers.
  */
 function stripComments(text: string): string {
-  return text.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/\/\*[\s\S]*$/, '');
 }
 
 /**
@@ -779,20 +819,52 @@ function discoverDedupBlocks(
     const nextDecl = declarations.find(([at]) => at > (m.index as number));
     const end = Math.min(start + DISCOVERY_WINDOW, nextDecl ? nextDecl[0] : source.length);
     const window = stripComments(source.slice(start, end));
-    // `(?<![\w$])` anchors the Set name to an identifier boundary (third
-    // review follow-up on #688 review). Without it `${variable}` matches as a
-    // SUFFIX of any longer identifier, so a Set named `catSeen` picks up
-    // `subcatSeen.has(...)` — someone else's guard, yielding a key that is
-    // wrong and well-formed at the same time. The declaration bound above does
-    // not help: it separates functions, and 25 of the decoder's 36 Sets share
-    // decodeAllCollections, so their windows overlap freely. The sibling
-    // scanner never had this because its `if (!` prefix pins the name to the
-    // character after the `!`; this is the last place in either file where a
-    // scan could latch onto something that is not its target. Verified before
-    // tightening: no Set name in the decoder is a proper suffix of another
-    // (36 Sets, 27 distinct names, 0 suffix pairs), and anchoring changes 0 of
-    // the 36 resolved keys — a hole closed, not a pin moved.
-    const use = new RegExp(`(?<![\\w$])${variable}\\.has\\(([^;]*?)\\)\\s*\\)`).exec(window);
+    // `(?<![\w$.])` anchors the Set name to an identifier boundary (third and
+    // fourth review follow-ups on #688 review). Two shapes, one class — the
+    // scan latching onto a `.has(` that is not its target:
+    //
+    //   - SUFFIX: without the lookbehind at all, `${variable}` matches as the
+    //     tail of any longer identifier, so a Set named `catSeen` picks up
+    //     `subcatSeen.has(...)`.
+    //   - MEMBER EXPRESSION: `.` is not in `[\w$]`, so the first version of
+    //     this anchor still let a local `const seen` match `ctx.seen.has(...)`
+    //     — a different Set entirely, a property on some object.
+    //
+    // Both produce a key that is wrong and well-formed at the same time, which
+    // then passes fieldFreeBlocks and looks like a good answer to whoever
+    // regenerates DEDUP_BLOCKS from it. The declaration bound above does not
+    // help with either: it separates functions, and 25 of the decoder's 36
+    // Sets share decodeAllCollections, so their windows overlap freely.
+    //
+    // The sibling scanner is immune to both for free, because its `if (!`
+    // prefix pins the name to the character after the `!`. With `.` excluded,
+    // the two scanners finally agree on what counts as "this Set's guard".
+    //
+    // Verified before tightening, both times: no Set name in the decoder is a
+    // proper suffix of another (36 Sets, 27 distinct names, 0 suffix pairs),
+    // and all 36 `.has(` receivers are bare identifiers (0 preceded by a dot).
+    // Neither tightening changes any of the 36 resolved keys — holes closed,
+    // no pins moved.
+    //
+    // The `\)\s*\)` tail is load-bearing and is NOT an `if (!` remnant: it is
+    // what lets this pattern match `decoder.ts`'s one non-`if` guard,
+    // `!(txn.pending && supersededPendingIds.has(txn.transaction_id))`.
+    // Requiring `if (!` here — the obvious "make it match the sibling" move —
+    // silently drops that block (checked: an `if \(!`-prefixed pattern does
+    // not match that line).
+    //
+    // RESIDUAL, recorded rather than fixed: the capture is lazy and stops at
+    // the first `)` that is followed by another, so a guard nesting a call —
+    // `if (!seen.has(String(row.id)))` — pins the truncated text
+    // "String(row.id". Not a detection hole (the string still moves when the
+    // field does, so the pin and fieldFreeBlocks both stay honest), but a
+    // maintainer regenerating the pin would get an entry that does not parse.
+    // No live instance: 0 of the decoder's 36 `.has(` sites nest a call.
+    // Capturing with `balanced()` would fix it, and is deliberately not done
+    // here — that is a behaviour change to a scanner with no failing case
+    // behind it, which is the same reason the sibling's per-Set window was
+    // left unbounded two revisions ago.
+    const use = new RegExp(`(?<![\\w$.])${variable}\\.has\\(([^;]*?)\\)\\s*\\)`).exec(window);
     let key = use ? (use[1] as string).replace(/\s+/g, ' ').trim() : 'NONE';
     // Resolve a bare identifier to the expression it is assigned from. Three
     // blocks dedup on `const key = \`${a}:${b}\``, and pinning the string
@@ -957,7 +1029,13 @@ describe('dedup coverage is declared, not assumed (#668 review)', () => {
 
   test('every block is twin-tested, structural, or listed as untested', () => {
     const unexplained = Object.keys(discovered).filter(
-      (b) => !TWIN_TESTED.has(b) && !(b in STRUCTURAL_KEYS) && !UNTESTED_BY_CHOICE.has(b)
+      // `Object.hasOwn`, not `in` (review nit): the two scanners above were
+      // switched off `in` for prototype-chain reasons and this site was left
+      // behind, so the same construct read two different ways in one file.
+      // Unreachable here for the same reason it is unreachable there — every
+      // block key contains a `|` — but "unreachable and documented" and
+      // "unreachable and not mentioned" are different states to leave code in.
+      (b) => !TWIN_TESTED.has(b) && !Object.hasOwn(STRUCTURAL_KEYS, b) && !UNTESTED_BY_CHOICE.has(b)
     );
     expect(unexplained).toEqual([]);
   });
@@ -1448,9 +1526,15 @@ describe('discoverDedupBlocks anchors the Set name it matches (#688 review)', ()
   // declaration bound does not help here: both Sets live in one function, and
   // inside decodeAllCollections 25 of the decoder's 36 Sets do exactly that,
   // so their windows overlap freely. The sibling scanner is immune for free —
-  // its `if (!` prefix forces the name to start right after the `!` — and this
-  // is the last place in either file where a scan could latch onto something
-  // that is not its target.
+  // its `if (!` prefix forces the name to start right after the `!`.
+  //
+  // This closes the identifier-SUFFIX half only. When it was written it
+  // claimed to be "the last place in either file where a scan could latch onto
+  // something that is not its target", and the next review round found the
+  // other half one character away: `.` is not in `[\w$]`, so a member
+  // expression still got through. See the member-expression describe below —
+  // the two fixtures are halves of one class, kept apart because they fail for
+  // different reasons and each has to be able to fail on its own.
   const FIXTURE_SRC = `
 export function decodeSuffix(): unknown {
   const catSeen = new Set<string>();
@@ -1502,5 +1586,70 @@ export function decodeSentinel(): unknown {
 
   test('and is therefore still reported by the live field-free invariant', () => {
     expect(fieldFreeBlocks(discoverDedupBlocks(FIXTURE_SRC))).toEqual(['decodeSentinel|seen']);
+  });
+});
+
+describe('discoverDedupBlocks anchors past a member expression too (#688 review)', () => {
+  // `(?<![\w$])` excludes word characters and `$` but NOT `.`, so a local
+  // `const seen` still matched `ctx.seen.has(...)` — a DIFFERENT Set, a
+  // property on some object, whose guard got credited to the local one. Same
+  // consequence as the suffix case closed one round earlier, one character
+  // away: a key that is wrong and well-formed at once, and one that passes
+  // fieldFreeBlocks for the same reason. The sibling scanner is immune to this
+  // half too, since `if (!` forces the name to begin right after the `!`.
+  const FIXTURE_SRC = `
+export function decodeMember(): unknown {
+  const seen = new Set<string>();
+  const ids = raw.map((r) => r.thing_id);
+  if (!ctx.seen.has(row.row_id)) {
+    ctx.seen.add(row.row_id);
+  }
+}
+`;
+
+  test('a local Set does not borrow a member-expression Set of the same name', () => {
+    expect(discoverDedupBlocks(FIXTURE_SRC)).toEqual({ 'decodeMember|seen': 'NONE' });
+  });
+
+  test('the borrowed member-expression guard would otherwise pass the live invariant', () => {
+    expect(fieldFreeBlocks(discoverDedupBlocks(FIXTURE_SRC))).toEqual(['decodeMember|seen']);
+  });
+});
+
+describe('stripComments drops a block comment the window cut in half (#688 review)', () => {
+  test('a decoy guard inside a truncated block comment does not win the key', () => {
+    // stripComments removes block comments with `/\*[\s\S]*?\*\//`, which needs
+    // the CLOSING `*/`. Both scanners slice a window and strip second, so a
+    // window whose end lands inside a block comment leaves that comment's text
+    // in the scanned string, eligible to match the guard regex exactly like
+    // live code — the failure revision 7's strip was added to prevent, reached
+    // through the window boundary instead of through a `//` line.
+    //
+    // This one had a LIVE instance, unlike most residuals recorded here:
+    // `decodeAllCollections|tagSeen`'s window ends inside the docblock above
+    // `getDecodeTimeoutMs`, and that prose sits in the scanned window today.
+    // Harmless only because it contains no `.has(` and no `const x = ...;`.
+    //
+    // The filler puts the DISCOVERY_WINDOW boundary inside the comment below,
+    // so the decoy guard is inside the window and the comment's closer is not.
+    const filler = 'x'.repeat(DISCOVERY_WINDOW - 200);
+    const FIXTURE_SRC = `
+export function decodeTruncated(): unknown {
+  const seen = new Set<string>();
+  const pad = '${filler}';
+  /* decoy guard, sliced in half by the window boundary:
+     if (!seen.has(decoy.decoy_id)) {
+     ${'y'.repeat(400)}
+   */
+  if (!seen.has(real.real_id)) {
+    seen.add(real.real_id);
+  }
+}
+`;
+    // NONE, not `decoy.decoy_id`: the real guard sits past the window, so the
+    // honest answer is "no guard found here" — and NONE is a state the live
+    // field-free invariant rejects, where `decoy.decoy_id` would have sailed
+    // through it.
+    expect(discoverDedupBlocks(FIXTURE_SRC)).toEqual({ 'decodeTruncated|seen': 'NONE' });
   });
 });

--- a/tests/core/dedup-identity.test.ts
+++ b/tests/core/dedup-identity.test.ts
@@ -31,7 +31,7 @@
  * or explicitly listed as untested-by-choice.
  *
  * Note "block", not "comment", and "expression", not "name". Both distinctions
- * were bought the hard way — eight revisions, each one narrower than its own
+ * were bought the hard way — nine revisions, each one narrower than its own
  * comment claimed, each narrowing found by review rather than by the suite:
  *
  *   1. five hand-written tests, claiming "every collection"
@@ -63,7 +63,17 @@
  *      is still top-level-`function`-only, so a Set in an arrow function or
  *      a method is credited to the preceding declaration and bounded by the
  *      following one, and stripComments's string-literal ASSUMPTION (below)
- *      is unchanged
+ *      is unchanged — and the name it matched was still un-anchored, so a
+ *      Set could borrow a longer identifier's guard inside the one function
+ *      the bound cannot split
+ *   9. the matched name anchored to an identifier boundary, so `catSeen` no
+ *      longer matches `subcatSeen.has(`, and the 'NONE' sentinel taken out
+ *      of band so a `const NONE = row.id` can no longer rewrite "unguarded"
+ *      into a field-bearing key that passes fieldFreeBlocks — but revision
+ *      6's opaque-call class (`keyFor(row.id)`) is still open, attribution
+ *      is still top-level-`function`-only, and the sibling scanner's
+ *      per-Set window is still a bare slice, safe because its `if (!`
+ *      anchor makes a run-off loud rather than because it is bounded
  *
  * Revision 2 could not see `dedupeAndSortInvestmentPrices`, which carries no
  * comment — the site that shipped #622, the previous instance of this exact
@@ -589,6 +599,14 @@ function discoverAggregatePushTargets(
   // all, so `Object.hasOwn` never sees it and the target is dropped in silence
   // instead of throwing — the half of the `in` nit that `Object.hasOwn` alone
   // does not close.
+  //
+  // DEPENDS ON `toEqual`, NOT `toStrictEqual`: both scanners now return
+  // null-prototype objects, and four assertions in this file compare one
+  // against a plain object literal. `toEqual` ignores the prototype;
+  // `toStrictEqual` compares it and would fail with the famously unhelpful
+  // "serializes to the same string". There is no `toStrictEqual` in this file
+  // today — if a future review suggests tightening one of those comparisons,
+  // this is why it does not apply here.
   const found: Record<string, string> = Object.create(null);
   for (const m of scoped.matchAll(/const (\w+) = new Set<string>\(\)/g)) {
     const setVar = m[1] as string;
@@ -704,10 +722,20 @@ const TWIN_TESTED = new Set(
  * pinned from the NEXT function's guard instead of reported as unguarded.
  * That is a plausible-looking wrong answer, and it is the same unbounded
  * forward scan this file's sibling closed with `balanced()` and
- * `decodeAllCollectionsBody()`; this was the last instance of it left in
- * either file. Bounding it changed no pin: comparing the char-bounded and
- * declaration-bounded resolution across all 36 real blocks yields 0
- * differences, so it closes a hole rather than moving a pin.
+ * `decodeAllCollectionsBody()`; this was the last FUNCTION-level instance of
+ * it left in either file. Bounding it changed no pin: comparing the
+ * char-bounded and declaration-bounded resolution across all 36 real blocks
+ * yields 0 differences, so it closes a hole rather than moving a pin.
+ *
+ * "Function-level" is the qualifier that makes that claim true (third review
+ * follow-up): `discoverAggregatePushTargets`'s own per-Set window is still a
+ * bare DISCOVERY_WINDOW slice inside the already-scoped
+ * decodeAllCollectionsBody. It is safe for a reason rather than by
+ * construction — its guard regex is `if (!`-anchored, so a window that runs
+ * off can only find a guard belonging to another Set, and that yields either
+ * a duplicate push target (throws) or none (fails the `toBe(25)` pin). Both
+ * are loud. Left as-is rather than bounded, because the reason is real and
+ * bounding it would be a change with no failing case behind it.
  *
  * ATTRIBUTION LIMIT, shared by `enclosing` and by the bound above, since
  * both read the same `declarations` list: that list comes from
@@ -739,7 +767,8 @@ function discoverDedupBlocks(
   // line to `{}` leaves all tests green, which is why the pinned fixture for
   // the drop lives on the sibling scanner (whose keys ARE bare identifiers)
   // and not here. Kept so the two scanners read the same way; recorded as
-  // unreachable so nobody later mistakes it for a live guard.
+  // unreachable so nobody later mistakes it for a live guard. Carries the same
+  // `toEqual`-not-`toStrictEqual` dependency documented on the sibling above.
   const found: Record<string, string> = Object.create(null);
   for (const m of source.matchAll(/const (\w+) = new Set<string>\(\)/g)) {
     const variable = m[1] as string;
@@ -750,14 +779,37 @@ function discoverDedupBlocks(
     const nextDecl = declarations.find(([at]) => at > (m.index as number));
     const end = Math.min(start + DISCOVERY_WINDOW, nextDecl ? nextDecl[0] : source.length);
     const window = stripComments(source.slice(start, end));
-    const use = new RegExp(`${variable}\\.has\\(([^;]*?)\\)\\s*\\)`).exec(window);
+    // `(?<![\w$])` anchors the Set name to an identifier boundary (third
+    // review follow-up on #688 review). Without it `${variable}` matches as a
+    // SUFFIX of any longer identifier, so a Set named `catSeen` picks up
+    // `subcatSeen.has(...)` — someone else's guard, yielding a key that is
+    // wrong and well-formed at the same time. The declaration bound above does
+    // not help: it separates functions, and 25 of the decoder's 36 Sets share
+    // decodeAllCollections, so their windows overlap freely. The sibling
+    // scanner never had this because its `if (!` prefix pins the name to the
+    // character after the `!`; this is the last place in either file where a
+    // scan could latch onto something that is not its target. Verified before
+    // tightening: no Set name in the decoder is a proper suffix of another
+    // (36 Sets, 27 distinct names, 0 suffix pairs), and anchoring changes 0 of
+    // the 36 resolved keys — a hole closed, not a pin moved.
+    const use = new RegExp(`(?<![\\w$])${variable}\\.has\\(([^;]*?)\\)\\s*\\)`).exec(window);
     let key = use ? (use[1] as string).replace(/\s+/g, ' ').trim() : 'NONE';
     // Resolve a bare identifier to the expression it is assigned from. Three
     // blocks dedup on `const key = \`${a}:${b}\``, and pinning the string
     // "key" pins NOTHING — changing what key is built from would not move it.
     // That is this file's own bug class yet again: a guard recording a name
     // where it means a value.
-    if (/^\w+$/.test(key)) {
+    //
+    // Gated on `use` so the 'NONE' sentinel never enters this step. 'NONE'
+    // matches /^\w+$/ like any identifier, so without the gate a
+    // `const NONE = row.id;` in the window rewrote the sentinel into
+    // "NONE = row.id" — which contains a property access and therefore PASSES
+    // fieldFreeBlocks, reporting an unguarded block as guarded. A fail-open in
+    // this file's headline invariant, reached through the sentinel rather than
+    // through the scan. `const NONE` appears nowhere in the repo today
+    // (checked), which is precisely the kind of guarantee that should not be
+    // load-bearing: `use &&` makes the sentinel out-of-band by construction.
+    if (use && /^\w+$/.test(key)) {
       const assigned = new RegExp(`const ${key} = ([^;]+);`).exec(window);
       if (assigned) key = `${key} = ${(assigned[1] as string).replace(/\s+/g, ' ').trim()}`;
     }
@@ -1346,19 +1398,22 @@ export function decodeTwoScopes(): unknown {
 });
 
 describe('discoverDedupBlocks bounds its window at the next declaration (#688 review)', () => {
-  test('a Set whose own guard is gone reports NONE, not a key from the next function', () => {
-    // DISCOVERY_WINDOW is a character count, not a syntactic boundary, and 18
-    // of the decoder's 36 real blocks have a 3 000-character window that
-    // reaches past the end of their own function. So a Set whose guard was
-    // removed or refactored away does not come back as unguarded — the scan
-    // walks into the NEXT function and pins it to a guard that belongs to
-    // something else. `decodeUnguarded|seen` would be pinned to `row.row_id`,
-    // which looks like a perfectly good answer and is the wrong one; the
-    // field-free invariant would pass it, and the maintainer who regenerates
-    // DEDUP_BLOCKS from it bakes in a claim about code that does not exist.
-    // Same unbounded-forward-scan class `balanced()` and
-    // decodeAllCollectionsBody() close for the sibling scanner.
-    const FIXTURE_SRC = `
+  // DISCOVERY_WINDOW is a character count, not a syntactic boundary, and 18 of
+  // the decoder's 36 real blocks have a 3 000-character window that reaches
+  // past the end of their own function. So a Set whose guard was removed or
+  // refactored away does not come back as unguarded — the scan walks into the
+  // NEXT function and pins it to a guard that belongs to something else.
+  // `decodeUnguarded|seen` would be pinned to `row.row_id`, which looks like a
+  // perfectly good answer and is the wrong one; the field-free invariant would
+  // pass it, and the maintainer who regenerates DEDUP_BLOCKS from it bakes in
+  // a claim about code that does not exist. Same unbounded-forward-scan class
+  // `balanced()` and decodeAllCollectionsBody() close for the sibling scanner.
+  //
+  // One fixture, two tests, deliberately shared (third review follow-up): the
+  // second test's whole point is that it is the SAME scenario seen through the
+  // live invariant, and two byte-identical copies left that composition for
+  // the reader to discover by diffing.
+  const FIXTURE_SRC = `
 export function decodeUnguarded(): unknown {
   const seen = new Set<string>();
   const ids = raw.map((r) => r.thing_id);
@@ -1371,6 +1426,8 @@ export function decodeGuarded(): unknown {
   }
 }
 `;
+
+  test('a Set whose own guard is gone reports NONE, not a key from the next function', () => {
     expect(discoverDedupBlocks(FIXTURE_SRC)).toEqual({
       'decodeUnguarded|seen': 'NONE',
       'decodeGuarded|seen': 'row.row_id',
@@ -1381,19 +1438,69 @@ export function decodeGuarded(): unknown {
     // The bound is only useful because `NONE` is a state the live invariant
     // rejects: bounding the window turns a plausible wrong key into a loud
     // one rather than into a different kind of silence.
-    const FIXTURE_SRC = `
-export function decodeUnguarded(): unknown {
-  const seen = new Set<string>();
-  const ids = raw.map((r) => r.thing_id);
-}
+    expect(fieldFreeBlocks(discoverDedupBlocks(FIXTURE_SRC))).toEqual(['decodeUnguarded|seen']);
+  });
+});
 
-export function decodeGuarded(): unknown {
-  const seen = new Set<string>();
-  if (!seen.has(row.row_id)) {
-    seen.add(row.row_id);
+describe('discoverDedupBlocks anchors the Set name it matches (#688 review)', () => {
+  // `catSeen` is a suffix of `subcatSeen`, so an un-anchored
+  // `${variable}\.has\(` matches the LONGER identifier's guard. The
+  // declaration bound does not help here: both Sets live in one function, and
+  // inside decodeAllCollections 25 of the decoder's 36 Sets do exactly that,
+  // so their windows overlap freely. The sibling scanner is immune for free —
+  // its `if (!` prefix forces the name to start right after the `!` — and this
+  // is the last place in either file where a scan could latch onto something
+  // that is not its target.
+  const FIXTURE_SRC = `
+export function decodeSuffix(): unknown {
+  const catSeen = new Set<string>();
+  const subcatSeen = new Set<string>();
+  if (!subcatSeen.has(sub.subcategory_id)) {
+    subcatSeen.add(sub.subcategory_id);
   }
 }
 `;
-    expect(fieldFreeBlocks(discoverDedupBlocks(FIXTURE_SRC))).toEqual(['decodeUnguarded|seen']);
+
+  test('a Set whose name is a suffix of another does not borrow the longer guard', () => {
+    expect(discoverDedupBlocks(FIXTURE_SRC)).toEqual({
+      'decodeSuffix|catSeen': 'NONE',
+      'decodeSuffix|subcatSeen': 'sub.subcategory_id',
+    });
+  });
+
+  test('the borrowed guard would otherwise pass the live field-free invariant', () => {
+    // Why the anchor matters rather than merely tidying: the borrowed key
+    // `sub.subcategory_id` contains a property access, so fieldFreeBlocks
+    // accepts it. The wrong answer is not just wrong, it is well-formed —
+    // and a maintainer regenerating DEDUP_BLOCKS from it would pin a claim
+    // about a guard that belongs to a different Set.
+    expect(fieldFreeBlocks(discoverDedupBlocks(FIXTURE_SRC))).toEqual(['decodeSuffix|catSeen']);
+  });
+});
+
+describe('discoverDedupBlocks keeps its NONE sentinel out of band (#688 review)', () => {
+  // `NONE` matches /^\w+$/, so before the `use &&` guard the sentinel was fed
+  // into the bare-identifier resolution exactly like a real identifier. A
+  // `const NONE = ...` in the window then rewrote "no guard found" into a
+  // resolved-looking key — and because that key contains a property access it
+  // passes fieldFreeBlocks, so an UNGUARDED block reports as guarded. A
+  // fail-open in this file's headline invariant, reached through the sentinel
+  // rather than through the scan. `const NONE` appears nowhere in the repo
+  // today, which is exactly the kind of guarantee that should not be load
+  // bearing.
+  const FIXTURE_SRC = `
+export function decodeSentinel(): unknown {
+  const seen = new Set<string>();
+  const NONE = row.id;
+  const ids = raw.map((r) => r.thing_id);
+}
+`;
+
+  test('an unguarded Set stays NONE even when a const NONE is in scope', () => {
+    expect(discoverDedupBlocks(FIXTURE_SRC)).toEqual({ 'decodeSentinel|seen': 'NONE' });
+  });
+
+  test('and is therefore still reported by the live field-free invariant', () => {
+    expect(fieldFreeBlocks(discoverDedupBlocks(FIXTURE_SRC))).toEqual(['decodeSentinel|seen']);
   });
 });

--- a/tests/core/dedup-identity.test.ts
+++ b/tests/core/dedup-identity.test.ts
@@ -441,13 +441,49 @@ const DISCOVERY_WINDOW = 3000;
  * Both are "a parser silently returns an empty or partial slice" — the exact
  * construct the sibling PR (#685/#688 test-guard cleanup) has spent several
  * revisions closing elsewhere in this repo. The regex tightening narrows
- * WHICH shapes can trigger this; the length assertion is what actually
- * closes it, because it does not depend on anticipating every shape that
- * can go wrong — only on the fact that a real function body this large does
- * not shrink to a sliver. The real body is ~18,000 characters; the floor
- * below is set with a wide margin under that, wide enough to never trip on
- * a legitimate edit, tight enough that no degenerate slice can sneak under
- * it undetected.
+ * WHICH shapes can trigger this; the two assertions below are what actually
+ * close it — one on SIZE, one on CONTENT — because neither depends on
+ * anticipating every shape that can go wrong.
+ *
+ * SIZE (`minPlausibleLength`): a real body this large does not shrink to a
+ * sliver. The real body is ~18,000 characters; the floor is set with a wide
+ * margin under that. But size alone is a HEURISTIC, not a content check
+ * (review follow-up, round 2 of this exact finding) — it is defeated by
+ * padding: `Promise<{ field0: boolean; ...400 more... } & AllCollectionsResult>`
+ * produces a slice north of 7,000 characters, clearing the floor, while
+ * still being the wrong slice (the type literal's padding, not the
+ * function body).
+ *
+ * CONTENT (below): the slice must contain `const \w+ = new Set<string>\(\)`
+ * — the exact construct the scan exists to find. Its absence means the scan
+ * cannot possibly do its job, so this assertion fails for the same reason
+ * the scan would; its presence is necessary, though (see next paragraph)
+ * NOT sufficient, for the slice to be genuine.
+ *
+ * TRIED TO DEFEAT THIS, both attempts against the padded-type-literal shape
+ * above: (1) a bare `marker: 'new Set<string>()'` field embeds the literal
+ * SUBSTRING and defeats a naive `.includes()` check — closed by requiring
+ * the full `const \w+ = new Set<string>\(\)` shape, not just the bare
+ * text. (2) a `marker: 'const attackerVar = new Set<string>();'` field
+ * embeds that FULL shape too, as string content, and DOES defeat the
+ * content check — confirmed by running it through this exact regex. This
+ * is not a tuning gap: a regex has no notion of "inside a string literal,"
+ * so any text-based marker, however specific, can be reproduced inside a
+ * string-literal-typed field by a sufficiently deliberate payload — the
+ * same categorical limit `balanced()`'s own ASSUMPTION documents for
+ * unbalanced brackets inside strings. Closing it fully needs a real
+ * TypeScript parser, not a bigger regex; out of scope for a test-guard file
+ * whose actual adversary is an accidental refactor, not a hostile input.
+ * What the content check DOES close: every REALISTIC reshape (an
+ * accidental brace in a return type is never accompanied by a hand-forged
+ * fake dedup-block string deliberately designed to fool this exact
+ * function). And even the maximally-adversarial payload above does not
+ * pass silently end to end — the per-block scan in
+ * `discoverAggregatePushTargets` still finds no genuine guard for the fake
+ * declaration and returns `{}`, so the count-pin and the `AGGREGATE_SET_VAR`
+ * pin still catch it, exactly as they did before this fix — only the
+ * DIAGNOSTIC quality regresses (caught two layers downstream instead of
+ * named here), not correctness.
  */
 const MIN_PLAUSIBLE_BODY_LENGTH = 5000;
 
@@ -455,6 +491,15 @@ function decodeAllCollectionsBody(
   source: string,
   minPlausibleLength: number = MIN_PLAUSIBLE_BODY_LENGTH
 ): string {
+  // Pre-existing brittleness, not introduced by the checks below and not
+  // worth fixing: the anchor is literal about the single spaces between
+  // `export`/`async`/`function`. A reformatted `export  async  function` (or
+  // a linter regression that stops collapsing them) fails to match at all —
+  // but that already fails LOUD, via the "could not locate" throw right
+  // below, which is the failure mode every check in this function is built
+  // to produce. Left as-is rather than generalized to `\s+`, since a
+  // silent-partial-slice bug is what this function exists to prevent, and a
+  // silent-empty-match bug is not that.
   const decl = /^export async function decodeAllCollections\([^)]*\)\s*:[^{]*\{/m.exec(source);
   if (!decl) {
     throw new Error(
@@ -466,6 +511,11 @@ function decodeAllCollectionsBody(
   if (body.length < minPlausibleLength) {
     throw new Error(
       `discoverAggregatePushTargets: decodeAllCollectionsBody extracted an implausibly short body (${body.length} chars, expected at least ${minPlausibleLength}) — the anchor likely matched a brace embedded in the return type instead of the function's own opening brace, or balanced() ran off the end of the source without finding a match`
+    );
+  }
+  if (!/const \w+ = new Set<string>\(\)/.test(body)) {
+    throw new Error(
+      "discoverAggregatePushTargets: decodeAllCollectionsBody extracted a body containing no `const X = new Set<string>()` declaration — it cannot be decodeAllCollections's real body, since that construct is what the scan exists to find; the anchor likely matched a brace embedded in the return type instead of the function's own opening brace"
     );
   }
   return body;
@@ -914,5 +964,63 @@ export async function decodeAllCollections(dbPath: string): Promise<{ ok: boolea
 }
 `;
     expect(() => discoverAggregatePushTargets(FIXTURE_SRC)).toThrow(/implausibly short body/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: padding a type literal past the length floor must still not
+// pass silently — the content marker is the second, independent check
+// (review follow-up, round 2 of the #688 review)
+// ---------------------------------------------------------------------------
+
+describe('decodeAllCollectionsBody rejects a padded-but-content-free slice (#688 review)', () => {
+  test('400 fake fields clear the length floor but contain no Set declaration — caught by the content marker', () => {
+    // The demonstrated attack: pad the same brace-in-return-type shape with
+    // enough harmless fields to clear MIN_PLAUSIBLE_BODY_LENGTH. The slice
+    // is now long enough to pass the size check, and is STILL the wrong
+    // slice — the type literal's padding, not the function body. Real
+    // decodeAllCollections's own body always contains at least one
+    // `const X = new Set<string>()`; this padding, by construction, never
+    // does.
+    const fields = Array.from({ length: 400 }, (_, i) => `field${i}: boolean`).join('; ');
+    const FIXTURE_SRC = `
+export async function decodeAllCollections(dbPath: string): Promise<{ ${fields} } & AllCollectionsResult> {
+  const xSeen = new Set<string>();
+}
+`;
+    expect(() => discoverAggregatePushTargets(FIXTURE_SRC)).toThrow(
+      /no `const X = new Set<string>\(\)` declaration/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Documented, accepted residual: a payload that embeds the content marker
+// ITSELF inside a string-literal-typed field defeats decodeAllCollectionsBody's
+// checks — the same categorical limit balanced()'s own ASSUMPTION already
+// documents for unbalanced brackets inside strings. Not a regression guard
+// for a bug this PR fixes; a permanent, executable record that even the
+// worst case does not pass silently END TO END, because the downstream
+// per-block scan still finds nothing to attribute.
+// ---------------------------------------------------------------------------
+
+describe('a maximally-adversarial payload defeats the slicer but not the downstream pins (#688 review)', () => {
+  test('embedding the exact marker text as string content clears both slicer checks, yet the scan still finds nothing', () => {
+    const fields = Array.from({ length: 400 }, (_, i) => `field${i}: boolean`).join('; ');
+    const FIXTURE_SRC = `
+export async function decodeAllCollections(dbPath: string): Promise<{ marker: 'const attackerVar = new Set<string>();'; ${fields} } & AllCollectionsResult> {
+  const xSeen = new Set<string>();
+}
+`;
+    // decodeAllCollectionsBody does NOT throw — both its checks pass on the
+    // wrong slice, exactly as documented above.
+    const found = discoverAggregatePushTargets(FIXTURE_SRC);
+    // But the per-block scan, run on that wrong slice, finds no genuine
+    // `.has(...)`-guarded `.push(` for the fake declaration — the STRING
+    // content has the shape of a Set declaration but not of a real guard —
+    // so the overall result is still the empty map the count-pin and the
+    // AGGREGATE_SET_VAR pin would both catch downstream. Silently WRONG
+    // slice, but not silently PASSING.
+    expect(found).toEqual({});
   });
 });


### PR DESCRIPTION
# Summary

Closes seven review findings against two test guards and the #662 post-mortem. The guards are
what fail when the decoder silently drops a field or a dedup key stops pinning the identity it
claims to — so the theme here is making each one able to fail, not just able to run.

Closes #685
Closes #688

Note: #688's `getHoldings` finding (the missing `user_deleted`/`user_hidden` filter) is **not**
in this PR — it is tracked separately as #683.

## What changed

**`tests/core/decoder-field-completeness.test.ts`**
- The `for...of [...]` surfacing scan found its loop body with `body.indexOf('{', end)`, which
  searched forward for the next `{` anywhere and could latch onto an unrelated later block.
  Now requires the brace to be adjacent to the header.
- One convention per function: the `lists` extraction, `rowIdents`, and the surfacing scans ran
  on raw source while only the `warnUnreadFields` census ran on stripped text. Stripped once at
  the top instead.
- The `PASSTHROUGH_PROCESSORS` docblock read as a complete list; a processor with a passthrough
  loop can still be excluded when its row is an inline literal. The decoder has eleven such
  loops and the set holds ten — `processInvestmentSplit` is now named as the exclusion.

**`tests/core/dedup-identity.test.ts`**
- The bare-identifier invariant rejected only a bare word or `NONE`, so `key = keyFor(row)`
  passed while pinning no field. Now requires a property access. Zero false positives across all
  36 pinned blocks.
- `AGGREGATE_SET_VAR` was a hand-written map nothing verified — the same unchecked coverage claim
  the derivation was meant to remove, for half the set. Now derived from decoder source.
- The push-target scan was an unbounded forward search that could cross block boundaries; bounded
  with a `balanced()` matcher, and the window is comment-stripped.

**`docs/bugs/662-account-dedup-drops-documents.md`** — revision table finished.

## Bug fix?

Root cause:       Two guards asserted over regions they located with unbounded forward scans, and a third pinned a key expression without requiring it to name a field — so each could pass while covering less than it claimed.
Bug class:        A guard that executes its target but cannot detect its own deletion — coverage without detection (#596).
Detector added:   Every strengthened assertion is now mutation-checked, and each scanner takes its source as a parameter so it can be pinned against a synthetic snippet rather than whatever the tree happens to contain. `discoverAggregatePushTargets` was parameterised specifically so its bound became detectable.
Siblings checked: `decoder-field-completeness.test.ts` had the same unbounded-scan shape and is fixed here. The remaining `stripComments`/`balanced` assumptions are documented with their failure directions rather than left implicit. No other guard in `tests/core/` locates a region by unbounded forward search.
Ledger updated:   n/a — not an external-assumption bug.

## External assumptions

None

## Verification

- `bun run check` — 3027 pass / 20 skip / 0 fail. `src/` diff is **zero lines**; this branch touches only tests and docs.
- **Mutation-checked, every strengthened assertion, and re-run independently at review:**
  - restore the unbounded `indexOf` brace scan → red, `ghost_field` credited
  - inject a `keyFor`-shaped dedup block → red on the new invariant, **green on the old one**
  - rename a push target (`goals` → `goalsList`) → red; the same mutation against the old
    hand-written map → **green**, which is the evidence that the derivation is a derivation and
    not a re-expression
  - revert the `balanced()` bound → red, and for the right reason: the wrong array credited to
    the wrong Set variable, not an incidental count change

## Known limits, stated rather than implied

`balanced()` is not string-aware. A stray `{` inside a string literal in a guard body shifts the
boundary outward and can mis-credit a later push (fails OPEN); a stray `}` drops the real push
(fails closed). Zero of the 36 real guard bodies contain one today. Both directions are pinned by
fixtures that are explicitly labelled as documenting an accepted residual, **not** as regression
guards — a future fix should update them rather than be alarmed by them breaking.

The tightened invariant narrows the opaque-call class rather than closing it: `key = keyFor(row.id)`
still passes while pinning nothing, because the check reads the call site's text. Recorded in the
post-mortem as revision 6's gap.
