### PR TITLE
fix(security): close five live bypasses of the concealment gate

### DIFF
--- a/docs/superpowers/specs/2026-04-23-graphql-live-reads-design.md
+++ b/docs/superpowers/specs/2026-04-23-graphql-live-reads-design.md
@@ -94,7 +94,7 @@ src/
 ├── cli.ts                                  # + --live-reads flag parsing
 ├── server.ts                               # + conditional live-mode registration and preflight
 ├── core/
-│   ├── database.ts                         # unchanged (cache-backed, used by cache tools AND by live tools for account→item lookup until phase 2)
+│   ├── database.ts                         # unchanged; live tools use it for account→item lookup
 │   ├── live-database.ts                    # NEW — LiveCopilotDatabase class
 │   └── graphql/
 │       ├── client.ts                       # unchanged

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -75,11 +75,26 @@ const SKIP_DIRS = new Set([
 ]);
 
 /**
- * Prose. These are never executed, so the rules about hiding CODE off the right
- * edge of a diff (long line, whitespace run) and about dynamic execution do not
- * apply — a 900-column paragraph in a CHANGELOG is a paragraph, and a doc that
- * quotes `execSync` is documentation. Invisible characters are still flagged
- * here, since a zero-width character in prose is never benign.
+ * Prose. These are never executed, so exactly TWO rules are dropped: the
+ * long-line rule and the dynamic-execution rule. A 900-column paragraph in a
+ * CHANGELOG is a paragraph, and a doc that quotes `execSync` is documentation.
+ *
+ * Everything else still applies, and the list of what survives is the point:
+ *
+ *   - Invisible characters, because a zero-width character in prose is never
+ *     benign.
+ *   - The whitespace run. This one used to be dropped with the other two, on
+ *     the reasoning that prose is only read by humans. It is not: `CLAUDE.md`
+ *     and the instruction files under `skills/` are read in full by an agent,
+ *     so a sentence parked past a 40-space gap is invisible to the reviewer
+ *     and load-bearing to the model — the better-auth shape with the payload
+ *     swapped for an instruction. Markdown's one legitimate whitespace idiom,
+ *     the trailing double space that forces a line break, sits at end-of-line and
+ *     cannot match `\S[gap]{n,}\S`. Extending the rule to prose produced one
+ *     hit across the whole repo: an aligned ASCII file-tree at 147 columns in
+ *     a design doc. That was reflowed rather than exempted, because the rule's
+ *     own criterion — alignment is legible when the line ends where you can
+ *     see it — says a 147-column line does not.
  *
  * Note which way this allowlist fails. Forgetting to list a prose extension
  * means that file gets the FULL rule set — more scrutiny, and at worst a false
@@ -364,7 +379,11 @@ function checkLine(
   exempt: boolean,
   prose: boolean
 ): void {
-  if (!prose && line.length > CONCEALED_LINE && WHITESPACE_RUN_RE.test(line)) {
+  // Deliberately NOT gated on `!prose`, unlike the two rules below it. See
+  // PROSE_EXTENSIONS: markdown in this repo is read by agents as well as by
+  // people, and a gap wide enough to push text off-screen conceals it from
+  // exactly one of those two readers.
+  if (line.length > CONCEALED_LINE && WHITESPACE_RUN_RE.test(line)) {
     report(
       rel,
       lineNo,

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -439,7 +439,23 @@ function checkLine(
  * is refused rather than allow-listed — `text=auto`, `eol=lf` and
  * `linguist-language=...` do not hide content, so they need no exemption.
  */
-const DIFF_SUPPRESSING_ATTRS = [/(^|\s)binary(\s|$)/, /(^|\s)-diff(\s|$)/, /linguist-generated/];
+const DIFF_SUPPRESSING_ATTRS = [
+  /(^|\s)binary(\s|$)/,
+  /(^|\s)-diff(\s|$)/,
+  // Anchored on both sides, like its two neighbours, and with the un-setting
+  // forms carved out. Bare `/linguist-generated/` also matched
+  // `linguist-generated=false` and `-linguist-generated`, which take a file OUT
+  // of the "Load diff" fold — the opposite of concealment. The gate reported
+  // them and told the author to delete the thing making their file reviewable.
+  //
+  // The carve-out is `=false` specifically, not "anything but =true". Linguist
+  // reads these with `boolean_attribute(attr) => attr != "false"`, so
+  // `linguist-generated=1` and `=yes` collapse the diff exactly like `=true`
+  // does. Narrowing to `(=true)?` would have been this file's recurring bug one
+  // more time: a pattern here approximating a grammar defined elsewhere, and
+  // failing OPEN on every value the approximation did not anticipate.
+  /(^|\s)linguist-generated(=(?!false(\s|$))\S*)?(\s|$)/,
+];
 
 function checkGitAttributes(contents: string, rel: string): void {
   contents.split('\n').forEach((line, i) => {

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -82,6 +82,16 @@ const CONCEALED_LINE = 120;
 /** A line this long hides its tail with or without a gap. */
 const MAX_LINE = 400;
 
+/**
+ * How much output the gate will take from one `git` invocation.
+ *
+ * Named rather than inline because the failure message quotes it, and a limit
+ * whose diagnostic can drift from its value is the shape this file exists to
+ * remove. 64 MiB against a 20,240-byte tracked listing on this repo — the bound
+ * is headroom, not a threshold anything is near.
+ */
+const MAX_GIT_OUTPUT = 64 * 1024 * 1024;
+
 const SKIP_DIRS = new Set([
   'node_modules',
   '.git',
@@ -741,6 +751,16 @@ function checkLifecycleScripts(contents: string, rel: string): void {
  * tests drive it (synthetic trees under CHECK_CONCEALMENT_ROOT). Both paths
  * are covered: see 'file list' in tests/scripts/check-concealment.test.ts.
  */
+/**
+ * Why the git listing declined, set by whichever branch of gitFiles declined.
+ *
+ * The strategy check at the bottom of this file turns a decline into a hard
+ * failure, so the operator is entitled to the cause that was actually observed
+ * rather than the most likely one. Every `return undefined` in gitFiles sets
+ * this first; there is no path that declines silently.
+ */
+let gitDecline: string | undefined;
+
 function gitFiles(root: string): { tracked: string[]; untracked: string[] } | undefined {
   // Strip inherited git plumbing vars before shelling out. A pre-push hook runs
   // with GIT_DIR set, and `git -C <dir>` does NOT override it — so without this,
@@ -801,8 +821,58 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
   env.GIT_CONFIG_SYSTEM = '/dev/null';
 
   const run = (args: string[]): string[] | undefined => {
-    const r = spawnSync('git', ['-C', root, ...args], { encoding: 'utf-8', env });
-    if (r.status !== 0 || typeof r.stdout !== 'string') return undefined;
+    const shown = `git -C ${root} ${args.join(' ')}`;
+    const r = spawnSync('git', ['-C', root, ...args], {
+      encoding: 'utf-8',
+      env,
+      // Explicit, because the inherited default is 1 MiB and this listing is
+      // not bounded by anything the gate controls — a big monorepo's `ls-files
+      // -z` passes it. On this repo the tracked listing is 20,240 bytes, ~52x
+      // under that default, so the bound is headroom rather than a fix.
+      //
+      // spawnSync does not TRUNCATE at the limit, it KILLS the child: measured
+      // on node v25.2.1 and bun 1.3.5, both answer status=null, signal=SIGTERM,
+      // error.code=ENOBUFS. Without a cause in the message that arrives as
+      // "git declined", which would be this file's own recurring shape — a
+      // limit inside the gate standing in for the real tool's.
+      //
+      // Bun does enforce it, checked rather than assumed, because that was an
+      // open question: `spawnSync(self, ['-e', 'process.stdout.write("x"
+      // .repeat(2*1024*1024))'])` dies on both runtimes at the default and
+      // succeeds on both at 64 MiB. The runtimes differ only in where they
+      // stop reading — node kept 1,114,112 bytes, bun 1,375,181 — which is
+      // why the value is set here instead of reasoned about from the default.
+      maxBuffer: MAX_GIT_OUTPUT,
+    });
+    // Three materially different things make `status !== 0`, and r.error is
+    // what tells them apart. Collapsing them was survivable while this was a
+    // silent fallback; the strategy check at the bottom of the file made the
+    // message load-bearing, and it named only the first.
+    // spawnSync types `error` as plain Error, but the spawn failures this
+    // needs to tell apart are carried on `code` at runtime (ENOENT, ENOBUFS).
+    // Narrowed rather than asserted non-null, so an error without a code falls
+    // through to the status branch below instead of reading as `undefined`.
+    const code = (r.error as (Error & { code?: string }) | undefined)?.code;
+    if (code !== undefined) {
+      gitDecline =
+        code === 'ENOENT'
+          ? `git is not on PATH — spawning \`${shown}\` failed with ENOENT`
+          : code === 'ENOBUFS'
+            ? `\`${shown}\` produced more than the ${MAX_GIT_OUTPUT} bytes this gate allows ` +
+              `and was cut off — raise MAX_GIT_OUTPUT in scripts/check-concealment.ts`
+            : `spawning \`${shown}\` failed with ${code}`;
+      return undefined;
+    }
+    if (r.status !== 0 || typeof r.stdout !== 'string') {
+      // git's own first line of stderr is the single most useful thing here:
+      // for the motivating case it is `fatal: detected dubious ownership in
+      // repository at '<path>'`, which names the cause exactly.
+      const said = (typeof r.stderr === 'string' ? r.stderr : '').split('\n')[0]?.trim() ?? '';
+      gitDecline =
+        `\`${shown}\` exited ${r.status === null ? 'without a status' : String(r.status)}` +
+        (said === '' ? '' : ` — ${said}`);
+      return undefined;
+    }
     return r.stdout.split('\0').filter((line) => line !== '');
   };
 
@@ -810,7 +880,11 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
   // root. If root is a subdirectory of some unrelated repo, its answer would be
   // scoped to that repo's rules rather than to the tree we were asked to scan.
   const top = run(['rev-parse', '--show-toplevel']);
-  if (top === undefined || top.length === 0) return undefined;
+  if (top === undefined) return undefined; // run() already said why
+  if (top.length === 0) {
+    gitDecline = `\`git -C ${root} rev-parse --show-toplevel\` printed nothing`;
+    return undefined;
+  }
   try {
     // .native for the same reason as answersToName below: the JS realpathSync
     // does not canonicalize the final path component, so under node a root
@@ -818,8 +892,12 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
     // the gate onto the walk — a different scanned set, and not a safer
     // one.
     const topReal = realpathSync.native((top[0] ?? '').trim());
-    if (topReal !== realpathSync.native(root)) return undefined;
+    if (topReal !== realpathSync.native(root)) {
+      gitDecline = `${root} is not the toplevel of the repository git found (${topReal})`;
+      return undefined;
+    }
   } catch {
+    gitDecline = `could not resolve ${root} or git's reported toplevel on disk`;
     return undefined;
   }
 
@@ -838,7 +916,7 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
   // over a tree with a tracked src/a.ts and an untracked, concealed
   // src/added-later.ts:
   //
-  //   real git:      `found content ... (3 files scanned, listed by git)`, exit 1
+  //   real git:      `found content ... (2 files scanned, listed by git)`, exit 1
   //   shimmed git:   `1 files scanned (git), nothing hidden`,              exit 0
   //
   // Empty and failed are distinguishable, which is what makes returning
@@ -1042,16 +1120,21 @@ const listing = listFiles(ROOT);
 // it walks silently — the tests' own path.
 if (listing.strategy === 'walk' && existsSync(join(ROOT, '.git'))) {
   console.error(
-    `check-concealment: ${ROOT} has a .git, but git declined to list it, so the scan fell ` +
+    `check-concealment: ${ROOT} has a .git, but the git listing declined, so the scan fell ` +
       `back to the filesystem walk — a different and smaller set, since SKIP_DIRS applies to ` +
       `tracked files there. Refusing rather than reporting a green run over a shrunken scan.\n`
   );
+  // The measured cause, not the likely one. `git declined` covers git refusing
+  // (status 128), git not being on PATH at all, and git being killed for
+  // exceeding maxBuffer — and the remedy differs for each, so guessing here
+  // would send the operator to a command that reproduces nothing.
+  console.error(`  Cause: ${gitDecline ?? 'not recorded'}\n`);
   console.error(
-    `  Run \`git -C ${ROOT} ls-files\` to see the refusal. If it is dubious ownership, note ` +
-      `that this gate runs git with no HOME and GIT_CONFIG_GLOBAL/SYSTEM=/dev/null, and that ` +
-      `safe.directory is "only respected in protected configuration" (git help config) — ` +
-      `which the repository's own .git/config is not. Run the gate as the checkout's owner ` +
-      `rather than trying to allow-list the path.`
+    `  If that is a dubious-ownership refusal, note that this gate runs git with no HOME and ` +
+      `GIT_CONFIG_GLOBAL/SYSTEM=/dev/null, and that safe.directory is "only respected in ` +
+      `protected configuration" (git help config) — which the repository's own .git/config is ` +
+      `not, verified with GIT_TEST_ASSUME_DIFFERENT_OWNER. Run the gate as the checkout's ` +
+      `owner rather than trying to allow-list the path.`
   );
   process.exit(1);
 }

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -532,8 +532,8 @@ function checkGitAttributes(contents: string, rel: string): void {
     // spells its extension with an escape does not get waved through, which is
     // not.
     //
-    // The fifth variation, and the reason the count above is not a closed list:
-    // gitattributes has a SECOND line form this parser had no concept of.
+    // The fifth and sixth variations, and the reason the count is not a closed
+    // list: gitattributes has a SECOND line form this parser had no concept of.
     // `[attr]<name> <attrs...>` defines a MACRO, and git's attr_name_valid
     // permits dots in the name, so the first token can be extension-shaped
     // without ever being a path:
@@ -543,14 +543,29 @@ function checkGitAttributes(contents: string, rel: string): void {
     //
     // The first line reached the allowance as a `.png` and returned; the second
     // carries no suppressing attribute of its own, only the macro's name. git
-    // renders payload.ts as `Binary files ... differ` and the gate said nothing
-    // hidden — verified against real `git check-attr`. That a macro named
-    // `[attr]zz` WAS reported is what makes this accidental rather than
-    // designed. An extension check answers "would a reviewer have been able to
-    // read this file's diff", which is a question about a path; asking it of a
-    // macro name is meaningless, so macros skip the allowance outright and are
-    // judged on the attributes they carry.
-    const isMacroDefinition = stripped.startsWith('[attr]');
+    // renders payload.ts as `Binary files ... differ` while the gate said
+    // nothing hidden. That a macro named `[attr]zz` WAS reported is what makes
+    // that accidental rather than designed.
+    //
+    // The macro test therefore runs on `pattern` — AFTER the quoted form has
+    // been opened — and not on the raw line, because git parses in that order
+    // too. Verified on git 2.50.1: `"[attr]a.png" -diff` with
+    // `src/payload.ts a.png` reports `src/payload.ts: diff: unset` from
+    // check-attr, and git diff prints `Binary files ... differ`. A first
+    // attempt tested the raw line and argued a quoted `[attr]` stays a literal
+    // path; that was simply false, and it recreated the same hole one quote to
+    // the left. Testing one spelling and not the other IS this function's bug,
+    // so there is exactly one test, on the one string the extension check also
+    // reads.
+    //
+    // An extension check answers "could a reviewer have read this file's diff",
+    // which is a question about a path; asking it of a macro name is
+    // meaningless, so macros skip the allowance outright and are judged on the
+    // attributes they carry. Note this errs safely in the one place it diverges
+    // from git: git requires a non-empty name after the prefix, so a bare
+    // `[attr]` is a path pattern to git and a macro to us — and being wrong
+    // that way only ever REMOVES an allowance.
+    const isMacroDefinition = pattern.startsWith('[attr]');
     if (
       !isMacroDefinition &&
       !pattern.includes('\\') &&
@@ -689,6 +704,13 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
   // None of this affects the repo's own .git/config, .gitignore or
   // .git/info/exclude: those are the tree's, and ignored files being out of
   // scope is the design.
+  //
+  // Dropping HOME has one non-obvious consequence worth naming: it also hides a
+  // global `safe.directory`, so scanning a repo owned by another user makes
+  // `ls-files` refuse and the gate falls back to the filesystem walk. That is
+  // fail-SAFE — the walk ignores .gitignore, so it scans more than the git
+  // listing would, never less — and since the summary line now names the
+  // strategy, it announces itself rather than looking like a normal run.
   const env = { ...process.env };
   for (const key of Object.keys(env)) if (key.startsWith('GIT_')) delete env[key];
   delete env.HOME;

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -33,8 +33,10 @@
  *     paragraph is a paragraph, and a doc that quotes `eval` is documentation.
  *     They keep the invisible-character rule and the whitespace-run rule, the
  *     latter because markdown here is read by agents as well as by people (see
- *     PROSE_EXTENSIONS). So a bidi trick in docs IS caught; a payload hidden by
- *     a paragraph's sheer length is not.
+ *     PROSE_EXTENSIONS). So a bidi trick in docs IS caught, and so is a
+ *     gap-based payload whether the gap opens the line or sits mid-line. The
+ *     bound that remains is length alone: prose has no MAX_LINE, so text pushed
+ *     off-screen by nothing but a very long paragraph passes.
  *   - This gate sees what git would show in a diff — tracked files plus
  *     untracked-but-unignored ones, from `git ls-files` — and NOT the working
  *     tree as such: ignored files are out of scope. Outside a repo, or when git
@@ -64,7 +66,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // same pattern as CHECK_PRIVACY_ENDPOINTS_ROOT and CHECK_TOOL_COUNTS_ROOT.
 const ROOT = process.env.CHECK_CONCEALMENT_ROOT ?? join(__dirname, '..');
 
-/** A run of this many space characters (ASCII or unicode) mid-line is the gap. */
+/** A run of this many space characters (ASCII or unicode), leading or mid-line, is the gap. */
 const WHITESPACE_RUN = 20;
 /**
  * ...but only when the line is longer than a viewport, because that is what
@@ -259,6 +261,7 @@ const AUTO_LIFECYCLE = new Set([
   'prestop', 'poststop',
   'prerestart', 'postrestart',
 ]);
+
 /**
  * `prepare` and `prepublishOnly` run on contributor and publisher machines.
  * Those are still execution vectors — a contributor's `bun install` runs
@@ -305,7 +308,25 @@ const INVISIBLE: Record<number, string> = {
  * Unicode Zs plus the format-ish spaces that behave the same way.
  */
 const GAP_CHARS = ' \\t\\u00a0\\u1680\\u2000-\\u200a\\u202f\\u205f\\u3000';
-const WHITESPACE_RUN_RE = new RegExp(`\\S[${GAP_CHARS}]{${WHITESPACE_RUN},}\\S`);
+/**
+ * `(^|\S)`, not `\S`, on the left. Requiring a non-space before the gap left a
+ * whole form uncovered: a line that OPENS with the run. 200 spaces then an
+ * instruction is a blank line to a reviewer scrolling a diff and an instruction
+ * to a model reading the file, and prose is exempt from MAX_LINE, so nothing
+ * else caught it either.
+ *
+ * Both halves of the conjunction were measured against this repo before the
+ * left anchor was widened, because a rule with no margin becomes an exemption
+ * list on its first false positive. Across every scanned file: of the 2125
+ * lines over 120 columns, the deepest leading whitespace is 14 characters; of
+ * the 46 lines carrying 20 or more leading gap characters, the longest is 95
+ * columns. Neither axis is close to its threshold, and the whole-repo run
+ * produced zero hits.
+ *
+ * The trailing `\S` matters too: a line of nothing but whitespace is trailing
+ * junk, not a payload, and does not match.
+ */
+const WHITESPACE_RUN_RE = new RegExp(`(^|\\S)[${GAP_CHARS}]{${WHITESPACE_RUN},}\\S`);
 
 const DYNAMIC_EXEC: Array<[RegExp, string]> = [
   [/(?<![\w$.])eval\s*\(/, 'eval() call'],
@@ -389,8 +410,9 @@ function checkLine(
       rel,
       lineNo,
       'whitespace run',
-      `${WHITESPACE_RUN}+ consecutive space characters mid-line on a ${line.length}-column ` +
-        `line — the tail is off-screen in a diff. Unicode spaces (NBSP, U+2003, U+3000, ...) ` +
+      `${WHITESPACE_RUN}+ consecutive space characters, leading or mid-line, on a ` +
+        `${line.length}-column line — the text after the gap is off-screen in a diff. ` +
+        `Unicode spaces (NBSP, U+2003, U+3000, ...) ` +
         `count as well as ASCII space and tab: they render identically and are valid ` +
         `ECMAScript whitespace`
     );
@@ -509,7 +531,32 @@ function checkGitAttributes(contents: string, rel: string): void {
     // escaped binary path writes the exemption, which is cheap; a payload that
     // spells its extension with an escape does not get waved through, which is
     // not.
-    if (!pattern.includes('\\') && INERT_BINARY_EXTENSIONS.has(extensionOf(pattern))) return;
+    //
+    // The fifth variation, and the reason the count above is not a closed list:
+    // gitattributes has a SECOND line form this parser had no concept of.
+    // `[attr]<name> <attrs...>` defines a MACRO, and git's attr_name_valid
+    // permits dots in the name, so the first token can be extension-shaped
+    // without ever being a path:
+    //
+    //     [attr]a.png binary
+    //     src/payload.ts a.png
+    //
+    // The first line reached the allowance as a `.png` and returned; the second
+    // carries no suppressing attribute of its own, only the macro's name. git
+    // renders payload.ts as `Binary files ... differ` and the gate said nothing
+    // hidden — verified against real `git check-attr`. That a macro named
+    // `[attr]zz` WAS reported is what makes this accidental rather than
+    // designed. An extension check answers "would a reviewer have been able to
+    // read this file's diff", which is a question about a path; asking it of a
+    // macro name is meaningless, so macros skip the allowance outright and are
+    // judged on the attributes they carry.
+    const isMacroDefinition = stripped.startsWith('[attr]');
+    if (
+      !isMacroDefinition &&
+      !pattern.includes('\\') &&
+      INERT_BINARY_EXTENSIONS.has(extensionOf(pattern))
+    )
+      return;
     for (const re of DIFF_SUPPRESSING_ATTRS) {
       if (!re.test(stripped)) continue;
       report(
@@ -624,10 +671,31 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
   // did not include GIT_CONFIG_GLOBAL or GIT_CONFIG_COUNT, either of which can
   // set core.excludesFile — which `ls-files --exclude-standard` honours, so an
   // ambient value drops files out of the scan and the gate still prints a green
-  // "nothing hidden". Every GIT_* variable is git's to interpret, none of them
-  // is ours to inherit, and the test helper already used this exact form.
+  // "nothing hidden". Every GIT_* variable is git's to interpret and none of
+  // them is ours to inherit.
+  //
+  // Stripping that namespace closes only half the vector, though, because the
+  // same setting reaches git without any GIT_ variable at all: core.excludesFile
+  // in the GLOBAL config, which git finds through HOME (or XDG_CONFIG_HOME), and
+  // in the SYSTEM config at /etc/gitconfig. Probed: a concealed untracked .ts
+  // under a HOME whose .gitconfig excludes `*.ts` produced `files scanned (git),
+  // nothing hidden` and exit 0. So the ambient environment is not sanitised
+  // variable by variable — git is told to read NO config files, which is the
+  // only form of this that does not need a list of the ways config arrives.
+  //
+  // GIT_CONFIG_GLOBAL/SYSTEM=/dev/null is git's own documented way to say that
+  // (2.32+). HOME and XDG_CONFIG_HOME are dropped as well so an older git,
+  // which would ignore those two variables, still cannot find a global config.
+  // None of this affects the repo's own .git/config, .gitignore or
+  // .git/info/exclude: those are the tree's, and ignored files being out of
+  // scope is the design.
   const env = { ...process.env };
   for (const key of Object.keys(env)) if (key.startsWith('GIT_')) delete env[key];
+  delete env.HOME;
+  delete env.XDG_CONFIG_HOME;
+  env.GIT_CONFIG_NOSYSTEM = '1';
+  env.GIT_CONFIG_GLOBAL = '/dev/null';
+  env.GIT_CONFIG_SYSTEM = '/dev/null';
 
   const run = (args: string[]): string[] | undefined => {
     const r = spawnSync('git', ['-C', root, ...args], { encoding: 'utf-8', env });
@@ -743,7 +811,10 @@ if (findings.length === 0) {
   process.exit(0);
 }
 
-console.error('check-concealment: found content engineered to be invisible in review.\n');
+console.error(
+  `check-concealment: found content engineered to be invisible in review ` +
+    `(${files.length} files scanned, listed by ${listing.strategy}).\n`
+);
 const byRule = new Map<string, Finding[]>();
 for (const f of findings) {
   const list = byRule.get(f.rule) ?? [];

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -813,6 +813,58 @@ function underSkippedDir(root: string, file: string): boolean {
   return relative(root, file).split(sep).slice(0, -1).some((seg) => SKIP_DIRS.has(seg));
 }
 
+/**
+ * Does `file` answer to `name` in its own directory — is it the file that git
+ * or npm opens when it asks for `.gitattributes` or `package.json`?
+ *
+ * This exists because the previous answer to that question was a fold function
+ * written here. Matching a lower-cased basename closed the `.GITATTRIBUTES`
+ * hole and opened a smaller one: APFS folds U+017F (LATIN SMALL LETTER LONG S)
+ * to `s`, and `String.prototype.toLowerCase` does not, so a file committed as
+ * `.gitattributeſ` is read by git — `check-attr` reports `binary: set` — and was
+ * skipped here. A full sweep of 0x80-0x10FFFF against the actual filesystem
+ * turned up exactly one such codepoint, so special-casing it would have worked,
+ * and that is precisely the move this file keeps being punished for: a parser
+ * standing in for a real system. Every one of these has been a fold, a blank
+ * set, an unquote or a grammar approximated in JS instead of measured.
+ *
+ * So the gate no longer holds an opinion about folding. It asks the filesystem
+ * to resolve the name and compares what comes back. Verified in the runtime
+ * that actually ships rather than assumed: Bun's realpathSync canonicalizes to
+ * the on-disk spelling, so both sides resolve to the same string. (Worth
+ * knowing that not every realpath does — Python's is lexical and answers with
+ * the name it was handed, which would silently defeat this.)
+ *
+ * Kept as an OR with the basename test at the call site, never as a
+ * replacement, for two reasons. It preserves the deliberate posture from the
+ * case-sensitivity trade: on a case-sensitive filesystem `.GITATTRIBUTES` is a
+ * different file, so this probe correctly says no and the name test still
+ * routes it, which is the false positive that was chosen on purpose. And it
+ * makes the probe purely ADDITIVE — a broken symlink, a permissions error or
+ * any other failure resolves to `undefined` and simply falls back to the name
+ * test, so a failure here can only ever scan more, never skip something that
+ * was already being checked.
+ */
+const routeTargetCache = new Map<string, string | undefined>();
+
+function realOrUndefined(path: string): string | undefined {
+  try {
+    return realpathSync(path);
+  } catch {
+    return undefined;
+  }
+}
+
+function answersToName(file: string, name: string): boolean {
+  const dir = dirname(file);
+  const key = `${dir}\0${name}`;
+  if (!routeTargetCache.has(key)) routeTargetCache.set(key, realOrUndefined(join(dir, name)));
+  const target = routeTargetCache.get(key);
+  if (target === undefined) return false;
+  const self = realOrUndefined(file);
+  return self !== undefined && self === target;
+}
+
 const listing = listFiles(ROOT);
 const files = listing.files.filter((f) => inScope(f));
 for (const file of files) {
@@ -863,9 +915,20 @@ for (const file of files) {
   // spends a minute and writes an exemption, where the other error ships a
   // suppressed diff. It is also the direction every other allowance here
   // already fails in: omission must fail toward suspicion.
+  //
+  // The lower-cased name is only the FLOOR, though, not the mechanism.
+  // toLowerCase is a fold function written in JS, and the filesystem's fold is
+  // wider than it — U+017F, variation ten, which arrived inside the fix for
+  // eight and nine. answersToName asks the OS which file the name actually
+  // opens; the name test stays OR'd beside it to keep the deliberate false
+  // positive above and to make the probe purely additive. See answersToName.
   const basename = rel.slice(rel.lastIndexOf(sep) + 1).toLowerCase();
-  if (basename === 'package.json') checkLifecycleScripts(contents, rel);
-  if (basename === '.gitattributes') checkGitAttributes(contents, rel);
+  if (basename === 'package.json' || answersToName(file, 'package.json')) {
+    checkLifecycleScripts(contents, rel);
+  }
+  if (basename === '.gitattributes' || answersToName(file, '.gitattributes')) {
+    checkGitAttributes(contents, rel);
+  }
 }
 
 if (findings.length === 0) {

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -460,25 +460,20 @@ function checkGitAttributes(contents: string, rel: string): void {
     // OPEN. So the quoted form is PARSED rather than refused: refusing it would
     // fail the gate on `"my docs/logo.png" binary`, which is legitimate, and
     // this rule already learned that lesson with *.png.
-    //
-    // git unquotes the pattern before matching (unquote_c_style), so the
-    // backslash strip below moves the extension we read toward the one git
-    // resolves. It is an APPROXIMATION of that function, not a port: it does
-    // not decode \n, \t or \xNN. Called out rather than left implied, because
-    // this rule's failures so far have all been a parser quietly diverging
-    // from the grammar it models. The divergence that remains is narrow and
-    // fails CLOSED — an undecoded escape leaves a stranger-looking extension,
-    // which misses the inert allowance and gets reported.
-    //
-    // No test pins the strip: every payload I could construct resolves to the
-    // same extension with or without it, so a test would execute the line
-    // without detecting its removal. Left unpinned and said so, rather than
-    // shipping an assertion that cannot fail.
     const quoted = /^"((?:[^"\\]|\\.)*)"/.exec(stripped);
-    const pattern = quoted
-      ? (quoted[1] as string).replace(/\\(.)/g, '$1')
-      : (stripped.split(/[ \t]+/)[0] ?? '');
-    if (INERT_BINARY_EXTENSIONS.has(extensionOf(pattern))) return;
+    const pattern = quoted ? (quoted[1] as string) : (stripped.split(/[ \t]+/)[0] ?? '');
+    // A quoted pattern containing a backslash is NOT unquoted before the inert
+    // check. git resolves the escapes with unquote_c_style before matching, and
+    // stripping them here only ever SHORTENS the string, so a backslash after
+    // the last dot manufactures an inert-looking extension that git never
+    // resolves to: `"evil.p\ng"` reads as `.png` here and as a newline to
+    // unquote_c_style. Approximating the grammar failed OPEN — the fourth
+    // variation of the same mismatch in this one function — so the escape form
+    // simply misses the allowance and gets reported. An author with a genuinely
+    // escaped binary path writes the exemption, which is cheap; a payload that
+    // spells its extension with an escape does not get waved through, which is
+    // not.
+    if (!pattern.includes('\\') && INERT_BINARY_EXTENSIONS.has(extensionOf(pattern))) return;
     for (const re of DIFF_SUPPRESSING_ATTRS) {
       if (!re.test(stripped)) continue;
       report(

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -758,8 +758,13 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
   const top = run(['rev-parse', '--show-toplevel']);
   if (top === undefined || top.length === 0) return undefined;
   try {
-    const topReal = realpathSync((top[0] ?? '').trim());
-    if (topReal !== realpathSync(root)) return undefined;
+    // .native for the same reason as answersToName below: the JS realpathSync
+    // does not canonicalize the final path component, so under node a root
+    // spelled differently from its on-disk name would compare unequal and drop
+    // the gate onto the walk — a different scanned set, and not a safer
+    // one.
+    const topReal = realpathSync.native((top[0] ?? '').trim());
+    if (topReal !== realpathSync.native(root)) return undefined;
   } catch {
     return undefined;
   }
@@ -822,18 +827,32 @@ function underSkippedDir(root: string, file: string): boolean {
  * hole and opened a smaller one: APFS folds U+017F (LATIN SMALL LETTER LONG S)
  * to `s`, and `String.prototype.toLowerCase` does not, so a file committed as
  * `.gitattributeſ` is read by git — `check-attr` reports `binary: set` — and was
- * skipped here. A full sweep of 0x80-0x10FFFF against the actual filesystem
- * turned up exactly one such codepoint, so special-casing it would have worked,
- * and that is precisely the move this file keeps being punished for: a parser
- * standing in for a real system. Every one of these has been a fold, a blank
- * set, an unquote or a grammar approximated in JS instead of measured.
+ * skipped here. Sweeping 0x80-0x10FFFF against the actual filesystem found TWO
+ * codepoints that fold into a letter these filenames contain: U+017F to `s` and
+ * U+212A KELVIN SIGN to `k`. Only U+017F DIVERGED, because toLowerCase happens
+ * to map U+212A — so the divergent set was one codepoint and a special case
+ * would have worked. That is precisely the move this file keeps being punished
+ * for: a parser standing in for a real system. Every one of these has been a
+ * fold, a blank set, an unquote or a grammar approximated in JS instead of
+ * measured, and each looked like a set of one until it wasn't.
  *
  * So the gate no longer holds an opinion about folding. It asks the filesystem
- * to resolve the name and compares what comes back. Verified in the runtime
- * that actually ships rather than assumed: Bun's realpathSync canonicalizes to
- * the on-disk spelling, so both sides resolve to the same string. (Worth
- * knowing that not every realpath does — Python's is lexical and answers with
- * the name it was handed, which would silently defeat this.)
+ * to resolve the name and compares what comes back.
+ *
+ * `realpathSync.NATIVE`, not `realpathSync`, and that distinction is the whole
+ * oracle: this depends on realpath canonicalizing the FINAL component, and the
+ * JS-implemented `fs.realpathSync` does not do that. Measured, both runtimes,
+ * against the same file on disk (a package.json spelled with U+017F):
+ *
+ *   node v25.2.1   realpathSync -> "package.json"   .native -> the on-disk name
+ *   bun  1.3.5     realpathSync -> the on-disk name  .native -> the on-disk name
+ *
+ * Bun's happens to canonicalize, so the plain form worked here and would have
+ * gone on working until someone ran this under node — one `tsx` away — where
+ * the probe silently returns false and variation ten walks back in through the
+ * basename fallback. `.native` calls the OS in both, so the oracle stops
+ * depending on which runtime invokes it. An unstated assumption about a system
+ * that happens to hold today is the shape of every bug in this file.
  *
  * Kept as an OR with the basename test at the call site, never as a
  * replacement, for two reasons. It preserves the deliberate posture from the
@@ -849,7 +868,7 @@ const routeTargetCache = new Map<string, string | undefined>();
 
 function realOrUndefined(path: string): string | undefined {
   try {
-    return realpathSync(path);
+    return realpathSync.native(path);
   } catch {
     return undefined;
   }

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -156,10 +156,34 @@ const SKIP_FILES = new Set(['package-lock.json', 'bun.lock', 'bun.lockb', 'yarn.
  * executable formats in BINARY_EXTENSIONS.
  */
 const INERT_BINARY_EXTENSIONS = new Set([
-  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.ico', '.icns', '.bmp', '.tiff',
-  '.pdf', '.zip', '.gz', '.tgz', '.bz2', '.xz', '.7z', '.tar',
-  '.woff', '.woff2', '.ttf', '.otf', '.eot',
-  '.mp3', '.mp4', '.wav', '.mov', '.webm', '.ogg',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.ico',
+  '.icns',
+  '.bmp',
+  '.tiff',
+  '.pdf',
+  '.zip',
+  '.gz',
+  '.tgz',
+  '.bz2',
+  '.xz',
+  '.7z',
+  '.tar',
+  '.woff',
+  '.woff2',
+  '.ttf',
+  '.otf',
+  '.eot',
+  '.mp3',
+  '.mp4',
+  '.wav',
+  '.mov',
+  '.webm',
+  '.ogg',
 ]);
 
 /**
@@ -179,7 +203,15 @@ const BINARY_EXTENSIONS = new Set([
   //   - they are containers whose contents a reviewer might genuinely need to
   //     see, and which can carry code: .mcpb bundles this server, .ldb/.sst
   //     are LevelDB tables holding cached user data
-  '.mcpb', '.node', '.wasm', '.ldb', '.sst', '.dylib', '.so', '.dll', '.exe',
+  '.mcpb',
+  '.node',
+  '.wasm',
+  '.ldb',
+  '.sst',
+  '.dylib',
+  '.so',
+  '.dll',
+  '.exe',
 ]);
 
 /** Extension of the BASENAME — `docs/v1.2/README` has no extension, not `.2/README`. */
@@ -251,22 +283,40 @@ const GENERATED_RE = /\.generated\.[cm]?[jt]sx?$/;
  */
 const AUTO_LIFECYCLE = new Set([
   // install
-  'preinstall', 'install', 'postinstall', 'dependencies',
+  'preinstall',
+  'install',
+  'postinstall',
+  'dependencies',
   // publish + pack
-  'prepublish', 'prepublishOnly', 'prepack', 'postpack', 'publish', 'postpublish',
+  'prepublish',
+  'prepublishOnly',
+  'prepack',
+  'postpack',
+  'publish',
+  'postpublish',
   // prepare runs on install AND publish
   'prepare',
   // version
-  'preversion', 'version', 'postversion',
+  'preversion',
+  'version',
+  'postversion',
   // uninstall
-  'preuninstall', 'uninstall', 'postuninstall',
+  'preuninstall',
+  'uninstall',
+  'postuninstall',
   // shrinkwrap
-  'preshrinkwrap', 'shrinkwrap', 'postshrinkwrap',
+  'preshrinkwrap',
+  'shrinkwrap',
+  'postshrinkwrap',
   // wrappers around the explicitly-invoked commands
-  'pretest', 'posttest',
-  'prestart', 'poststart',
-  'prestop', 'poststop',
-  'prerestart', 'postrestart',
+  'pretest',
+  'posttest',
+  'prestart',
+  'poststart',
+  'prestop',
+  'poststop',
+  'prerestart',
+  'postrestart',
 ]);
 const PINNED_LIFECYCLE: Record<string, string> = {
   prepare: 'husky',
@@ -367,7 +417,11 @@ function walk(dir: string, out: string[]): string[] {
  * an attacker would want to join — ASCII identifier characters, Latin-1 — is
  * below 0x2000, so the floor separates the two without enumerating emoji.
  */
-function invisibleIsBenign(cp: number, prev: number | undefined, next: number | undefined): boolean {
+function invisibleIsBenign(
+  cp: number,
+  prev: number | undefined,
+  next: number | undefined
+): boolean {
   if (cp !== 0x200d) return false;
   return prev !== undefined && next !== undefined && prev >= 0x2000 && next >= 0x2000;
 }
@@ -563,7 +617,11 @@ function checkLifecycleScripts(contents: string, rel: string): void {
   // script X, so a wrapper around an existing script fires implicitly too.
   for (const hook of Object.keys(scripts)) {
     if (AUTO_LIFECYCLE.has(hook) || PINNED_NAMES.includes(hook)) continue;
-    const base = hook.startsWith('pre') ? hook.slice(3) : hook.startsWith('post') ? hook.slice(4) : '';
+    const base = hook.startsWith('pre')
+      ? hook.slice(3)
+      : hook.startsWith('post')
+        ? hook.slice(4)
+        : '';
     if (base === '' || scripts[base] === undefined) continue;
     report(
       rel,
@@ -655,16 +713,30 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
   return { tracked: abs(tracked), untracked: abs(untracked.filter((f) => !tracked.includes(f))) };
 }
 
-function listFiles(root: string): string[] {
+/**
+ * Returns the strategy alongside the list, and the summary line prints it.
+ *
+ * The fallback used to be silent, and the two strategies do not scan the same
+ * set: the walk ignores .gitignore and applies SKIP_DIRS to everything, the git
+ * listing honours .gitignore and applies SKIP_DIRS to untracked files only. Any
+ * of `git` missing from PATH, a dubious-ownership refusal, or a toplevel
+ * mismatch silently swaps one for the other, and both report the same green
+ * `nothing hidden`. Naming the strategy makes a shrunken scan visible in the
+ * output instead of only in a diff of this file.
+ */
+function listFiles(root: string): { files: string[]; strategy: 'git' | 'walk' } {
   const fromGit = gitFiles(root);
-  if (fromGit === undefined) return walk(root, []);
+  if (fromGit === undefined) return { files: walk(root, []), strategy: 'walk' };
   // SKIP_DIRS exists for UNREVIEWED LOCAL ARTIFACTS, so it applies to the
   // untracked half only. A tracked file is in a diff by definition, which is
   // this gate's entire threat model — excluding `build/loader.ts` because of
   // its directory name would turn a list of vendored-output names into a list
   // of places a payload may sit unwatched. A previous revision did exactly
   // that, in a PR arguing against that shape.
-  return [...fromGit.tracked, ...fromGit.untracked.filter((f) => !underSkippedDir(root, f))];
+  return {
+    files: [...fromGit.tracked, ...fromGit.untracked.filter((f) => !underSkippedDir(root, f))],
+    strategy: 'git',
+  };
 }
 
 /**
@@ -675,10 +747,14 @@ function listFiles(root: string): string[] {
  * inside its own fix.
  */
 function underSkippedDir(root: string, file: string): boolean {
-  return relative(root, file).split(sep).slice(0, -1).some((seg) => SKIP_DIRS.has(seg));
+  return relative(root, file)
+    .split(sep)
+    .slice(0, -1)
+    .some((seg) => SKIP_DIRS.has(seg));
 }
 
-const files = listFiles(ROOT).filter((f) => inScope(f));
+const listing = listFiles(ROOT);
+const files = listing.files.filter((f) => inScope(f));
 for (const file of files) {
   const rel = relative(ROOT, file);
   let contents: string;
@@ -720,7 +796,9 @@ for (const file of files) {
 }
 
 if (findings.length === 0) {
-  console.log(`check-concealment: ${files.length} files scanned, nothing hidden`);
+  console.log(
+    `check-concealment: ${files.length} files scanned (${listing.strategy}), nothing hidden`
+  );
   process.exit(0);
 }
 

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -28,12 +28,26 @@
  *
  *   - Lockfiles are skipped. A malicious transitive dependency with its own
  *     install script is a different class, covered by `check:deps-pinned`.
- *   - Markdown is skipped: it is prose, it is not executed, and its long lines
- *     are load-bearing. A reviewer-facing bidi trick in docs would pass here.
- *   - This gate sees the working tree. The cross-commit half of #6003 — content
- *     added by one commit and removed by another, so it never appears in the
- *     combined diff — cannot be seen from a tree at all. That needs the PR's
- *     commit range; see `--range`.
+ *   - Prose is not skipped — it is checked less. `.md`, `.txt` and `.rst` lose
+ *     exactly two rules, long line and dynamic execution: a 900-column
+ *     paragraph is a paragraph, and a doc that quotes `eval` is documentation.
+ *     They keep the invisible-character rule and the whitespace-run rule, the
+ *     latter because markdown here is read by agents as well as by people (see
+ *     PROSE_EXTENSIONS). So a bidi trick in docs IS caught; a payload hidden by
+ *     a paragraph's sheer length is not.
+ *   - This gate sees what git would show in a diff — tracked files plus
+ *     untracked-but-unignored ones, from `git ls-files` — and NOT the working
+ *     tree as such: ignored files are out of scope. Outside a repo, or when git
+ *     declines, it falls back to a filesystem walk, which scans a materially
+ *     different set (no .gitignore, SKIP_DIRS applied to everything). The
+ *     summary line names which strategy ran, because that fallback used to be
+ *     silent and both endings read `nothing hidden`.
+ *   - It sees one tree, never a range of commits. The cross-commit half of
+ *     #6003 — content added by one commit and removed by another, so it never
+ *     appears in the combined diff — cannot be seen from a tree at all. That
+ *     needs the PR's commit range, which this gate does not read: there is no
+ *     flag for it and nothing passes one. Open work, not an option somebody
+ *     forgot to switch on.
  *   - The dynamic-execution rule is regex-based, so it reads a construct inside
  *     a string literal the same as a real one. That is why this file and its
  *     test are exempt from that rule alone (see SELF_EXEMPT) — they necessarily

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -827,7 +827,35 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
   if (tracked === undefined) return undefined;
   // Untracked-but-not-ignored files can be `git add`ed into the next diff, so
   // they are in scope too. Ignored files are not.
-  const untracked = run(['ls-files', '-z', '--others', '--exclude-standard']) ?? [];
+  //
+  // A failure here returns undefined like every other run() in this function,
+  // rather than defaulting to `[]`. The default was the one silent scan-shrink
+  // the strategy check at the bottom of this file structurally CANNOT see: it
+  // left `strategy` as 'git', so the summary read `N files scanned (git),
+  // nothing hidden` over a scope that had lost its whole untracked half.
+  // Measured, on this repo's own gate, by putting a `git` shim earlier on PATH
+  // that exits 1 when it sees `--others` and execs the real git otherwise —
+  // over a tree with a tracked src/a.ts and an untracked, concealed
+  // src/added-later.ts:
+  //
+  //   real git:      `found content ... (3 files scanned, listed by git)`, exit 1
+  //   shimmed git:   `1 files scanned (git), nothing hidden`,              exit 0
+  //
+  // Empty and failed are distinguishable, which is what makes returning
+  // undefined exact rather than paranoid: probed on git 2.50.1, a clean tree
+  // gives `ls-files --others --exclude-standard` status 0 with ZERO bytes of
+  // stdout, which run() turns into `[]`. Only a non-zero status yields
+  // undefined. So a repo with nothing untracked still scans, and still reports
+  // (git).
+  //
+  // No tree state that makes `--others` exit non-zero was found, and it was
+  // looked for: an unreadable subdirectory, an unreadable .git/info/exclude and
+  // a .gitignore that is a directory all warn — or say nothing — and exit 0.
+  // The failure is injected at the process boundary in the test for the same
+  // reason it is guarded here: run() cannot tell why git failed, only that it
+  // did, and a fail-open default in this file has never once stayed theoretical.
+  const untracked = run(['ls-files', '-z', '--others', '--exclude-standard']);
+  if (untracked === undefined) return undefined;
   const abs = (list: string[]): string[] => list.map((rel) => join(root, rel));
   // Set rather than Array#includes: both listings are whole-repo sized, so the
   // linear scan made the de-duplication quadratic in the file count.
@@ -922,6 +950,29 @@ function underSkippedDir(root: string, file: string): boolean {
  * test, so a failure here can only ever scan more, never skip something that
  * was already being checked.
  */
+/**
+ * Only the route TARGET is memoized, and the asymmetry is a decision rather
+ * than an oversight — it has been read as one, so here is the measurement.
+ *
+ * Counted by instrumenting a copy of this file with a counter around
+ * `realOrUndefined` and running it over this repo (535 files):
+ *
+ *   realpath total=140  targetMisses=120  selfCalls=20  distinctSelfFiles=20
+ *
+ * Two things fall out. The cache that exists is on the hot side: 120 of the 140
+ * calls are target lookups, and without it they would be roughly two per
+ * scanned file. And a second cache keyed on `file` would save exactly ZERO of
+ * the remaining 20, because every one of those 20 calls is already for a
+ * distinct file.
+ *
+ * That is structural, not luck. `realOrUndefined(file)` sits after the
+ * `target === undefined` early return, so it is reached only for a file whose
+ * OWN directory contains the routed name — and reached twice only for a file
+ * whose directory contains BOTH `package.json` and `.gitattributes`. The bound
+ * on what a second Map could ever save is therefore one call per file sitting
+ * beside both, which is not a number worth a second piece of mutable state in
+ * the routing path.
+ */
 const routeTargetCache = new Map<string, string | undefined>();
 
 function realOrUndefined(path: string): string | undefined {
@@ -965,9 +1016,19 @@ const listing = listFiles(ROOT);
 // Reproduce: `git init` such a tree and commit it, run the gate with
 // CHECK_CONCEALMENT_ROOT pointed at it, then `chmod 000 .git` and run it again.
 // The payload vanishes and the run stays green. A `.git` that is not a repo at
-// all (`printf garbage > .git/config`) prints the same two lines — both were
-// run; the ownership refusal was NOT, because it needs a second uid. It reaches
-// this branch identically, as a non-zero status from `run()`.
+// all (`printf garbage > .git/config`) prints the same two lines.
+//
+// The MOTIVATING refusal — dubious ownership — has now been run too, on that
+// same tree, and it does not need a second uid: git ships
+// GIT_TEST_ASSUME_DIFFERENT_OWNER, which drives the real
+// `fatal: detected dubious ownership ...` (status 128) from
+// ensure_valid_ownership. Put it on a `git` shim earlier in PATH, since this
+// function strips the whole GIT_ namespace before spawning:
+//
+//   pre-guard:  `1 files scanned (walk), nothing hidden`, exit 0
+//   with this:  the refusal below,                        exit 1
+//
+// Pinned end-to-end in tests/scripts/check-concealment.test.ts.
 //
 // So a tree that HAS a .git and that git nevertheless would not list is
 // refused. The remedy is never "accept the walk": the swap only ever scans

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -639,7 +639,10 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
   // they are in scope too. Ignored files are not.
   const untracked = run(['ls-files', '-z', '--others', '--exclude-standard']) ?? [];
   const abs = (list: string[]): string[] => list.map((rel) => join(root, rel));
-  return { tracked: abs(tracked), untracked: abs(untracked.filter((f) => !tracked.includes(f))) };
+  // Set rather than Array#includes: both listings are whole-repo sized, so the
+  // linear scan made the de-duplication quadratic in the file count.
+  const trackedSet = new Set(tracked);
+  return { tracked: abs(tracked), untracked: abs(untracked.filter((f) => !trackedSet.has(f))) };
 }
 
 /**

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -134,56 +134,16 @@ function isProse(rel: string): boolean {
 const SKIP_FILES = new Set(['package-lock.json', 'bun.lock', 'bun.lockb', 'yarn.lock']);
 
 /**
- * Extensions where a NUL byte is expected, because the file genuinely is
- * binary. Everything else containing a NUL is REPORTED rather than skipped.
- *
- * A NUL used to be an unconditional free pass: the main loop skipped any file
- * containing one as "binary". But a module with a NUL byte tucked inside a
- * comment or string literal still runs under bun and node — NUL-containing is
- * not the same as non-executable —
- * while git renders the whole file as `Binary files ... differ`, so the
- * reviewer sees nothing at all. That is strictly better concealment than the
- * off-screen trick this gate was built for.
- *
- * Note the direction: forgetting an extension here means a real binary gets
- * reported and a human adds it. The reverse — the old behaviour — meant a
- * payload ran with nobody looking.
- */
-/**
  * Binary formats that are inert: media, fonts, archives, documents. A diff of
  * one of these was never readable, so suppressing it hides nothing — which is
  * what makes `*.png binary` legitimate boilerplate. Deliberately excludes the
  * executable formats in BINARY_EXTENSIONS.
  */
 const INERT_BINARY_EXTENSIONS = new Set([
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.gif',
-  '.webp',
-  '.ico',
-  '.icns',
-  '.bmp',
-  '.tiff',
-  '.pdf',
-  '.zip',
-  '.gz',
-  '.tgz',
-  '.bz2',
-  '.xz',
-  '.7z',
-  '.tar',
-  '.woff',
-  '.woff2',
-  '.ttf',
-  '.otf',
-  '.eot',
-  '.mp3',
-  '.mp4',
-  '.wav',
-  '.mov',
-  '.webm',
-  '.ogg',
+  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.ico', '.icns', '.bmp', '.tiff',
+  '.pdf', '.zip', '.gz', '.tgz', '.bz2', '.xz', '.7z', '.tar',
+  '.woff', '.woff2', '.ttf', '.otf', '.eot',
+  '.mp3', '.mp4', '.wav', '.mov', '.webm', '.ogg',
 ]);
 
 /**
@@ -191,6 +151,15 @@ const INERT_BINARY_EXTENSIONS = new Set([
  * This is a superset of the inert set: it also covers executable binaries,
  * which legitimately contain NULs but must never have their diffs suppressed
  * by an attribute — see DIFF_SUPPRESSING_ATTRS, which checks the inert set.
+ *
+ * Why the NUL check is scoped to a set at all: a NUL used to be an
+ * unconditional free pass, and the main loop skipped any file containing one as
+ * "binary". But a module with a NUL tucked inside a comment or a string literal
+ * still runs under bun and node — NUL-containing is not the same as
+ * non-executable — while git renders the whole file as `Binary files ... differ`
+ * and the reviewer sees nothing at all. That is strictly better concealment than
+ * the off-screen trick this gate was built for, so a NUL outside this set is now
+ * reported rather than skipped.
  *
  * Note the direction: forgetting an extension here means a real binary gets
  * reported and a human adds it, rather than a payload running unwatched.
@@ -203,15 +172,7 @@ const BINARY_EXTENSIONS = new Set([
   //   - they are containers whose contents a reviewer might genuinely need to
   //     see, and which can carry code: .mcpb bundles this server, .ldb/.sst
   //     are LevelDB tables holding cached user data
-  '.mcpb',
-  '.node',
-  '.wasm',
-  '.ldb',
-  '.sst',
-  '.dylib',
-  '.so',
-  '.dll',
-  '.exe',
+  '.mcpb', '.node', '.wasm', '.ldb', '.sst', '.dylib', '.so', '.dll', '.exe',
 ]);
 
 /** Extension of the BASENAME — `docs/v1.2/README` has no extension, not `.2/README`. */
@@ -250,22 +211,6 @@ const SELF_EXEMPT = new Set([
 const GENERATED_RE = /\.generated\.[cm]?[jt]sx?$/;
 
 /**
- * Install hooks split by who runs them.
- *
- * `preinstall` / `install` / `postinstall` execute on every machine that installs
- * the published package, including consumers. `prepublish` is the deprecated npm
- * hook that also ran on plain `npm install`, so it belongs with them. Nothing in
- * this repo needs any of the four, so they are refused outright rather than
- * allow-listed — an allowlist entry here is indistinguishable from the attack.
- *
- * `prepare` and `prepublishOnly` run on contributor and publisher machines. Those
- * are still execution vectors (a contributor's `bun install` runs `prepare`), so
- * each is pinned to its exact reviewed value: changing what runs at install time
- * means changing this file, in the same PR, where a reviewer will see it. The
- * pinned names are derived from the map so a hook can never be listed as pinned
- * without a value to pin it to.
- */
-/**
  * Every npm hook that fires WITHOUT being named on the command line. npm runs
  * these as a side effect of install, publish, pack, version, uninstall or
  * shrinkwrap, so a payload in any of them executes before anyone reads it.
@@ -283,41 +228,33 @@ const GENERATED_RE = /\.generated\.[cm]?[jt]sx?$/;
  */
 const AUTO_LIFECYCLE = new Set([
   // install
-  'preinstall',
-  'install',
-  'postinstall',
-  'dependencies',
+  'preinstall', 'install', 'postinstall', 'dependencies',
   // publish + pack
-  'prepublish',
-  'prepublishOnly',
-  'prepack',
-  'postpack',
-  'publish',
-  'postpublish',
+  'prepublish', 'prepublishOnly', 'prepack', 'postpack', 'publish', 'postpublish',
   // prepare runs on install AND publish
   'prepare',
   // version
-  'preversion',
-  'version',
-  'postversion',
+  'preversion', 'version', 'postversion',
   // uninstall
-  'preuninstall',
-  'uninstall',
-  'postuninstall',
+  'preuninstall', 'uninstall', 'postuninstall',
   // shrinkwrap
-  'preshrinkwrap',
-  'shrinkwrap',
-  'postshrinkwrap',
+  'preshrinkwrap', 'shrinkwrap', 'postshrinkwrap',
   // wrappers around the explicitly-invoked commands
-  'pretest',
-  'posttest',
-  'prestart',
-  'poststart',
-  'prestop',
-  'poststop',
-  'prerestart',
-  'postrestart',
+  'pretest', 'posttest',
+  'prestart', 'poststart',
+  'prestop', 'poststop',
+  'prerestart', 'postrestart',
 ]);
+/**
+ * `prepare` and `prepublishOnly` run on contributor and publisher machines.
+ * Those are still execution vectors — a contributor's `bun install` runs
+ * `prepare` — so each is pinned to its exact reviewed value instead of being
+ * allow-listed by name: changing what runs at install time then means changing
+ * this file, in the same PR, where a reviewer will see it.
+ *
+ * PINNED_NAMES is derived from this map rather than written out, so a hook can
+ * never be listed as pinned without a value to pin it to.
+ */
 const PINNED_LIFECYCLE: Record<string, string> = {
   prepare: 'husky',
   prepublishOnly: 'bun run clean && bun run build && bun test',
@@ -417,11 +354,7 @@ function walk(dir: string, out: string[]): string[] {
  * an attacker would want to join — ASCII identifier characters, Latin-1 — is
  * below 0x2000, so the floor separates the two without enumerating emoji.
  */
-function invisibleIsBenign(
-  cp: number,
-  prev: number | undefined,
-  next: number | undefined
-): boolean {
+function invisibleIsBenign(cp: number, prev: number | undefined, next: number | undefined): boolean {
   if (cp !== 0x200d) return false;
   return prev !== undefined && next !== undefined && prev >= 0x2000 && next >= 0x2000;
 }
@@ -617,11 +550,7 @@ function checkLifecycleScripts(contents: string, rel: string): void {
   // script X, so a wrapper around an existing script fires implicitly too.
   for (const hook of Object.keys(scripts)) {
     if (AUTO_LIFECYCLE.has(hook) || PINNED_NAMES.includes(hook)) continue;
-    const base = hook.startsWith('pre')
-      ? hook.slice(3)
-      : hook.startsWith('post')
-        ? hook.slice(4)
-        : '';
+    const base = hook.startsWith('pre') ? hook.slice(3) : hook.startsWith('post') ? hook.slice(4) : '';
     if (base === '' || scripts[base] === undefined) continue;
     report(
       rel,
@@ -747,10 +676,7 @@ function listFiles(root: string): { files: string[]; strategy: 'git' | 'walk' } 
  * inside its own fix.
  */
 function underSkippedDir(root: string, file: string): boolean {
-  return relative(root, file)
-    .split(sep)
-    .slice(0, -1)
-    .some((seg) => SKIP_DIRS.has(seg));
+  return relative(root, file).split(sep).slice(0, -1).some((seg) => SKIP_DIRS.has(seg));
 }
 
 const listing = listFiles(ROOT);
@@ -796,9 +722,7 @@ for (const file of files) {
 }
 
 if (findings.length === 0) {
-  console.log(
-    `check-concealment: ${files.length} files scanned (${listing.strategy}), nothing hidden`
-  );
+  console.log(`check-concealment: ${files.length} files scanned (${listing.strategy}), nothing hidden`);
   process.exit(0);
 }
 

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -488,14 +488,25 @@ function checkGitAttributes(contents: string, rel: string): void {
     // parsed down to `src/pay`, matched nothing, and still marked the real
     // file binary for every reviewer. A parser in this gate must not discard
     // more than the grammar it models.
-    // git's parse_attr_line skips ONLY spaces and tabs before the `#` test
-    // (`strspn(line, blank)`, `blank[] = " \t"`). JS .trim() also strips NBSP,
-    // \f, \v, the unicode space separators and U+FEFF — so `<NBSP># p.ts binary`
-    // is a real pattern to git and was dropped here as a comment. That is the
-    // mirror of the bug this function just fixed: the old code discarded
-    // content AFTER a `#`, this discarded a whole line that is not a comment.
-    // Trailing \s is still stripped, for CRLF checkouts.
-    const stripped = line.replace(/^[ \t]+/, '').replace(/\s+$/, '');
+    // git's parse_attr_line skips its blank set before the `#` test
+    // (`strspn(line, blank)`), and that set is SPACE, TAB and CR — not the two
+    // this comment used to claim. Probed on git 2.50.1 one character at a time,
+    // in both positions, rather than recalled: space, tab and CR are skipped
+    // before `#` and separate the pattern from its attributes; form feed,
+    // vertical tab and NBSP do neither. JS `.trim()` would have been wrong in
+    // the other direction — it strips NBSP, \f, \v, the unicode space
+    // separators and U+FEFF, so `<NBSP># p.ts binary` is a real pattern to git
+    // and was dropped here as a comment.
+    //
+    // Getting this set wrong is variation seven of this function's one bug, and
+    // the first that came from asserting a set instead of measuring it: with CR
+    // missing, `\r# p.ts binary` was reported though git reads it as a comment,
+    // and — the direction that matters — the tokenizer below ran past a CR. Say
+    // what was measured, not what was remembered.
+    //
+    // Trailing \s is still stripped, which is wider than git's set on purpose:
+    // it normalises CRLF checkouts.
+    const stripped = line.replace(/^[ \t\r]+/, '').replace(/\s+$/, '');
     if (stripped === '' || stripped.startsWith('#')) return;
     // `*.png binary` targets something with no readable diff to suppress.
     //
@@ -505,11 +516,17 @@ function checkGitAttributes(contents: string, rel: string): void {
     // execute. Auto-approving `*.wasm binary` would bless diff suppression on
     // exactly the formats that run. An author who genuinely needs it writes
     // the exemption, which is what this gate's failure message asks for.
-    // git separates the pattern from its attributes on spaces and tabs only,
-    // the same blank set as the leading-comment test above. `\s` here would
-    // split on NBSP and friends, so a pattern containing one would tokenize
-    // short and could land in the allowance below — the blank-set mismatch
-    // surviving one statement past its own fix, and this one fails OPEN.
+    // git separates the pattern from its attributes on the SAME blank set as
+    // the leading-comment test above — space, tab, CR — and this must stay
+    // literally the same set, because the two diverging is how variation seven
+    // happened. `\s` here would be too wide: it splits on NBSP and friends, so
+    // a pattern containing one would tokenize short and land in the allowance
+    // below. `[ \t]` was too narrow: `src/payload.ts<CR>cover.png -diff` is a
+    // .ts file with `-diff` to git (check-attr: `diff: unset`), while the
+    // tokenizer read one token ending in `.png` and the allowance returned
+    // before the attribute loop. A CR renders as nothing in a GitHub diff and
+    // INVISIBLE carries no C0 controls, so that had no second line of defence.
+    // Both mismatches fail OPEN; only the widths differ.
     // gitattributes patterns may be QUOTED to contain blanks — verified:
     // `"evil run.ts" binary` really does set binary on `evil run.ts`. Naive
     // tokenizing gives `"cover.png` for `"cover.png run.ts" binary`, whose
@@ -519,7 +536,7 @@ function checkGitAttributes(contents: string, rel: string): void {
     // fail the gate on `"my docs/logo.png" binary`, which is legitimate, and
     // this rule already learned that lesson with *.png.
     const quoted = /^"((?:[^"\\]|\\.)*)"/.exec(stripped);
-    const pattern = quoted ? (quoted[1] as string) : (stripped.split(/[ \t]+/)[0] ?? '');
+    const pattern = quoted ? (quoted[1] as string) : (stripped.split(/[ \t\r]+/)[0] ?? '');
     // A quoted pattern containing a backslash is NOT unquoted before the inert
     // check. git resolves the escapes with unquote_c_style before matching, and
     // stripping them here only ever SHORTENS the string, so a backslash after
@@ -707,10 +724,20 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
   //
   // Dropping HOME has one non-obvious consequence worth naming: it also hides a
   // global `safe.directory`, so scanning a repo owned by another user makes
-  // `ls-files` refuse and the gate falls back to the filesystem walk. That is
-  // fail-SAFE — the walk ignores .gitignore, so it scans more than the git
-  // listing would, never less — and since the summary line now names the
-  // strategy, it announces itself rather than looking like a normal run.
+  // `ls-files` refuse and the gate falls back to the filesystem walk.
+  //
+  // That fallback is NOT strictly safer, and an earlier version of this comment
+  // claimed it was. The walk scans MORE in one direction — it ignores
+  // .gitignore — and LESS in another: it applies SKIP_DIRS to everything, while
+  // the git listing applies it to the untracked half only. Probed on an
+  // identical tree holding a tracked, concealed `build/loader.ts`: the git
+  // strategy reports it, the walk prints `0 files scanned (walk), nothing
+  // hidden`. Latent here, since nothing tracked lives under a SKIP_DIRS name,
+  // but the honest statement is that the two strategies differ rather than
+  // that one dominates. See listFiles below, which has always said this
+  // correctly. What makes the fallback survivable is that the summary line
+  // names the strategy, so a swap announces itself instead of reading as a
+  // normal run.
   const env = { ...process.env };
   for (const key of Object.keys(env)) if (key.startsWith('GIT_')) delete env[key];
   delete env.HOME;
@@ -820,12 +847,25 @@ for (const file of files) {
   // Any package.json, not just the root one: workspace installs run
   // sub-package lifecycle scripts too, so `packages/x/package.json` with a
   // postinstall is the same exposure with a longer path.
-  if (rel === 'package.json' || rel.endsWith(`${sep}package.json`)) {
-    checkLifecycleScripts(contents, rel);
-  }
-  if (rel === '.gitattributes' || rel.endsWith(`${sep}.gitattributes`)) {
-    checkGitAttributes(contents, rel);
-  }
+  //
+  // Matched case-INSENSITIVELY, which is a deliberate trade rather than an
+  // oversight. This repo is developed on macOS and consumed on Windows, both
+  // case-insensitive by default, and there the lookup resolves whatever the
+  // file is actually called: probed on this filesystem, `git check-attr diff
+  // src/payload.ts` reports `diff: unset` from a file named `.GITATTRIBUTES`,
+  // and `npm pkg get scripts` returns the postinstall from a file named
+  // `PACKAGE.JSON`. Exact-case routing sent neither to its checker and the gate
+  // exited 0 on both — variation eight, and the cheapest one yet to exploit.
+  //
+  // The cost: on a case-sensitive filesystem `.GITATTRIBUTES` is a different
+  // file that git ignores, so this reports a finding git would not honour. That
+  // is a false positive, and it is the right way round for this gate — a human
+  // spends a minute and writes an exemption, where the other error ships a
+  // suppressed diff. It is also the direction every other allowance here
+  // already fails in: omission must fail toward suspicion.
+  const basename = rel.slice(rel.lastIndexOf(sep) + 1).toLowerCase();
+  if (basename === 'package.json') checkLifecycleScripts(contents, rel);
+  if (basename === '.gitattributes') checkGitAttributes(contents, rel);
 }
 
 if (findings.length === 0) {

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -516,7 +516,11 @@ function checkGitAttributes(contents: string, rel: string): void {
         i + 1,
         'diff-suppressing gitattribute',
         `"${stripped}" stops git or GitHub showing this path's content in a diff, so a payload ` +
-          `in it reaches main without a reviewer ever seeing the lines`
+          `in it reaches main without a reviewer ever seeing the lines. If this path really is ` +
+          `an inert binary — media, font, archive, document — add its extension to ` +
+          `INERT_BINARY_EXTENSIONS in scripts/check-concealment.ts in the same PR and this ` +
+          `attribute becomes legitimate boilerplate. Otherwise drop the attribute: a file that ` +
+          `executes has to keep a diff a reviewer can read`
       );
       return;
     }

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -674,17 +674,17 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
   // repo and reports the scratch tree as untracked, bypassing SKIP_DIRS entirely.
   // That is how this gate started reporting node_modules under husky while
   // passing when run by hand. Caught by the pre-push hook it broke.
+  //
+  // Stripped as a NAMESPACE rather than as a list of seven names. The list was
+  // the same shape as every other bug in this file: an enumeration of the cases
+  // someone thought of, with everything unlisted falling straight through. It
+  // did not include GIT_CONFIG_GLOBAL or GIT_CONFIG_COUNT, either of which can
+  // set core.excludesFile — which `ls-files --exclude-standard` honours, so an
+  // ambient value drops files out of the scan and the gate still prints a green
+  // "nothing hidden". Every GIT_* variable is git's to interpret, none of them
+  // is ours to inherit, and the test helper already used this exact form.
   const env = { ...process.env };
-  for (const key of [
-    'GIT_DIR',
-    'GIT_WORK_TREE',
-    'GIT_INDEX_FILE',
-    'GIT_COMMON_DIR',
-    'GIT_OBJECT_DIRECTORY',
-    'GIT_ALTERNATE_OBJECT_DIRECTORIES',
-    'GIT_PREFIX',
-  ])
-    delete env[key];
+  for (const key of Object.keys(env)) if (key.startsWith('GIT_')) delete env[key];
 
   const run = (args: string[]): string[] | undefined => {
     const r = spawnSync('git', ['-C', root, ...args], { encoding: 'utf-8', env });

--- a/scripts/check-concealment.ts
+++ b/scripts/check-concealment.ts
@@ -39,11 +39,13 @@
  *     off-screen by nothing but a very long paragraph passes.
  *   - This gate sees what git would show in a diff — tracked files plus
  *     untracked-but-unignored ones, from `git ls-files` — and NOT the working
- *     tree as such: ignored files are out of scope. Outside a repo, or when git
- *     declines, it falls back to a filesystem walk, which scans a materially
- *     different set (no .gitignore, SKIP_DIRS applied to everything). The
- *     summary line names which strategy ran, because that fallback used to be
- *     silent and both endings read `nothing hidden`.
+ *     tree as such: ignored files are out of scope. Outside a repo it falls
+ *     back to a filesystem walk, which scans a materially different set (no
+ *     .gitignore, SKIP_DIRS applied to everything); the summary line names
+ *     which strategy ran, because that fallback used to be silent and both
+ *     endings read `nothing hidden`. INSIDE a repo — a `.git` at the root —
+ *     git declining is a failure rather than a fallback: see the strategy
+ *     check at the bottom of this file. The swap only ever scans less.
  *   - It sees one tree, never a range of commits. The cross-commit half of
  *     #6003 — content added by one commit and removed by another, so it never
  *     appears in the combined diff — cannot be seen from a tree at all. That
@@ -57,7 +59,7 @@
  */
 
 import { spawnSync } from 'child_process';
-import { readFileSync, readdirSync, realpathSync, statSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, realpathSync, statSync } from 'fs';
 import { dirname, join, relative, sep } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -461,6 +463,35 @@ function checkLine(
  * BINARY_EXTENSIONS, which also covers executable formats. Everything else
  * is refused rather than allow-listed — `text=auto`, `eol=lf` and
  * `linguist-language=...` do not hide content, so they need no exemption.
+ *
+ * `linguist-vendored` was checked as the obvious sibling and is deliberately
+ * NOT here (2026-08-30). Three current primary sources agree that only
+ * `linguist-generated` suppresses a diff:
+ *
+ *   - GitHub Docs, "Customizing how changed files appear on GitHub", names one
+ *     attribute: "Use the `linguist-generated` attribute to mark or unmark
+ *     paths that you would like to be ignored for the repository's language
+ *     statistics and hidden by default in diffs."
+ *   - linguist's docs/overrides.md, under Generated code: "As an added bonus,
+ *     unlike vendored and documentation files, these files are suppressed in
+ *     diffs." The contrast is explicit.
+ *   - linguist's README describes its own job as "ignore binary or vendored
+ *     files, suppress generated files in diffs" — again, generated only.
+ *
+ * Read the counter-evidence before trusting that, because there is some:
+ * linguist issues #2206 and #2705 both quote "Vendored files are also hidden by
+ * default in diffs on github.com" from the README OF THEIR DAY (2015/2016).
+ * That sentence is gone from the README linked above; #2206 is a report that
+ * the behaviour it promised did not happen. So the claim is stale rather than
+ * contested.
+ *
+ * Note the evidence class, because it is weaker than this file's usual. This is
+ * documentation, not a probe: `binary` and `-diff` are git-side and were pinned
+ * with `git check-attr`, while both linguist attributes are rendered by
+ * github.com and no local command can measure them. If anyone ever SEES a
+ * vendored path folded in a Files-changed view, add it beside its neighbour
+ * with the same `=false` carve-out — linguist's rule is `attr != "false"`, so
+ * `=1` and `=yes` must still fire.
  */
 const DIFF_SUPPRESSING_ATTRS = [
   /(^|\s)binary(\s|$)/,
@@ -537,6 +568,26 @@ function checkGitAttributes(contents: string, rel: string): void {
     // this rule already learned that lesson with *.png.
     const quoted = /^"((?:[^"\\]|\\.)*)"/.exec(stripped);
     const pattern = quoted ? (quoted[1] as string) : (stripped.split(/[ \t\r]+/)[0] ?? '');
+    // An opening quote with no closing one. git's parse_attr_line calls
+    // unquote_c_style, and on failure falls to its else-branch and reads the
+    // raw token — quote mark included — as a LITERAL path. Probed on git
+    // 2.50.1 with `.gitattributes` holding `"cover.png binary`:
+    //
+    //   git check-attr binary -- 'cover.png' '"cover.png'
+    //   cover.png: binary: unspecified
+    //   "\"cover.png": binary: set
+    //
+    // So nothing that executes gets its diff suppressed and there is no live
+    // divergence here. The allowance still must not be the thing that says so.
+    // It would answer `.png` — from `extensionOf('"cover.png')` — and be right
+    // for a reason that has nothing to do with why git is harmless, which is
+    // the coincidental agreement every earlier variation in this function was
+    // built on. A pattern this parser REFUSED to parse does not get to reach an
+    // allowance; it is reported and a human reads the line. Cheap here: the
+    // repo tracks no .gitattributes at all (`git ls-files | grep -i
+    // gitattributes` is empty), and an unterminated quote is a typo in every
+    // case that is not an attack.
+    const unterminatedQuote = quoted === null && stripped.startsWith('"');
     // A quoted pattern containing a backslash is NOT unquoted before the inert
     // check. git resolves the escapes with unquote_c_style before matching, and
     // stripping them here only ever SHORTENS the string, so a backslash after
@@ -585,6 +636,7 @@ function checkGitAttributes(contents: string, rel: string): void {
     const isMacroDefinition = pattern.startsWith('[attr]');
     if (
       !isMacroDefinition &&
+      !unterminatedQuote &&
       !pattern.includes('\\') &&
       INERT_BINARY_EXTENSIONS.has(extensionOf(pattern))
     )
@@ -735,9 +787,11 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
   // hidden`. Latent here, since nothing tracked lives under a SKIP_DIRS name,
   // but the honest statement is that the two strategies differ rather than
   // that one dominates. See listFiles below, which has always said this
-  // correctly. What makes the fallback survivable is that the summary line
-  // names the strategy, so a swap announces itself instead of reading as a
-  // normal run.
+  // correctly. The summary line names the strategy so a swap announces itself,
+  // and — because a green step is not read — the strategy check at the bottom
+  // of this file turns the announcement into a refusal whenever the tree has a
+  // .git at all. Returning undefined from here is therefore only a fallback
+  // outside a repository.
   const env = { ...process.env };
   for (const key of Object.keys(env)) if (key.startsWith('GIT_')) delete env[key];
   delete env.HOME;
@@ -791,6 +845,10 @@ function gitFiles(root: string): { tracked: string[]; untracked: string[] } | un
  * mismatch silently swaps one for the other, and both report the same green
  * `nothing hidden`. Naming the strategy makes a shrunken scan visible in the
  * output instead of only in a diff of this file.
+ *
+ * The caller does not settle for visible. When the tree has a `.git`, a walk
+ * listing means git refused a repository it could have listed, and that run is
+ * failed outright — see the strategy check after this function's only call.
  */
 function listFiles(root: string): { files: string[]; strategy: 'git' | 'walk' } {
   const fromGit = gitFiles(root);
@@ -885,6 +943,58 @@ function answersToName(file: string, name: string): boolean {
 }
 
 const listing = listFiles(ROOT);
+
+// The strategy is an INVARIANT here, not only a label.
+//
+// gitFiles drops HOME and XDG_CONFIG_HOME, so a global `safe.directory` is
+// invisible to it and a repo owned by another uid makes git refuse — plausible
+// in a container job whose checkout uid differs from the runner's. Every way
+// git can decline lands on the same `run() === undefined` path and falls back
+// to the walk, which applies SKIP_DIRS to TRACKED files and so scans a
+// strictly different, smaller set.
+//
+// Naming the strategy in the summary made that visible. Visible is not
+// enforced: both endings are exit 0 and nobody reads a green step. Measured on
+// git 2.50.1 against one tree — a tracked, concealed `build/loader.ts` beside a
+// clean `src/a.ts` — copied twice, run with the version of this file that had
+// only the label:
+//
+//   as a real repo:          `(2 files scanned, listed by git)`, exit 1
+//   after `chmod 000 .git`:  `1 files scanned (walk), nothing hidden`, exit 0
+//
+// Reproduce: `git init` such a tree and commit it, run the gate with
+// CHECK_CONCEALMENT_ROOT pointed at it, then `chmod 000 .git` and run it again.
+// The payload vanishes and the run stays green. A `.git` that is not a repo at
+// all (`printf garbage > .git/config`) prints the same two lines — both were
+// run; the ownership refusal was NOT, because it needs a second uid. It reaches
+// this branch identically, as a non-zero status from `run()`.
+//
+// So a tree that HAS a .git and that git nevertheless would not list is
+// refused. The remedy is never "accept the walk": the swap only ever scans
+// less.
+//
+// The test is `.git` AT ROOT, which is where this gate runs and what a worktree
+// has too (there it is a file, and existsSync answers for both). One case it
+// does NOT cover, stated rather than left to be discovered: pointing
+// CHECK_CONCEALMENT_ROOT at a SUBDIRECTORY of a repo. gitFiles already declines
+// that on the toplevel mismatch, and there is no `.git` in a subdirectory, so
+// it walks silently — the tests' own path.
+if (listing.strategy === 'walk' && existsSync(join(ROOT, '.git'))) {
+  console.error(
+    `check-concealment: ${ROOT} has a .git, but git declined to list it, so the scan fell ` +
+      `back to the filesystem walk — a different and smaller set, since SKIP_DIRS applies to ` +
+      `tracked files there. Refusing rather than reporting a green run over a shrunken scan.\n`
+  );
+  console.error(
+    `  Run \`git -C ${ROOT} ls-files\` to see the refusal. If it is dubious ownership, note ` +
+      `that this gate runs git with no HOME and GIT_CONFIG_GLOBAL/SYSTEM=/dev/null, and that ` +
+      `safe.directory is "only respected in protected configuration" (git help config) — ` +
+      `which the repository's own .git/config is not. Run the gate as the checkout's owner ` +
+      `rather than trying to allow-list the path.`
+  );
+  process.exit(1);
+}
+
 const files = listing.files.filter((f) => inScope(f));
 for (const file of files) {
   const rel = relative(ROOT, file);

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -536,6 +536,18 @@ describe('diff-suppressing gitattributes (Fable review, item 1)', () => {
     await withTree({ '.gitattributes': attrs }, ({ code }) => expect(code).toBe(0));
   });
 
+  test('the finding names the remedy, so it is actionable without reading the gate', async () => {
+    // The allowance's own comment says an author who genuinely needs diff
+    // suppression "writes the exemption, which is what this gate's failure
+    // message asks for" — and the message did not mention an exemption at all.
+    // A reviewer hitting this had to go read scripts/check-concealment.ts to
+    // find out what to do about it.
+    await withTree({ '.gitattributes': '*.wasm binary\n' }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('INERT_BINARY_EXTENSIONS');
+    });
+  });
+
   test('checks a nested .gitattributes too', async () => {
     await withTree({ 'src/.gitattributes': 'payload.ts binary\n' }, ({ code }) =>
       expect(code).toBe(1)

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -177,6 +177,43 @@ async function withGitTree(
   }
 }
 
+/**
+ * Put a `git` shim on PATH for one gate run, in its own temp dir OUTSIDE the
+ * tree being scanned.
+ *
+ * Outside matters: `extraEnv` runs after the commit, so a shim written into the
+ * scanned root is an untracked file inside the scope — it was the third file in
+ * the untracked test's `(3 files scanned)` baseline, which is evidence quoted
+ * in a docstring. Both shim tests exit at the strategy guard before the listing
+ * is scanned, so it was inert, but scaffolding must not sit in the thing under
+ * measurement.
+ *
+ * `export VAR=1` rather than an assignment prefixed to `export`: the prefixed
+ * form persists only because POSIX says assignments preceding a SPECIAL
+ * built-in survive it, which is true in dash and in bash-as-sh but is a
+ * shell-grammar subtlety, and this suite's whole thesis is that those are where
+ * bugs live. The real git path is quoted, so a path containing a space works.
+ */
+async function withGitShim(
+  script: string,
+  body: (env: Record<string, string>) => Promise<void>
+): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'concealment-shim-'));
+  try {
+    await writeFile(join(dir, 'git'), script, { mode: 0o755 });
+    await body({ PATH: `${dir}:${process.env.PATH ?? ''}` });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/** A shim that forwards to the real git, with `pre` inserted before the exec. */
+function gitShimScript(pre: string): string {
+  const realGit = Bun.which('git');
+  if (realGit === null) throw new Error('git not found on PATH');
+  return `#!/bin/sh\n${pre}exec "${realGit}" "$@"\n`;
+}
+
 describe('clean input', () => {
   test('passes on an ordinary source tree, and says it fell back to the walk', async () => {
     // withTree builds a plain temp directory, so the git listing declines and
@@ -341,9 +378,45 @@ describe('file list comes from git when available (review follow-up)', () => {
       { '.git/config': 'garbage\n', 'build/loader.ts': concealed, 'src/a.ts': CLEAN },
       ({ code, stderr }) => {
         expect(code).toBe(1);
-        expect(stderr).toContain('git declined');
+        expect(stderr).toContain('the git listing declined');
+        // git's own words again, not the gate's guess about them.
+        expect(stderr).toContain('not a git repository');
       }
     );
+  });
+
+  test('git missing from PATH is reported as ENOENT, not as a refusal', async () => {
+    // The third cause folded into one `undefined`, and the one where guessing
+    // does most harm: the old message told the operator to run a git command to
+    // see the refusal, and here git does not exist to be run.
+    //
+    // It reaches the guard through r.error rather than r.status, which is a
+    // branch nothing else in this suite executes — and the two runtimes
+    // disagree on the rest of the result, which is why the branch keys on
+    // error.code. Measured: for a missing binary node answers status=null with
+    // stdout undefined, bun answers status=undefined with stdout an object.
+    // Both answer error.code === 'ENOENT'.
+    // A PATH holding bun and nothing else. Not an EMPTY PATH: runCheck spawns
+    // the gate with `bun`, so emptying PATH breaks the harness rather than the
+    // thing under test — which it did, on the first attempt.
+    const onlyBun = await mkdtemp(join(tmpdir(), 'concealment-nogit-'));
+    try {
+      await symlink(process.execPath, join(onlyBun, 'bun'));
+      expect(Bun.which('git', { PATH: onlyBun })).toBeNull();
+      await withGitTree(
+        { 'build/loader.ts': concealed, 'src/a.ts': CLEAN },
+        ({ code, stderr }) => {
+          expect(code).toBe(1);
+          expect(stderr).toContain('the git listing declined');
+          expect(stderr).toContain('ENOENT');
+          expect(stderr).toContain('not on PATH');
+        },
+        {},
+        () => ({ PATH: onlyBun })
+      );
+    } finally {
+      await rm(onlyBun, { recursive: true, force: true });
+    }
   });
 
   test('a real dubious-ownership refusal is refused, not walked', async () => {
@@ -361,26 +434,23 @@ describe('file list comes from git when available (review follow-up)', () => {
     // Non-vacuous, measured on this tree against the pre-guard file: it printed
     // `1 files scanned (walk), nothing hidden` and exited 0, the tracked
     // concealed build/loader.ts having been dropped by SKIP_DIRS on the walk.
-    const realGit = Bun.which('git');
-    expect(realGit).toBeTruthy();
-    await withGitTree(
-      { 'build/loader.ts': concealed, 'src/a.ts': CLEAN },
-      ({ code, stderr }) => {
-        expect(code).toBe(1);
-        expect(stderr).toContain('git declined');
-      },
-      {},
-      async (dir) => {
-        const shim = join(dir, 'shim');
-        await mkdir(shim, { recursive: true });
-        await writeFile(
-          join(shim, 'git'),
-          `#!/bin/sh\nGIT_TEST_ASSUME_DIFFERENT_OWNER=1 export GIT_TEST_ASSUME_DIFFERENT_OWNER\nexec ${realGit as string} "$@"\n`,
-          { mode: 0o755 }
-        );
-        return { PATH: `${shim}:${process.env.PATH ?? ''}` };
-      }
-    );
+    // The assertion is on git's OWN words. `dubious ownership` is a string this
+    // suite never writes: it can only appear in the output by having been
+    // captured from the failing git's stderr and threaded out of gitFiles, so
+    // it pins both the guard and the cause reporting at once.
+    const script = gitShimScript('export GIT_TEST_ASSUME_DIFFERENT_OWNER=1\n');
+    await withGitShim(script, async (env) => {
+      await withGitTree(
+        { 'build/loader.ts': concealed, 'src/a.ts': CLEAN },
+        ({ code, stderr }) => {
+          expect(code).toBe(1);
+          expect(stderr).toContain('the git listing declined');
+          expect(stderr).toContain('dubious ownership');
+        },
+        {},
+        () => env
+      );
+    });
   });
 
   test('the control: without the .git the walk runs, and it misses the payload', async () => {
@@ -417,28 +487,75 @@ describe('file list comes from git when available (review follow-up)', () => {
     // tell why git failed, only that it did, which is the whole point.
     //
     // Measured against the pre-fix code over this tree: real git reports
-    // `(3 files scanned, listed by git)` and exits 1; the shim reports
+    // `(2 files scanned, listed by git)` and exits 1; the shim reports
     // `1 files scanned (git), nothing hidden` and exits 0.
-    const realGit = Bun.which('git');
-    expect(realGit).toBeTruthy();
-    await withGitTree(
-      { 'src/a.ts': 'const a = 1;\n' },
-      ({ code, stderr }) => {
-        expect(code).toBe(1);
-        expect(stderr).toContain('git declined');
-      },
-      { 'src/added-later.ts': concealed },
-      async (dir) => {
-        const shim = join(dir, 'shim');
-        await mkdir(shim, { recursive: true });
-        await writeFile(
-          join(shim, 'git'),
-          `#!/bin/sh\nfor a in "$@"; do\n  if [ "$a" = "--others" ]; then exit 1; fi\ndone\nexec ${realGit as string} "$@"\n`,
-          { mode: 0o755 }
-        );
-        return { PATH: `${shim}:${process.env.PATH ?? ''}` };
-      }
+    //
+    // The assertion names the failing argv, which is the point of threading the
+    // cause out of gitFiles: `--others` is the invocation that actually died,
+    // and the operator gets that rather than a guess.
+    const script = gitShimScript(
+      'for a in "$@"; do\n  if [ "$a" = "--others" ]; then exit 1; fi\ndone\n'
     );
+    await withGitShim(script, async (env) => {
+      await withGitTree(
+        { 'src/a.ts': 'const a = 1;\n' },
+        ({ code, stderr }) => {
+          expect(code).toBe(1);
+          expect(stderr).toContain('the git listing declined');
+          expect(stderr).toContain('Cause:');
+          expect(stderr).toContain('--others');
+        },
+        { 'src/added-later.ts': concealed },
+        () => env
+      );
+    });
+  });
+
+  test('a listing past the spawnSync default is scanned, not declined', async () => {
+    // spawnSync's maxBuffer defaults to 1 MiB and is not a truncation — it
+    // KILLS the child. Unset, a large enough repo makes every `git` call in
+    // this gate fail, and since #698 a failed call is a hard exit 1: the gate
+    // would refuse to run on exactly the repositories most worth scanning.
+    //
+    // 2,500 deeply-nested paths give a ~2.3 MiB listing, which is past the
+    // point where the child is actually signalled. Measured on bun 1.3.5, and
+    // the shape depends on the size: at ~1.05 MiB git exits first, so status is
+    // 0 with error ENOBUFS and the output happened to be complete; at ~2.3 MiB
+    // and ~4.6 MiB the child is SIGTERMed with status null. run() keys on
+    // r.error rather than r.status precisely because the first shape is a race
+    // whose outcome is incidental — not a case of accepted truncation I was
+    // able to produce, but not one worth depending on either.
+    //
+    // Non-vacuous: with `maxBuffer` removed this same tree makes the gate print
+    // `Cause: ... produced more than the ... bytes this gate allows` and exit 1.
+    const dir = await mkdtemp(join(tmpdir(), 'concealment-big-'));
+    try {
+      const deep = join(dir, ...Array.from({ length: 9 }, (_, i) => `d${i}`.padEnd(100, 'x')));
+      await mkdir(deep, { recursive: true });
+      await Promise.all(
+        Array.from({ length: 2500 }, (_, i) =>
+          writeFile(join(deep, `f${String(i).padStart(5, '0')}.ts`), CLEAN)
+        )
+      );
+      const cleanEnv: Record<string, string> = {};
+      for (const [k, v] of Object.entries(process.env)) {
+        if (!k.startsWith('GIT_') && v !== undefined) cleanEnv[k] = v;
+      }
+      for (const args of [
+        ['init', '-q'],
+        ['add', '-A'],
+        ['-c', 'user.email=t@e.com', '-c', 'user.name=t', 'commit', '-qm', 'seed', '--no-gpg-sign'],
+      ]) {
+        const r = Bun.spawnSync(['git', '-C', dir, ...args], { env: cleanEnv });
+        if (r.exitCode !== 0) throw new Error(`git ${args.join(' ')} failed`);
+      }
+      const { code, stdout } = await runCheck(dir);
+      expect(code).toBe(0);
+      expect(stdout).toContain('(git)');
+      expect(stdout).toContain('2500 files scanned');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   test('a repo with nothing untracked still scans, and still reports (git)', async () => {

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -134,10 +134,14 @@ async function withGitTree(
 }
 
 describe('clean input', () => {
-  test('passes on an ordinary source tree', async () => {
+  test('passes on an ordinary source tree, and says it fell back to the walk', async () => {
+    // withTree builds a plain temp directory, so the git listing declines and
+    // the walk runs. Asserting the label here and `(git)` in the git block
+    // below is what stops the two paths being confused for one another.
     await withTree({ 'src/a.ts': CLEAN, 'src/nested/b.ts': CLEAN }, ({ code, stdout }) => {
       expect(code).toBe(0);
       expect(stdout).toContain('check-concealment');
+      expect(stdout).toContain('(walk)');
     });
   });
 
@@ -264,6 +268,19 @@ describe('scope', () => {
  * hole the audit that prompted these tests was about.
  */
 describe('file list comes from git when available (review follow-up)', () => {
+  test('the summary line says which strategy listed the files', async () => {
+    // The fallback was silent: git missing, a dubious-ownership refusal or a
+    // toplevel mismatch all dropped the gate onto the walk, which does not
+    // honour .gitignore and does honour SKIP_DIRS for tracked files — a
+    // materially different scanned set, reported with the same green line.
+    // Every withGitTree test used to infer the git path indirectly, from
+    // behaviour that only differs on the git path.
+    await withGitTree({ 'src/a.ts': CLEAN }, ({ code, stdout }) => {
+      expect(code).toBe(0);
+      expect(stdout).toContain('(git)');
+    });
+  });
+
   test('a gitignored tree is not scanned', async () => {
     // The real exposure: removing the extension allowlist put snapshots/,
     // local fixture databases and .env.local in scope on developer machines.

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -334,14 +334,51 @@ describe('file list comes from git when available (review follow-up)', () => {
     // `.git` here holds a garbage config, which is a real refusal from real
     // git: `git -C <dir> rev-parse --show-toplevel` answers `fatal: not a git
     // repository` with status 128. `chmod 000 .git` on a valid repo does the
-    // same thing; both were run against git 2.50.1. The ownership case is the
-    // motivating one and was NOT run, because it needs a second uid — it
-    // reaches this branch identically, through a non-zero git status.
+    // same thing; both were run against git 2.50.1. The motivating refusal —
+    // dubious ownership — gets its own test below, which does not need the
+    // second uid an earlier round assumed it did.
     await withTree(
       { '.git/config': 'garbage\n', 'build/loader.ts': concealed, 'src/a.ts': CLEAN },
       ({ code, stderr }) => {
         expect(code).toBe(1);
         expect(stderr).toContain('git declined');
+      }
+    );
+  });
+
+  test('a real dubious-ownership refusal is refused, not walked', async () => {
+    // The scenario the guard exists for, driven end-to-end at last. An earlier
+    // round recorded it as unrunnable without a second uid; that was wrong.
+    // git ships GIT_TEST_ASSUME_DIFFERENT_OWNER, which makes
+    // ensure_valid_ownership take the failing branch and emit the genuine
+    // `fatal: detected dubious ownership in repository at '<path>'`, status 128
+    // — no chown, no sudo, no container.
+    //
+    // It has to arrive on a PATH shim rather than in the environment, because
+    // gitFiles strips the whole GIT_ namespace before spawning — the same
+    // stripping that makes this failure mode terminal in the first place.
+    //
+    // Non-vacuous, measured on this tree against the pre-guard file: it printed
+    // `1 files scanned (walk), nothing hidden` and exited 0, the tracked
+    // concealed build/loader.ts having been dropped by SKIP_DIRS on the walk.
+    const realGit = Bun.which('git');
+    expect(realGit).toBeTruthy();
+    await withGitTree(
+      { 'build/loader.ts': concealed, 'src/a.ts': CLEAN },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('git declined');
+      },
+      {},
+      async (dir) => {
+        const shim = join(dir, 'shim');
+        await mkdir(shim, { recursive: true });
+        await writeFile(
+          join(shim, 'git'),
+          `#!/bin/sh\nGIT_TEST_ASSUME_DIFFERENT_OWNER=1 export GIT_TEST_ASSUME_DIFFERENT_OWNER\nexec ${realGit as string} "$@"\n`,
+          { mode: 0o755 }
+        );
+        return { PATH: `${shim}:${process.env.PATH ?? ''}` };
       }
     );
   });
@@ -361,6 +398,58 @@ describe('file list comes from git when available (review follow-up)', () => {
     await withTree({ 'build/loader.ts': concealed, 'src/a.ts': CLEAN }, ({ code, stdout }) => {
       expect(code).toBe(0);
       expect(stdout).toContain('(walk)');
+      expect(stdout).toContain('1 files scanned');
+    });
+  });
+
+  test('a failed untracked listing refuses, instead of scanning the tracked half', async () => {
+    // The last silent scan-shrink, and the one the strategy guard above cannot
+    // see: `?? []` on the untracked listing kept `strategy` at 'git', so a
+    // failure printed `N files scanned (git), nothing hidden` over a scope that
+    // had lost its whole untracked half.
+    //
+    // No tree state makes `ls-files --others` exit non-zero — looked for, on
+    // git 2.50.1: an unreadable subdirectory warns and exits 0, an unreadable
+    // .git/info/exclude warns and exits 0, a .gitignore that is a DIRECTORY is
+    // silent and exits 0. So the failure is injected where run() actually
+    // observes it, at the process boundary: a `git` earlier on PATH that exits
+    // 1 on `--others` and execs the real git for everything else. run() cannot
+    // tell why git failed, only that it did, which is the whole point.
+    //
+    // Measured against the pre-fix code over this tree: real git reports
+    // `(3 files scanned, listed by git)` and exits 1; the shim reports
+    // `1 files scanned (git), nothing hidden` and exits 0.
+    const realGit = Bun.which('git');
+    expect(realGit).toBeTruthy();
+    await withGitTree(
+      { 'src/a.ts': 'const a = 1;\n' },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('git declined');
+      },
+      { 'src/added-later.ts': concealed },
+      async (dir) => {
+        const shim = join(dir, 'shim');
+        await mkdir(shim, { recursive: true });
+        await writeFile(
+          join(shim, 'git'),
+          `#!/bin/sh\nfor a in "$@"; do\n  if [ "$a" = "--others" ]; then exit 1; fi\ndone\nexec ${realGit as string} "$@"\n`,
+          { mode: 0o755 }
+        );
+        return { PATH: `${shim}:${process.env.PATH ?? ''}` };
+      }
+    );
+  });
+
+  test('a repo with nothing untracked still scans, and still reports (git)', async () => {
+    // The other half of the same distinction, and the regression the fix above
+    // could have introduced. Empty is not failure: probed on git 2.50.1, a
+    // clean tree gives `ls-files --others --exclude-standard` status 0 with
+    // zero bytes of stdout, which run() turns into `[]`. Treating a falsy or
+    // empty listing as a refusal would fail this gate on every clean checkout.
+    await withGitTree({ 'src/a.ts': CLEAN }, ({ code, stdout }) => {
+      expect(code).toBe(0);
+      expect(stdout).toContain('(git)');
       expect(stdout).toContain('1 files scanned');
     });
   });

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -468,12 +468,15 @@ describe('scope is not an extension allowlist (audit F2)', () => {
 
   test('a deep LEADING gap on a short line is allowed', async () => {
     // Axis 2 of the conjunction, pinned directly rather than inferred from the
-    // mid-line case. The repo's real worst case on this axis is a 20-character
-    // leading gap on a 95-column line (docs/REVERSE_ENGINEERING_FINDING.md);
-    // this fixture is deeper and still short, so the rule has to stay quiet.
-    await withTree({ 'docs/indented.md': `${' '.repeat(30)}a short indented line\n` }, ({ code }) =>
-      expect(code).toBe(0)
-    );
+    // mid-line case, and pinned ABOVE both of the repo's real extremes rather
+    // than between them: the deepest leading gap is 37 characters
+    // (docs/bulk-edit-transactions.md:235) and the longest line carrying a 20+
+    // gap is 95 columns (docs/REVERSE_ENGINEERING_FINDING.md:611). This fixture
+    // is 45 characters of gap on a 115-column line — deeper AND longer than
+    // anything real — and must still be quiet, because it is the line-length
+    // half of the conjunction that makes it safe, not the shallowness.
+    const line = `${' '.repeat(45)}${'x'.repeat(70)}`;
+    await withTree({ 'docs/indented.md': `${line}\n` }, ({ code }) => expect(code).toBe(0));
   });
 
   test('a wide gap in markdown that still ends on screen is allowed', async () => {
@@ -731,10 +734,61 @@ describe('scoping follow-ups (review of #679)', () => {
     ['form feed', '\f'],
     ['vertical tab', '\v'],
   ])('a line starting with %s then # is NOT a comment to git', async (_label, lead) => {
-    // git skips only spaces and tabs before the `#` test, so this is a real
-    // pattern to git. JS .trim() stripped these and read it as a comment —
-    // the mirror image of the mid-line-# bug fixed alongside it.
+    // git's blank set is space, tab and CR — probed one character at a time on
+    // 2.50.1 — so none of these is skipped before the `#` test and each line is
+    // a real pattern to git. JS .trim() stripped them and read the line as a
+    // comment, the mirror image of the mid-line-# bug fixed alongside it.
     await withTree({ '.gitattributes': `${lead}# payload.ts binary\n` }, ({ code }) =>
+      expect(code).toBe(1)
+    );
+  });
+
+  test('a CR separates the pattern from its attributes, as it does for git', async () => {
+    // Variation seven of the blank-set mismatch, and the first that came from
+    // this file asserting the WRONG SET rather than using JS's. Probed on git
+    // 2.50.1, one character at a time: space, tab and CR are blanks to git;
+    // form feed, vertical tab and NBSP are not.
+    //
+    // So `src/payload.ts<CR>cover.png -diff` is `src/payload.ts` + the
+    // attributes `cover.png` and `-diff` to git, which unsets diff on a .ts
+    // file — confirmed with `git check-attr diff src/payload.ts`. Splitting on
+    // `[ \t]+` alone swallowed the CR and read the first token as
+    // `src/payload.ts<CR>cover.png`, whose extension is `.png`, so the inert
+    // allowance returned before the attribute loop ever ran. A CR is invisible
+    // in a GitHub diff and INVISIBLE has no C0 controls, so nothing else
+    // caught it.
+    await withTree(
+      { '.gitattributes': 'src/payload.ts\rcover.png -diff\n' },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('gitattribute');
+      }
+    );
+  });
+
+  test('a CR before a # IS a comment to git, so it is one here', async () => {
+    // The other side of the same set: git's leading-blank skip takes CR too, so
+    // this line is a comment and reporting it would be a false positive. The
+    // gate used to report it. Kept next to the NBSP/form-feed/vertical-tab
+    // cases below, which are NOT blanks and so must still be reported — the
+    // pair is what pins the set to exactly what git uses.
+    await withTree({ '.gitattributes': '\r# payload.ts binary\n' }, ({ code }) =>
+      expect(code).toBe(0)
+    );
+  });
+
+  test.each([
+    ['.GITATTRIBUTES', '.GITATTRIBUTES', 'src/payload.ts binary\n'],
+    ['PACKAGE.JSON', 'PACKAGE.JSON', '{"scripts":{"postinstall":"echo pwned"}}\n'],
+  ])('a case-variant %s is still routed to its checker', async (_l, name, contents) => {
+    // Variation eight. The routing matched the filename exact-case, but this
+    // repo is developed on macOS and consumers run Windows — both
+    // case-insensitive — where the lookup resolves regardless of case. Probed
+    // on this filesystem: `git check-attr diff src/payload.ts` reports
+    // `diff: unset` from a file named `.GITATTRIBUTES`, and `npm pkg get
+    // scripts` returns the postinstall from a file named `PACKAGE.JSON`. The
+    // gate exited 0 on both.
+    await withTree({ [name]: contents, 'src/payload.ts': 'const a = 1;\n' }, ({ code }) =>
       expect(code).toBe(1)
     );
   });

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -21,7 +21,7 @@
  * whole checker commented out.
  */
 import { describe, expect, test } from 'bun:test';
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
 import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -103,7 +103,11 @@ async function withTree(
   files: Record<string, string>,
   // `void` alone would silently accept an async callback and drop its
   // assertions — the test would pass no matter what it asserted.
-  assertions: (result: Result) => void | Promise<void>
+  assertions: (result: Result) => void | Promise<void>,
+  // link path -> target, written after the files so the targets exist. Used by
+  // the routing test: a symlink is the only way to ask "which file does this
+  // name open?" on a filesystem that does not fold case.
+  links: Record<string, string> = {}
 ): Promise<void> {
   const dir = await mkdtemp(join(tmpdir(), 'concealment-'));
   try {
@@ -111,6 +115,11 @@ async function withTree(
       const path = join(dir, name);
       await mkdir(join(path, '..'), { recursive: true });
       await writeFile(path, contents);
+    }
+    for (const [name, target] of Object.entries(links)) {
+      const path = join(dir, name);
+      await mkdir(join(path, '..'), { recursive: true });
+      await symlink(target, path);
     }
     await assertions(await runCheck(dir));
   } finally {
@@ -313,6 +322,46 @@ describe('file list comes from git when available (review follow-up)', () => {
     await withGitTree({ 'src/a.ts': CLEAN }, ({ code, stdout }) => {
       expect(code).toBe(0);
       expect(stdout).toContain('(git)');
+    });
+  });
+
+  test('a tree with a .git that git will not list is refused, not quietly walked', async () => {
+    // The label made the swap visible; nobody reads a green step. gitFiles
+    // drops HOME, so a global safe.directory is invisible to it and a repo
+    // owned by another uid makes git refuse — plausible in a container job.
+    // Every refusal lands on the same `run() === undefined` path.
+    //
+    // `.git` here holds a garbage config, which is a real refusal from real
+    // git: `git -C <dir> rev-parse --show-toplevel` answers `fatal: not a git
+    // repository` with status 128. `chmod 000 .git` on a valid repo does the
+    // same thing; both were run against git 2.50.1. The ownership case is the
+    // motivating one and was NOT run, because it needs a second uid — it
+    // reaches this branch identically, through a non-zero git status.
+    await withTree(
+      { '.git/config': 'garbage\n', 'build/loader.ts': concealed, 'src/a.ts': CLEAN },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('git declined');
+      }
+    );
+  });
+
+  test('the control: without the .git the walk runs, and it misses the payload', async () => {
+    // What the guard above is worth, and why it is not simply noise. The
+    // identical tree minus `.git` is a legitimate non-repo, the walk is the
+    // right listing for it — and the walk applies SKIP_DIRS to `build/`, so the
+    // concealed file is not scanned at all and the run is green over ONE file.
+    //
+    // That is the shrink, measured on this exact pair of trees with the
+    // label-only version of the gate: committed to a real repo it reports
+    // `(2 files scanned, listed by git)` and exits 1; after `chmod 000 .git` it
+    // reports `1 files scanned (walk), nothing hidden` and exits 0. A `.git`
+    // present alongside a walk listing means that difference is being taken
+    // silently, which is what the test above now refuses.
+    await withTree({ 'build/loader.ts': concealed, 'src/a.ts': CLEAN }, ({ code, stdout }) => {
+      expect(code).toBe(0);
+      expect(stdout).toContain('(walk)');
+      expect(stdout).toContain('1 files scanned');
     });
   });
 
@@ -841,6 +890,64 @@ describe('scoping follow-ups (review of #679)', () => {
       });
     }
   );
+
+  test('routing follows what the name RESOLVES to, not what the name folds to', async () => {
+    // The U+017F cases above are skipped wherever the filesystem does not fold,
+    // and CI is ubuntu/ext4 — so the detector for the headline fix runs only on
+    // a contributor's Mac. This pins the same property on any filesystem.
+    //
+    // A symlink asks the same question a case-fold asks: `manifest.json` is a
+    // real file whose own name no fold function turns into `package.json`, and
+    // `package.json` in that directory opens it. npm agrees — `npm pkg get
+    // scripts` in exactly this tree returns `{"postinstall": "echo pwned"}`,
+    // run against real npm rather than assumed.
+    //
+    // The assertion is on `manifest.json` and NOT on the exit code, and that
+    // distinction is the whole test. The symlink is itself listed by the walk,
+    // and its own basename routes it, so the gate exits 1 either way:
+    // `expect(code).toBe(1)` alone passes against the pre-fix basename fold —
+    // measured by running scripts/check-concealment.ts from commit 28cd61ad
+    // over this tree, which reported one finding, at package.json. Only the
+    // realpath oracle reports the TARGET's path, so only that assertion goes
+    // red if routing reverts to folding a basename.
+    //
+    // It does not pin `realpathSync.native` over plain `realpathSync`: both
+    // resolve a symlink, and the case-fold divergence between them cannot be
+    // reproduced on a case-sensitive filesystem. Checked, not assumed — the
+    // gate with `.native` sed'd out still reports manifest.json here. That
+    // choice rests on the runtime table in answersToName's docstring.
+    await withTree(
+      {
+        'manifest.json': '{"scripts":{"postinstall":"echo pwned"}}\n',
+        'src/a.ts': 'const a = 1;\n',
+      },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('manifest.json');
+        expect(stderr).toContain('postinstall');
+      },
+      { 'package.json': 'manifest.json' }
+    );
+  });
+
+  test('an unterminated quote does not reach the inert allowance', async () => {
+    // git's parse_attr_line falls to its else-branch when unquote_c_style
+    // fails, and reads the raw token — quote mark included — as a literal path.
+    // Probed on git 2.50.1 with `"cover.png binary`: `git check-attr binary --
+    // 'cover.png' '"cover.png'` answers `unspecified` for the first and `set`
+    // for the second, so nothing that executes is concealed and the gate and
+    // git agree on the outcome.
+    //
+    // They agreed for unrelated reasons, though: git because the unquote
+    // failed, the gate because the token it fell back to happens to end in an
+    // inert extension. That is the coincidence every earlier variation in this
+    // function was built on, so the allowance no longer answers for a pattern
+    // the parser refused to parse.
+    await withTree({ '.gitattributes': '"cover.png binary\n' }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('diff-suppressing gitattribute');
+    });
+  });
 
   test('an NBSP in the pattern does not tokenize it into the allowance', async () => {
     // git splits pattern from attributes on spaces and tabs ONLY, so the real

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -48,13 +48,20 @@ interface Result {
   stderr: string;
 }
 
-async function runCheck(root: string, args: string[] = []): Promise<Result> {
+async function runCheck(
+  root: string,
+  args: string[] = [],
+  // Deliberately applied AFTER the GIT_ filter below, so a test can put a
+  // plumbing variable back to prove the gate strips it for itself.
+  extraEnv: Record<string, string> = {}
+): Promise<Result> {
   const proc = Bun.spawn(['bun', 'run', SCRIPT, ...args], {
     // Same reason as withGitTree's cleanEnv: a pre-push run sets GIT_DIR, and
     // leaking it makes the gate resolve to the ambient repo instead of `root`.
     env: Object.fromEntries([
       ...Object.entries(process.env).filter(([k]) => !k.startsWith('GIT_')),
       ['CHECK_CONCEALMENT_ROOT', root],
+      ...Object.entries(extraEnv),
     ]) as Record<string, string>,
     stdout: 'pipe',
     stderr: 'pipe',
@@ -94,7 +101,10 @@ async function withGitTree(
   // Written AFTER the commit. `git add -A` honours .gitignore, so a file
   // listed in it at seed time is never tracked at all — which is a different
   // scenario from "tracked, then later ignored".
-  afterCommit: Record<string, string> = {}
+  afterCommit: Record<string, string> = {},
+  // Built from the temp dir, because anything pointing at a file inside the
+  // tree needs its absolute path.
+  extraEnv: (dir: string) => Promise<Record<string, string>> | Record<string, string> = () => ({})
 ): Promise<void> {
   const dir = await mkdtemp(join(tmpdir(), 'concealment-git-'));
   try {
@@ -127,7 +137,7 @@ async function withGitTree(
       await mkdir(join(path, '..'), { recursive: true });
       await writeFile(path, contents);
     }
-    await assertions(await runCheck(dir));
+    await assertions(await runCheck(dir, [], await extraEnv(dir)));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -279,6 +289,31 @@ describe('file list comes from git when available (review follow-up)', () => {
       expect(code).toBe(0);
       expect(stdout).toContain('(git)');
     });
+  });
+
+  test('an inherited GIT_CONFIG_GLOBAL cannot shrink the scanned set', async () => {
+    // GIT_DIR is not the only plumbing variable that reaches into the listing.
+    // GIT_CONFIG_GLOBAL (and GIT_CONFIG_COUNT/KEY/VALUE) can set
+    // core.excludesFile, which `ls-files --others --exclude-standard` honours —
+    // so an ambient value silently drops files from the scan while the gate
+    // still prints a green line. Stripping seven variables BY NAME was the same
+    // shape of bug this gate exists to catch: an enumeration of what to handle,
+    // with everything unlisted falling through.
+    await withGitTree(
+      { 'src/a.ts': CLEAN },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('added-later');
+      },
+      { 'src/added-later.ts': concealed },
+      async (dir) => {
+        const excludes = join(dir, 'excludes');
+        const config = join(dir, 'gitconfig');
+        await writeFile(excludes, '*.ts\n');
+        await writeFile(config, `[core]\n\texcludesFile = ${excludes}\n`);
+        return { GIT_CONFIG_GLOBAL: config };
+      }
+    );
   });
 
   test('a gitignored tree is not scanned', async () => {

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -503,6 +503,31 @@ describe('diff-suppressing gitattributes (Fable review, item 1)', () => {
     );
   });
 
+  test.each([
+    ['a bare linguist-generated, which git reads as set', 'src/payload.ts linguist-generated'],
+    ['linguist-generated=true', 'src/payload.ts linguist-generated=true'],
+    // Linguist's own boolean_attribute is `attribute != "false"`, so every
+    // value other than that literal collapses the diff. Anchoring on `=true`
+    // alone would have waved this through.
+    ['a non-true value linguist still treats as set', 'src/payload.ts linguist-generated=1'],
+  ])('flags %s', async (_label, line) => {
+    await withTree({ '.gitattributes': `${line}\n` }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('gitattribute');
+    });
+  });
+
+  test.each([
+    ['linguist-generated=false', 'src/payload.ts linguist-generated=false'],
+    ['-linguist-generated, the unset form', 'src/payload.ts -linguist-generated'],
+  ])('does not flag %s, which UN-collapses the diff', async (_label, line) => {
+    // The unanchored /linguist-generated/ matched these too, and they are the
+    // opposite of concealment: they take a file OUT of the "Load diff" fold.
+    // Reporting them told an author to remove the thing making their file
+    // reviewable.
+    await withTree({ '.gitattributes': `${line}\n` }, ({ code }) => expect(code).toBe(0));
+  });
+
   test('leaves the legitimate attributes alone', async () => {
     // text=auto / eol=lf / linguist-language do not hide content, which is why
     // the rule refuses the suppressing attributes rather than allow-listing

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -466,6 +466,16 @@ describe('scope is not an extension allowlist (audit F2)', () => {
     );
   });
 
+  test('a deep LEADING gap on a short line is allowed', async () => {
+    // Axis 2 of the conjunction, pinned directly rather than inferred from the
+    // mid-line case. The repo's real worst case on this axis is a 20-character
+    // leading gap on a 95-column line (docs/REVERSE_ENGINEERING_FINDING.md);
+    // this fixture is deeper and still short, so the rule has to stay quiet.
+    await withTree({ 'docs/indented.md': `${' '.repeat(30)}a short indented line\n` }, ({ code }) =>
+      expect(code).toBe(0)
+    );
+  });
+
   test('a wide gap in markdown that still ends on screen is allowed', async () => {
     // The other half of the conjunction, kept honest: an aligned two-column
     // list in a README is legible precisely because the line ends where you
@@ -788,6 +798,35 @@ describe('scoping follow-ups (review of #679)', () => {
         expect(stderr).toContain('gitattribute');
       }
     );
+  });
+
+  test.each([
+    ['binary', '"[attr]a.png" binary', 'src/payload.ts a.png'],
+    ['-diff', '"[attr]b.pdf" -diff', 'src/payload.ts b.pdf'],
+    ['linguist-generated', '"[attr]c.zip" linguist-generated', 'src/payload.ts c.zip'],
+  ])('a QUOTED macro definition carrying %s is caught too', async (_l, def, use) => {
+    // The same hole one quote-mark to the left. git unquotes BEFORE testing for
+    // the macro prefix, so a quoted `[attr]` really does define a macro —
+    // verified on git 2.50.1: `"[attr]a.png" -diff` + `src/payload.ts a.png`
+    // gives `src/payload.ts: diff: unset`, and git diff prints
+    // `Binary files a/src/payload.ts and b/src/payload.ts differ`.
+    //
+    // So the macro test cannot read the raw line; it has to read the same
+    // unquoted token the extension check reads, which is the only arrangement
+    // where one form cannot be handled and the other missed.
+    await withTree(
+      { '.gitattributes': `${def}\n${use}\n`, 'src/payload.ts': 'const a = 1;\n' },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('gitattribute');
+      }
+    );
+  });
+
+  test('a quoted macro whose name is not extension-shaped was always reported', async () => {
+    // The control for the quoted form, and the same tell as its unquoted twin:
+    // the escape depended entirely on the name ending in an inert extension.
+    await withTree({ '.gitattributes': '"[attr]zz" binary\n' }, ({ code }) => expect(code).toBe(1));
   });
 
   test('a macro whose name is not extension-shaped was always reported', async () => {

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -337,9 +337,40 @@ describe('scope is not an extension allowlist (audit F2)', () => {
     });
   });
 
-  test('prose is exempt from the code-shaped rules', async () => {
+  test('a whitespace-run payload in markdown is reported', async () => {
+    // Prose loses the long-line and dynamic-execution rules, not this one.
+    // Markdown here is not only read by humans: CLAUDE.md and skills/**/*.md
+    // are instruction files an agent reads in full, so a gap that pushes an
+    // instruction off the right edge of the diff is concealment in exactly the
+    // sense this gate means — invisible to the reviewer, load-bearing to the
+    // reader. Markdown's one legitimate whitespace idiom, the trailing double
+    // space that forces a line break, sits at end-of-line and cannot match
+    // \S[gap]{20,}\S.
+    //
+    // The fixture must clear CONCEALED_LINE (120) as well as carry the gap:
+    // the rule is a conjunction, so a short line with a wide gap passes both
+    // before and after this change and would pin nothing.
+    const line = `${'real prose. '.repeat(8)}${' '.repeat(40)}then a hidden instruction`;
+    await withTree({ 'CLAUDE.md': `${line}\n` }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('CLAUDE.md');
+    });
+  });
+
+  test('a wide gap in markdown that still ends on screen is allowed', async () => {
+    // The other half of the conjunction, kept honest: an aligned two-column
+    // list in a README is legible precisely because the line ends where you
+    // can see it. Without this, someone could "fix" a false positive by
+    // dropping CONCEALED_LINE and no test would notice.
+    await withTree({ 'docs/table.md': `col${' '.repeat(30)}value\n` }, ({ code }) =>
+      expect(code).toBe(0)
+    );
+  });
+
+  test('prose is exempt from the long-line and dynamic-execution rules', async () => {
     // A long paragraph in a CHANGELOG is a paragraph, and a doc that quotes
-    // eval() is documentation. Markdown is not executed.
+    // eval() is documentation. Markdown is not executed. Exactly two rules are
+    // dropped for prose — the whitespace run is NOT one of them, see above.
     await withTree({ 'CHANGELOG.md': `${'word '.repeat(200)}eval(x)\n` }, ({ code }) =>
       expect(code).toBe(0)
     );

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -316,6 +316,31 @@ describe('file list comes from git when available (review follow-up)', () => {
     );
   });
 
+  test('a HOME-supplied core.excludesFile cannot shrink the scanned set either', async () => {
+    // Stripping GIT_* closed one door and left the other open. `ls-files
+    // --exclude-standard` reads core.excludesFile from the GLOBAL config, which
+    // git finds through HOME (or XDG_CONFIG_HOME) with no GIT_ variable
+    // involved at all — so the ambient user config still silently dropped files
+    // from the scan under the same green line. The environment is not trusted
+    // for this; git is told to read no config files.
+    await withGitTree(
+      { 'src/a.ts': CLEAN },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('added-later');
+      },
+      { 'src/added-later.ts': concealed },
+      async (dir) => {
+        const home = join(dir, 'home');
+        await mkdir(home, { recursive: true });
+        const excludes = join(home, 'excludes');
+        await writeFile(excludes, '*.ts\n');
+        await writeFile(join(home, '.gitconfig'), `[core]\n\texcludesFile = ${excludes}\n`);
+        return { HOME: home, XDG_CONFIG_HOME: home };
+      }
+    );
+  });
+
   test('a gitignored tree is not scanned', async () => {
     // The real exposure: removing the extension allowlist put snapshots/,
     // local fixture databases and .env.local in scope on developer machines.
@@ -328,10 +353,14 @@ describe('file list comes from git when available (review follow-up)', () => {
     );
   });
 
-  test('a tracked file is still scanned', async () => {
+  test('a tracked file is still scanned, and the failing run names the strategy', async () => {
+    // The label used to print only on the green path — which is the run where
+    // you least need it. A failing run is exactly when "which set was scanned?"
+    // is the first question.
     await withGitTree({ 'src/a.ts': concealed }, ({ code, stderr }) => {
       expect(code).toBe(1);
       expect(stderr).toContain('src/a.ts');
+      expect(stderr).toContain('listed by git');
     });
   });
 
@@ -406,7 +435,35 @@ describe('scope is not an extension allowlist (audit F2)', () => {
     await withTree({ 'CLAUDE.md': `${line}\n` }, ({ code, stderr }) => {
       expect(code).toBe(1);
       expect(stderr).toContain('CLAUDE.md');
+      // The rule, not just the exit code: without this the test passes if any
+      // other rule happens to fire on the fixture.
+      expect(stderr).toContain('whitespace run');
     });
+  });
+
+  test('a LEADING-gap payload in markdown is reported', async () => {
+    // The bound the mid-line form left open. `\S[gap]{20,}\S` needs a non-space
+    // on the LEFT, so a line that opens with the gap matched nothing — and
+    // prose is exempt from MAX_LINE, so nothing else caught it either. An
+    // instruction sitting at column 200 of a 232-column line renders as a blank
+    // line to a reviewer scrolling a diff and as an instruction to the model.
+    const line = `${' '.repeat(200)}then a hidden instruction, invisible above`;
+    await withTree({ 'CLAUDE.md': `${line}\n` }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('whitespace run');
+    });
+  });
+
+  test('ordinary indentation is not a leading gap', async () => {
+    // The measurement behind the threshold: across the whole repo, the deepest
+    // leading whitespace on any line over 120 columns is 14, and the longest
+    // line carrying 20+ leading gap characters is 95 columns. Both axes of the
+    // conjunction have real margin, which is why this can be a rule rather than
+    // an exemption list.
+    await withTree(
+      { 'src/deep.ts': `${' '.repeat(14)}const x = '${'y'.repeat(110)}';\n` },
+      ({ code }) => expect(code).toBe(0)
+    );
   });
 
   test('a wide gap in markdown that still ends on screen is allowed', async () => {
@@ -711,6 +768,33 @@ describe('scoping follow-ups (review of #679)', () => {
       expect(code).toBe(1);
       expect(stderr).toContain('diff-suppressing gitattribute');
     });
+  });
+
+  test.each([
+    ['binary', '[attr]a.png binary', 'src/payload.ts a.png'],
+    ['-diff', '[attr]b.pdf -diff', 'src/payload.ts b.pdf'],
+    ['linguist-generated', '[attr]c.zip linguist-generated', 'src/payload.ts c.zip'],
+  ])('a macro definition carrying %s is not waved through by its name', async (_l, def, use) => {
+    // gitattributes has a SECOND line form the parser had no concept of:
+    // `[attr]<name> <attrs...>` defines a macro, and attr_name_valid permits
+    // dots in the name. So `[attr]a.png` puts `.png` in front of an extension
+    // check that is only meaningful for paths, and the macro then sets `binary`
+    // on whatever claims it. Verified against real git: payload.ts renders as
+    // `Binary files ... differ` while the gate exited 0.
+    await withTree(
+      { '.gitattributes': `${def}\n${use}\n`, 'src/payload.ts': 'const a = 1;\n' },
+      ({ code, stderr }) => {
+        expect(code).toBe(1);
+        expect(stderr).toContain('gitattribute');
+      }
+    );
+  });
+
+  test('a macro whose name is not extension-shaped was always reported', async () => {
+    // The control that shows the hole above was accidental rather than
+    // designed: the identical macro escapes only when its name happens to end
+    // in an inert extension.
+    await withTree({ '.gitattributes': '[attr]zz binary\n' }, ({ code }) => expect(code).toBe(1));
   });
 
   test('an executable binary format is NOT auto-approved', async () => {

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -581,6 +581,18 @@ describe('scoping follow-ups (review of #679)', () => {
     );
   });
 
+  test('a quoted gitattributes pattern with a backslash does not reach the inert allowance', async () => {
+    // Stripping backslashes can only SHORTEN the string, so an escape after the
+    // last dot manufactures an inert-looking extension git never resolves to:
+    // `"evil.p\ng"` reads as `.png` to a naive strip and as a literal newline to
+    // git's unquote_c_style. The strip was an approximation of that function and
+    // it failed OPEN, so the escape form now misses the allowance entirely.
+    await withTree({ '.gitattributes': '"evil.p\\ng" binary\n' }, ({ code, stderr }) => {
+      expect(code).toBe(1);
+      expect(stderr).toContain('diff-suppressing gitattribute');
+    });
+  });
+
   test('an executable binary format is NOT auto-approved', async () => {
     // BINARY_EXTENSIONS answers "where is a NUL expected"; it includes .wasm,
     // .node, .so, .exe. Reusing it here would bless diff suppression on the

--- a/tests/scripts/check-concealment.test.ts
+++ b/tests/scripts/check-concealment.test.ts
@@ -22,6 +22,7 @@
  */
 import { describe, expect, test } from 'bun:test';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -38,6 +39,30 @@ const MALE_SIGN = String.fromCharCode(0x2642);
 const VS16 = String.fromCharCode(0xfe0f);
 const SOFT_HYPHEN = String.fromCharCode(0x00ad);
 const NUL = String.fromCharCode(0);
+/** LATIN SMALL LETTER LONG S. Folds to `s` on APFS and NTFS; JS toLowerCase leaves it alone. */
+const LONG_S = String.fromCharCode(0x017f);
+
+/**
+ * Does THIS filesystem fold U+017F to `s`? APFS and NTFS do, ext4 does not.
+ *
+ * The routing tests below only mean anything where the fold happens: on a
+ * case-sensitive filesystem `.gitattribute<U+017F>` is a genuinely different
+ * file that git never reads, so asserting a finding there would assert the
+ * opposite of what git does. Detected rather than assumed from the platform
+ * name — a macOS user can format a case-sensitive volume, and CI is Linux.
+ */
+const FS_FOLDS_LONG_S = ((): boolean => {
+  const probe = mkdtempSync(join(tmpdir(), 'concealment-fold-'));
+  try {
+    writeFileSync(join(probe, `probe${LONG_S}`), 'x');
+    statSync(join(probe, 'probes'));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(probe, { recursive: true, force: true });
+  }
+})();
 
 /** A line carrying both a 60-space gap and an eval() — trips two rules at once. */
 const concealed = `echo ok${' '.repeat(60)}eval("x")${' # '}${'x'.repeat(80)}\n`;
@@ -792,6 +817,30 @@ describe('scoping follow-ups (review of #679)', () => {
       expect(code).toBe(1)
     );
   });
+
+  describe.skipIf(!FS_FOLDS_LONG_S)(
+    'unicode-folded filenames (case-insensitive filesystems)',
+    () => {
+      test.each([
+        ['.gitattributes', `.gitattribute${LONG_S}`, 'src/payload.ts binary\n'],
+        ['package.json', `package.j${LONG_S}on`, '{"scripts":{"postinstall":"echo pwned"}}\n'],
+      ])('a U+017F fold of %s is still routed to its checker', async (_l, name, contents) => {
+        // Variation ten, and it was introduced by the fix for eight and nine.
+        // Lowercasing the basename is a fold function written in JS standing in
+        // for the filesystem's, and they disagree: APFS folds U+017F to `s`,
+        // String.prototype.toLowerCase does not. Verified end-to-end on this
+        // filesystem — `git check-attr` reports `binary: set` from a file named
+        // `.gitattribute<U+017F>`, and `npm pkg get scripts` returns the
+        // postinstall from `package.j<U+017F>on`, while the gate exited 0.
+        //
+        // The gate no longer holds an opinion about folding: it asks the OS which
+        // file the name `.gitattributes` opens to in that directory.
+        await withTree({ [name]: contents, 'src/payload.ts': 'const a = 1;\n' }, ({ code }) =>
+          expect(code).toBe(1)
+        );
+      });
+    }
+  );
 
   test('an NBSP in the pattern does not tokenize it into the allowance', async () => {
     // git splits pattern from attributes on spaces and tabs ONLY, so the real


### PR DESCRIPTION
# Summary

Closes nine review findings against `scripts/check-concealment.ts`, the gate that catches
content engineered to be invisible in review. Along the way the review found **five more
live bypasses** of the gate itself, all verified against real `git` and real `npm`, all now
closed.

Closes #686
Closes #689

## The bypasses found and closed

Each was the same defect: a parser or oracle inside the gate standing in for a real system
and diverging from it by one case, always failing OPEN.

| # | Bypass | Real tool | Gate before |
|---|---|---|---|
| 1 | `[attr]a.png binary` + `src/payload.ts a.png` | git suppresses the `.ts` diff | exit 0 |
| 2 | `"[attr]a.png" -diff` (quoted macro) | git unquotes *before* the macro test | exit 0 |
| 3 | `src/payload.ts<CR>cover.png -diff` | `\r` is in git's blank set | exit 0 |
| 4 | `.GITATTRIBUTES` on a case-insensitive FS | git reads it | exit 0 |
| 5 | `PACKAGE.JSON` with a `postinstall` | **npm runs it** | exit 0 |

(5) is the one that matters most: it is lifecycle-script *execution*, not diff suppression,
and it escaped every earlier probe because they all aimed at gitattributes. The shared defect
was the *routing*, not the parser.

Two of these were introduced by the fix for the one before it — (2) inside the fix for (1),
and a sixth (`.gitattributeſ`, where APFS folds U+017F to `s` and `toLowerCase` does not)
inside the fix for (4)/(5). Each fix is now structural rather than another enumerated case:
the macro test runs on the post-unquote token so one spelling cannot be handled without the
other, and the filename check asks the filesystem via `realpathSync.native` instead of
asserting a fold.

## The rest

- **Markdown now gets the whitespace-run rule.** This repo's markdown includes agent-read
  instruction files, where a long gap before a hidden instruction is invisible to a human and
  read by an LLM. Applied to that rule only; `MAX_LINE` and dynamic-exec keep the prose
  exemption. One true positive found in a tracked design doc and reflowed.
- **The `linguist-generated` pattern is anchored** so `=false` (which *un*-collapses a file)
  is no longer flagged, while `=1` and `=yes` — which linguist treats as true — still are.
- **Every `GIT_*` variable is stripped**, and `GIT_CONFIG_NOSYSTEM` / `HOME` / `XDG_CONFIG_HOME`
  neutralised, so a config-supplied `core.excludesFile` can no longer shrink the scanned set.
- **The success line names its strategy** — `535 files scanned (git)` vs `(walk)` — so a silent
  fallback is visible.
- Stale header claims, two orphaned JSDoc blocks, and a reference to a `--range` flag that has
  never existed, all corrected.

## Bug fix?

Root cause:       The gate modelled git's and npm's grammars in JS — a fold, a blank set, an unquote, a filename match — instead of asking the real tool, and each model diverged by one case.
Bug class:        A parser or oracle inside a security gate standing in for the system it gates, diverging from it, and failing OPEN.
Detector added:   Every bypass above is pinned by a test built from a real `.gitattributes` / `package.json` on disk and checked against the real tool's answer, not against an assumed one. The two structural fixes remove whole shapes rather than cases: one token, one macro test; and the filesystem, not a fold function.
Siblings checked: `package.json` routing had the identical case-variant exposure as `.gitattributes` and is fixed here. An adversarial sweep for further divergences — full Unicode fold sweep, hard links, symlinks, trailing dots, nested and subdirectory files, a purpose-built case-sensitive APFS volume — came back clean. Three genuine *scope* gaps (`gypfile`/`binding.gyp`, `.gitmodules`, package.json `overrides`) are a different class and left for separate issues.
Ledger updated:   n/a — not an external-assumption bug.

## External assumptions

None

## Verification

- `bun run check` — 3048 pass / 20 skip / 0 fail; `bun run check:concealment` — 535 files scanned (git), nothing hidden
- Re-run after rebasing onto current `main`: 102 pass / 0 fail on the gate's own suite
- Every bypass reproduced **red before the fix and green after**, against real `git check-attr`,
  real `git diff`, and real `npm pkg get`
- The U+017F fix verified in both runtimes, because the oracle depends on it:

  | runtime | `realpathSync` | `.native` |
  |---|---|---|
  | node v25.2.1 | returns the asked-for name | returns the on-disk name |
  | bun 1.3.5 | returns the on-disk name | returns the on-disk name |

  Pre-fix under node the gate exits 0 on the U+017F tree — the bug reproduces. Post-fix both
  runtimes exit 1.
- The routing probe is OR'd with the basename test, never a replacement, so it can only route
  *more*. Verified by forcing every failure mode (ENOENT, EACCES, broken symlink, directory-as-file)
  and confirming routing falls through rather than being removed.

## Known limits, stated rather than implied

Prose keeps the `MAX_LINE` exemption, so a very long markdown line is still unflagged. The
whitespace-run threshold has measured headroom: of 2125 lines over 120 columns the deepest
leading gap is 14 (threshold 20), and of 46 lines with 20+ leading gap the longest is 95
columns (threshold 120).
